### PR TITLE
Playbook for installing Operator Framework (#105)

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -33,6 +33,8 @@ jobs:
           /github/workspace/platforms/jupyterhub.yml
           /github/workspace/platforms/kubeflow.yml
           /github/workspace/tools/install_tools.yml
+          /github/workspace/tools/intel_tools.yml
+          /github/workspace/tools/olm.yml
         # [optional]
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.

--- a/tools/intel_tools.yml
+++ b/tools/intel_tools.yml
@@ -31,7 +31,7 @@
       state: present
 
 # Install the Intel Cluster Checker
-- hosts: cluster 
+- hosts: cluster
   tasks:
   - name: Import the Intel(R) Cluster Checker Repo GPG Key
     rpm_key:

--- a/tools/olm.yml
+++ b/tools/olm.yml
@@ -1,0 +1,21 @@
+#  Copyright 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+# olm.yml: Install Operator Lifecycle Manager (OLM) for Operator Framework
+
+- name: Deploy Operator Lifecycle Manager (OLM) CRDs
+  command: kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/crds.yaml
+
+- name: Deploy Operator Lifecycle Manager (OLM)
+  command: kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/olm.yaml


### PR DESCRIPTION
Fixes #105

I placed the `olm.yml` playbook inside the `tools` directory as an optional install.

`olm.yml` execute 2 plays:
1. Deploys the OLM CRDs
2. Deploys the OLM service