### PR TITLE
Update AMD benchmark code to work with new architecture 

### DIFF
--- a/benchmarks/amd_benchmark.yml
+++ b/benchmarks/amd_benchmark.yml
@@ -35,7 +35,7 @@
   when: not ( hostvars['127.0.0.1']['update_user_repo_executed'] | default(false) | bool )
 
 - name: Benchmarks for AMD
-  hosts: slurm_control_node, slurm_node, login
+  hosts: slurm_control_node
   gather_facts: true
   roles:
     - amd_benchmark

--- a/benchmarks/roles/amd_benchmark/tasks/configure_slurm.yml
+++ b/benchmarks/roles/amd_benchmark/tasks/configure_slurm.yml
@@ -1,4 +1,4 @@
-#  Copyright 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+#  Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,84 +13,65 @@
 #  limitations under the License.
 ---
 
-- name: Update slurm.conf in configless mode
+- name: Set default run once value
+  ansible.builtin.set_fact:
+    run_once_conditional: false
+
+- name: Set slurm.conf path for nfs_share
+  ansible.builtin.set_fact:
+    slurm_conf_path: "{{ hostvars['127.0.0.1']['share_path'] }}{{ slurm_nfs_folder }}{{ slurm_conf_path }}"
+    run_once_conditional: true
+  when: hostvars['127.0.0.1']['slurm_installation_type'] == 'nfs_share'
+
+- name: Update SelectType in slurm.conf
+  ansible.builtin.replace:
+    path: "{{ slurm_conf_path }}"
+    regexp: 'SelectType=(.*)'
+    replace: 'SelectType=select/cons_tres'
+  register: set_select_type_status
+  run_once: "{{ run_once_conditional }}"
+
+- name: Add SelectTypeParameters in slurm.conf
+  ansible.builtin.lineinfile:
+    path: "{{ slurm_conf_path }}"
+    insertafter: '^SelectType='
+    line: 'SelectTypeParameters=CR_Core'
+  register: set_select_type_parm_status
+  run_once: "{{ run_once_conditional }}"
+
+- name: Set default slurm restart value
+  ansible.builtin.set_fact:
+    restart_slurm: false
+
+- name: Check if slurm services need to be restarted
+  ansible.builtin.set_fact:
+    restart_slurm: true
   when:
-    - hostvars['127.0.0.1']['slurm_installation_type'] == "configless"
-    - "'slurm_control_node' in group_names"
-  block:
-    - name: Update SelectType in slurm.conf
-      ansible.builtin.replace:
-        path: "{{ slurm_conf_path }}"
-        regexp: 'SelectType=(.*)'
-        replace: 'SelectType=select/cons_tres'
+    - hostvars['127.0.0.1']['restart_slurm_services']
+    - (set_select_type_status is changed) or (set_select_type_parm_status is changed)
 
-    - name: Add SelectTypeParameters in slurm.conf
-      ansible.builtin.lineinfile:
-        path: "{{ slurm_conf_path }}"
-        insertafter: '^SelectType='
-        line: 'SelectTypeParameters=CR_Core'
+- name: Restart slurmcltd service
+  ansible.builtin.include_tasks: restart_slurm.yml
+  vars:
+    slurm_service_type: "slurmctld"
+  when: restart_slurm
 
-    - name: Add SelectTypeParameters in slurm.conf
-      ansible.builtin.lineinfile:
-        path: "{{ slurm_conf_path }}"
-        insertafter: '^SelectType='
-        line: 'SelectTypeParameters=CR_Core'
+- name: Get list of slurm compute nodes
+  ansible.builtin.command: sinfo -h --format="%n"
+  register: sinfo_output
+  delegate_to: "{{  groups['slurm_control_node'] | first }}"
+  failed_when: false
+  changed_when: false
+  run_once: true
+  when: restart_slurm
 
