### PR TITLE
Fix issue with cannot connect to localhost when running verification playbook

### DIFF
--- a/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/main.yml
+++ b/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Include omnia_config.yml
   block:
     - ansible.builtin.include_tasks: include_omnia_config.yml
-  delegate_to: localhost
+  delegate_to: 127.0.0.1
 
 - name: Verify hl-qual on Gaudi nodes
   ansible.builtin.include_tasks: hlqual_validation.yml


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Omnia will create a node group involving localhost before NFS setup, which overwrites the default attribute. This causes an issue cannot connect to localhost when running the verification playbook.

Fix: Use 127.0.0.1 instead