### PR TITLE
Update csi_powerscale_prereq.yml: Adding the validation check

### DIFF
--- a/scheduler/roles/k8s_csi_powerscale_plugin/tasks/csi_powerscale_prereq.yml
+++ b/scheduler/roles/k8s_csi_powerscale_plugin/tasks/csi_powerscale_prereq.yml
@@ -99,7 +99,7 @@
         group: "{{ group_value }}"
         mode: "{{ permission_644 }}"
 
-    # check if powerscale is pininging
+    # check if powerscale is pininging by reading endpoint value from secrets.yaml file
     - name: Load values.yaml file
       ansible.builtin.include_vars:
         file: "{{ hostvars['localhost']['csi_powerscale_driver_values_file_path'] }}"
@@ -112,17 +112,18 @@
       no_log: true
 
     - name: Extract PowerScale endpoint IP or Host from loaded secret data
-      set_fact:
+      ansible.builtin.set_fact:
         powerscale_host: "{{ clusters.isilonClusters[0].endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"
 
     - name: Check if the extracted PowerScale IP or Host is reachable
       ansible.builtin.command:
         cmd: "ping -c 1 {{ powerscale_host }}"  # Replace {{ power_scale_host }} with your actual host variable
       register: ping_result
-      ignore_errors: yes  # Continue even if the ping fail
+      ignore_errors: true  # Continue even if the ping fail
+      changed_when: false
 
     - name: Print ping result or error if ping fails
-      debug:
+      ansible.builtin.debug:
         msg: >
           {% if ping_result.rc == 0 %}
             Powerscale Host reachable! Output: {{ ping_result.stdout }}

--- a/scheduler/roles/k8s_csi_powerscale_plugin/tasks/csi_powerscale_prereq.yml
+++ b/scheduler/roles/k8s_csi_powerscale_plugin/tasks/csi_powerscale_prereq.yml
@@ -99,6 +99,70 @@
         group: "{{ group_value }}"
         mode: "{{ permission_644 }}"
 
+    # check if powerscale is pininging
+    - name: Load values.yaml file
+      ansible.builtin.include_vars:
+        file: "{{ hostvars['localhost']['csi_powerscale_driver_values_file_path'] }}"
+        name: csi_powerscale_values_file
+
+    - name: Load secret file for input validation
+      ansible.builtin.include_vars:
+        file: "{{ hostvars['localhost']['csi_powerscale_driver_secret_file_path'] }}"
+        name: clusters
+      no_log: true
+
+    - name: Extract PowerScale endpoint IP or Host from loaded secret data
+      set_fact:
+        powerscale_host: "{{ clusters.isilonClusters[0].endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"
+
+    - name: Check if the extracted PowerScale IP or Host is reachable
+      ansible.builtin.command:
+        cmd: "ping -c 1 {{ powerscale_host }}"  # Replace {{ power_scale_host }} with your actual host variable
+      register: ping_result
+      ignore_errors: yes  # Continue even if the ping fail
+
+    - name: Print ping result or error if ping fails
+      debug:
+        msg: >
+          {% if ping_result.rc == 0 %}
+            Powerscale Host reachable! Output: {{ ping_result.stdout }}
+          {% else %}
+            Powerscale Host not reachable. Error: {{ ping_result.stderr }}
+          {% endif %}
+
+    - name: Generate Base64 authentication token
+      ansible.builtin.shell: >
+        set -o pipefail && \
+        echo -n "{{ clusters.isilonClusters[0].username }}:{{ clusters.isilonClusters[0].password }}" | base64
+      register: auth_token
+      changed_when: false
+      no_log: true
+
+    - name: Set the URL for the API request
+      ansible.builtin.set_fact:
+        api_url: >-
+          {{
+             'https://' +  item.endpoint if 'https' not in  item.endpoint else  item.endpoint
+          }}:{{  item.endpointPort if  item.endpointPort is defined else csi_powerscale_values_file.endpointPort }}/platform/1/auth/id
+      loop: "{{ clusters.isilonClusters }}"
+      no_log: true
+
+    - name: Make GET request to verify powerscale endpoint and credential
+      ansible.builtin.uri:
+        url: "{{ api_url }}"
+        method: GET
+        headers:
+          Authorization: "Basic {{ auth_token.stdout }}"
+        validate_certs: false
+      register: response
+      ignore_errors: true
+      no_log: true
+
+    - name: Fail if API call to powerscale was not successful
+      ansible.builtin.fail:
+        msg: "{{ fail_msg_api_call }}: {{ response.msg }}"
+      when: response.status != 200
+
     - name: Encrypt secret file
       ansible.builtin.command: >-
         ansible-vault encrypt {{ hostvars['localhost']['csi_powerscale_driver_secret_file_path'] }}


### PR DESCRIPTION

Update csi_powerscale_prereq.yml: Adding the validation check at head-node level for powerscale reachability.

### Issues Resolved by this Pull Request
**Pre-requisite Check for PowerScale Accessibility in CSI Driver Installation**

To prevent pods from entering a crashloop state due to unreachable PowerScale from the headnode or worker nodes, an additional check should be added as part of the pre-requisite step in the CSI driver installation process. This will help identify the issue before it occurs.

Fixes #

### Description of the Solution
A ping and GET API request check has been implemented.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
