### PR TITLE
Issue #1918: Initiate reposync of codereadybuilder outside of ISO repo directory 

### DIFF
--- a/airgap/roles/rhel/tasks/modify_repos.yml
+++ b/airgap/roles/rhel/tasks/modify_repos.yml
@@ -36,9 +36,7 @@
     mode: "{{ directory_permissions }}"
 
 - name: Initiate reposync of CodeReadyBuilder (This might take 10 mins)
-  ansible.builtin.command: >-
-  reposync -p {{ codereadybuilder_path }} --download-metadata
-  --repo=codeready-builder-for-rhel-8-x86_64-rpms -a x86_64,noarch --norepopath -n
+  ansible.builtin.command: "reposync -p {{ codereadybuilder_path }} --download-metadata --repo={{ codeready_repo_name }} -a x86_64,noarch --norepopath -n"
   changed_when: false
 
 # Modify xcat osimage

--- a/airgap/roles/rhel/tasks/modify_repos.yml
+++ b/airgap/roles/rhel/tasks/modify_repos.yml
@@ -37,8 +37,8 @@
 
 - name: Initiate reposync of CodeReadyBuilder (This might take 10 mins)
   ansible.builtin.command: >-
-  "reposync -p {{ codereadybuilder_path }} --download-metadata
-  --repo=codeready-builder-for-rhel-8-x86_64-rpms -a x86_64,noarch --norepopath -n"
+  reposync -p {{ codereadybuilder_path }} --download-metadata
+  --repo=codeready-builder-for-rhel-8-x86_64-rpms -a x86_64,noarch --norepopath -n
   changed_when: false
 
 # Modify xcat osimage

--- a/airgap/roles/rhel/tasks/modify_repos.yml
+++ b/airgap/roles/rhel/tasks/modify_repos.yml
@@ -22,9 +22,50 @@
     - "{{ rhel_repo_folder_path }}/BaseOS/Packages"
 
 # Reposync of AppStream and BaseOS
-- name: Initiate reposync of AppStream, BaseOS and CodeReadyBuilder Repos (This might take 20-25 mins)
+- name: Initiate reposync of AppStream, BaseOS (This might take 20-25 mins)
   ansible.builtin.command: "reposync -p {{ rhel_repo_folder_path }}/{{ item.0 }} --download-metadata --repo={{ item.1 }} -a x86_64,noarch --norepopath -n"
   changed_when: false
   with_together:
-    - ['AppStream', 'BaseOS', 'CodeReadyBuilder']
-    - ['rhel-8-for-x86_64-appstream-rpms', 'rhel-8-for-x86_64-baseos-rpms', 'codeready-builder-for-rhel-8-x86_64-rpms']
+    - ['AppStream', 'BaseOS']
+    - ['rhel-8-for-x86_64-appstream-rpms', 'rhel-8-for-x86_64-baseos-rpms']
+
+- name: Create folder for CodeReadyBuilder
+  ansible.builtin.file:
+    path: "{{ codereadybuilder_path }}"
+    state: directory
+
+- name: Initiate reposync of CodeReadyBuilder (This might take 10 mins)
+  ansible.builtin.command: "reposync -p {{ codereadybuilder_path }} --download-metadata --repo=codeready-builder-for-rhel-8-x86_64-rpms -a x86_64,noarch --norepopath -n"
+  changed_when: false
+
+# Modify xcat osimage
+
+- name: Fetch xcat osimage name for provision_os
+  ansible.builtin.shell: >
+    set -o pipefail && \
+    lsdef -t osimage | grep "{{ osimage_search_key }}" | grep "{{ provision_os }}" | grep "{{ provision_os_version }}"
+  changed_when: false
+  register: fetch_osimage
+  failed_when: false
+
+- name: Set provision_os_image
+  ansible.builtin.set_fact:
+    provision_os_image: "{{ fetch_osimage.stdout.split(' ')[0] }}"
+  when: fetch_osimage.rc == 0
+
+- name: Retry fetching xcat osimage name for provision_os
+  ansible.builtin.shell: >
+    set -o pipefail && \
+    lsdef -t osimage | grep "{{ osimage_search_key }}" | grep "{{ provision_os }}"
+  changed_when: false
+  register: retry_fetch_osimage
+  when: fetch_osimage.rc != 0
+
+- name: Set provision_os_image
+  ansible.builtin.set_fact:
+    provision_os_image: "{{ retry_fetch_osimage.stdout.split(' ')[0] }}"
+  when: fetch_osimage.rc != 0
+
+- name: Configure CodeReadyBuilder repo to osimage
+  ansible.builtin.command: chdef -t osimage -o {{ provision_os_image }} -p pkgdir={{ codereadybuilder_path }}
+  changed_when: true

--- a/airgap/roles/rhel/tasks/modify_repos.yml
+++ b/airgap/roles/rhel/tasks/modify_repos.yml
@@ -33,9 +33,12 @@
   ansible.builtin.file:
     path: "{{ codereadybuilder_path }}"
     state: directory
+    mode: "{{ directory_permissions }}"
 
 - name: Initiate reposync of CodeReadyBuilder (This might take 10 mins)
-  ansible.builtin.command: "reposync -p {{ codereadybuilder_path }} --download-metadata --repo=codeready-builder-for-rhel-8-x86_64-rpms -a x86_64,noarch --norepopath -n"
+  ansible.builtin.command: >-
+  "reposync -p {{ codereadybuilder_path }} --download-metadata
+  --repo=codeready-builder-for-rhel-8-x86_64-rpms -a x86_64,noarch --norepopath -n"
   changed_when: false
 
 # Modify xcat osimage

--- a/airgap/roles/rhel/vars/main.yml
+++ b/airgap/roles/rhel/vars/main.yml
@@ -18,3 +18,4 @@ rhsm_release_file_path: "/opt/omnia/.data/rhsm_release"
 codereadybuilder_path: "/install/CodeReadyBuilder{{ provision_os_version }}/x86_64"
 osimage_search_key: install-compute
 directory_permissions: 0755
+codeready_repo_name: codeready-builder-for-rhel-8-x86_64-rpms

--- a/airgap/roles/rhel/vars/main.yml
+++ b/airgap/roles/rhel/vars/main.yml
@@ -17,3 +17,4 @@ subscription_warning_msg: "[WARNING] redhat subscription not enabled. Please ena
 rhsm_release_file_path: "/opt/omnia/.data/rhsm_release"
 codereadybuilder_path: "/install/CodeReadyBuilder{{ provision_os_version }}/x86_64"
 osimage_search_key: install-compute
+directory_permissions: 0755

--- a/airgap/roles/rhel/vars/main.yml
+++ b/airgap/roles/rhel/vars/main.yml
@@ -15,3 +15,5 @@
 os_supported_rhel: "redhat"
 subscription_warning_msg: "[WARNING] redhat subscription not enabled. Please enable the subscription and proceed."
 rhsm_release_file_path: "/opt/omnia/.data/rhsm_release"
+codereadybuilder_path: "/install/CodeReadyBuilder{{ provision_os_version }}/x86_64"
+osimage_search_key: install-compute


### PR DESCRIPTION

Fixes #1918

### Description of the Solution
Reposync of codereadybuilder will now be done outside of ISO Repo Directory and this reposynced directory will be added to pkgdir of xcat osimage.
