### PR TITLE
Issue #140: Changing ansible lint job name to ansible-lint

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -7,7 +7,7 @@ on:
       - devel
 
 jobs:
-  build:
+  ansible-lint:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Changed name of Ansible lint job from `build` to `ansible-lint` to provide better description during CI checks.

Fixes #140 