### PR TITLE
Intel Gaudi SW update to 1.19.2

### DIFF
--- a/accelerator/tests/test_Gaudi2_hlqual_validation.yml
+++ b/accelerator/tests/test_Gaudi2_hlqual_validation.yml
@@ -265,28 +265,6 @@
       failed_when: "'FAILED' in edp_stress_test_result.stdout"
       changed_when: false
 
-    - name: Hl_qual e2e concurrency test
-      environment:
-        __python_cmd: "python{{ pver }}"
-        LOG_LEVEL_ALL: "{{ habana_tests['log_level_all'] }}"
-        ENABLE_CONSOLE: "{{ habana_tests['enable_console'] }}"
-        HABANA_LOGS: "{{ habana_tests['habana_logs'] }}"
-        GC_KERNEL_PATH: "{{ habana_tests['gc_kernel_path'] }}"
-        HABANA_SCAL_BIN_PATH: "{{ habana_tests['habana_scal_bin_path'] }}"
-        HABANA_PLUGINS_LIB_PATH: "{{ habana_tests['habana_plugins_lib_path'] }}"
-        DATA_LOADER_AEON_LIB_PATH: "{{ habana_tests['data_loader_aeon_lib_path'] }}"
-        RDMA_CORE_ROOT: "{{ habana_tests['rdma_core_root'] }}"
-        RDMA_CORE_LIB: "{{ habana_tests['rdma_core_lib'] }}"
-      ansible.builtin.shell: |
-        set -o pipefail
-        ./hl_qual -gaudi2 -c all -rmod parallel -t 30 -dis_mon -e2e_concurrency
-      args:
-        executable: /bin/bash
-        chdir: "{{ habana_tests['gaudi2_qual_bin_path'] }}"
-      register: e2e_concurrency_test_result
-      failed_when: "'FAILED' in e2e_concurrency_test_result.stdout"
-      changed_when: false
-
     - name: Hl_qual SER test
       environment:
         __python_cmd: "python{{ pver }}"

--- a/accelerator/tests/test_Gaudi3_hlqual_validation.yml
+++ b/accelerator/tests/test_Gaudi3_hlqual_validation.yml
@@ -151,30 +151,6 @@
       register: serdes_base_dirbw_test_result
       failed_when: "'FAILED' in serdes_base_dirbw_test_result.stdout"
 
-    - name: Unload habanalabs kernel module
-      modprobe:
-        name: habanalabs
-        state: absent
-
-    - name: Load habanalabs kernel module with timeout_locked param
-      modprobe:
-        name: habanalabs
-        state: present
-        params: 'timeout_locked=0'
-
-    - name: Bring DOWN all Gaudi3 NICs
-      shell: "cd /opt/habanalabs/qual/gaudi3/bin && ./manage_network_ifs.sh --down"
-
-    - name: Bring UP all Gaudi3 NICs
-      shell: "cd /opt/habanalabs/qual/gaudi3/bin && ./manage_network_ifs.sh --up"
-
-    - name: Retry until HPUs NICs are ready
-      shell: "cd /opt/habanalabs/qual/gaudi3/bin && ./manage_network_ifs.sh --status | grep down | wc -l"
-      register: result
-      until: (result.stdout == "0")
-      retries: 5
-      delay: 5
-
     - name: hl_qual HBM DMA stress test
       environment:
         __python_cmd: "python{{ pver }}"
@@ -250,27 +226,6 @@
         chdir: "{{ habana_tests['gaudi3_qual_bin_path'] }}"
       register: edp_stress_test_result
       failed_when: "'FAILED' in edp_stress_test_result.stdout"
