### PR TITLE
updated inventory file examples

### DIFF
--- a/examples/host_inventory_file
+++ b/examples/host_inventory_file
@@ -4,14 +4,18 @@ all:
       children:
         manager:
           hosts:
-            compute000:
+            manager.omnia.local:
+        nfs_node:
+          hosts:
+            manager.omnia.local:
+        login_node:
+          hosts:
+            login1.omnia.local:
         workers:
           children:
             compute:
               hosts:
-                compute001:
-            gpus:
-              hosts:
-                compute002:
-                compute003:
-                compute004:
+                compute001.omnia.local;
+                compute002.omnia.local;
+                compute003.omnia.local;
+                compute004.omnia.local;

--- a/examples/host_inventory_file.ini
+++ b/examples/host_inventory_file.ini
@@ -1,13 +1,19 @@
 [manager]
-friday
+manager.omnia.local
+
+[nfs_node]
+manager.omnia.local
+
+[login_node]
+login1.omnia.local
 
 [compute]
-compute000
-compute[002:005]
+compute[000:064]
 
 [workers:children]
 compute
 
 [cluster:children]
 manager
+login_node
 workers


### PR DESCRIPTION
host_inventory_file now shows examples for applying `login_node` and `nfs_node` roles

Signed-off-by: John Lockman <jlockman3@gmail.com>


