### PR TITLE
Ansible temporary file dir change for Selinux

### DIFF
--- a/accelerator/ansible.cfg
+++ b/accelerator/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/accelerator.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/accelerator/ansible.cfg
+++ b/accelerator/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/accelerator.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/omnia.log
 # Set the remote temporary directory to a shared path to avoid SELinux issues
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,7 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/omnia.log
+# Set the remote temporary directory to a shared path to avoid SELinux issues
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/benchmarks/ansible.cfg
+++ b/benchmarks/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/benchmarks.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/benchmarks/ansible.cfg
+++ b/benchmarks/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/benchmarks.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/discovery/ansible.cfg
+++ b/discovery/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/discovery.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/discovery/ansible.cfg
+++ b/discovery/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/discovery.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/discovery/roles/discovery_validations/common/tasks/decrypt_provision_credentials_config.yml
+++ b/discovery/roles/discovery_validations/common/tasks/decrypt_provision_credentials_config.yml
@@ -42,8 +42,3 @@
     create: true
   when: ansible_vault_search_key not in provision_credentials_config_content.stdout
   tags: init
-
-- name: Provide permission provision_credentials_vault_path
-  ansible.builtin.command: chcon {{ selinux_context }} {{ provision_credentials_vault_path }}
-  changed_when: true
-  when: ansible_vault_search_key not in provision_credentials_config_content.stdout

--- a/discovery/roles/discovery_validations/common/vars/main.yml
+++ b/discovery/roles/discovery_validations/common/vars/main.yml
@@ -53,7 +53,6 @@ provision_config_cred_syntax_fail_msg: "Failed. Syntax errors present in provisi
 provision_credentials_config_filename: "{{ hostvars['localhost']['input_project_dir'] }}/provision_config_credentials.yml"
 provision_credentials_vault_path: "{{ hostvars['localhost']['input_project_dir'] }}/.provision_credential_vault_key"
 conf_file_mode: "0644"
-selinux_context: "system_u:object_r:container_file_t:s0"
 
 # Usage: include_local_repo_config.yml
 local_repo_config_file: "{{ hostvars['localhost']['input_project_dir'] }}/local_repo_config.yml"

--- a/discovery/roles/metadata_update/tasks/update_metadata.yml
+++ b/discovery/roles/metadata_update/tasks/update_metadata.yml
@@ -25,11 +25,6 @@
     mode: "{{ conf_file_mode }}"
   when: not metadata_status.stat.exists
 
-- name: Provide permission to metadata.yml
-  ansible.builtin.command: chcon {{ selinux_context }} {{ meta_path }}
-  changed_when: true
-  when: not metadata_status.stat.exists
-
 - name: Update netmask for admin and bmc network in metadata.yml file
   block:
     - name: Update netmask_bits

--- a/discovery/roles/metadata_update/vars/main.yml
+++ b/discovery/roles/metadata_update/vars/main.yml
@@ -16,4 +16,3 @@
 # Usage: update_metadata.yml
 meta_path: "/opt/omnia/.data/provision_metadata.yml"
 conf_file_mode: "0644"
-selinux_context: "system_u:object_r:container_file_t:s0"

--- a/local_repo/ansible.cfg
+++ b/local_repo/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/local_repo.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/local_repo/ansible.cfg
+++ b/local_repo/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/local_repo.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/network/ansible.cfg
+++ b/network/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/network.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/network/ansible.cfg
+++ b/network/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/network.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -201,6 +201,8 @@ else
     echo -e "${RED}Failed to start Omnia core container.${NC}"
 fi
 
+# Create the ansible tmp directory if it does not exist.
+mkdir -p "$omnia_path/omnia/tmp/.ansible/tmp"
 # Create the input directory if it does not exist.
 echo -e "${GREEN}Creating the input directory if it does not exist.${NC}"
 mkdir -p "$omnia_path/omnia/input/project_default/"
@@ -249,7 +251,7 @@ echo -e "${GREEN}
          Entering the container from Omnia Infrastructure Manager(OIM):
            Through podman:
            # podman exec -it -u root omnia_core bash
-           
+
            Direct SSH:
            # ssh omnia_core
 

--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -203,6 +203,7 @@ fi
 
 # Create the ansible tmp directory if it does not exist.
 mkdir -p "$omnia_path/omnia/tmp/.ansible/tmp"
+chmod 757 "$omnia_path/omnia/tmp/.ansible/tmp"
 # Create the input directory if it does not exist.
 echo -e "${GREEN}Creating the input directory if it does not exist.${NC}"
 mkdir -p "$omnia_path/omnia/input/project_default/"

