### PR TITLE
feat(inventory): fetch bmc ip using ipmitool instead of racadm

### DIFF
--- a/provision/roles/post_provision/tasks/provisioned_node_inventory.yml
+++ b/provision/roles/post_provision/tasks/provisioned_node_inventory.yml
@@ -39,7 +39,7 @@
 - name: Fetch BMC IP
   ansible.builtin.shell: >
     set -o pipefail && \
-    ipmitool lan print 1 | grep "IP Address              :"
+    ipmitool lan print 1 | grep -E "IP Address\s+:"
   register: fetch_bmc_ip
   changed_when: false
 

--- a/provision/roles/post_provision/tasks/provisioned_node_inventory.yml
+++ b/provision/roles/post_provision/tasks/provisioned_node_inventory.yml
@@ -39,13 +39,13 @@
 - name: Fetch BMC IP
   ansible.builtin.shell: >
     set -o pipefail && \
-    racadm get iDRAC.IPv4.Address | grep Address
+    ipmitool lan print 1 | grep "IP Address              :"
   register: fetch_bmc_ip
   changed_when: false
 
 - name: Set BMC IP
   ansible.builtin.set_fact:
-    bmc_ip: "{{ fetch_bmc_ip.stdout.split('=')[1] }}"
+    bmc_ip: "{{ fetch_bmc_ip.stdout.split(':')[1] }}"
   when: fetch_bmc_ip.stdout is defined
 
 - name: Check IP and service tag already present in node_inventory


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #2207

### Description of the Solution

change from #1985 original code
fetch bmc ip using ipmitool instead of racadm
This is to accomodate for DPUs and unsupported racadm OSes

Both methods work:
```
$ racadm get iDRAC.IPv4.Address
[Key=iDRAC.Embedded.1#IPv4.1]
Address=10.10.10.1
```
vs
```
$ ipmitool lan print 1 | grep "IP Address              :"
IP Address              : 10.10.10.1
```

### Suggested Reviewers
@sujit-jadhav @j0hnL @abhishek-sa1