### PR TITLE
Updates for admin interface routing metric for passive OIM nodes

### DIFF
--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
@@ -45,7 +45,7 @@ if ! ifconfig | grep -w {{ hostvars['omnia_provision']['admin_nic'] }}; then
     done
 
     if [ -z "$INTERFACE" ]; then
-        echo "ERROR:: No admin interface found." >> "$LOGFILE"
+        echo "ERROR: No admin interface found." >> "$LOGFILE"
         exit 1
     fi
 
@@ -54,12 +54,19 @@ if ! ifconfig | grep -w {{ hostvars['omnia_provision']['admin_nic'] }}; then
     # 70-persistent-net.rules must be used as the file for consistent interface naming
     [ -f {{ persistent_rules_file }} ] || touch {{ persistent_rules_file }}
     echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"${MAC}\",ATTR{type}==\"${TYPE}\",NAME=\"{{ hostvars['omnia_provision']['admin_nic'] }}\"" >> {{ persistent_rules_file }}
-    CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w ${INTERFACE} | cut -d' ' -f1)
+    CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w ${INTERFACE} | head -1 |cut -d' ' -f1)
     nmcli connection modify ${CONNECTION_PROFILE} connection.interface-name ""
     nmcli connection modify ${CONNECTION_PROFILE} match.interface-name {{ hostvars['omnia_provision']['admin_nic'] }} || { echo "ERROR: Using nmcli to match the interface name." >> "$LOGFILE"; exit 1; }
 
     echo "INFO: Renamed the admin interface to {{ hostvars['omnia_provision']['admin_nic'] }}." >> "$LOGFILE"
+
+else
+    CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w {{ hostvars['omnia_provision']['admin_nic'] }} | head -1 | cut -d' ' -f1)
 fi
+
+nmcli connection modify ${CONNECTION_PROFILE} ipv4.route-metric 1 || { echo "ERROR: Using nmcli to update the admin interface's metric." >> "$LOGFILE"; exit 1; }
+
+echo "INFO: Updated the admin interface's metric to 1." >> "$LOGFILE"
 
 echo "$(date) - INFO - Finished OIM HA Post Script." >> "$LOGFILE"
 echo "---------------------------"

--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
@@ -33,9 +33,9 @@ if [ "$str_os_type" = "redhat" ]; then
     sudo dnf install -y podman
 fi
 
-echo "INFO: Renaming admin interface to {{ hostvars['omnia_provision']['admin_nic'] }}." >> "$LOGFILE"
-# Ensure the management interface name is the same as active OIM, if not add the active OIM's interface name as an alternative name
+# Ensure the management interface name is the same as the active OIM, if not change it to the active OIM's interface name.
 if ! ifconfig | grep -w {{ hostvars['omnia_provision']['admin_nic'] }}; then
+    echo "INFO: Renaming admin interface to {{ hostvars['omnia_provision']['admin_nic'] }}." >> "$LOGFILE"
     passive_oim_node_ips="{{ hostvars['omnia_provision']['passive_oim_nodes'].query_result | map(attribute='admin_ip') | join(' ') }}"
     for admin_ip in ${passive_oim_node_ips};do
         INTERFACE=$(ip addr show | awk "/${admin_ip}/{print \$NF; exit}")


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Sets the admin interface's metric for passive nodes to 1 to avoid potential routing conflicts with other default routes. 

### Description of the Solution
Sets the connection profile's metric for the admin interface to 1. 

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@abhishek-sa1 