### PR TITLE
feat(dpu): add parameters for dpu bmc credentials

### DIFF
--- a/docs/source/InstallationGuides/InstallingProvisionTool/index.rst
+++ b/docs/source/InstallationGuides/InstallingProvisionTool/index.rst
@@ -22,4 +22,5 @@ This playbook achieves the following tasks:
     installprovisiontool
     ViewingDB
     provisionservers
+    provisiondpus
 

--- a/docs/source/InstallationGuides/InstallingProvisionTool/provisiondpus.rst
+++ b/docs/source/InstallationGuides/InstallingProvisionTool/provisiondpus.rst
@@ -1,0 +1,35 @@
+Configuring DPUs with out-of-band management
++++++++++++++++++++++++++++++++++++++++++++++++
+
+For pre-configured DPU BMCs, ``provision/bluefield.yml`` can be used to provision the DPUs.
+
+**Before running bluefield.yml**
+
+* The dpu_bmc_inventory file is updated with the DPU BMC IP addresses.
+
+* The Redfish services are enabled in the DPU BMC settings under Services.
+
+* The provision tool has discovered the DPUs using SNMP/mapping.
+
+
+**Configurations performed by bluefield.yml**
+
+* Omnia validates and configures the active DPU NICs in PXE device settings when provision_method is set to PXE. (If no active NIC is found, bluefield.yml will fail on the target node.)
+
+* Once all configurations are in place, the ``bluefield.yml`` initiates a PXE boot for configuration to take effect.
+
+.. note::
+    * DPUs that have not been discovered by the Provision tool will not be provisioned with the OS image.
+    * Since the BMC discovery method PXE boots target DPU BMCs while running the provision tool, this script is not recommended for such DPUs.
+
+
+**Running bluefield.yml**
+
+::
+
+    ansible-playbook bluefield.yml -i dpu_bmc_inventory -e dpu_bmc_username='' -e dpu_bmc_password=''
+
+Where the ``dpu_bmc_inventory`` points to the file mentioned above and  the ``dpu_bmc_username`` and ``dpu_bmc_password`` are the credentials used to authenticate into DPU BMC.
+
+
+

--- a/docs/source/Roles/Provision/provisiondpus.rst
+++ b/docs/source/Roles/Provision/provisiondpus.rst
@@ -1,0 +1,35 @@
+Configuring DPUs with out-of-band management
++++++++++++++++++++++++++++++++++++++++++++++++
+
+For pre-configured DPU BMCs, ``provision/bluefield.yml`` can be used to provision the DPUs.
+
+**Before running bluefield.yml**
+
+* The dpu_bmc_inventory file is updated with the DPU BMC IP addresses.
+
+* The Redfish services are enabled in the DPU BMC settings under Services.
+
+* The provision tool has discovered the DPUs using SNMP/mapping.
+
+
+**Configurations performed by bluefield.yml**
+
+* Omnia validates and configures the active DPU NICs in PXE device settings when provision_method is set to PXE. (If no active NIC is found, bluefield.yml will fail on the target node.)
+
+* Once all configurations are in place, the ``bluefield.yml`` initiates a PXE boot for configuration to take effect.
+
+.. note::
+    * DPUs that have not been discovered by the Provision tool will not be provisioned with the OS image.
+    * Since the BMC discovery method PXE boots target DPU BMCs while running the provision tool, this script is not recommended for such DPUs.
+
+
+**Running bluefield.yml**
+
+::
+
+    ansible-playbook bluefield.yml -i dpu_bmc_inventory -e dpu_bmc_username='' -e dpu_bmc_password=''
+
+Where the ``dpu_bmc_inventory`` points to the file mentioned above and  the ``dpu_bmc_username`` and ``dpu_bmc_password`` are the credentials used to authenticate into DPU BMC.
+
+
+

--- a/provision/roles/bluefield/tasks/check_prerequisites.yml
+++ b/provision/roles/bluefield/tasks/check_prerequisites.yml
@@ -19,3 +19,31 @@
   with_items: "{{ bluefield_collections }}"
   run_once: true
 
+- name: Initialize variables
+  ansible.builtin.set_fact:
+    provision_status: false
+
+- name: Check if provisioned_dpu_bmc_inventory file exists
+  ansible.builtin.stat:
+    path: "{{ provisioned_dpu_bmc_inventory_path }}"
+  register: provisioned_dpu_bmc_check
+  run_once: true
+
+- name: Check the provisioned_dpu_bmc_inventory output
+  ansible.builtin.command: cat {{ provisioned_dpu_bmc_inventory_path }}
+  changed_when: false
+  register: provisioned_dpu_bmc_list
+  run_once: true
+  when: provisioned_dpu_bmc_check.stat.exists
+
+- name: Set provision status - CLI
+  ansible.builtin.set_fact:
+    provision_status: true
+  when:
+    - provisioned_dpu_bmc_check.stat.exists
+    - inventory_hostname in provisioned_dpu_bmc_list.stdout
+
+- name: Removing hosts already provisioned - CLI
+  ansible.builtin.debug:
+    msg: "{{ provision_skip_msg_cli }}"
+  when: provision_status

