### PR TITLE
ci: bump checkout action release to latest v4

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     # Important: This sets up your GITHUB_WORKSPACE environment variable
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: ansible-lint 
       # replace "master" with any valid ref


### PR DESCRIPTION
### Issues Resolved by this Pull Request

Fixes #

### Description of the Solution

this eliminates github warning
```
[ansible-lint](https://github.com/dell/omnia/actions/runs/7504897551/job/20432960106)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

### Suggested Reviewers

@sujit-jadhav 