### PR TITLE
nfs-kernel-server package is not applicable for RHEL and rocky

### DIFF
--- a/storage/roles/nfs_sas/vars/main.yml
+++ b/storage/roles/nfs_sas/vars/main.yml
@@ -54,7 +54,6 @@ nfs_utilities:
     - nfs-kernel-server
   rhel:
     - nfs-utils
-    - nfs-kernel-server
     - firewalld
 
 nfs_services:


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
