### PR TITLE
Fix hccl test that sometime fails when running verify_intel_gaudi playbook

### DIFF
--- a/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/hccl_gaudi3_validation.yml
+++ b/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/hccl_gaudi3_validation.yml
@@ -153,7 +153,7 @@
     HCCL_COMM_ID: "{{ verify_intel_gaudi_habana_extra['hccl_comm_id'] }}"
   ansible.builtin.shell: |
     set -o pipefail
-    python3 run_hccl_demo.py -clean --test all2all --nranks 8 --loop 1000 --node_id 0 --size 4m --ranks_per_node 8
+    python3 run_hccl_demo.py -clean --test all2all --nranks 8 --loop 1000 --node_id 0 --size 256m --ranks_per_node 8
   args:
     executable: /bin/bash
     chdir: "{{ hccl_demo_untar_folder }}"


### PR DESCRIPTION
Using 4m size for all2all hccl_test we may get different BW results which cause the playbook to fail.
Using 256m size we get a more consistent result.

### Suggested Reviewers
@priti-parate
