### PR TITLE
fixed vllm-nvidia installation issue

### DIFF
--- a/tools/roles/vllm/tasks/vllm_install.yml
+++ b/tools/roles/vllm/tasks/vllm_install.yml
@@ -45,8 +45,8 @@
   when: processing_unit == "nvidia"
   block:
     - name: Install vLLM package
-      ansible.builtin.command: >
-        "{{ vllm_python_version }} -m pip install {{ vllm_nvidia_package }} {{ vllm_numpy_package }} --break-system-packages --ignore-installed"
+      ansible.builtin.command: >-
+        {{ vllm_python_version }} -m pip install {{ vllm_nvidia_package }} {{ vllm_numpy_package }} --break-system-packages --ignore-installed
       changed_when: false
       failed_when: false
       register: nvidia_deployment_output


### PR DESCRIPTION
### Issues Resolved by this Pull Request
vLLM installation failed on the NVIDIA node due to a lint fix. This issue has now been resolved.

### Suggested Reviewers
@abhishek-sa1 @priti-parate 
