### PR TITLE
Issue #1102: control_plane_k8s node in NotReady state on rhel OS

### DIFF
--- a/control_plane/roles/control_plane_common/tasks/fetch_rhsm_inputs.yml
+++ b/control_plane/roles/control_plane_common/tasks/fetch_rhsm_inputs.yml
@@ -106,6 +106,3 @@
     - name: Show failure msg
       fail:
         msg: "{{ failure_msg.msg }}"
-
-  when:
-    - rhsm_support | lower == "true"

--- a/control_plane/roles/control_plane_k8s/tasks/main.yml
+++ b/control_plane/roles/control_plane_k8s/tasks/main.yml
@@ -30,5 +30,24 @@
 - name: Initialize K8s
   import_tasks: k8s_init.yml
 
+- name: Waiting for 15 seconds for nodes to be ready
+  pause:
+    seconds: 15
+
+- name: Get K8s nodes status
+  command: kubectl get nodes
+  changed_when: false
+  failed_when: false
+  register: k8s_nodes
+
+- block:
+  - name: Reset kubeadm
+    command: kubeadm reset -f
+    changed_when: false
+
+  - name: Initialise k8s
+    include_tasks: k8s_init.yml
+  when: "' Ready' not in k8s_nodes.stdout"
+
 - name: Deploy K8s dashboard
   import_tasks: k8s_services.yml

--- a/control_plane/roles/control_plane_k8s/tasks/main.yml
+++ b/control_plane/roles/control_plane_k8s/tasks/main.yml
@@ -46,7 +46,7 @@
     changed_when: false
 
   - name: Initialise k8s
-    include_tasks: k8s_init.yml
+    import_tasks: k8s_init.yml
   when: "' Ready' not in k8s_nodes.stdout"
 
 - name: Deploy K8s dashboard


### PR DESCRIPTION
Fixes #1102

### Description of the Solution
kubeadm didnt configure kubelet config file properly. It happens sometimes and as a fix we have to do kubeadm reset and run kubeadm init again.

### Suggested Reviewers
@sujit-jadhav 