-
-    - name: hl_qual e2e concurrency test
-      environment:
-        __python_cmd: "python{{ pver }}"
-        LOG_LEVEL_ALL: "{{ habana_tests['log_level_all'] }}"
-        ENABLE_CONSOLE: "{{ habana_tests['enable_console'] }}"
-        HABANA_LOGS: "{{ habana_tests['habana_logs'] }}"
-        GC_KERNEL_PATH: "{{ habana_tests['gc_kernel_path'] }}"
-        HABANA_SCAL_BIN_PATH: "{{ habana_tests['habana_scal_bin_path'] }}"
-        HABANA_PLUGINS_LIB_PATH: "{{ habana_tests['habana_plugins_lib_path'] }}"
-        DATA_LOADER_AEON_LIB_PATH: "{{ habana_tests['data_loader_aeon_lib_path'] }}"
-        RDMA_CORE_ROOT: "{{ habana_tests['rdma_core_root'] }}"
-        RDMA_CORE_LIB: "{{ habana_tests['rdma_core_lib'] }}"
-      ansible.builtin.shell: |
-        set -o pipefail
-        ./hl_qual -gaudi3 -c all -rmod parallel -t 30 -dis_mon -e2e_concurrency
-      args:
-        executable: /bin/bash
-        chdir: "{{ habana_tests['gaudi3_qual_bin_path'] }}"
-      register: e2e_concurrency_test_result
-      failed_when: "'FAILED' in e2e_concurrency_test_result.stdout"
 
     - name: hl_qual SER test
       environment:

--- a/accelerator/tests/test_vars/test_Gaudi_vars.yml
+++ b/accelerator/tests/test_vars/test_Gaudi_vars.yml
@@ -18,7 +18,7 @@ oim_dir: "../"
 Gaudi_validation_script_path: test_Gaudi_validation.yml
 inventory: ../inventory.ini
 
-Gaudi_Default_version: "1.19.1"
+Gaudi_Default_version: "1.19.2"
 
 version_pass: 'Gaudi driver version installed on the nodes matched successfully with the default version'
 version_fail: 'Gaudi driver version installed on the nodes does not matched with the default version'

--- a/docs/source/OmniaInstallGuide/Ubuntu/AdvancedConfigurationsUbuntu/CustomLocalRepo.rst
+++ b/docs/source/OmniaInstallGuide/Ubuntu/AdvancedConfigurationsUbuntu/CustomLocalRepo.rst
@@ -29,7 +29,7 @@ Use the local repository feature to create a customized set of local repositorie
             {"name": "telemetry"},
             {"name": "ucx", "version": "1.15.0"},
             {"name": "openmpi", "version": "4.1.6"},
-            {"name": "intelgaudi", "version": "1.19.1-26"},
+            {"name": "intelgaudi", "version": "1.19.2-32"},
             {"name": "csi_driver_powerscale", "version":"v2.13.0"}
         ],
         "bcm_roce": [

--- a/docs/source/OmniaInstallGuide/Ubuntu/CreateLocalRepo/InputParameters.rst
+++ b/docs/source/OmniaInstallGuide/Ubuntu/CreateLocalRepo/InputParameters.rst
@@ -37,7 +37,7 @@ Input parameters for Local Repositories
             {"name": "telemetry"},
             {"name": "ucx", "version": "1.15.0"},
             {"name": "openmpi", "version": "4.1.6"},
-            {"name": "intelgaudi", "version": "1.19.1-26"},
+            {"name": "intelgaudi", "version": "1.19.2-32"},
             {"name": "csi_driver_powerscale", "version":"v2.13.0"}
         ],
 

--- a/docs/source/OmniaInstallGuide/Ubuntu/CreateLocalRepo/localrepos.rst
+++ b/docs/source/OmniaInstallGuide/Ubuntu/CreateLocalRepo/localrepos.rst
@@ -31,7 +31,7 @@ Configure specific local repositories
 
             ::
 
-                {"name": "intelgaudi", "version": "1.19.1-26"},
+                {"name": "intelgaudi", "version": "1.19.2-32"},
 
         * Add the following line below the ``softwares`` section:
 

--- a/docs/source/OmniaInstallGuide/samplefiles.rst
+++ b/docs/source/OmniaInstallGuide/samplefiles.rst
@@ -90,7 +90,7 @@ software_config.json for Ubuntu
             {"name": "telemetry"},
             {"name": "ucx", "version": "1.15.0"},
             {"name": "openmpi", "version": "4.1.6"},
-            {"name": "intelgaudi", "version": "1.19.1-26"},
+            {"name": "intelgaudi", "version": "1.19.2-32"},
             {"name": "csi_driver_powerscale", "version":"v2.13.0"}
         ],
 

--- a/docs/source/Tables/omnia_installed_software.csv
+++ b/docs/source/Tables/omnia_installed_software.csv
@@ -7,8 +7,8 @@ NVIDIA container runtime,"Apache 2.0, GPL-3.0, LGPL-3.0",NVIDIA container runtim
 libnvidia-container,Apache 2.0,NVIDIA container runtime library,1.16.2
 habanalabs-container-runtime,Apache 2.0,"Intel Habana container runtime library
 
