### PR TITLE
Updating docs to point to the latest readthedocs instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Omnia (Latin: all or everything) is a deployment tool to turn servers with RPM-b
 
 ## Omnia Documentation
 
-Omnia Documentation is hosted on [Read The Docs](https://omnia-documentation.readthedocs.io/en/latest/index.html).
+Omnia Documentation is hosted on [Read The Docs](https://omnia-doc.readthedocs.io/en/latest/index.html).
 
 Current Status: ![GitHub](https://readthedocs.org/projects/omnia-documentation/badge/?version=latest)
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -3,7 +3,7 @@ Omnia Documentation
 
 **Omnia** is an open source project hosted on `GitHub <https://github.com/dellhpc/omnia>`_. Go to `GitHub <https://github.com/dellhpc/omnia>`_ to view the source, open issues, ask questions, and participate in the project.
 
-The Omnia docs are hosted here: https://omnia-documentation.readthedocs.io/en/latest/index.html and are written in reStructuredText (`.rst`).
+The Omnia docs are hosted here: https://omnia-doc.readthedocs.io/en/latest/index.html and are written in reStructuredText (`.rst`).
 
 Building Docs
 --------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ project = 'Omnia'
 copyright = '2023, Dell Technologies'
 author = 'dellhpc/omnia'
 release = '1.4.2'
-rst_epilog = "If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_."
+rst_epilog = "*If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_.*"
 
 import sys
 import os

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,7 @@ project = 'Omnia'
 copyright = '2023, Dell Technologies'
 author = 'dellhpc/omnia'
 release = '1.4.2'
+rst_epilog = "If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_."
 
 import sys
 import os

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ project = 'Omnia'
 copyright = '2023, Dell Technologies'
 author = 'dellhpc/omnia'
 release = '1.4.2'
-rst_epilog = "*If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_.*"
+rst_epilog = "If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_."
 
 import sys
 import os

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,6 +61,7 @@ For a better understanding of what Omnia does, check out our `docs <https://omni
    Contributing/index
    appendix
 
+.. footer:: If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_.
 
 .. |Omnia version| image:: https://img.shields.io/github/v/release/dellhpc/omnia?include_prereleases
 .. |Downloads| image:: https://img.shields.io/github/downloads/dellhpc/omnia/total

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,7 +61,7 @@ For a better understanding of what Omnia does, check out our `docs <https://omni
    Contributing/index
    appendix
 
-.. footer:: If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_.
+*If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_.*
 
 .. |Omnia version| image:: https://img.shields.io/github/v/release/dellhpc/omnia?include_prereleases
 .. |Downloads| image:: https://img.shields.io/github/downloads/dellhpc/omnia/total

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,7 +61,6 @@ For a better understanding of what Omnia does, check out our `docs <https://omni
    Contributing/index
    appendix
 
-*If you have any feedback about Omnia documentation, please reach out at `omnia.readme@dell.com <mailto:omnia.readme@dell.com>`_.*
 
 .. |Omnia version| image:: https://img.shields.io/github/v/release/dellhpc/omnia?include_prereleases
 .. |Downloads| image:: https://img.shields.io/github/downloads/dellhpc/omnia/total

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Omnia is made available under the `Apache 2.0 license. <https://opensource.org/l
 
 .. note:: Omnia playbooks are licensed under the Apache 2.0 license.  Once an end-user initiates Omnia, that end-user will enable deployment of other open source software that is licensed separately by their respective developer communities. For a comprehensive list of software and their licenses, `click here <Overview/SupportMatrix/omniainstalledsoftware.html>`_ . Dell (or any other contributors) shall have no liability regarding and no responsibility to provide support for an end-users use of any open source software and end-users are encouraged to ensure that they are complying with all such licenses.  Omnia is provided “as is” without any warranty, express or implied.  Dell (or any other contributors) shall have no liability for any direct, indirect, incidental, punitive, special, or consequential damages for an end-users use of Omnia.
 
-For a better understanding of what Omnia does, check out our `docs <https://omnia-documentation.readthedocs.io/en/latest/index.html>`_!
+For a better understanding of what Omnia does, check out our `docs <https://omnia-doc.readthedocs.io/en/latest/index.html>`_!
 
 
 **Omnia Community Members**


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Updating docs to point to the latest readthedocs instance: https://omnia-doc.readthedocs.io/en/latest/

We also need to update the dellhpc/omnia metadata to point here: https://omnia-doc.readthedocs.io/en/latest/

Fixes #2021 

### Suggested Reviewers
@sujit-jadhav 
