### PR TITLE
Issue #605: Fixed errors that are coming due to new buildah version

### DIFF
--- a/control_plane/roles/control_plane_device/tasks/check_prerequisites.yml
+++ b/control_plane/roles/control_plane_device/tasks/check_prerequisites.yml
@@ -39,7 +39,7 @@
       verbosity: 2
 
 - name: Inspect the mngmnt_network_container image
-  command: "buildah images {{ mngmnt_network_image_name }}"
+  command: "buildah images"
   register: mngmnt_network_container_image_result
   failed_when: false
   changed_when: false
@@ -55,7 +55,7 @@
 - name: Update mngmnt_network_container image status
   set_fact:
     mngmnt_network_container_image_status: true
-  when: "'No such image' not in mngmnt_network_container_image_result.stderr"
+  when: mngmnt_network_image_name in mngmnt_network_container_image_result.stdout
   tags: install
 
 - name: Update mngmnt_network_container container status

--- a/control_plane/roles/control_plane_ib/tasks/check_prerequisites.yml
+++ b/control_plane/roles/control_plane_ib/tasks/check_prerequisites.yml
@@ -40,7 +40,7 @@
       verbosity: 2
 
 - name: Inspect the infiniband_container image
-  command: "buildah images {{ infiniband_image_name }}"
+  command: "buildah images"
   register: infiniband_container_image_result
   failed_when: false
   changed_when: false
@@ -56,7 +56,7 @@
 - name: Update infiniband_container image status
   set_fact:
     infiniband_container_image_status: true
-  when: "'No such image' not in infiniband_container_image_result.stderr"
+  when: infiniband_image_name in infiniband_container_image_result.stdout
   tags: install
 
 - name: Update infiniband_container container status

--- a/control_plane/roles/provision_cobbler/tasks/check_prerequisites.yml
+++ b/control_plane/roles/provision_cobbler/tasks/check_prerequisites.yml
@@ -50,7 +50,7 @@
   when: "'cobbler' not in k8s_namespaces.stdout"
 
 - name: Inspect the cobbler image
-  command: "buildah images {{ cobbler_image_name }}"
+  command: "buildah images"
   register: cobbler_image_result
   failed_when: false
   changed_when: false
@@ -66,7 +66,7 @@
 - name: Update cobbler image status
   set_fact:
     cobbler_image_status: true
-  when: "'No such image' not in cobbler_image_result.stderr"
+  when: cobbler_image_name in cobbler_image_result.stdout
   tags: install
 
 - name: Update cobbler container status

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,7 +100,7 @@ AWX	|	Apache-2.0	|	19.1.0	|	Web-based User Interface
 AWX.AWX	|	Apache-2.0	|	19.1.0	|	Galaxy collection to perform awx configuration
 AWXkit	|	Apache-2.0	|	to be updated	|	To perform configuration through CLI commands
 Cri-o	|	Apache-2.0	|	1.21	|	Container Service
-Buildah	|	Apache-2.0	|	1.19.8	|	Tool to build and run container
+Buildah	|	Apache-2.0	|	1.21.4	|	Tool to build and run container
 PostgreSQL	|	Copyright (c) 1996-2020, PostgreSQL Global Development Group	|	10.15	|	Database Management System
 Redis	|	BSD-3-Clause License	|	6.0.10	|	In-memory database
 NGINX	|	BSD-2-Clause License	|	1.14	|	-


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Fixes #605

### Description of the Solution
Since, in the buildah new version, the error message is changed, i.e from `No such image` to `image not known`, I have updated the when condition in `check_prerequisities` where we are checking if a particular image is already present in the server.

