### PR TITLE
Fix device inventory template failure for ethernet switches

### DIFF
--- a/control_plane/roles/collect_device_info/files/create_inventory.yml
+++ b/control_plane/roles/collect_device_info/files/create_inventory.yml
@@ -119,6 +119,12 @@
       when: "'$ANSIBLE_VAULT;' in config_content.stdout"
       run_once: true
 
+    - name: Install paramiko
+      command: pip3 install paramiko -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com
+      delegate_to: localhost
+      run_once: true
+      changed_when: false
+
     - name: Initialize variables
       set_fact:
         idrac_inventory_status: false

--- a/control_plane/roles/network_ethernet/tasks/pre_requisites.yml
+++ b/control_plane/roles/network_ethernet/tasks/pre_requisites.yml
@@ -16,6 +16,7 @@
 - name: Install paramiko
   command: pip3 install paramiko -i http://pypi.douban.com/simple/ --trusted-host pypi.douban.com
   delegate_to: localhost
+  run_once: true
   changed_when: false
 
 - name: Check if ethernet_tor_vars.yml exists


### PR DESCRIPTION
Fixes #638

### Description of the Solution
Added paramiko module installation for device inventory template.

### Suggested Reviewers
@lwilson @j0hnL 
