### PR TITLE
feat(dpu): add force pxe task

### DIFF
--- a/provision/roles/bluefield/tasks/configure_pxe_boot.yml
+++ b/provision/roles/bluefield/tasks/configure_pxe_boot.yml
@@ -22,6 +22,15 @@
       bmc_user: "root"
       bmc_password: "tbd"
 
+- name: Force PXE boot
+  ansible.builtin.include_role:
+    name: nvidia.dpu_ops.bf_bmc
+  vars:
+    - bmc_action: "-C 17 chassis bootdev pxe options=efiboot"
+      bmc_host: "tbd"
+      bmc_user: "root"
+      bmc_password: "tbd"
+
 - name: Configure boot order for PXE booting
   ansible.builtin.include_role:
     name: nvidia.dpu_ops.bf2_boot


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #

### Description of the Solution

Force PXE boot using IPMI until `nvidia.dpu_ops.bf2_boot` is fixed.
See https://docs.nvidia.com/networking/display/bluefieldbmcv2310/boot+configuration

### Suggested Reviewers

@sujit-jadhav