### PR TITLE
Deploy Gaudi device plugin on Gaudi nodes only

### DIFF
--- a/scheduler/roles/k8s_habana_container_runtime/tasks/main.yml
+++ b/scheduler/roles/k8s_habana_container_runtime/tasks/main.yml
@@ -30,3 +30,10 @@
       when:
         - accelerator_type is defined
         - accelerator_type == "habana"
+
+    - name: Set fact for nodes with Gaudi
+      ansible.builtin.set_fact:
+        node_has_gaudi: true
+      when:
+        - accelerator_type is defined
+        - accelerator_type == "habana"

--- a/scheduler/roles/k8s_start_services/tasks/deploy_k8s_services.yml
+++ b/scheduler/roles/k8s_start_services/tasks/deploy_k8s_services.yml
@@ -87,12 +87,36 @@
 
 # HABANA PLUGIN
 - name: Deploy Habana Device plugin
-  ansible.builtin.command: "kubectl create -f '{{ habana_device_plugin_yaml_url }}'"
-  changed_when: true
   when:
     - "'habanalabs-device-plugin-daemonset' not in k8s_pods.stdout"
     - k8s_version >= minimal_gaudi_k8s_version
     - hostvars['localhost']['is_gaudi_cluster'] is defined
+  block:
+    - name: Label nodes with Gaudi
+      ansible.builtin.command: "kubectl label nodes {{ item }} {{ node_label_for_habana_device_plugin }}=true --overwrite"
+      when: "hostvars[item]['node_has_gaudi'] | default(false)"
+      loop: "{{ groups['kube_node'] | default([]) }}"
+
+    - name: Download habana-device-plugin yaml file
+      ansible.builtin.uri:
+        url: "{{ habana_device_plugin_yaml_url }}"
+        return_content: true
+      register: habana_device_plugin_yaml_content
+
+    - name: Modify habana-device-plugin yaml file
+      ansible.builtin.set_fact:
+        with_node_selector: |
+          {{ habana_device_plugin_yaml_content.content }}
+                nodeSelector:
+                  {{ node_label_for_habana_device_plugin }}: 'true'
+
+    - name: Install habana-device-plugin
+      ansible.builtin.shell: |
+        set -o pipefail
+        echo "{{ with_node_selector }}" | kubectl create -f - 
+      changed_when: true
+      args:
+        executable: /bin/bash
 
 # MPI OPERATOR
 - name: Install MPI Operator

--- a/scheduler/roles/k8s_start_services/vars/main.yml
+++ b/scheduler/roles/k8s_start_services/vars/main.yml
@@ -38,6 +38,7 @@ xilinx_device_plugin_yaml_url: "{{ hostvars['localhost']['offline_manifest_path'
 spark_operator_repo: "{{ hostvars['localhost']['offline_tarball_path'] }}/spark-operator-v1beta2-1.3.8-3.1.1.tar.gz"
 rocm_device_plugin_yaml_url: "{{ hostvars['localhost']['offline_manifest_path'] }}/rocm-device-plugin.yaml"
 habana_device_plugin_yaml_url: "{{ hostvars['localhost']['offline_manifest_path'] }}/habana-device-plugin.yaml"
+node_label_for_habana_device_plugin: "intel.com/gaudi.present"
 nfs_dir_mode: "0777"
 pod_wait_time: 300
 nfs_subdir_external_provisioner_repo: "{{ hostvars['localhost']['offline_tarball_path'] }}/nfs-subdir-external-provisioner-4.0.18.tar.gz"


### PR DESCRIPTION
Label nodes with Gaudi accelerators and use a node selector to only run the device plugin on those nodes.