### PR TITLE
Intel Gaudi v1.19.1 Fix vLLM and ds examples

### DIFF
--- a/examples/ai_examples/intel/deepSpeed/ds_configuration.yml
+++ b/examples/ai_examples/intel/deepSpeed/ds_configuration.yml
@@ -36,6 +36,9 @@ spec:
               command: ["/bin/bash", "-c"]
               args:
                 - >-
+                  /usr/bin/ssh-keygen -A;
+                  echo "    KexAlgorithms curve25519-sha256,sntrup761x25519-sha512@openssh.com" |  tee -a /etc/ssh/ssh_config;
+                  /usr/sbin/sshd;
                   HOSTSFILE=$OMPI_MCA_orte_default_hostfile;
                   MASTER_ADDR="$(head -n 1 $HOSTSFILE | sed -n s/[[:space:]]slots.*//p)";
                   SETUP_CMD="git clone  https://github.com/huggingface/optimum-habana /optimum-habana";
@@ -45,7 +48,7 @@ spec:
 
                   git clone  https://github.com/huggingface/optimum-habana /optimum-habana;
                   cd /optimum-habana;
-                  git checkout v1.14.1;
+                  git checkout v1.15.0;
                   sed -i '194s|deepspeed|deepspeed --force_multi|' optimum/habana/distributed/distributed_runner.py;
                   pip install .;
                   pip install -r examples/language-modeling/requirements.txt;
@@ -65,7 +68,7 @@ spec:
                     bash -i -c '
                     git clone  https://github.com/huggingface/optimum-habana /optimum-habana
                     cd /optimum-habana
-                    git checkout v1.14.1
+                    git checkout v1.15.0
                     hf_home_var="os.environ[\"HF_HOME\"] = \"${HF_HOME}\""
                     token_var="os.environ[\"HUGGING_FACE_HUB_TOKEN\"] = \"${HUGGING_FACE_HUB_TOKEN}\""
                     https_var="os.environ[\"https_proxy\"] = \"${https_proxy}\""
@@ -141,6 +144,12 @@ spec:
               volumeMounts:
                 - name: datasets
                   mountPath: /storage
+              command: ["/bin/bash", "-c"]
+              args:
+                - >-
+                    /usr/bin/ssh-keygen -A;
+                    /usr/sbin/sshd;
+                    sleep 365d;
           volumes:
             - name: datasets
               persistentVolumeClaim:

--- a/examples/ai_examples/intel/vllm/vllm_configuration.yml
+++ b/examples/ai_examples/intel/vllm/vllm_configuration.yml
@@ -67,6 +67,7 @@ spec:
               cd vllm-fork
               pip install -v -r requirements-hpu.txt
               export VLLM_TARGET_DEVICE=hpu
+              pip install triton==3.1.0
               python3 setup.py install
               python3 -m vllm.entrypoints.openai.api_server --model $LLM_MODEL --dtype auto  --block-size 128 --max-num-seqs 128 --gpu-memory-utilization 0.5 --tensor-parallel-size $NUM_HPU
           ports:


### PR DESCRIPTION
### Issues Resolved by this Pull Request
vLLM and Deepspeed examples are not working with latest Gaudi SW
Fixes #

- With latest Intel Gaudi PyTorch sontainer ssh key need to be configured for mpi jobs
- Install missing package in vLLM example

### Suggested Reviewers
@priti-parate  @abhishek-sa1 