-.. note:: This is preliminary code and may change before official release.",1.19.1-26
-habanalabs-k8s-device-plugin,Apache 2.0,HABANA device plugin for Kubernetes,1.19.1-26
+.. note:: This is preliminary code and may change before official release.",1.19.2-32
+habanalabs-k8s-device-plugin,Apache 2.0,HABANA device plugin for Kubernetes,1.19.2-32
 Python-pip,MIT License,Python Package,24.2
 kubelet,Apache 2.0,"Provides external, versioned ComponentConfig API types for configuring the kubelet",1.31.4
 kubeadm,Apache 2.0,Provides “fast paths” for creating Kubernetes clusters.,1.31.4
@@ -109,5 +109,5 @@ calico,Apache 2.0,"Calico is an open-source networking and security solution for
 flannel,Apache 2.0,Flannel is a simple and easy-to-configure network fabric for containers. It is part of the Kubernetes ecosystem and primarily used to provide a network overlay that connects containers across multiple nodes.,0.22.0
 csi-powerscale,Apache 2.0,CSI Driver for Dell PowerScale devices,2.13.0
 external-snapshotter,Apache 2.0,Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint.,8.0.1
-Prometheus Gaudi metric exporter,Apache 2.0,This is a Prometheus exporter implementation that enables the collection of Intel Gaudi AI accelerator metrics in a container cluster for compute workload.,1.19.1-26
+Prometheus Gaudi metric exporter,Apache 2.0,This is a Prometheus exporter implementation that enables the collection of Intel Gaudi AI accelerator metrics in a container cluster for compute workload.,1.19.2-32
 DeepSpeed Intel,Apache 2.0,"DeepSpeed is a deep learning optimization library that makes distributed training and inference easy, efficient, and effective.",v2Beta1

--- a/examples/ai_examples/intel/deepSpeed/ds_configuration.yml
+++ b/examples/ai_examples/intel/deepSpeed/ds_configuration.yml
@@ -14,8 +14,7 @@ spec:
       template:
         spec:
           containers:
-            - image: vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest
-              # In case of Ubuntu 24.04 OS, use image:vault.habana.ai/gaudi-docker/1.18.0/ubuntu24.04/habanalabs/pytorch-installer-2.4.0:latest
+            - image: vault.habana.ai/gaudi-docker/1.19.2/ubuntu24.04/habanalabs/pytorch-installer-2.5.1:latest
               name: gaudi-llm-ds-ft-launcher
               env:
                 - name: HF_HOME
@@ -75,19 +74,19 @@ spec:
                     https_var="os.environ[\"https_proxy\"] = \"${https_proxy}\""
                     http_var="os.environ[\"http_proxy\"] = \"${http_proxy}\""
                     no_proxy_var="os.environ[\"no_proxy\"] = \"${no_proxy}\""
-                    sed -i "56i\\${https_var}" examples/language-modeling/run_lora_clm.py
-                    sed -i "57i\\${http_var}" examples/language-modeling/run_lora_clm.py
-                    sed -i "58i\\${hf_home_var}" examples/language-modeling/run_lora_clm.py
-                    sed -i "59i\\${token_var}" examples/language-modeling/run_lora_clm.py
-                    sed -i "60i\\${no_proxy_var}" examples/language-modeling/run_lora_clm.py
 
+                    sed -i "56i\\${hf_home_var}" examples/language-modeling/run_lora_clm.py
+                    sed -i "57i\\${token_var}" examples/language-modeling/run_lora_clm.py
+                    sed -i "58i\\${no_proxy_var}" examples/language-modeling/run_lora_clm.py
                     pip install .
                     pip install -r examples/language-modeling/requirements.txt
                     pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.19.0
                     ';
 
                     cd /optimum-habana/examples/language-modeling/;
-                    python ../gaudi_spawn.py --hostfile=$HOSTSFILE --use_deepspeed --world_size $N_CARDS  run_lora_clm.py --model_name_or_path $LLM_MODEL \
+                    eval $(ssh-agent);
+                    ssh-add;
+                    python3 ../gaudi_spawn.py --hostfile=$HOSTSFILE --use_deepspeed --world_size $N_CARDS  run_lora_clm.py --model_name_or_path $LLM_MODEL \
                     --dataset_name tatsu-lab/alpaca \
                     --bf16 True \
                     --output_dir ./model_lora_llama_ddp \
