### PR TITLE
oim omniadb entry, omnia_core ssh config, and bmc vip input validation fix

### DIFF
--- a/common/library/module_utils/input_validation/schema/high_availability_config.json
+++ b/common/library/module_utils/input_validation/schema/high_availability_config.json
@@ -62,7 +62,15 @@
               },
               "bmc_virtual_ip_address": {
                 "type": "string",
-                "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+                "oneOf": [
+                  {
+                    "maxLength": 0
+                  },
+                  {
+                    "minLength": 1,
+                    "pattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+                  }
+                ]
               },
               "active_node_service_tag": {
                 "type": "string",

--- a/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
@@ -167,14 +167,16 @@ def validate_oim_ha(errors, config_type, ha_data, network_spec_data, roles_confi
         roles_groups = roles_config_json.get("Groups", [])
         for _, group_data in roles_groups.items():
             static_range = group_data.get("bmc_details", {}).get("static_range", '')
-            if static_range:
+            if static_range and bmc_virtual_ip:
                 bmc_vip_conflict = validation_utils.is_ip_within_range(static_range, bmc_virtual_ip)
                 if bmc_vip_conflict:
                     errors.append(create_error_msg(f"{config_type} bmc_virtual_ip_address conflict with roles_config:", bmc_virtual_ip, en_us_validation_msg.bmc_virtual_ip_not_valid))
 
-        if bmc_network["dynamic_range"] != 'N/A':       
+        bmc_vip_conflict_dynamic = False
+        bmc_vip_conflict_dynamic_conversion = False
+        if bmc_network["dynamic_range"] and bmc_network["dynamic_range"] != 'N/A' and bmc_virtual_ip:       
             bmc_vip_conflict_dynamic = validation_utils.is_ip_within_range(bmc_network["dynamic_range"], bmc_virtual_ip)
-        if bmc_network["dynamic_conversion_static_range"] != 'N/A':
+        if bmc_network["dynamic_conversion_static_range"] and bmc_network["dynamic_conversion_static_range"] != 'N/A' and bmc_virtual_ip:
             bmc_vip_conflict_dynamic_conversion = validation_utils.is_ip_within_range(bmc_network["dynamic_conversion_static_range"], bmc_virtual_ip)
         if bmc_vip_conflict_dynamic or bmc_vip_conflict_dynamic_conversion:
             errors.append(create_error_msg(f"{config_type} bmc_virtual_ip_address conflict with network_spec", bmc_virtual_ip, en_us_validation_msg.bmc_virtual_ip_not_valid))

--- a/prepare_oim/prepare_oim.yml
+++ b/prepare_oim/prepare_oim.yml
@@ -99,7 +99,8 @@
         name: deploy_containers/common
         tasks_from: add_known_hosts.yml
       vars:
-        target_port: "{{ provision_ssh_port }}"
+        target_container: "omnia_provision"
+        target_port: "2223"
 
     - name: Add kubespray container host keys to known_hosts of omnia_core  # noqa:role-name[path]
       ansible.builtin.include_role:

--- a/prepare_oim/roles/deploy_containers/common/tasks/add_known_hosts.yml
+++ b/prepare_oim/roles/deploy_containers/common/tasks/add_known_hosts.yml
@@ -39,3 +39,14 @@
       ansible.builtin.command: ssh-keyscan localhost >> /root/.ssh/known_hosts
       changed_when: true
       failed_when: false
+
+- name: Append to omnia core's SSH config file
+  when: target_container is defined and target_port is defined
+  ansible.builtin.blockinfile:
+    path: "{{ ssh_config }}"
+    block: |
+      Host {{ target_container }}
+        HostName localhost
+        Port {{ target_port }}
+        User root
+        StrictHostKeyChecking no

--- a/prepare_oim/roles/deploy_containers/common/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/common/vars/main.yml
@@ -78,3 +78,6 @@ retry_count: "5"
 delay_time: "10"
 podman_login_fail_msg: "Podman login failed. Please ensure the podman login credentials in the input/omnia_config_credentials.yml are valid.
 If they are, this error can occur due to a pull limit issue or multiple requests. Please try running the playbook again after waiting for a while."
+
+# Usage: add_known_hosts.yml
+ssh_config: "/root/.ssh/config"

--- a/shared_libraries/provision/db_operations/add_oim_db.py
+++ b/shared_libraries/provision/db_operations/add_oim_db.py
@@ -45,8 +45,8 @@ def oim_details_db():
     """
     conn = omniadb_connection.create_connection()
     cursor = conn.cursor()
-    sql = "select admin_mac from cluster.nodeinfo where admin_mac=%s"
-    cursor.execute(sql, (pxe_mac_address,))
+    sql = "select admin_mac from cluster.nodeinfo where admin_mac=%s or node=%s"
+    cursor.execute(sql, (pxe_mac_address, node_name))
     pxe_mac_op = cursor.fetchone()
     if pxe_mac_op is None:
             if str(bmc_nic_ip) == "0.0.0.0":


### PR DESCRIPTION
### Issues Resolved by this Pull Request

- Update to only allow one "oim" omniadb entry to be added when the discovery playbook is run so that duplicate entries aren't entered if the playbook is run on an oim ha node. 
- Config added for omnia_provision, now through the core container if the fingerprint of the omnia provisioning container changes then a user can "ssh omnia_provision". Note: they will still get the identity change warning. The ssh config is only updated in the core container. 
- BMC VIP input validation update for if the bmc virtual ip is an empty string. 

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@abhishek-sa1 @suman-square 