### PR TITLE
Defect fix: omnia_startup.sh is failing to remove /etc/fstab entry

### DIFF
--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -145,7 +145,7 @@ cleanup_config(){
             cp "$fstab_file" "$fstab_file.bak"
 
             # Remove the line from the fstab file.
-             sed -i "$omnia_path/d" "$fstab_file"
+             sed -i "\#$omnia_path#d" "$fstab_file"
              if [ $? -ne 0 ]; then
                 echo -e "${RED} Failed to remove the entry from /etc/fstab.${NC}"
             fi


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Defect fix for omnia_startup.sh is failing to remove /etc/fstab entry

### Suggested Reviewers
@abhishek-sa1 @priti-parate @Aditya-DP @nethra