### PR TITLE
slurm_restd not installing in leap

### DIFF
--- a/roles/slurm_restd/tasks/main.yml
+++ b/roles/slurm_restd/tasks/main.yml
@@ -13,11 +13,14 @@
 #  limitations under the License.
 ---
 
-- name: Install jansson
-  include_tasks: install_jansson.yml
+- name: Execute slurm restd on rocky
+  block:
+    - name: Install jansson
+      include_tasks: install_jansson.yml
 
-- name: Install libjwt
-  include_tasks: install_libjwt.yml
+    - name: Install libjwt
+      include_tasks: install_libjwt.yml
 
-- name: Generate Token
-  include_tasks: generate_token.yml
+    - name: Generate Token
+      include_tasks: generate_token.yml
+  when: os_supported_leap not in compute_os


### PR DESCRIPTION
### Description of the Solution
Skipping installation of slurm_restd in leap due to bug 959 

### Suggested Reviewers
@sujit-jadhav 