### PR TITLE
fixed nfs mount validation

### DIFF
--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -297,7 +297,9 @@ init_container_config() {
 
         # Validate if NFS server share path is mounted
         echo -e "${BLUE} Validating if NFS server share path is mounted.${NC}"
-        if grep -qs "$nfs_server_ip:$nfs_server_share_path" /proc/mounts; then
+	# strip the trailing slash from nfs_server_share_path
+	strip_nfs_server_share_path="${nfs_server_share_path%/}"
+        if grep -qs "$nfs_server_ip:$strip_nfs_server_share_path" /proc/mounts; then
             echo -e "${GREEN} NFS server share path is mounted.${NC}"
         else
             echo -e "${RED} NFS server share path is not mounted. Provide valid NFS server details. ${NC}"


### PR DESCRIPTION
Fixed - Omnia_startup.sh fails to mount NFS share path, when user gives "NFS server share path: path ending with OS file delimiters 

@abhishek-sa1 @priti-parate @suman-square @Aditya-DP 