### PR TITLE
Clarify NFS share variables

### DIFF
--- a/roles/k8s_nfs_client_setup/tasks/main.yml
+++ b/roles/k8s_nfs_client_setup/tasks/main.yml
@@ -36,7 +36,7 @@
   tags: nfs_client
 
 - name: Mounting NFS Share
-  command: "mount {{ groups['manager'][0] }}:{{ nfs_mnt_dir }} {{ nfs_mnt_dir }}"
+  command: "mount {{ mounthost }}:{{ nfs_share_dir }} {{ nfs_mnt_dir }}"
   changed_when: true
   args:
     warn: false
@@ -46,6 +46,6 @@
 - name: Configuring Automount NFS Shares on reboot
   lineinfile:
     path: "{{ fstab_file_path }}"
-    line: "{{ groups['manager'][0] }}:{{ nfs_mnt_dir }}     {{ nfs_mnt_dir }}  nfs     nosuid,rw,sync,hard,intr 0 0"
+    line: "{{ mounthost }}:{{ nfs_share_dir }}     {{ nfs_mnt_dir }}  nfs     nosuid,rw,sync,hard,intr 0 0"
   when: groups['manager'][0] not in mounted_share.stdout
   tags: nfs_client

--- a/roles/k8s_nfs_client_setup/vars/main.yml
+++ b/roles/k8s_nfs_client_setup/vars/main.yml
@@ -14,6 +14,9 @@
 ---
 
 nfs_mnt_dir: /home/k8snfs
+nfs_share_dir: /home/k8snfs
+
+mounthost: "{{ groups['manager'][0] }}"
 
 nfs_mnt_dir_mode: 0755
 


### PR DESCRIPTION
I've created two new variables for the k8s_nfs_client_setup role:

nfs_share_dir : The directory that is being exported by the NFS server (e.g. server:/exportdir )

This is useful for situations where the exported directory is mounted in a different location on the NFS server than the NFS client.

mounthost: "{{ groups['manager'][0] }}"  # Shorthand for the extracted manager host name from the groups dictionary.

