### PR TITLE
Update to allow root ssh after a node is provisioned

### DIFF
--- a/discovery/roles/postscripts/common/templates/omnia_hostname.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_hostname.j2
@@ -34,4 +34,8 @@ if [ "$str_os_type" = "debian" ];then
 fi
 echo "Updating CA trust store"
 update-ca-trust extract
+
+echo "Enabling root ssh login"
+sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' {{ sshd_config_file }}
+
 echo "-----------------------------"

--- a/discovery/roles/postscripts/common/vars/main.yml
+++ b/discovery/roles/postscripts/common/vars/main.yml
@@ -72,3 +72,6 @@ genesis_package_path:
 container_tar_file: "omnia_images.tar"
 container_images_path: "{{ oim_shared_path }}/omnia/images/{{ container_tar_file }}"
 persistent_rules_file: "/etc/udev/rules.d/70-persistent-net.rules"
+
+# Usage: omnia_hostname.j2
+sshd_config_file: "/etc/ssh/sshd_config"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Adding logic to allow for root ssh for provisioned nodes. 

### Description of the Solution
Adding PermitRootLogin to the ssh config. 

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@abhishek-sa1 @priti-parate 