### PR TITLE
feat(dpu): use redfish for CEC update

### DIFF
--- a/provision/roles/bluefield/tasks/update_firmware.yml
+++ b/provision/roles/bluefield/tasks/update_firmware.yml
@@ -20,7 +20,13 @@
     - bmc_url: "{{ bmc.url }}/{{ bmc.file }}"
 
 - name: Update CEC firmware of DPU
-  raw: "wget --no-check-certificate {{ bmc.url }}/{{ bmc.cec }} -O /tmp/images/{{ bmc.cec }}"
+  community.general.redfish_command:
+    category: Update
+    command: SimpleUpdate
+    baseuri: "tbd"
+    username: "root"
+    password: "tbd"
+    update_image_uri: "{{ bmc.url }}/{{ bmc.cec }}"
 
 - name: Update DPU NIC firmware
   ansible.builtin.include_role:


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #

### Description of the Solution

for CEC need to use redfish 
see https://docs.nvidia.com/networking/display/bluefieldbmcv2310/bmc+management
see https://docs.ansible.com/ansible/latest/collections/community/general/redfish_command_module.html

### Suggested Reviewers

@sujit-jadhav