### PR TITLE
Removing enabling of omnia_pcs from postbootscript

### DIFF
--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
@@ -87,7 +87,6 @@ if ! ifconfig | grep -w {{ hostvars['omnia_provision']['admin_nic'] }}; then
 fi
 
 # Enable and start the pcs container
-sudo systemctl enable omnia_pcs || { echo "Error enabling omnia_pcs service." >> "$LOGFILE"; exit 1; }
 sudo systemctl start omnia_pcs || { echo "Error starting omnia_pcs service." >> "$LOGFILE"; exit 1; }
 echo "$(date) - INFO - Finished OIM Passive node setup." >> "$LOGFILE"
 echo "---------------------------"

--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
@@ -4,7 +4,7 @@
 #      Configure a passive OIM node.
 #################################################################################################################
 # Define log file
-LOGFILE="/var/log/omnia/pcs_setup.log"
+LOGFILE="/var/log/xcat/xcat.log"
 
 # Get the directory of the log file
 log_dir=$(dirname "$LOGFILE")


### PR DESCRIPTION
### Description of the Solution
Quadlet file already enables the service at boot, so this is not needed and will throw an error when trying to enable.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@abhishek-sa1 