### PR TITLE
cobbler pxe loop fix and utils

### DIFF
--- a/appliance/roles/provision/files/temp_centos7.ks
+++ b/appliance/roles/provision/files/temp_centos7.ks
@@ -61,3 +61,10 @@ reboot
 @core
 net-tools
 %end
+
+%post
+$SNIPPET('post_install_kernel_options')
+$SNIPPET('cobbler_register')
+$SNIPPET('kickstart_done')
+%end
+

--- a/cobbler_utils/create_system_profiles.sh
+++ b/cobbler_utils/create_system_profiles.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ $# -lt 1 ] ; then
+    echo -e "\nNeed mapping file\n"
+    echo -e "e.g. $(basename $0) mapping.csv\n"
+    exit 1
+fi
+
+MAPPING=$1
+
+if [ ! -e $MAPPING ] ; then
+    echo -e "\nMapping file $MAPPING does not exist\n"
+    exit 1
+fi
+
+if [ ! -d profiles ] ; then
+	mkdir profiles
+fi
+
+echo -e "#!/bin/bash\n" > profiles/addall.sh
+
+for profile in $(cat $MAPPING | grep -v ^MAC) ; do
+
+    MAC=$(echo $profile | cut -d "," -f 1 )
+    HOSTNAME=$(echo $profile | cut -d "," -f 2 )
+    IPADDR=$(echo $profile | cut -d "," -f 3 )
+    OUTFILE=${HOSTNAME}.sh
+
+    cat template.sh \
+    | sed -e "s/^HOSTNAME=/HOSTNAME=\"$HOSTNAME\"/" \
+    -e "s/^IPADDR=/IPADDR=\"$IPADDR\"/" \
+    -e "s/^MAC=/MAC=\"$MAC\"/" > profiles/$OUTFILE
+
+    echo "./$OUTFILE" >> profiles/addall.sh
+
+    chmod 755 profiles/$OUTFILE
+
+done
+
+echo -e "\ncobbler sync\n" >> profiles/addall.sh
+
+chmod 755 profiles/addall.sh
+
+

--- a/cobbler_utils/template.sh
+++ b/cobbler_utils/template.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+HOSTNAME=
+IPADDR=
+MAC=
+INTERFACE="em1"
+PROFILE="CentOS7-x86_64"
+
+cobbler system remove --name=$HOSTNAME 2>&1 > /dev/null
+
+cobbler system add --name=$HOSTNAME --hostname=$HOSTNAME --profile=$PROFILE
+
+cobbler system edit --name=$HOSTNAME --interface=$INTERFACE --mac=$MAC
+
+cobbler system edit --name=$HOSTNAME --kopts="ksdevice=$MAC nomodeset consoleblank=0"
+
+cobbler system edit --name=$HOSTNAME --kopts-post="nomodeset consoleblank=0"
+
+#cobbler sync
+


### PR DESCRIPTION
Signed-off-by: Lee Reynolds <Lee.Reynolds@asu.edu>

### Issues Resolved by this Pull Request
Cobbler in omnia is not tracking system profiles.  This means that all imaging is essentially manual.  Also, the cobbler7.ks kickstart file is was missing the cobbler specific code to register the imaging of nodes, which resulted in systems set to PXE first being stuck in an infinite PXE loop, being reimaged repeatedly.

Fixes #

### Description of the Solution
1 ) New version of omnia/appliance/roles/provision/files/temp_centos7.ks that includes the following lines at the end:

%post                                                                           
$SNIPPET('post_install_kernel_options')                                         
$SNIPPET('cobbler_register')                                                    
$SNIPPET('kickstart_done')                                                      
%end

These lines are necessary, especially "kickstart_done" to tell the system being imaged to poke the cobbler server and let it know that install has completed.

2) New cobbler utility and helper scripts that allow users to create system profiles for cobbler from the mapping.csv file

omnia/cobbler_utils/create_system_profiles.sh
omnia/cobbler_utils/template.sh

(These scripts are intended to be temporary until I can work out how to achieve the same result using Ansible.)

These will have to be used from within the cobbler container as follows:

cp mapping.csv omnia/cobbler_utils/
docker exec -it cobbler /bin/bash
cd /root/omnia/docker_utils
./create_system_profiles.sh mapping.csv
cd profiles
./addall.sh

At this point systems listed in mapping.csv that are set to PXE by default will be imaged automatically upon boot, but only imaged once.  These systems will also show up in the cobbler web gui and under "cobbler system list" CLI command

The web interface can be used to set an system to be imaged at boot, or the following CLI commands can be used from within the cobbler container:

cobbler system edit --name=s61-1 --netboot-enabled=0
cobbler sync

Combined with ipmitool or racadm initiating the reboot of nodes, these scripts will enable the automatic imaging of multiple nodes without users having to log into ipmi web consoles at all.

### Suggested Reviewers
j0hnL
lwilson
