### PR TITLE
Slurm exporter port change from default port 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For Omnia documentation, including installation and contribution instructions, p
 <img src="docs/images/pisa.png" height="100px" alt="Universita di Pisa"> <img src="https://user-images.githubusercontent.com/83095575/117071024-64956c80-ace3-11eb-9d90-2dac7daef11c.png" height="80px" alt="Arizona State University"> <img src="https://www.vizias.com/uploads/1/1/8/9/118906653/published/thick-blue-white-ring-letters-full.png" height="60px" alt="Vizias">
 
 ## Contributors
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to everyone who makes Omnia possible ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/roles/k8s_start_services/tasks/main.yml
+++ b/roles/k8s_start_services/tasks/main.yml
@@ -13,6 +13,9 @@
 #  limitations under the License.
 ---
 
+- name: Include common variables
+  include_vars: ../../slurm_exporter/vars/main.yml
+
 - name: Wait for CoreDNS to restart
   command: kubectl rollout status deployment/coredns -n kube-system
   changed_when: false
@@ -147,8 +150,8 @@
 - name: Add the host IP to config file
   replace:
     path: "{{ slurm_exporter_config_file_path }}{{ slurm_exporter_config_file }}"
-    regexp: "localhost"
-    replace: "{{ public_ip.stdout }}"
+    regexp: "localhost:8080"
+    replace: "{{ public_ip.stdout }}:{{ slurm_exporter_port }}"
   tags: init
 
 - name: Prometheus deployment

--- a/roles/slurm_exporter/files/prometheus-slurm-exporter.service
+++ b/roles/slurm_exporter/files/prometheus-slurm-exporter.service
@@ -2,7 +2,7 @@
 Description = Start prometheus slurm exporter
 
 [Service]
-ExecStart = /usr/bin/prometheus-slurm-exporter
+ExecStart = /usr/bin/prometheus-slurm-exporter "--listen-address=0.0.0.0:8080"
 Restart = always
 RestartSec = 15
 

--- a/roles/slurm_exporter/tasks/install_prometheus.yml
+++ b/roles/slurm_exporter/tasks/install_prometheus.yml
@@ -37,4 +37,4 @@
           scrape_interval:  30s
           scrape_timeout:   30s
           static_configs:
-            - targets: ['localhost:8080']
+            - targets: ['localhost:{{ slurm_exporter_port }}']

--- a/roles/slurm_exporter/tasks/start_services.yml
+++ b/roles/slurm_exporter/tasks/start_services.yml
@@ -13,12 +13,35 @@
 # limitations under the License.
 ---
 
+- name: Firewall port addition for slurm exporter
+  firewalld:
+    zone: public
+    port: "{{ item }}"
+    permanent: true
+    state: enabled
+  with_items:
+    - "{{ slurm_exporter_port }}/tcp"
+    - "{{ slurm_exporter_port }}/udp"
+  tags: firewalld
+
+- name: Reload firewalld
+  command: firewall-cmd --reload
+  changed_when: true
+  tags: firewalld
+
 - name: Create systemd unit file
   copy:
     src: "{{ role_path }}/files/prometheus-slurm-exporter.service"
     dest: "{{ systemd_path_dest }}"
     remote_src: no
     mode: "{{ file_permission }}"
+
+- name: Update the port in service file
+  replace:
+    path: "{{ systemd_path_dest }}/prometheus-slurm-exporter.service"
+    regexp: "0.0.0.0:8080"
+    replace: "0.0.0.0:{{ slurm_exporter_port }}"
+  tags: init
 
 - name: Start services
   systemd:

--- a/roles/slurm_exporter/vars/main.yml
+++ b/roles/slurm_exporter/vars/main.yml
@@ -35,6 +35,7 @@ prometheus_config_file: "{{ prometheus_inst_path }}/prometheus.yml"
 #Usage: start_service.yml
 file_permission: "0755"
 systemd_path_dest: "/etc/systemd/system/"
+slurm_exporter_port: "8081"
 
 #Usage: configure_prometheus_pod.yml
 slurm_config_file: "slurm_exporter_config.yaml"


### PR DESCRIPTION
### Issues Resolved by this Pull Request


Fixes #402 

### Description of the Solution
Updated the slurm exporter port from default port 8080 to port 8081
1. Added a new variable slurm_exporter_port: 8081
2. Updated the service file with a default listen address 0.0.0.0:8080 and modifying the port to the value in slurm_exporter_port variable.
3. Added the port into firewalld.
4. Updated the k8s_start_services file to update the port to the value in slurm_exporter_port
Going ahead for any port changes in slurm exporter, only one variable has to be updated.

### Suggested Reviewers
@lwilson @j0hnL 
