### PR TITLE
Added play to install MPI Operator under startservices role

### DIFF
--- a/kubernetes/roles/startservices/tasks/main.yml
+++ b/kubernetes/roles/startservices/tasks/main.yml
@@ -82,3 +82,7 @@
 - name: Prometheus deployment
   shell: helm install stable/prometheus --set alertmanager.persistentVolume.storageClass=nfs-client,server.persistentVolume.storageClass=nfs-client,server.service.type=LoadBalancer --generate-name
   tags: init
+
+- name: Install MPI Operator
+  shell: kubectl create -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.2.2/deploy/mpi-operator.yaml
+  tags: init

--- a/kubernetes/roles/startservices/tasks/main.yml
+++ b/kubernetes/roles/startservices/tasks/main.yml
@@ -84,5 +84,5 @@
   tags: init
 
 - name: Install MPI Operator
-  shell: kubectl create -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.2.2/deploy/mpi-operator.yaml
+  shell: kubectl create -f https://raw.githubusercontent.com/kubeflow/mpi-operator/master/deploy/mpi-operator.yaml 
   tags: init


### PR DESCRIPTION
Ansible play to install mpi-operator v0.2.2 from github raw content: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.2.2/deploy/mpi-operator.yaml

This PR resolves issue #44. 

Signed-off-by: Lucas A. Wilson <luke.wilson@dell.com>