### PR TITLE
Fixed vllm_build issue

### DIFF
--- a/input/config/ubuntu/20.04/vllm.json
+++ b/input/config/ubuntu/20.04/vllm.json
@@ -2,7 +2,18 @@
 
   "vllm": { 
 
-    "cluster": []
+    "cluster": [
+      {
+        "package": "docker-ce-cli=5:20.10.20~3-0~ubuntu-focal",
+        "type": "deb",
+        "repo_name": "docker-ce-repo"
+      },
+      {
+        "package": "docker-ce=5:20.10.20~3-0~ubuntu-focal",
+        "type": "deb",
+        "repo_name": "docker-ce-repo"
+      }
+    ]
 
   },
   "vllm_amd": { 

--- a/input/config/ubuntu/22.04/vllm.json
+++ b/input/config/ubuntu/22.04/vllm.json
@@ -2,7 +2,18 @@
 
   "vllm": { 
 
-    "cluster": []
+    "cluster": [
+      {
+        "package": "docker-ce-cli=5:24.0.4-1~ubuntu.22.04~jammy",
+        "type": "deb",
+        "repo_name": "docker-ce-repo"
+      },
+      {
+        "package": "docker-ce=5:24.0.4-1~ubuntu.22.04~jammy",
+        "type": "deb",
+        "repo_name": "docker-ce-repo"
+      }
+    ]
 
   },
   "vllm_amd": { 

--- a/input/config/ubuntu/24.04/vllm.json
+++ b/input/config/ubuntu/24.04/vllm.json
@@ -2,7 +2,18 @@
 
   "vllm": { 
 
-    "cluster": []
+    "cluster": [
+      {
+        "package": "docker-ce-cli=5:27.3.1-1~ubuntu.24.04~noble",
+        "type": "deb",
+        "repo_name": "docker-ce-repo"
+      },
+      {
+        "package": "docker-ce=5:27.3.1-1~ubuntu.24.04~noble",
+        "type": "deb",
+        "repo_name": "docker-ce-repo"
+      }
+    ]
 
   },
   "vllm_amd": { 

--- a/utils/vllm_build/roles/vllm_build/tasks/main.yml
+++ b/utils/vllm_build/roles/vllm_build/tasks/main.yml
@@ -23,6 +23,12 @@
 - name: Validate site_config.yml
   ansible.builtin.include_tasks: validate_site_config.yml
 
+- name: Load software_config.json as software_config
+  ansible.builtin.include_vars:
+    file: "{{ software_config_file }}"
+    name: software_config
+  register: include_software_config
+
 - name: Validate provision_config_credentials.yml
   ansible.builtin.include_tasks: validate_provision_config_credentials.yml
 

--- a/utils/vllm_build/roles/vllm_build/tasks/prereq_ubuntu.yml
+++ b/utils/vllm_build/roles/vllm_build/tasks/prereq_ubuntu.yml
@@ -12,9 +12,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ---
-- name: Initialize epoch version
+- name: Load and parse vllm.json
   ansible.builtin.set_fact:
-    epoch_version: ""
+    vllm: "{{ lookup('file', vllm_json_path) | from_json }}"
+
+- name: Extract docker-ce-cli package version from json file
+  block:
+    - name: Extract docker-ce version
+      ansible.builtin.set_fact:
+        docker_version: "{{ (vllm.vllm.cluster | selectattr('package', 'match', '^docker-ce-cli=') | map(attribute='package') | first).split('=')[1].split('-')[0] }}"  # noqa: yaml[line-length]
+  rescue:
+    - name: Display message if docker-ce-cli package is not found in json file
+      ansible.builtin.fail:
+        msg: "{{ ubuntu_docker_package_missing }}"
 
 - name: Install certificate package
   ansible.builtin.package:
@@ -73,7 +83,7 @@
         msg: "{{ docker_update_repos_fail_msg }}"
 
 - name: Get epoch number of docker-ce/docker-ce-cli
-  ansible.builtin.shell: "set -o pipefail | apt-cache show docker-ce | grep 'Version: 5:24.0.4' | awk '{print $2}'"
+  ansible.builtin.shell: "set -o pipefail | apt-cache show docker-ce-cli | grep 'Version: {{ docker_version }}' | awk '{print $2}'"
   register: epoch_output
   changed_when: false
 

--- a/utils/vllm_build/roles/vllm_build/vars/main.yml
+++ b/utils/vllm_build/roles/vllm_build/vars/main.yml
@@ -19,7 +19,7 @@ include_local_repo_access_msg: "Failed to include {{ local_repo_access_path }}.
 Please run discovery_provision.yml before running the playbook vllm_build.yml."
 
 # Usage prereq.yml
-software_config_file: "{{ role_path }}/../../../input/software_config.json"
+software_config_file: "{{ role_path }}/../../../../input/software_config.json"
 vllm_json_path: "{{ role_path }}/../../../../input/config/{{ software_config.cluster_os_type }}/{{ software_config.cluster_os_version }}/vllm.json"
 sources_list_dest: /etc/apt/sources.list.d
 docker_repo_temp: templates/docker_repo.j2


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Docker installation failed on vllm_build.yml because of an empty epoch number being retrieved from the task. So, I added the Docker packages to the vllm JSON file and created a task to fetch the epoch number from that JSON file.

### Suggested Reviewers
@abhishek-sa1 @Kratika-P Please review
