### PR TITLE
Issue #970: Skip metallb installation if already deployed

### DIFF
--- a/roles/k8s_start_services/tasks/deploy_k8s_services.yml
+++ b/roles/k8s_start_services/tasks/deploy_k8s_services.yml
@@ -38,7 +38,6 @@
   command: "helm repo add metallb '{{ metallb_helm_url }}'"
   changed_when: false
   tags: init
- 
 
 - name: Create MetalLB Setup Config Files
   copy:
@@ -60,7 +59,8 @@
 
 - name: Deploy Metallb
   command: "helm install metallb metallb/metallb  -f '{{ metallb_config_file_dest }}'"
-  changed_when: false
+  changed_when: true
+  when: "'metallb' not in k8s_pods.stdout"
   tags: init
 
 - name: Start k8s dashboard


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #970 

### Description of the Solution
- Added condition to skip metallab task if already deployed

### Suggested Reviewers
@sujit-jadhav 