@@ -131,8 +130,7 @@ spec:
         spec:
           hostIPC: true
           containers:
-            - image: vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest
-              # In case of Ubuntu 24.04 OS, use image:vault.habana.ai/gaudi-docker/1.18.0/ubuntu24.04/habanalabs/pytorch-installer-2.4.0:latest
+            - image: vault.habana.ai/gaudi-docker/1.19.2/ubuntu24.04/habanalabs/pytorch-installer-2.5.1:latest
               name: gaudi-llm-ds-ft-worker
               resources:
                 limits:

--- a/examples/ai_examples/intel/vllm/vllm_configuration.yml
+++ b/examples/ai_examples/intel/vllm/vllm_configuration.yml
@@ -34,8 +34,7 @@ spec:
         app: vllm-llama-app
     spec:
       containers:
-        - image: vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest
-          # In case of Ubuntu 24.04 OS, use image:vault.habana.ai/gaudi-docker/1.18.0/ubuntu24.04/habanalabs/pytorch-installer-2.4.0:latest
+        - image: vault.habana.ai/gaudi-docker/1.19.2/ubuntu24.04/habanalabs/pytorch-installer-2.5.1:latest
           name: vllm-llama-openai
           imagePullPolicy: Always
           workingDir: /root
@@ -64,11 +63,10 @@ spec:
             - "/bin/sh"
             - "-c"
             - |
-              git clone -b v0.6.4.post2+Gaudi-1.19.0 https://github.com/HabanaAI/vllm-fork.git
+              git clone -b v0.6.4.post2+Gaudi-1.19.2 https://github.com/HabanaAI/vllm-fork.git
               cd vllm-fork
               pip install -v -r requirements-hpu.txt
               export VLLM_TARGET_DEVICE=hpu
-              pip install triton==3.1.0
               python3 setup.py install
               python3 -m vllm.entrypoints.openai.api_server --model $LLM_MODEL --dtype auto  --block-size 128 --max-num-seqs 128 --gpu-memory-utilization 0.5 --tensor-parallel-size $NUM_HPU
           ports:

