### PR TITLE
Add .devcontainer.json

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "init": true,
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "redhat.ansible"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Solution

This change adds a `.devcontainer.json` file that enables developers to use a container as their full-featured development environment. It can be used by IDEs, GitHub Codespaces, and other software such as Devbox, DevPod, and more.

More information is available at https://containers.dev/

### Suggested Reviewers
@sujit-jadhav
