### PR TITLE
modified pcs_vars file path

### DIFF
--- a/discovery/roles/postscripts/common/vars/main.yml
+++ b/discovery/roles/postscripts/common/vars/main.yml
@@ -20,8 +20,7 @@ xcat_manpath_env: "/opt/xcat/share/man:$MANPATH"
 perl_badlang_env: 0
 xcat_path: /opt/xcat/bin
 omnia_metadata_file: "/opt/omnia/.data/oim_metadata.yml"
-pcs_vars: "{{ role_path }}/../../../prepare_oim/roles/deploy_containers/pcs/vars/main.yml"
-
+pcs_vars: "{{ role_path }}/../../../../prepare_oim/roles/deploy_containers/pcs/vars/main.yml"
 # Usage: check_nodes_all.yml
 all_nodes_warning_msg: "[WARNING] Not found any nodes using the given discovery mechanism.
 Verify all the input parameters are valid and re-run discovery_provision.yml"


### PR DESCRIPTION

### Description of the Solution
The discovery_provision.yml playbook was failing on the task "Include vars from the pcs container" due to an invalid pcs_vars file path, so corrected the file path.

### Suggested Reviewers
@abhishek-sa1 @suman-square @nethramg please review it.
