### PR TITLE
Issue #1162: Passwordless ssh not working for multiple compute nodes 

### DIFF
--- a/control_plane/tools/roles/cluster_preperation/tasks/main.yml
+++ b/control_plane/tools/roles/cluster_preperation/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: Set Facts
   set_fact:
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+    ssh_key_status: false
 
 - name: Disable host key checking
   replace:

--- a/control_plane/tools/roles/cluster_preperation/tasks/passwordless_ssh.yml
+++ b/control_plane/tools/roles/cluster_preperation/tasks/passwordless_ssh.yml
@@ -58,6 +58,12 @@
   shell: ssh-keygen -t rsa -b 4096 -f "{{ rsa_id_file }}" -q -N "{{ passphrase }}" <<<y >/dev/null 2>&1
   when:
     - not ssh_status
+    - not ssh_key_status
+
+- name: Update public key status
+  set_fact:
+    ssh_key_status: true
+  when: not ssh_status
 
 - name: Creating ssh config file with IdentifyFile value
   copy:

--- a/omnia.yml
+++ b/omnia.yml
@@ -247,4 +247,3 @@
 
 - name: Passwordless SSH between manager and compute nodes
   include: control_plane/tools/passwordless_ssh.yml
-  when: hostvars['127.0.0.1']['control_plane_status']


### PR DESCRIPTION
Fixes #1162

### Description of the Solution
ssh key on manager node is now not refreshed for every connection made.
