### PR TITLE
Shell Script for bringing up resources in PCS container

### DIFF
--- a/prepare_oim/roles/deploy_containers/pcs/tasks/deploy_pcs_container.yml
+++ b/prepare_oim/roles/deploy_containers/pcs/tasks/deploy_pcs_container.yml
@@ -100,3 +100,8 @@
   ansible.builtin.systemd:
     name: omnia_pcs
     state: started
+
+- name: Run PCS start script after container is started
+  containers.podman.podman_container_exec:
+    name: "{{ pcs_container_name }}"
+    command: "/bin/sh -c '/opt/omnia/pcs/pcs-start.sh'"

--- a/prepare_oim/roles/deploy_containers/pcs/templates/pcs-start.sh.j2
+++ b/prepare_oim/roles/deploy_containers/pcs/templates/pcs-start.sh.j2
@@ -49,4 +49,4 @@ pcs resource create {{ kubespray_name }} ocf:heartbeat:podman \
 
 pcs resource group add omnia_containers {{ omnia_core_name }} {{ provision_container_name }} {% if hostvars['localhost']['k8s_support'] %} {{ kubespray_name }} {% endif %}
 
-pcs resource defaults migration-threshold={{ migration_threshold }}
+pcs resource defaults update migration-threshold={{ migration_threshold }}

--- a/prepare_oim/roles/deploy_containers/pcs/templates/pcs-start.sh.j2
+++ b/prepare_oim/roles/deploy_containers/pcs/templates/pcs-start.sh.j2
@@ -17,4 +17,36 @@ systemctl start corosync
 systemctl start pacemaker
 pcs property set stonith-enabled=false
 pcs property set no-quorum-policy=ignore
+
+pcs resource create {{ omnia_core_name }} ocf:heartbeat:podman \
+ image={{ omnia_core_image }} \
+ name={{ omnia_core_name }} \
+ reuse=true \
+ run_opts="{{ omnia_core_run_opts }}" \
+ op monitor interval={{ monitor_interval }} timeout={{ monitor_timeout }} on-fail=restart \
+ op start interval={{ start_interval }} timeout={{ start_timeout }} on-fail=restart \
+ op stop interval={{ stop_interval }}  timeout={{ stop_timeout }}
+
+pcs resource create {{ provision_container_name }} ocf:heartbeat:podman \
+ name={{ provision_container_name }} \
+ image={{ provision_image }} \
+ reuse=true \
+ run_opts="{{ provision_run_opts }}" \
+ op monitor interval={{ monitor_interval }} timeout={{ monitor_timeout }} on-fail=restart \
+ op start interval={{ start_interval }} timeout={{ start_timeout }} on-fail=restart \
+ op stop interval={{ stop_interval }}  timeout={{ stop_timeout }}
+
+{% if hostvars['localhost']['k8s_support'] %}
+pcs resource create {{ kubespray_name }} ocf:heartbeat:podman \
+ name={{ kubespray_name }} \
+ image={{ kubespray_image }} \
+ reuse=true \
+ run_opts="{{ kubespray_run_opts }}" \
+ op monitor interval={{ monitor_interval }} timeout={{ monitor_timeout }} on-fail=restart \
+ op start interval={{ start_interval }} timeout={{ start_timeout }} on-fail=restart \
+ op stop interval={{ stop_interval }}  timeout={{ stop_timeout }}
+{% endif %}
+
+pcs resource group add omnia_containers {{ omnia_core_name }} {{ provision_container_name }} {% if hostvars['localhost']['k8s_support'] %} {{ kubespray_name }} {% endif %}
+
 pcs resource defaults migration-threshold={{ migration_threshold }}

--- a/prepare_oim/roles/deploy_containers/pcs/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pcs/vars/main.yml
@@ -52,3 +52,44 @@ pcs_container_failure_msg: |
   The deployment of the {{ pcs_container_name }} container has failed. To resolve this issue,
   please run the utility/oim_cleanup.yml playbook to clean up any existing OIM resources.
   After the cleanup, you can re-run the original playbook to deploy the {{ pcs_container_name }} container successfully.
