### PR TITLE
Code for CRI-O version on RHEL nodes

### DIFF
--- a/control_plane/roles/control_plane_k8s/tasks/k8s_installation.yml
+++ b/control_plane/roles/control_plane_k8s/tasks/k8s_installation.yml
@@ -83,10 +83,25 @@
       - https://packages.cloud.google.com/yum/doc/yum-key.gpg
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
-- name: Install common packages
+- name: Install common packages for rocky
   package:
-    name: "{{ common_packages }}"
+    name: "{{ k8s_common_packages_rocky }}"
     state: present
+  when: os_supported_rocky in mgmt_os
+
+- block:
+    - name: Install packages for RHEL
+      package:
+        name: "{{ k8s_common_packages_rhel }}"
+        state: present
+    
+    - name: Install cri-o for RHEL
+      yum:
+        name: cri-o
+        enablerepo: "{{ crio_repo }}"
+        disablerepo: "*"
+        state: present
+  when: os_supported_rhel in mgmt_os
 
 - name: Install k8s packages
   package:

--- a/control_plane/roles/control_plane_k8s/vars/main.yml
+++ b/control_plane/roles/control_plane_k8s/vars/main.yml
@@ -38,10 +38,14 @@ k8s_package_names:
   - kubectl
 version_kubectl: "v1.21.0"
 # Usage: k8s_installation.yml
-common_packages:
+k8s_common_packages_rocky:
   - openssl
   - bash-completion
   - cri-o
+  - buildah
+k8s_common_packages_rhel:
+  - openssl
+  - bash-completion
   - buildah
 k8s_packages:
   - kubelet-1.21.0
@@ -57,6 +61,7 @@ crio_repo2_url: https://download.opensuse.org/repositories/devel:kubic:libcontai
 crio_repo2_dest: /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:1.21.repo
 docker_repo_url: https://download.docker.com/linux/centos/docker-ce.repo
 docker_repo_dest: /etc/yum.repos.d/docker-ce.repo
+crio_repo: "devel_kubic_libcontainers_stable_cri-o_1.21,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
 
 # Usage: k8s_firewalld.yml
 k8s_master_ports:


### PR DESCRIPTION
Signed-off-by: Lakshmi-Patneedi <Lakshmi_Patneedi@Dellteam.com>

### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #1302 

### Description of the Solution
After executing control_plane, CRI-O 1.21.7 version should get installed on all RHEL nodes

### Suggested Reviewers
@sujit-jadhav 