### PR TITLE
Issue #1003: Changing default time range and refresh values in telemetry dashboards

### DIFF
--- a/telemetry/roles/grafana_config/files/PowerMap.json
+++ b/telemetry/roles/grafana_config/files/PowerMap.json
@@ -245,7 +245,7 @@
       "type": "hpcviz-idvl-hpcc-stream-net"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 33,
   "style": "dark",
   "tags": [],
@@ -292,7 +292,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/telemetry/roles/grafana_config/files/Sankey.json
+++ b/telemetry/roles/grafana_config/files/Sankey.json
@@ -470,7 +470,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/telemetry/roles/grafana_config/files/SpiralLayout.json
+++ b/telemetry/roles/grafana_config/files/SpiralLayout.json
@@ -305,7 +305,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/telemetry/roles/grafana_config/files/parallel-coordinate.json
+++ b/telemetry/roles/grafana_config/files/parallel-coordinate.json
@@ -294,7 +294,7 @@
       "type": "hpcviz-idvl-hpcc-parallel-coordinate"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 33,
   "style": "dark",
   "tags": [],
@@ -322,7 +322,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
### Description of the Solution
Default time range changed to now-24 hrs. Auto refresh for dashboard is disabled.

Fixes #1003 