+
+  
+#Usage: pcs-start.sh.j2:Common
+omnia_nfs_share: "{{ oim_shared_path }}/omnia"  # Define NFS share path
+oim_metadata_file: "{{ omnia_nfs_share }}/.data/oim_metadata.yml"
+monitor_interval: "30s"
+monitor_timeout: "20s"
+start_interval: "0s"
+start_timeout: "20s"
+stop_interval: "0s"
+stop_timeout: "90s"
+
+#Usage: pcs-start.sh.j2: omnia_core
+omnia_core_name: "omnia_core"
+core_container_image_tag: "latest"
+core_container_name: "omnia_core"
+omnia_core_image: "{{ omnia_core_name }}:{{ core_container_image_tag }}"
+omnia_core_run_opts: " -dt --hostname {{ omnia_core_name}} --restart=always --network=host -v {{ omnia_nfs_share }}:/opt/omnia:z -v {{ omnia_nfs_share }}/ssh_config/.ssh:/root/.ssh:z -e ROOT_PASSWORD_HASH={{ hostvars['localhost']['omnia_core_hashed_passwd'] }} --name {{ omnia_core_name }} --cap-add=CAP_AUDIT_WRITE "
+
+#Usage: pcs-start.sh.j2: omnia_provision
+provision_container_name: "omnia_provision"
+provision_image_name: "omnia_provision"
+provision_image_tag: "latest"
+provision_image: "localhost/{{ provision_image_name }}:{{ provision_image_tag }}"
+omnia_nfs_share: "{{ oim_shared_path }}/omnia"
+provision_dir: "{{ omnia_nfs_share }}/provision"
+xcatdata_dir: "{{ provision_dir }}/xcatdata"
+pgsql_data_dir: "{{ xcatdata_dir }}/pgsql/data"
+install_dir: "{{ provision_dir }}/install"
+tftpboot_dir: "{{ provision_dir }}/tftpboot"
+hosts_file: "{{ omnia_nfs_share }}/hosts"
+provision_logs_dir: "{{ omnia_nfs_share }}/logs/provision"
+provision_run_opts: "-d --network=host --restart=always --hostname {{ oim_hostname }} --privileged -v {{ omnia_nfs_share }}/ssh_config/.ssh:/root/.ssh:z -v {{ omnia_nfs_share }}:/opt/omnia:z -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v {{ xcatdata_dir }}:/xcatdata:z -v {{ install_dir }}:/install:z -v {{ tftpboot_dir }}:/tftpboot:z -v {{ provision_logs_dir }}/xcat:/var/log/xcat:z  -v {{ pgsql_data_dir }}:/var/lib/pgsql/data:z {{ hosts_file }}:/etc/hosts:z"
+
+#Usage: pcs-start.sh.j2: kubespray
+kubespray_image_name: "omnia_kubespray"
+kubespray_version: "{{ hostvars['localhost']['kubespray_version'] }}"
+kubespray_name: "omnia_kubespray_{{ kubespray_version }}"
+kubespray_image: "localhost/{{ kubespray_image_name }}:{{ kubespray_version }}"
+kubespray_run_opts: "-d -v {{ omnia_nfs_share }}/ssh_config/.ssh:/root/.ssh:z -v {{ omnia_nfs_share }}:/opt/omnia:z -v {{ hosts_file }}:/etc/hosts:z --network=host --restart=always --cap-add AUDIT_WRITE"
+

--- a/prepare_oim/roles/deploy_containers/pcs/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pcs/vars/main.yml
@@ -26,7 +26,7 @@ pcs_directories:
   - { path: "{{ pcs_container_dir }}", mode: "{{ read_write_execute_mode }}" }
   - { path: "{{ container_systemd_dir }}", mode: "{{ read_write_mode }}" }
 
-migration_threshold: 2
+migration_threshold: 0
 pcs_startup_file:
   - {template: "pcs-start.sh.j2", dest: "{{ oim_shared_path }}/omnia/pcs/pcs-start.sh", mode: "{{ read_write_execute_mode }}" }
   - {template: "corosync.conf.j2", dest: "{{ oim_shared_path }}/omnia/pcs/corosync.conf", mode: "{{ read_write_mode }}" }


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Now as the PCS container would be launched, this script will enable it to monitor other resources.

Fixes #

### Description of the Solution
Shell script will be sued by prepare_oim to create PCS resources so that PCS container will use same on reboot.

### Suggested Reviewers
@abhishek-s-a @priti-parate @suman-square @nethra