--- a/provision/roles/bluefield/tasks/configure_pxe_boot.yml
+++ b/provision/roles/bluefield/tasks/configure_pxe_boot.yml
@@ -18,18 +18,18 @@
     name: nvidia.dpu_ops.bf_bmc
   vars:
     - bmc_action: "-C 17 chassis power status"
-      bmc_host: "tbd"
-      bmc_user: "root"
-      bmc_password: "tbd"
+      bmc_host: "{{ inventory_hostname }}"
+      bmc_user: "{{ dpu_bmc_username }}"
+      bmc_password: "{{ dpu_bmc_password }}"
 
 - name: Force PXE boot
   ansible.builtin.include_role:
     name: nvidia.dpu_ops.bf_bmc
   vars:
     - bmc_action: "-C 17 chassis bootdev pxe options=efiboot"
-      bmc_host: "tbd"
-      bmc_user: "root"
-      bmc_password: "tbd"
+      bmc_host: "{{ inventory_hostname }}"
+      bmc_user: "{{ dpu_bmc_username }}"
+      bmc_password: "{{ dpu_bmc_password }}"
 
 - name: Configure boot order for PXE booting
   ansible.builtin.include_role:

--- a/provision/roles/bluefield/tasks/deploy_os.yml
+++ b/provision/roles/bluefield/tasks/deploy_os.yml
@@ -16,6 +16,10 @@
 - name: Configure PXE booting
   ansible.builtin.include_tasks: configure_pxe_boot.yml
 
+- name: Add the host to provisioned_dpu_bmc_inventory
+  ansible.builtin.debug:
+    msg: "tbd"
+
 - name: Provision OS
   ansible.builtin.debug:
     msg: "tbd"

--- a/provision/roles/bluefield/tasks/main.yml
+++ b/provision/roles/bluefield/tasks/main.yml
@@ -18,5 +18,8 @@
 - name: Check prerequisites
   ansible.builtin.include_tasks: check_prerequisites.yml
 
+# - name: Update firmware
+#   ansible.builtin.include_tasks: update_firmware.yml
+
 - name: Deploy OS
   ansible.builtin.include_tasks: deploy_os.yml

--- a/provision/roles/bluefield/tasks/update_firmware.yml
+++ b/provision/roles/bluefield/tasks/update_firmware.yml
@@ -13,6 +13,15 @@
 # limitations under the License.
 ---
 
+- name: Get Firmware Inventory
+  community.general.redfish_info:
+    category: Update
+    command: GetFirmwareInventory
+    baseuri: "{{ inventory_hostname }}"
+    username: "{{ dpu_bmc_username }}"
+    password: "{{ dpu_bmc_password }}"
+  register: result
+
 - name: Update BMC firmware of DPU
   ansible.builtin.include_role:
     name: nvidia.dpu_ops.manage_bf_bmc_fw
@@ -23,16 +32,16 @@
   community.general.redfish_command:
     category: Update
     command: SimpleUpdate
-    baseuri: "tbd"
-    username: "root"
-    password: "tbd"
+    baseuri: "{{ inventory_hostname }}"
+    username: "{{ dpu_bmc_username }}"
+    password: "{{ dpu_bmc_password }}"
     update_image_uri: "{{ bmc.url }}/{{ bmc.cec }}"
 
 - name: Update DPU NIC firmware
   ansible.builtin.include_role:
     name: nvidia.dpu_ops.manage_bf2_fw
   vars:
-    - bmc_host: "tbd"
-      bmc_user: "root"
-      bmc_password: "tbd"
+    - bmc_host: "{{ inventory_hostname }}"
+      bmc_user: "{{ dpu_bmc_username }}"
+      bmc_password: "{{ dpu_bmc_password }}"
 

--- a/provision/roles/bluefield/vars/main.yml
+++ b/provision/roles/bluefield/vars/main.yml
@@ -17,6 +17,7 @@
 
 # Usage: check_prerequisites.yml
 bluefield_collections: nvidia.dpu_ops:1.0.1
+provisioned_dpu_bmc_inventory_path: /opt/omnia/provisioned_dpu_bmc_inventory
 
 # Usage: configure_pxe_boot.yml
 bluefield_pxe_boot_dev: NET-OOB-IPV4


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #

### Description of the Solution

Run like:
```
ansible-playbook bluefield.yml -i dpu_bmc_inventory -e dpu_bmc_username='' -e dpu_bmc_password=''
```

### Suggested Reviewers

@sujit-jadhav 