### PR TITLE
fix dhcp gateway and dns

### DIFF
--- a/appliance/appliance_config.yml
+++ b/appliance/appliance_config.yml
@@ -45,6 +45,9 @@ mapping_file_path: ""
 
 # The dhcp range for assigning the IPv4 address to the baremetal nodes.
 # Example: 10.1.23.1
+dhcp_gateway: ""
+dhcp_dns1: ""
+dhcp_dns2: ""
 dhcp_start_ip_range: ""
 dhcp_end_ip_range: ""
 

--- a/appliance/roles/common/tasks/password_config.yml
+++ b/appliance/roles/common/tasks/password_config.yml
@@ -41,6 +41,9 @@
       iso_file_path | length < 1 or
       dhcp_start_ip_range | length < 1 or
       dhcp_end_ip_range | length < 1 or
+      dhcp_gateway | length < 1 or
+      dhcp_dns1 | length < 1 or
+      dhcp_dns2 | length < 1 or
       timezone | length < 1
 
 - name: Save input variables from file
@@ -50,6 +53,9 @@
     nic:  "{{ hpc_nic }}"
     internet_nic: "{{ public_nic }}"
     path_for_iso_file: "{{ iso_file_path }}"
+    dhcp_gateway: "{{ dhcp_gateway | ipv4 }}"
+    dhcp_dns1: "{{ dhcp_dns1 | ipv4 }}"
+    dhcp_dns2: "{{ dhcp_dns2 | ipv4 }}"
     dhcp_start_ip: "{{ dhcp_start_ip_range | ipv4 }}"
     dhcp_end_ip: "{{ dhcp_end_ip_range | ipv4 }}"
     mapping_file: false

--- a/appliance/roles/provision/files/temp_dhcp.template
+++ b/appliance/roles/provision/files/temp_dhcp.template
@@ -19,6 +19,8 @@ set vendorclass = option vendor-class-identifier;
 option pxe-system-type code 93 = unsigned integer 16;
 
 subnet subnet_mask netmask net_mask {
+option routers router-ip;
+option domain-name-servers dns1, dns2;
 option subnet-mask net_mask;
 range dynamic-bootp start end;
 default-lease-time  21600;

--- a/appliance/roles/provision/tasks/dhcp_configure.yml
+++ b/appliance/roles/provision/tasks/dhcp_configure.yml
@@ -32,6 +32,21 @@
     path: "{{ role_path }}/files/dhcp.template"
     regexp: '^option subnet-mask net_mask;'
     replace: 'option subnet-mask {{ netmask }};'
+  tags: install
+
+- name: Assign gateway
+  replace:
+    path: "{{ role_path }}/files/dhcp.template"
+    regexp: '^option routers router-ip;'
+    replace: 'option routers {{ dhcp_gateway }};'
+  tags: install
+
+- name: Assign DNS
+  replace:
+    path: "{{ role_path }}/files/dhcp.template"
+    regexp: '^option domain-name-servers dns1, dns2;'
+    replace: 'option domain-name-servers {{ dhcp_dns1 }}, {{ dhcp_dns2 }};'
+  tags: install
 
 - name: Assign DHCP range
   replace:


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Appliance does not supply dhcp clients with gateway and dns information

Fixes #

### Description of the Solution
Added variables for the default gateway and two dns servers to applicance_config.yml


### Suggested Reviewers
_@_lwilson
_@_j0hnL