### PR TITLE
Update ansible-lint.yml

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -29,13 +29,11 @@ jobs:
         #   playbook_2.yml
         targets: |
           /github/workspace/omnia.yml
-          /github/workspace/omnia_config.yml
           /github/workspace/control_plane/control_plane.yml
           /github/workspace/platforms/jupyterhub.yml
           /github/workspace/platforms/kubeflow.yml
           /github/workspace/tools/install_tools.yml
           /github/workspace/tools/intel_tools.yml
-          /github/workspace/tools/olm.yml
         # [optional]
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.


### PR DESCRIPTION
omnia_config.yml -- This file is var files and does not contain any play.
tools/olm.yml -- This yml file contains only two commands. "command" is not valid play for attribute.

We can remove these two files from lint check. This way all PR will not have any ansible lint issues.

### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
These changes are needed so that all PR will not failed at lint check status.

### Suggested Reviewers
_@lwilson_, _@j0hnL_