-- name: Update slurm.conf in nfs mode
-  when:
-    - hostvars['127.0.0.1']['slurm_installation_type'] == 'nfs_share'
-  block:
-    - name: Append share_path to variables when slurm_installation_type is nfs_share
-      ansible.builtin.set_fact:
-        slurm_conf_path: "{{ hostvars['127.0.0.1']['share_path'] }}{{ slurm_nfs_folder }}{{ slurm_conf_path }}"
-
-    - name: Update SelectType in slurm.conf
-      ansible.builtin.replace:
-        path: "{{ slurm_conf_path }}"
-        regexp: 'SelectType=(.*)'
-        replace: 'SelectType=select/cons_tres'
-
-    - name: Add SelectTypeParameters in slurm.conf
-      ansible.builtin.lineinfile:
-        path: "{{ slurm_conf_path }}"
-        insertafter: '^SelectType='
-        line: 'SelectTypeParameters=CR_Core'
-
-    - name: Add SelectTypeParameters in slurm.conf
-      ansible.builtin.lineinfile:
-        path: "{{ slurm_conf_path }}"
-        insertafter: '^SelectType='
-        line: 'SelectTypeParameters=CR_Core'
-
-- name: Restart slurmd on slurm_node
-  ansible.builtin.systemd:
-    name: slurmd
-    state: restarted
-    enabled: true
-  register: slurmd_status
-  until: slurmd_status is succeeded
-  retries: 5
-  delay: 30
-  when: "'slurm_node' in group_names"
-
-- name: Restart slurmd on login
-  ansible.builtin.systemd:
-    name: slurmd
-    state: restarted
-    enabled: true
-  register: slurmd_status
-  until: slurmd_status is succeeded
-  retries: 5
-  delay: 30
-  when: "'login' in group_names"
-
-- name: Restart slurmctld on slurm_control_node
-  ansible.builtin.systemd:
-    name: slurmctld
-    state: restarted
-    enabled: true
-  register: slurmctld_status
-  until: slurmctld_status is succeeded
-  retries: 5
-  delay: 30
-  when: "'slurm_control_node' in group_names"
+- name: Restart slurmd service
+  ansible.builtin.include_tasks: restart_slurm.yml
+  vars:
+    slurm_service_type: "slurmd"
+  args:
+    apply:
+      delegate_to: "{{ item }}"
+  run_once: true
+  loop: "{{ sinfo_output.stdout_lines }}"
+  when: restart_slurm

--- a/benchmarks/roles/amd_benchmark/tasks/configure_slurm.yml
+++ b/benchmarks/roles/amd_benchmark/tasks/configure_slurm.yml
@@ -57,7 +57,7 @@
   when: restart_slurm
 
 - name: Get list of slurm compute nodes
-  ansible.builtin.command: sinfo -h --format="%n"
+  ansible.builtin.command: sinfo -h -r --format="%n"
   register: sinfo_output
   delegate_to: "{{  groups['slurm_control_node'] | first }}"
   failed_when: false

--- a/benchmarks/roles/amd_benchmark/tasks/fetch_omnia_inputs.yml
+++ b/benchmarks/roles/amd_benchmark/tasks/fetch_omnia_inputs.yml
@@ -1,4 +1,4 @@
-#  Copyright 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+#  Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,42 +13,10 @@
 #  limitations under the License.
 ---
 
-- name: Check if omnia_vault_key exists
-  ansible.builtin.stat:
-    path: "{{ role_path }}/../../../input/{{ config_vaultname }}"
-  register: vault_key_result
-
-- name: Create ansible vault key if it does not exist
-  ansible.builtin.set_fact:
-    vault_key: "{{ lookup('password', '/dev/null chars=ascii_letters') }}"
-  when: not vault_key_result.stat.exists
-
-- name: Save vault key
-  ansible.builtin.lineinfile:
-    path: "{{ role_path }}/../../../input/{{ config_vaultname }}"
-    line: "{{ vault_key }}"
-    mode: "{{ vault_key_permission }}"
-    owner: root
-    create: true
-  when: not vault_key_result.stat.exists
-
-- name: Check if omnia config file is encrypted
-  ansible.builtin.command: cat {{ role_path }}/../../../input/{{ config_filename }}
-  changed_when: false
-  register: config_content
-  no_log: true
-
-- name: Decrpyt omnia_config.yml
-  ansible.builtin.command: >-
-    ansible-vault decrypt {{ role_path }}/../../../input/{{ config_filename }}
-    --vault-password-file {{ role_path }}/../../../input/{{ config_vaultname }}
-  when: "'$ANSIBLE_VAULT;' in config_content.stdout"
-  changed_when: true
-
 - name: Include variable file omnia_config.yml
   block:
     - name: Include variable file omnia_config.yml
