### PR TITLE
Add dkms autobuild to Gaudi accelerator.yml (#49)

### DIFF
--- a/accelerator/roles/intel/tasks/install_ubuntu.yml
+++ b/accelerator/roles/intel/tasks/install_ubuntu.yml
@@ -54,7 +54,8 @@
       loop: "{{ intel_gaudi_kernel_module_to_load }}"
 
     - name: Make sure dkms module is built for the current kernel
-      command: /usr/lib/dkms/dkms_autoinstaller start
+      ansible.builtin.command: /usr/lib/dkms/dkms_autoinstaller start
+      changed_when: true
 
     - name: Add Gaudi kernel modules
       community.general.modprobe:

--- a/accelerator/roles/intel/tasks/install_ubuntu.yml
+++ b/accelerator/roles/intel/tasks/install_ubuntu.yml
@@ -47,6 +47,15 @@
         name: "{{ intel_habana_packages | list }}"
         update_cache: true
 
+    - name: Remove (old) Gaudi kernel modules if present
+      community.general.modprobe:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ intel_gaudi_kernel_module_to_load }}"
+
+    - name: Make sure dkms module is built for the current kernel
+      command: /usr/lib/dkms/dkms_autoinstaller start
+
     - name: Add Gaudi kernel modules
       community.general.modprobe:
         name: "{{ item }}"

--- a/accelerator/roles/intel/tasks/make_sure_scale_out_interfaces_up.yml
+++ b/accelerator/roles/intel/tasks/make_sure_scale_out_interfaces_up.yml
@@ -23,6 +23,7 @@
   ansible.builtin.blockinfile:
     path: "{{ intel_bring_up_ports_script_path }}"
     create: true
+    mode: "{{ file_permissions }}"
     block: |
       #!/bin/bash
       /opt/habanalabs/qual/gaudi2/bin/manage_network_ifs.sh --up


### PR DESCRIPTION
If the provisioned node has internet a new kernel will be installed but Gaudi dkms module doesn't get automatically built. This will make sure this is done when the user run accelerator.yml