### PR TITLE
Issue #314: Updating elrepo URL to use major distribution variable

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -42,7 +42,7 @@ accelerator_discovery_script_mode: 0755
 
 elrepo_gpg_key_url: https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
 
-elrepo_rpm_url: https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
+elrepo_rpm_url: "https://www.elrepo.org/elrepo-release-{{ ansible_facts['distribution_major_version'] }}.el{{ ansible_facts['distribution_major_version'] }}.elrepo.noarch.rpm" 
 
 docker_repo_url: https://download.docker.com/linux/centos/docker-ce.repo
 


### PR DESCRIPTION
Signed-off-by: Lucas A. Wilson <luke.wilson@dell.com>

### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #314

### Description of the Solution
Replaced hardcoded elrepo URL in `roles/common/vars/main.yml` with version based on OS version:
```
elrepo_rpm_url: "https://www.elrepo.org/elrepo-release-{{ ansible_facts['distribution_major_version'] }}.el{{ ansible_facts['distribution_major_version'] }}.elrepo.noarch.rpm"
```

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.

@j0hnL 