-      ansible.builtin.include_vars: "{{ role_path }}/../../../input/{{ config_filename }}"
+      ansible.builtin.include_vars: "{{ input_project_dir }}/{{ config_filename }}"
       register: include_omnia_config
       no_log: true
   rescue:
@@ -70,8 +38,9 @@
   when:
     - slurm_installation_type | default("", true) not in ["nfs_share", "configless"]
 
-- name: Encrypt input config file
-  ansible.builtin.command: >-
-    ansible-vault encrypt {{ role_path }}/../../../input/{{ config_filename }}
-    --vault-password-file {{ role_path }}/../../../input/{{ config_vaultname }}
-  changed_when: false
+- name: Verify the value of restart_slurm_services
+  ansible.builtin.assert:
+    that:
+      - restart_slurm_services == true or restart_slurm_services == false
+    success_msg: "{{ restart_services_success_msg }}"
+    fail_msg: "{{ restart_services_failure_msg }}"

--- a/benchmarks/roles/amd_benchmark/tasks/fetch_storage_config.yml
+++ b/benchmarks/roles/amd_benchmark/tasks/fetch_storage_config.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 - name: Include variable file storage_config.yml
   block:
     - name: Include variable file storage_config.yml
-      ansible.builtin.include_vars: "{{ role_path }}/../../../input/{{ storage_config_filename }}"
+      ansible.builtin.include_vars: "{{ input_project_dir }}/{{ storage_config_filename }}"
       register: include_storage_config
       no_log: true
   rescue:

--- a/benchmarks/roles/amd_benchmark/tasks/main.yml
+++ b/benchmarks/roles/amd_benchmark/tasks/main.yml
@@ -1,4 +1,4 @@
-#  Copyright 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+#  Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 - name: Verify slurm is running
   ansible.builtin.include_tasks: pre_requisites.yml
 
-- name: Fetch software_config.json and check for intel_benchmarks support
+- name: Fetch software_config.json and check for amd_benchmarks support
   ansible.builtin.include_tasks: fetch_software_config.yml
 
 - name: Install packages

--- a/benchmarks/roles/amd_benchmark/tasks/restart_slurm.yml
+++ b/benchmarks/roles/amd_benchmark/tasks/restart_slurm.yml
@@ -1,0 +1,26 @@
+#  Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+
+- name: Reload "{{ slurm_service_type }}"
+  ansible.builtin.systemd_service:
+    name: "{{ slurm_service_type }}"
+    state: reloaded
+    daemon_reload: true
+    enabled: true
+
+- name: Restart "{{ slurm_service_type }}"
+  ansible.builtin.systemd_service:
+    name: "{{ slurm_service_type }}"
+    state: restarted

--- a/benchmarks/roles/amd_benchmark/vars/main.yml
+++ b/benchmarks/roles/amd_benchmark/vars/main.yml
@@ -48,10 +48,8 @@ nfs_client_params_slurm_share_success_msg: "Entry found in nfs_client_params wit
 
 # Usage: fetch_omnia_inputs.yml
 config_filename: "omnia_config.yml"
-config_vaultname: .omnia_vault_key
-vault_key_permission: "0644"
 omnia_config_syntax_fail_msg: "Failed. Syntax errors present in omnia_config.yml. Fix errors and re-run playbook again."
-file_perm: '0755'
-input_config_failure_msg: "None of the parameters in omnia_config.yml should be empty."
 slurm_installation_type_empty_failure_msg: "Slurm Installation type cannot be empty in omnia_config.yml"
 slurm_installation_type_wrong_failure_msg: "Slurm Installation Type should be either nfs_share or configless in omnia_config.yml"
+restart_services_success_msg: "restart_slurm_services successfully validated"
+restart_services_failure_msg: "Failed. restart_slurm_services accepts true or false in omnia_config.yml"


### PR DESCRIPTION
### Description of the Solution
Updated and tested: 
ansible-playbook local_repo.yml (To download intel and amd packages to the pulp container; Handled in the intel equivalent of this PR already https://github.com/dell/omnia/pull/2673)
ansible-playbook scheduler.yml -i inv -v (To install slurm and install openmpi and ucx packages; Handled in the intel equivalent of this PR already https://github.com/dell/omnia/pull/2673)
ansible-playbook amd_benchmark.yml -i inv -v (To install downloaded amd packages into cluster nodes)

The amd_benchmark.yml playbook is designed to handle both nfs_share and configless slurm configurations.

@jagadeeshnv @snarthan 
