### PR TITLE
Omnia Edge Install

### DIFF
--- a/kubernetes/host_inventory_file
+++ b/kubernetes/host_inventory_file
@@ -1,28 +1,20 @@
 all: 
-  hosts: 
   children:
-    master:
-      hosts:
-        compute000
-      vars: 
-        master_ip: 10.0.0.100
-    compute:
-      hosts:
-        compute002:
-        compute004:
-        compute005:
-    gpus:
-      hosts:
-        compute002:
-        compute004:
-        compute005:
-    workers:
-      children:
-        compute:
-        gpu: 
     cluster:
       children:
         master:
+          hosts:
+            compute000:
         workers:
-
-        
+          children:
+            compute:
+              hosts:
+                compute003:
+            gpus:
+              hosts:
+                compute002:
+                compute004:
+                compute005:
+      vars:
+        edge_install: false
+        master_ip: 10.0.0.100

--- a/kubernetes/host_inventory_file
+++ b/kubernetes/host_inventory_file
@@ -16,5 +16,5 @@ all:
                 compute004:
                 compute005:
       vars:
-        edge_install: false
+        single_node: false
         master_ip: 10.0.0.100

--- a/kubernetes/roles/common/tasks/main.yml
+++ b/kubernetes/roles/common/tasks/main.yml
@@ -82,20 +82,6 @@
     name: "@Infiniband Support"
     state: present
 
-- name: Install KSonnet
-  unarchive:
-    src: https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz
-    dest: /usr/bin/
-    extra_opts: [--strip-components=1]
-    remote_src: yes
-    exclude:
-      - ks_0.11.0_linux_amd64/CHANGELOG.md
-      - ks_0.11.0_linux_amd64/CODE-OF-CONDUCT.md
-      - ks_0.11.0_linux_amd64/CONTRIBUTING.md
-      - ks_0.11.0_linux_amd64/LICENSE
-      - ks_0.11.0_linux_amd64/README.md
-  tags: install
-
 - name: upgrade pip
   command: /bin/pip install --upgrade pip
   tags: install
@@ -142,7 +128,7 @@
 - name: Start and nfs-lock service
   service:
     name: nfs-lock
-    state: restarted
+    #state: restarted
     enabled: yes
   tags: install
 

--- a/kubernetes/roles/master/tasks/main.yml
+++ b/kubernetes/roles/master/tasks/main.yml
@@ -13,18 +13,18 @@
 #  limitations under the License.
 
 ---
-- name: Firewall Rule K8s:6443/tcp
-  command: firewall-cmd  --zone=internal --add-port=6443/tcp --permanent
-  tags: master
-
-- name: Firewall Rule K8s:10250/tcp
-  command: firewall-cmd  --zone=internal --add-port=10250/tcp --permanent
-  tags: master
-
-- name: Firewall Reload
-  command: firewall-cmd  --reload
-  tags: master
-
+#- name: Firewall Rule K8s:6443/tcp
+  #command: firewall-cmd  --zone=internal --add-port=6443/tcp --permanent
+  #tags: master
+#
+#- name: Firewall Rule K8s:10250/tcp
+  #command: firewall-cmd  --zone=internal --add-port=10250/tcp --permanent
+  #tags: master
+##
+#- name: Firewall Reload
+  #command: firewall-cmd  --reload
+  #tags: master
+#
 - name: Create /root/bin (if it doesn't exist)
   file:
     path: /root/bin

--- a/kubernetes/roles/startmaster/tasks/main.yml
+++ b/kubernetes/roles/startmaster/tasks/main.yml
@@ -112,7 +112,7 @@
 
 - name: Edge / Workstation Install allows pods to scheudle on master
   shell: kubectl taint nodes --all node-role.kubernetes.io/master-
-  when: edge_install 
+  when: single_node 
   tags: init
 
 

--- a/kubernetes/roles/startmaster/tasks/main.yml
+++ b/kubernetes/roles/startmaster/tasks/main.yml
@@ -110,6 +110,12 @@
   shell: kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}') > /root/k8s/token
   tags: init
 
+- name: Edge / Workstation Install allows pods to scheudle on master
+  shell: kubectl taint nodes --all node-role.kubernetes.io/master-
+  when: edge_install 
+  tags: init
+
+
 # If more debug information is needed during init uncomment the following 2 lines
 #- debug: var=init_output.stdout_lines
   #tags: init

--- a/kubernetes/roles/startworkers/tasks/main.yml
+++ b/kubernetes/roles/startworkers/tasks/main.yml
@@ -38,6 +38,7 @@
     kubeadm join --token={{ hostvars['K8S_TOKEN_HOLDER']['token'] }}
     --discovery-token-ca-cert-hash sha256:{{ hostvars['K8S_TOKEN_HOLDER']['hash'] }}
     {{ hostvars['K8S_TOKEN_HOLDER']['ip'] }}:6443
+  when: not edge_install
   tags: init
 
 

--- a/kubernetes/roles/startworkers/tasks/main.yml
+++ b/kubernetes/roles/startworkers/tasks/main.yml
@@ -38,7 +38,7 @@
     kubeadm join --token={{ hostvars['K8S_TOKEN_HOLDER']['token'] }}
     --discovery-token-ca-cert-hash sha256:{{ hostvars['K8S_TOKEN_HOLDER']['hash'] }}
     {{ hostvars['K8S_TOKEN_HOLDER']['ip'] }}:6443
-  when: not edge_install
+  when: not single_node
   tags: init
 
 


### PR DESCRIPTION
users can now set a variable in `host_inventory_file` to enable "Edge Install", allowing for a single server k8s instance

- removed old ksonnet install that is no longer used
- refaactored host_inventory_file to demonstarate global vars
closes ticket #40 

Signed-off-by: John Lockman <jlockman3@gmail.com>