### PR TITLE
install Slurm from EPEL rather than from source

### DIFF
--- a/roles/slurm_common/tasks/main.yml
+++ b/roles/slurm_common/tasks/main.yml
@@ -28,10 +28,8 @@
 
 - name: Install packages for slurm
   package:
-    name: "{{ item }}"
+    name: "{{ common_packages }}"
     state: present
-  with_items:
-    - "{{ common_packages }}"
   tags: install
 
 - name: Create munge key

--- a/roles/slurm_common/vars/main.yml
+++ b/roles/slurm_common/vars/main.yml
@@ -14,6 +14,8 @@
 ---
 
 common_packages:
+   - slurm-slurmd 
+   - slurm-pmi
    - munge
    - munge-libs
    - munge-devel

--- a/roles/slurm_manager/tasks/main.yml
+++ b/roles/slurm_manager/tasks/main.yml
@@ -49,18 +49,14 @@
 
 - name: Install packages for slurm
   package:
-    name: "{{ item }}"
+    name: "{{ slurm_packages }}"
     state: present
-  with_items:
-    - "{{ slurm_packages }}"
   tags: install
 
 - name: Install development tools
   package:
-    name: "{{ item }}"
+    name: "{{ dev_tools }}"
     state: present
-  with_items:
-    - "{{ dev_tools }}"
   tags: install
 
 - name: Verify if slurm is installed

--- a/roles/slurm_manager/vars/main.yml
+++ b/roles/slurm_manager/vars/main.yml
@@ -26,6 +26,8 @@ slurm_packages:
    - perl-Switch
    - libibumad
    - git
+   - slurm-slurmctld
+   - slurm-slurmdbd
 
 dev_tools:
    - rrdtool-devel

--- a/roles/slurm_workers/tasks/main.yml
+++ b/roles/slurm_workers/tasks/main.yml
@@ -57,16 +57,12 @@
   package:
     name: "{{ slurm_packages }}"
     state: present
-  with_items:
-    - "{{ slurm_packages }}"
   tags: install
 
 - name: Install development tools
   package:
-    name: "{{ item }}"
+    name: "{{ dev_tools }}"
     state: present
-  with_items:
-    - "{{ dev_tools }}"
   tags: install
 
 - name: Verify if slurm is installed


### PR DESCRIPTION
Slurm is now installed from the EPEL repo rather than building from source. I left in the code to build from source in the event that users want to build a specific version other than what is in EPEL. We will need to provide a switch or variable to allow users to install from source. 

Signed-off-by: John Lockman <jlockman3@gmail.com>

### Issues Resolved by this Pull Request
Fixes #318 

### Description of the Solution
changed slurm install from source to using the EPEL provided packages
