### PR TITLE
Devel

### DIFF
--- a/kubernetes/roles/startmaster/tasks/main.yml
+++ b/kubernetes/roles/startmaster/tasks/main.yml
@@ -14,7 +14,13 @@
   tags: init
 
 - name: Copy Kubernetes Config for root #do this for other users too?
-  copy: src=/etc/kubernetes/admin.conf dest=/root/.kube/config owner=root group=root mode=644
+  copy: 
+    src: /etc/kubernetes/admin.conf 
+    dest: /root/.kube/config 
+    owner: root 
+    group: root 
+    mode: 644
+    remote_src: yes
   tags: init
 
 - name: Cluster token

--- a/kubernetes/roles/startservices/tasks/main.yml
+++ b/kubernetes/roles/startservices/tasks/main.yml
@@ -59,6 +59,18 @@
   shell: kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta6/aio/deploy/recommended.yaml
   tags: init
 
+- name: Helm - Add Stable Repo
+  shell: helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+  tags: init
+
+- name: Helm - Add JupyterHub Repo
+  shell: helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+  tags: init
+
+- name: Helm - Update Repo
+  shell: helm repo update
+  tags: init
+
 - name: Start NFS Client Provisioner
   shell: helm install stable/nfs-client-provisioner --set nfs.server=10.0.0.1 --set nfs.path=/work --generate-name
   tags: init


### PR DESCRIPTION
* altered playbook copy command to work with remote_src, this allows the playbook to be installed on remote hosts and does not assume that you are logged into the master node

* auto install helm repos. This step missing and discovered when deploying on remote nodes that didn't have helm configured.