### PR TITLE
install epel-release before common packages

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -27,6 +27,12 @@
     group: root
     mode: "{{ accelerator_discovery_script_mode }}"
 
+- name: Add epel-release repo
+  package:
+    name: epel-release
+    state: present
+  tags: install
+
 - name: Add elrepo GPG key
   rpm_key:
     state: present

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -14,7 +14,6 @@
 ---
 
 common_packages:
-  - epel-release
   - yum-plugin-versionlock
   - gcc
   - nfs-utils


### PR DESCRIPTION
Omnia will now install all repos before attempting to install common packages.  This will fix issue #312 

Signed-off-by: John Lockman <jlockman3@gmail.com>

### Issues Resolved by this Pull Request
Fixes #312 


### Description of the Solution
add each repo as a task before installing `common` packages

