### PR TITLE
Fix issue when telemetry is not enabled

### DIFF
--- a/telemetry/roles/prometheus_gaudi/tasks/main.yml
+++ b/telemetry/roles/prometheus_gaudi/tasks/main.yml
@@ -13,8 +13,11 @@
 # limitations under the License.
 ---
 
-- name: Check if Gaudi Prometheus metric exporter need to be deployed
-  when: hostvars['127.0.0.1']['prometheus_gaudi_support']
+- name: Check if telemetry entry is present in software_config.json
+  when: hostvars['127.0.0.1']['telemetry_entry_present']
   block:
-    - name: Deploy Gaudi metric exporter
-      ansible.builtin.import_tasks: deploy_gaudi_metric_exporter.yml
+    - name: Check if Gaudi Prometheus metric exporter need to be deployed
+      when: hostvars['127.0.0.1']['prometheus_gaudi_support']
+      block:
+        - name: Deploy Gaudi metric exporter
+          ansible.builtin.include_tasks: deploy_gaudi_metric_exporter.yml


### PR DESCRIPTION


### Issues Resolved by this Pull Request
When telemetry is not enabled in software_config.json, prometheus_gaudi_support is undefined.

Fixes #
Check if telemetry is in the config first

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
@priti-parate  @abhishek-sa1 