### PR TITLE
Issue #662: Updating mpi-operator yaml url

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ Helm	|	Apache-2.0	|	3.5.0	|	Kubernetes Package Manager
 Helm Chart	|	-	|	0.9.0	|	-
 TensorFlow	|	Apache-2.0	|	2.1.0	|	Machine Learning framework
 Horovod	|	Apache-2.0	|	0.21.1	|	Distributed deep learning training framework for Tensorflow
-MPI	|	Copyright (c) 2018-2019 Triad National Security,LLC. All rights reserved.	|	0.2.3	|	HPC library
+MPI	|	Copyright (c) 2018-2019 Triad National Security,LLC. All rights reserved.	|	0.3.0	|	HPC library
 CoreDNS	|	Apache-2.0	|	1.6.2	|	DNS server that chains plugins
 CNI	|	Apache-2.0	|	0.3.1	|	Networking for Linux containers
 AWX	|	Apache-2.0	|	19.1.0	|	Web-based User Interface

--- a/roles/k8s_start_services/vars/main.yml
+++ b/roles/k8s_start_services/vars/main.yml
@@ -65,7 +65,7 @@ nfs_server_manager_node: "{{ ansible_host }}"
 
 nfs_server_nfs_node: "{{ groups['nfs_node'][0] }}"
 
-mpi_operator_yaml_url: https://raw.githubusercontent.com/kubeflow/mpi-operator/master/deploy/v1alpha2/mpi-operator.yaml
+mpi_operator_yaml_url: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.3.0/deploy/v1alpha2/mpi-operator.yaml
 
 nvidia_k8s_device_plugin_repo_url: https://nvidia.github.io/k8s-device-plugin
 
@@ -79,7 +79,7 @@ gpu_feature_discovery_version: 0.2.0
 
 fpga_device_plugin_yaml_url: https://raw.githubusercontent.com/Xilinx/FPGA_as_a_Service/master/k8s-fpga-device-plugin/fpga-device-plugin.yml
 
-rocm_device_plugin_yaml_url: https://raw.githubusercontent.com/RadeonOpenCompute/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+rocm_device_plugin_yaml_url: https://raw.githubusercontent.com/RadeonOpenCompute/k8s-device-plugin/v1.18.1/k8s-ds-amdgpu-dp.yaml
 
 slurm_exporter_config_file: extraScrapeConfigs.yaml
 


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #662 

### Description of the Solution
Updating mpi-operator yaml url to version 0.3.0

### Suggested Reviewers
