### PR TITLE
Issue #670: Skip failure due to iDRAC firmware updates

### DIFF
--- a/control_plane/roles/provision_idrac/tasks/update_firmware.yml
+++ b/control_plane/roles/provision_idrac/tasks/update_firmware.yml
@@ -66,7 +66,7 @@
         - idrac_error_message in update_firmware.msg
 
     - name: Firmware update job failed
-      fail:
+      debug:
         msg: "{{ firmware_job_fail_msg }}, Error: {{ update_firmware.msg }}"
       when:
         - update_firmware.failed


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #670 

### Description of the Solution
Updated idrac_firmware.yml to skip the failures during firmware update.