### PR TITLE
replace yum with package module

### DIFF
--- a/kubernetes/roles/common/tasks/main.yml
+++ b/kubernetes/roles/common/tasks/main.yml
@@ -19,7 +19,8 @@
   tags: install
 
 # add ElRepo GPG Key
-- rpm_key:
+- name: add ElRepo GPG Key
+  rpm_key:
     state: present
     key: https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
   tags: install
@@ -51,8 +52,8 @@
   command: /sbin/swapoff -a
   tags: install
 
-# Disable selinux
-- selinux:
+- name: Disable SELinux
+  selinux:
     state: disabled
   tags: install
 

--- a/kubernetes/roles/common/tasks/main.yml
+++ b/kubernetes/roles/common/tasks/main.yml
@@ -57,7 +57,7 @@
   tags: install
 
 - name: install common packages
-  yum:
+  package:
     name:
       - yum-plugin-versionlock
       - gcc
@@ -78,7 +78,7 @@
 
 
 - name: install InfiniBand Support
-  yum:
+  package:
     name: "@Infiniband Support"
     state: present
 

--- a/kubernetes/roles/computeGPU/tasks/main.yml
+++ b/kubernetes/roles/computeGPU/tasks/main.yml
@@ -33,8 +33,8 @@
     dest: /etc/yum.repos.d/nvidia-container-runtime.repo
   tags: install, testing
 
-# disable gpg key (because Nvidia doesn't know how to make that work yet for some reason)
-- replace:
+- name:  disable gpg key for nvidia-container-runtime
+  replace:
     path: /etc/yum.repos.d/nvidia-container-runtime.repo
     regexp: 'repo_gpgcheck=1'
     replace: 'repo_gpgcheck=0'

--- a/kubernetes/roles/computeGPU/tasks/main.yml
+++ b/kubernetes/roles/computeGPU/tasks/main.yml
@@ -14,7 +14,7 @@
 
 ---
 - name: install Nvidia driver
-  yum:
+  package:
     name:
       - kmod-nvidia
       #- nvidia-x11-drv
@@ -42,7 +42,7 @@
   tags: testing
 
 - name: install Nvidia-container-runtime-hook
-  yum:
+  package:
     name:
       #- nvidia-detect
       #- kmod-nvidia-410.73-1.el7_5.elrepo

--- a/kubernetes/roles/startmanager/tasks/main.yml
+++ b/kubernetes/roles/startmanager/tasks/main.yml
@@ -33,7 +33,7 @@
     dest: /root/.kube/config
     owner: root
     group: root
-    mode: 644
+    mode: 0644
     remote_src: yes
   tags: init
 
@@ -92,6 +92,9 @@
 - name: Create yaml repo for setup
   file:
     path: /root/k8s
+    owner: root
+    group: root
+    mode: 0755
     state: directory
   tags: init
 

--- a/slurm/roles/common/handlers/main.yml
+++ b/slurm/roles/common/handlers/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: restart ntpd
-  service: 
+  service:
     name=ntpd
     state=restarted
     enabled=yes
 
 - name: restart chrony
-  service: 
-    name=chronyd 
-    state=restarted 
+  service:
+    name=chronyd
+    state=restarted
     enabled=yes
 
 - name: sync ntp clocks

--- a/slurm/roles/common/tasks/ntp.yml
+++ b/slurm/roles/common/tasks/ntp.yml
@@ -1,5 +1,5 @@
 ---
-  
+
   - name: deploy ntp servers
     block:
       - name: deploy ntpd

--- a/slurm/roles/slurm-common/tasks/main.yml
+++ b/slurm/roles/slurm-common/tasks/main.yml
@@ -14,7 +14,7 @@
 ---
 
 - name: install packages for slurm
-  yum:
+  package:
     name:
       - munge
       - mariadb

--- a/slurm/roles/slurm-manager/tasks/main.yml
+++ b/slurm/roles/slurm-manager/tasks/main.yml
@@ -34,6 +34,7 @@
   copy:
     src: "{{ item }}"
     dest: /home/rpms/
+    mode: '0755'
   with_fileglob:
     - /root/rpmbuild/RPMS/x86_64/slurm*20*.rpm
   tags: install
@@ -90,7 +91,7 @@
   tags: install
 
 - name: Create Slurm Cluster
-  command: sacctmgr -i add cluster {{inventory_hostname}}
+  command: sacctmgr -i add cluster {{ inventory_hostname }}
   tags: install
 
 - name: Create Default Slurm Group

--- a/slurm/roles/start-slurm-workers/tasks/main.yml
+++ b/slurm/roles/start-slurm-workers/tasks/main.yml
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 ---
 - name: Install SLURM RPMs on compute
   yum:


### PR DESCRIPTION
replaced all `yum` with `package` module, the project still has other `yum` commands that need to be converted to use the module and use a where clause for different OS versions

Signed-off-by: John lockman <john.lockman@friday.local>