### PR TITLE
Ensure scale out interfaces are up after rebooting

### DIFF
--- a/accelerator/roles/intel/tasks/install_ubuntu.yml
+++ b/accelerator/roles/intel/tasks/install_ubuntu.yml
@@ -54,3 +54,6 @@
         name: "{{ item }}"
         state: present
       loop: "{{ intel_gaudi_kernel_module_to_load }}"
+
+- name: Set cron job for scale out interfaces
+  ansible.builtin.include_tasks: make_sure_scale_out_interfaces_up.yml

--- a/accelerator/roles/intel/tasks/make_sure_scale_out_interfaces_up.yml
+++ b/accelerator/roles/intel/tasks/make_sure_scale_out_interfaces_up.yml
@@ -1,0 +1,58 @@
+# Copyright 2024 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Check bring_up_ports.sh exists or not
+  ansible.builtin.stat:
+    path: "{{ intel_bring_up_ports_script_path }}"
+  register: check_bring_up_script
+
+- name: Create bring_up_ports.sh
+  when: not check_bring_up_script.stat.exists
+  ansible.builtin.blockinfile:
+    path: "{{ intel_bring_up_ports_script_path }}"
+    create: yes
+    block: |
+      #!/bin/bash
+      /opt/habanalabs/qual/gaudi2/bin/manage_network_ifs.sh --up
+      RET_CODE=$?
+      if [ "${RET_CODE}" -eq "1" ]; then
+        echo "One or more Gaudi 2 ports are down." >> /dev/stderr
+        return 1
+      fi
+
+- name: Change permission on bring_up_ports.sh file
+  file:
+    path: "{{ intel_bring_up_ports_script_path }}"
+    state: file
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Check for existing cron job
+  ansible.builtin.shell: |
+    set -o pipefail
+    crontab -l | grep -q "{{ intel_bring_up_ports_script_path }}"
+  args:
+    executable: /bin/bash
+  register: cron_job_check
+  ignore_errors: yes
+  changed_when: false
+
+- name: Create cronjob for bringing up Gaudi 2 ports
+  when: cron_job_check.rc != 0
+  ansible.builtin.cron:
+    name: "Bring up Gaudi 2 ports"
+    special_time: reboot
+    job: "{{ intel_bring_up_ports_script_path }}"

--- a/accelerator/roles/intel/vars/main.yml
+++ b/accelerator/roles/intel/vars/main.yml
@@ -51,3 +51,5 @@ intel_apt_base_packages:
   - numactl
   - unzip
   - wget
+
+intel_bring_up_ports_script_path: "/opt/omnia/cronjobs/bring_up_ports.sh"

--- a/discovery/roles/postscripts/common/templates/omnia_gaudi.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_gaudi.j2
@@ -15,6 +15,56 @@ HEADER_VER=$(uname -r)
 
 export DEBIAN_FRONTEND=noninteractive
 
+cron_job_for_scale_out_interfaces() {
+
+echo "Set cron job for Gaudi scale out interfaces" >> /var/log/xcat/xcat.log
+
+if [ ! -f /opt/habanalabs/qual/gaudi2/bin/manage_network_ifs.sh ] ; then
+  echo "File /opt/habanalabs/qual/gaudi2/bin/manage_network_ifs.sh not found, stop setting." >> /var/log/xcat/xcat.log
+  return 1
+fi
+
+base_dir="/opt/omnia/cronjobs"
+
+mkdir -p $base_dir
+
+script_to_run="$base_dir/bring_up_ports.sh"
+
+cat <<'EOF' > $script_to_run
+#!/bin/bash
+/opt/habanalabs/qual/gaudi2/bin/manage_network_ifs.sh --up
+RET_CODE=$?
+if [ "${RET_CODE}" -eq "1" ]; then
+  echo "One or more Gaudi 2 ports are down." >> /dev/stderr
+  return 1
+fi
+EOF
+
+chmod +x $script_to_run
+
+if ! systemctl is-active --quiet cron; then
+  echo "Cron service is not active, start and enable cron now." >> /var/log/xcat/xcat.log
+  sudo systemctl start cron
+  sudo systemctl enable cron
+fi
+
+cron_job="@reboot $script_to_run"
+
+temp_crontab=$(mktemp)
+
+crontab -l > $temp_crontab 2>/dev/null
+
+if grep -q "$cron_job" $temp_crontab ; then
+  echo "Cron job already configured." >> /var/log/xcat/xcat.log
+else
+  echo $cron_job >> $temp_crontab
+  crontab $temp_crontab
+fi
+
+rm $temp_crontab
+
+}
+
 # on node with gaudi
 if [[ $gaudi_check == *"Habana Labs Ltd"*  ]]; then
 
@@ -56,11 +106,14 @@ if [[ $gaudi_check == *"Habana Labs Ltd"*  ]]; then
       habanatools
 
     # This number was defined by Habana team and is the number used in IDC clusters
-    sysctl -w vm.nr_hugepages=156300
+    echo "vm.nr_hugepages=156300" > /etc/sysctl.d/90-gaudi.conf
 
     rm /etc/apt/sources.list.d/intelgaudi.list
 
     apt-get update
+
+    # make sure Gaudi scale out interfaces are up after rebooting
+    cron_job_for_scale_out_interfaces
 
     echo "Intel Gaudi drivers installation completed" >> /var/log/xcat/xcat.log
 


### PR DESCRIPTION
Add a cronjob that ensures that scale out interfaces are up after a reboot.