### PR TITLE
Issue #1604: Enable bind dn support for ldap client

### DIFF
--- a/input/omnia_config.yml
+++ b/input/omnia_config.yml
@@ -76,11 +76,24 @@ ldap_connection_type: "TLS"
 # This variable is mandatory if connection type is TLS
 ldap_ca_cert_path: /etc/openldap/certs/omnialdap.pem
 
-# This variable accepts th user home directory path
+# This variable accepts the user home directory path for ldap configuration
 # If nfs mount is created for user home, make sure you provide the
-# user mount home directory path
+# LDAP users mount home directory path
 # Default value is /home
 user_home_dir: "/home"
+
+# If LDAP server is configured with bind dn then bind dn user to be provided
+# By default the bind dn user is admin
+# Update this variable if bind dn is different from admin
+# If this value is not provided (when bind is configured in server)
+# then ldap authentication fails
+ldap_bind_username: "admin"
+
+# If LDAP server is configured with bind dn then bind dn password to be provided
+# Update this variable if bind dn is different from admin
+# If this value is not provided (when bind is configured in server)
+# then ldap authentication fails
+ldap_bind_password: ""
 
 # This variable is used to accept the domain name the user intends to configure
 # This variable is a mandatory requirement of both FreeIPA and LDAP Client 

--- a/scheduler/roles/ldap_client/files/sssd_tls.conf
+++ b/scheduler/roles/ldap_client/files/sssd_tls.conf
@@ -2,6 +2,7 @@
 config_file_version = 2
 services = nss, pam,autofs
 domains = default
+enable_files_domain = false
 
 [nss]
 
@@ -10,6 +11,7 @@ homedir_substring = /home
 [pam]
 
 [domain/default]
+enumerate = true
 id_provider = ldap
 autofs_provider = ldap
 auth_provider = ldap
@@ -17,6 +19,10 @@ chpass_provider = ldap
 ldap_uri =  ldap://server-ip
 ldap_search_base = dc=omnia,dc=test
 ldap_id_use_start_tls = True
+ldap_tls_cacert = /etc/openldap/certs/ldapserver.crt
 ldap_tls_cacertdir = /etc/openldap/certs
 cache_credentials = True
 ldap_tls_reqcert = allow
+#ldap_default_bind_dn = cn=admin,dc=omnia,dc=test
+#ldap_default_authtok_type = password
+#ldap_default_authtok = blank

--- a/scheduler/roles/ldap_client/tasks/configure_sssd_conf.yml
+++ b/scheduler/roles/ldap_client/tasks/configure_sssd_conf.yml
@@ -44,6 +44,35 @@
         path: "{{ sssd_conf_dest }}"
         regexp: "homedir_substring = /home"
         replace: "homedir_substring = {{ hostvars['127.0.0.1']['user_home_dir'] }}"
+
+    - name: Update the certificate path
+      ansible.builtin.replace:
+        path: "{{ sssd_conf_dest }}"
+        regexp: "ldap_tls_cacert = /etc/openldap/certs/ldapserver.crt"
+        replace: "ldap_tls_cacert = {{ hostvars['127.0.0.1']['ldap_ca_cert_path'] }}"
+
+    - name: Update bind dn details if it is provided in input file
+      block:
+        - name: Update the certificate path
+          ansible.builtin.replace:
+            path: "{{ sssd_conf_dest }}"
+            regexp: "#ldap_default_bind_dn = cn=admin,dc=omnia,dc=test"
+            replace: "ldap_default_bind_dn = cn={{ hostvars['127.0.0.1']['ldap_bind_username'] }},{{ reqd_domain_name }}"
+
+        - name: Update the authtok type
+          ansible.builtin.replace:
+            path: "{{ sssd_conf_dest }}"
+            regexp: "#ldap_default_authtok_type = password"
+            replace: "ldap_default_authtok_type = password"
+
+        - name: Update the ldap bind password
+          ansible.builtin.replace:
+            path: "{{ sssd_conf_dest }}"
+            regexp: "#ldap_default_authtok = blank"
+            replace: "ldap_default_authtok = {{ hostvars['127.0.0.1']['ldap_bind_password'] }}"
+      when:
+        - hostvars['127.0.0.1']['ldap_bind_username'] | length > 1
+        - hostvars['127.0.0.1']['ldap_bind_password'] | length > 1
   when:
     - hostvars['127.0.0.1']['ldap_connection_type'] == 'TLS' or
       hostvars['127.0.0.1']['ldap_connection_type'] == 'tls'


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Fixes #1604 

### Description of the Solution
Enable bind dn user configuration on ldap client when it is configured on ldap server

### Suggested Reviewers
@sujit-jadhav 