--- a/platforms/ansible.cfg
+++ b/platforms/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/platforms.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/platforms/ansible.cfg
+++ b/platforms/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/platforms.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/prepare_oim/ansible.cfg
+++ b/prepare_oim/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/prepare_oim.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/prepare_oim/ansible.cfg
+++ b/prepare_oim/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/prepare_oim.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/provision/ansible.cfg
+++ b/provision/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/provision.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/provision/ansible.cfg
+++ b/provision/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/provision.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/scheduler/ansible.cfg
+++ b/scheduler/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/scheduler.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/scheduler/ansible.cfg
+++ b/scheduler/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/scheduler.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/security/ansible.cfg
+++ b/security/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/security.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/security/ansible.cfg
+++ b/security/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/security.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/storage/ansible.cfg
+++ b/storage/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/storage.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/storage/ansible.cfg
+++ b/storage/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/storage.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/telemetry/ansible.cfg
+++ b/telemetry/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/telemetry.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/telemetry/ansible.cfg
+++ b/telemetry/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/telemetry.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/tools/ansible.cfg
+++ b/tools/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/tools.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/tools/ansible.cfg
+++ b/tools/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/tools.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/upgrade/ansible.cfg
+++ b/upgrade/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/upgrade.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 roles_path = ./roles:../prepare_oim/roles:../discovery/roles:../utils/roles
 host_key_checking = false
 forks = 5

--- a/upgrade/ansible.cfg
+++ b/upgrade/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/upgrade.log
+remote_tmp = /opt/omnia/tmp/.ansible
 roles_path = ./roles:../prepare_oim/roles:../discovery/roles:../utils/roles
 host_key_checking = false
 forks = 5

--- a/utils/ansible.cfg
+++ b/utils/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/utils.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/ansible.cfg
+++ b/utils/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/utils.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/cluster/ansible.cfg
+++ b/utils/cluster/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/utils_cluster.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/cluster/ansible.cfg
+++ b/utils/cluster/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/utils_cluster.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/ip_rule_assignment/ansible.cfg
+++ b/utils/ip_rule_assignment/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/ip_rule_assignment.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/ip_rule_assignment/ansible.cfg
+++ b/utils/ip_rule_assignment/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/ip_rule_assignment.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/k8s-upgrade/ansible.cfg
+++ b/utils/k8s-upgrade/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 roles_path = ./roles
 inventory  = ./inventory.ini
 remote_user = root

--- a/utils/k8s-upgrade/ansible.cfg
+++ b/utils/k8s-upgrade/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+remote_tmp = /opt/omnia/tmp/.ansible
 roles_path = ./roles
 inventory  = ./inventory.ini
-remote_user = root 
+remote_user = root

--- a/utils/performance_profile/ansible.cfg
+++ b/utils/performance_profile/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/performance_profile.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/performance_profile/ansible.cfg
+++ b/utils/performance_profile/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/performance_profile.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180
@@ -13,4 +14,3 @@ connect_timeout = 180
 [ssh_connection]
 retries = 3
 ssh_args = -o ControlMaster=auto -o ControlPersist=180
-

--- a/utils/server_spec_update/ansible.cfg
+++ b/utils/server_spec_update/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/server_spec_update.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/server_spec_update/ansible.cfg
+++ b/utils/server_spec_update/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/server_spec_update.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/software_update/ansible.cfg
+++ b/utils/software_update/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/software_update.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/software_update/ansible.cfg
+++ b/utils/software_update/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/software_update.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/verify_intel_gaudi/ansible.cfg
+++ b/utils/verify_intel_gaudi/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/verify_intel_gaudi.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/verify_intel_gaudi/ansible.cfg
+++ b/utils/verify_intel_gaudi/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/verify_intel_gaudi.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/vllm_build/ansible.cfg
+++ b/utils/vllm_build/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/vllm_build.log
-remote_tmp = /opt/omnia/tmp/.ansible
+remote_tmp = /opt/omnia/tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5
 timeout = 180

--- a/utils/vllm_build/ansible.cfg
+++ b/utils/vllm_build/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 log_path = /opt/omnia/log/core/playbooks/vllm_build.log
+remote_tmp = /opt/omnia/tmp/.ansible
 host_key_checking = false
 forks = 5
 timeout = 180


### PR DESCRIPTION
Resolved permission denied issue due to SELinux on files created by omnia container and accessed in provision container.

Ansible creates temporary files to perform tasks, which by default are created in the /root/.ansible directory. However, this directory is not shared, and containers have a private tag (MCS) label assigned for access boundaries. This caused issues when Ansible tried to access these files, resulting in a permission denied error.

The solution was to change the temporary file directory to a shared location, ensuring that the files created by Ansible have the appropriate tag and can be accessed by the provision container.

Reviewers: @priti-parate @abhishek-s-a @Kratika-P @Aditya-DP