### PR TITLE
oim_cleanup changes

### DIFF
--- a/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_pulp.yml
+++ b/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_pulp.yml
@@ -38,7 +38,6 @@
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
-        recurse: true
       with_items:
         - "{{ pulp_cleanup_directory }}"
 

--- a/utils/roles/oim_cleanup/oim_container_cleanup/vars/main.yml
+++ b/utils/roles/oim_cleanup/oim_container_cleanup/vars/main.yml
@@ -35,7 +35,6 @@ pulp_cleanup_directory:
   - "{{ omnia_nfs_share }}/pulp/pulp_ha/cli.toml"
   - "{{ omnia_nfs_share }}/log/pulp"
   - "{{ omnia_nfs_share }}/pulp/settings"
-  - "/opt/omnia/offline_repo/"
 
 # Usage: cleanup_provision.yml
 provision_container_name: "omnia_provision"

--- a/utils/roles/oim_cleanup/pre_requisite/tasks/pulp_offline_repo.yml
+++ b/utils/roles/oim_cleanup/pre_requisite/tasks/pulp_offline_repo.yml
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-
-- name: Import pre-requisite tasks
-  ansible.builtin.include_tasks: pre_requisite.yml
-
-- name: Check k8s support
-  ansible.builtin.include_tasks: check_k8s_support.yml
-
-- name: Check pulp offline repo
-  ansible.builtin.include_tasks: pulp_offline_repo.yml
+- name: Remove offline repo directory if exist
+  ansible.builtin.file:
+    path: "{{ offline_repo_path }}"
+    state: absent

--- a/utils/roles/oim_cleanup/pre_requisite/vars/main.yml
+++ b/utils/roles/oim_cleanup/pre_requisite/vars/main.yml
@@ -32,3 +32,6 @@ kube_version_on_unsupported_os: "Failed. On RHEL 9.4 OS, supported kubernetes ve
 k8s_to_kubespray:
   "1.29.5": "v2.27.0"
   "1.31.4": "v2.27.0"
+
+# Usage: pulp_offline_repo.yml
+offline_repo_path: "/opt/omnia/offline_repo"


### PR DESCRIPTION
Moving the task to localhost instead on oim, if mount location different then offline_repo is not getting deleted.
Considering, offline_repo path is always on localhost i.e omnia_core container - /opt/omnia/