--- a/examples/software_config_template/template_ubuntu_22.04_software_config.json
+++ b/examples/software_config_template/template_ubuntu_22.04_software_config.json
@@ -5,7 +5,7 @@
     "softwares": [
         {"name": "amdgpu", "version": "6.3.1"},
         {"name": "bcm_roce", "version": "232.1.133.2"},
-        {"name": "intelgaudi", "version": "1.19.1-26"},
+        {"name": "intelgaudi", "version": "1.19.2-32"},
         {"name": "cuda", "version": "12.3.2"},
         {"name": "ofed", "version": "24.01-0.3.3.1"},
         {"name": "openldap"},

--- a/examples/software_config_template/template_ubuntu_24.04_software_config.json
+++ b/examples/software_config_template/template_ubuntu_24.04_software_config.json
@@ -5,7 +5,7 @@
     "softwares": [
         {"name": "amdgpu", "version": "6.3.1"},
 	{"name": "bcm_roce", "version": "232.1.133.2"},
-        {"name": "intelgaudi", "version": "1.19.1-26"},
+        {"name": "intelgaudi", "version": "1.19.2-32"},
         {"name": "cuda", "version": "12.5.1"},
         {"name": "ofed", "version": "24.07-0.6.1.0"},
         {"name": "openldap"},

--- a/examples/ubuntu_software_config.json
+++ b/examples/ubuntu_software_config.json
@@ -12,7 +12,7 @@
         {"name": "jupyter"},
         {"name": "pytorch"},
         {"name": "tensorflow"},
-        {"name": "intelgaudi", "version": "1.19.1-26"}
+        {"name": "intelgaudi", "version": "1.19.2-32"}
     ],
 
     "bcm_roce": [

--- a/input/config/ubuntu/22.04/k8s.json
+++ b/input/config/ubuntu/22.04/k8s.json
@@ -229,7 +229,7 @@
     },
     {
       "package": "vault.habana.ai/docker-k8s-device-plugin/docker-k8s-device-plugin",
-      "tag": "1.19.1-26",
+      "tag": "1.19.2-32",
       "type": "image"
     },
     {

--- a/input/config/ubuntu/22.04/pytorch.json
+++ b/input/config/ubuntu/22.04/pytorch.json
@@ -46,7 +46,7 @@
 
     "cluster": [
       {
-        "package": "vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1",
+        "package": "vault.habana.ai/gaudi-docker/1.19.2/ubuntu22.04/habanalabs/pytorch-installer-2.5.1",
         "tag": "latest",
         "type": "image"
       }

--- a/input/config/ubuntu/24.04/k8s.json
+++ b/input/config/ubuntu/24.04/k8s.json
@@ -229,7 +229,7 @@
     },
     {
       "package": "vault.habana.ai/docker-k8s-device-plugin/docker-k8s-device-plugin",
-      "tag": "1.19.1-26",
+      "tag": "1.19.2-32",
       "type": "image"
     },
     {

--- a/input/config/ubuntu/24.04/pytorch.json
+++ b/input/config/ubuntu/24.04/pytorch.json
@@ -46,7 +46,7 @@
 
     "cluster": [
       {
-        "package": "vault.habana.ai/gaudi-docker/1.19.1/ubuntu24.04/habanalabs/pytorch-installer-2.5.1",
+        "package": "vault.habana.ai/gaudi-docker/1.19.2/ubuntu24.04/habanalabs/pytorch-installer-2.5.1",
         "tag": "latest",
         "type": "image"
       }

--- a/input/software_config.json
+++ b/input/software_config.json
@@ -12,7 +12,7 @@
         {"name": "jupyter"},
         {"name": "pytorch"},
         {"name": "tensorflow"},
-        {"name": "intelgaudi", "version": "1.19.1-26"}
+        {"name": "intelgaudi", "version": "1.19.2-32"}
     ],
 
     "bcm_roce": [

--- a/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/hlqual_gaudi2_validation.yml
+++ b/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/hlqual_gaudi2_validation.yml
@@ -274,29 +274,6 @@
   failed_when: "'FAILED' in edp_stress_test_result.stdout"
   changed_when: true
 
-- name: Run hl_qual e2e concurrency test
-  environment:
-    __python_cmd: "python{{ pver }}"
-    LOG_LEVEL_ALL: "{{ verify_intel_gaudi_habana_tests['log_level_all'] }}"
-    ENABLE_CONSOLE: "{{ verify_intel_gaudi_habana_tests['enable_console'] }}"
-    HABANA_LOGS: "{{ verify_intel_gaudi_habana_tests['habana_logs'] }}"
-    GC_KERNEL_PATH: "{{ verify_intel_gaudi_habana_tests['gc_kernel_path'] }}"
-    HABANA_SCAL_BIN_PATH: "{{ verify_intel_gaudi_habana_tests['habana_scal_bin_path'] }}"
-    HABANA_PLUGINS_LIB_PATH: "{{ verify_intel_gaudi_habana_tests['habana_plugins_lib_path'] }}"
-    DATA_LOADER_AEON_LIB_PATH: "{{ verify_intel_gaudi_habana_tests['data_loader_aeon_lib_path'] }}"
-    RDMA_CORE_ROOT: "{{ verify_intel_gaudi_habana_tests['rdma_core_root'] }}"
-    RDMA_CORE_LIB: "{{ verify_intel_gaudi_habana_tests['rdma_core_lib'] }}"
-    HABANALABS_HLTHUNK_TESTS_BIN_PATH: "{{ verify_intel_gaudi_habana_tests['habanalabs_hlthunk_tests_bin_path'] }}"
-  ansible.builtin.shell: |
-    set -o pipefail
-    ./hl_qual -gaudi2 -c all -rmod parallel -t 30 -dis_mon -e2e_concurrency
-  args:
-    executable: /bin/bash
-    chdir: "{{ verify_intel_gaudi_habana_tests['gaudi2_qual_bin_path'] }}"
-  register: e2e_concurrency_test_result
-  failed_when: "'FAILED' in e2e_concurrency_test_result.stdout"
-  changed_when: true
-
 - name: Run hl_qual SER test
   environment:
     __python_cmd: "python{{ pver }}"

--- a/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/hlqual_gaudi3_validation.yml
+++ b/utils/verify_intel_gaudi/roles/verify_intel_gaudi/tasks/hlqual_gaudi3_validation.yml
@@ -147,49 +147,6 @@
   failed_when: "'FAILED' in serdes_base_dirbw_test_result.stdout"
   changed_when: true
 
-- name: Unload habanalabs kernel module
-  community.general.modprobe:
-    name: habanalabs
-    state: absent
-
-- name: Load habanalabs kernel module with timeout_locked param
-  community.general.modprobe:
-    name: habanalabs
-    state: present
-    params: 'timeout_locked=0'
-
-- name: Bring DOWN all Gaudi3 NICs
-  ansible.builtin.shell: |
-    set -o pipefail
-    ./manage_network_ifs.sh --down
-  args:
-    executable: /bin/bash
-    chdir: "{{ verify_intel_gaudi_habana_tests['gaudi3_qual_bin_path'] }}"
-  changed_when: true
-
-- name: Bring UP all Gaudi3 NICs
-  ansible.builtin.shell: |
-    set -o pipefail
-    ./manage_network_ifs.sh --up
-  args:
-    executable: /bin/bash
-    chdir: "{{ verify_intel_gaudi_habana_tests['gaudi3_qual_bin_path'] }}"
-  changed_when: true
-
-- name: Retry until HPUs NICs are ready
-  ansible.builtin.shell: |
-    set -o pipefail
-    ./manage_network_ifs.sh --status | grep down | wc -l
-  args:
-    executable: /bin/bash
-    chdir: "{{ verify_intel_gaudi_habana_tests['gaudi3_qual_bin_path'] }}"
-  register: result
-  until: (result.stdout == "0")
-  retries: 5
-  delay: 5
-  changed_when: false
-  failed_when: false
-
 - name: Run hl_qual HBM DMA stress test
   environment:
     __python_cmd: "python{{ pver }}"
@@ -272,29 +229,6 @@
     chdir: "{{ verify_intel_gaudi_habana_tests['gaudi3_qual_bin_path'] }}"
   register: edp_stress_test_result
   failed_when: "'FAILED' in edp_stress_test_result.stdout"
-  changed_when: true
-
-- name: Run hl_qual e2e concurrency test
-  environment:
-    __python_cmd: "python{{ pver }}"
-    LOG_LEVEL_ALL: "{{ verify_intel_gaudi_habana_tests['log_level_all'] }}"
-    ENABLE_CONSOLE: "{{ verify_intel_gaudi_habana_tests['enable_console'] }}"
-    HABANA_LOGS: "{{ verify_intel_gaudi_habana_tests['habana_logs'] }}"
-    GC_KERNEL_PATH: "{{ verify_intel_gaudi_habana_tests['gc_kernel_path'] }}"
-    HABANA_SCAL_BIN_PATH: "{{ verify_intel_gaudi_habana_tests['habana_scal_bin_path'] }}"
-    HABANA_PLUGINS_LIB_PATH: "{{ verify_intel_gaudi_habana_tests['habana_plugins_lib_path'] }}"
-    DATA_LOADER_AEON_LIB_PATH: "{{ verify_intel_gaudi_habana_tests['data_loader_aeon_lib_path'] }}"
-    RDMA_CORE_ROOT: "{{ verify_intel_gaudi_habana_tests['rdma_core_root'] }}"
-    RDMA_CORE_LIB: "{{ verify_intel_gaudi_habana_tests['rdma_core_lib'] }}"
-    HABANALABS_HLTHUNK_TESTS_BIN_PATH: "{{ verify_intel_gaudi_habana_tests['habanalabs_hlthunk_tests_bin_path'] }}"
-  ansible.builtin.shell: |
-    set -o pipefail
-    ./hl_qual -gaudi3 -c all -rmod parallel -t 30 -dis_mon -e2e_concurrency
-  args:
-    executable: /bin/bash
-    chdir: "{{ verify_intel_gaudi_habana_tests['gaudi3_qual_bin_path'] }}"
-  register: e2e_concurrency_test_result
-  failed_when: "'FAILED' in e2e_concurrency_test_result.stdout"
   changed_when: true
 
 - name: Run hl_qual SER test


### PR DESCRIPTION
- Intel Gaudi 1.19.2 SW update.
- Disable failing e2e hl_qal test failing with Ubuntu 24.04.
- Update Intel AI examples to 1.19.2 container images and SW.

### Suggested Reviewers
@priti-parate