### PR TITLE
Updates to correct default routing for service and oim ha nodes

### DIFF
--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node.j2
@@ -45,7 +45,7 @@ if ! ifconfig | grep -w {{ hostvars['omnia_provision']['admin_nic'] }}; then
     done
 
     if [ -z "$INTERFACE" ]; then
-        echo "ERROR:: No admin interface found." >> "$LOGFILE"
+        echo "ERROR: No admin interface found." >> "$LOGFILE"
         exit 1
     fi
 
@@ -54,7 +54,7 @@ if ! ifconfig | grep -w {{ hostvars['omnia_provision']['admin_nic'] }}; then
     # 70-persistent-net.rules must be used as the file for consistent interface naming
     [ -f {{ persistent_rules_file }} ] || touch {{ persistent_rules_file }}
     echo "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"${MAC}\",ATTR{type}==\"${TYPE}\",NAME=\"{{ hostvars['omnia_provision']['admin_nic'] }}\"" >> {{ persistent_rules_file }}
-    CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w ${INTERFACE} | cut -d' ' -f1)
+    CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w ${INTERFACE} | cut -d' ' -f1 | head -n 1)
     nmcli connection modify ${CONNECTION_PROFILE} connection.interface-name ""
     nmcli connection modify ${CONNECTION_PROFILE} match.interface-name {{ hostvars['omnia_provision']['admin_nic'] }} || { echo "ERROR: Using nmcli to match the interface name." >> "$LOGFILE"; exit 1; }
 

--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node_postboot.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node_postboot.j2
@@ -27,6 +27,8 @@ if [ $(ip route | grep default | wc -l) -gt 1 ]; then
     # Remove the admin nic as a default route if there are multiple default routes
     # Note: No need to restart network manager as it automatically removes any default routes associated with the NIC
     if ip route | grep default | grep -q {{ hostvars['omnia_provision']['admin_nic'] }}; then
+        CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w {{ hostvars['omnia_provision']['admin_nic'] }} | cut -d' ' -f1 | head -n 1)
+        nmcli connection modify ${CONNECTION_PROFILE} ipv4.never-default yes >> "$LOGFILE"
         nmcli device modify {{ hostvars['omnia_provision']['admin_nic'] }} ipv4.never-default yes >> "$LOGFILE"
     else
         echo "Admin NIC is not in a default route, skipping." >> "$LOGFILE"

--- a/discovery/roles/postscripts/common/templates/omnia_oim_ha_node_postboot.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_oim_ha_node_postboot.j2
@@ -22,6 +22,17 @@ fi
 echo "--------------------------" >> "$LOGFILE"
 echo "$(date) - INFO - Starting OIM Passive node setup." >> "$LOGFILE"
 
+echo "INFO: Ensuring internet default route is correct." >> "$LOGFILE"
+if [ $(ip route | grep default | wc -l) -gt 1 ]; then
+    # Remove the admin nic as a default route if there are multiple default routes
+    # Note: No need to restart network manager as it automatically removes any default routes associated with the NIC
+    if ip route | grep default | grep -q {{ hostvars['omnia_provision']['admin_nic'] }}; then
+        nmcli device modify {{ hostvars['omnia_provision']['admin_nic'] }} ipv4.never-default yes >> "$LOGFILE"
+    else
+        echo "Admin NIC is not in a default route, skipping." >> "$LOGFILE"
+    fi
+fi
+
 {% if omnia_share_option == "NFS" %}
 # Create omnia_path directory if it does not exist
 echo "INFO: Creating omnia shared path directory if it does not exist" >> "$LOGFILE"

--- a/discovery/roles/postscripts/common/templates/omnia_service_node_postboot.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_service_node_postboot.j2
@@ -26,6 +26,16 @@ run_or_fail() {
 echo "--------------------------" >> "$LOGFILE"
 echo "$(date) - INFO - Starting Omnia Service node postboot configuration" >> "$LOGFILE"
 
+echo "INFO: Ensuring internet default route is correct." >> "$LOGFILE"
+if [ $(ip route | grep default | wc -l) -gt 1 ]; then
+    # Remove the admin nic as a default route if there are multiple default routes
+    # Note: No need to restart network manager as it automatically removes any default routes associated with the NIC
+    if ip route | grep default | grep -q {{ hostvars['omnia_provision']['admin_nic'] }}; then
+        nmcli device modify {{ hostvars['omnia_provision']['admin_nic'] }} ipv4.never-default yes >> "$LOGFILE"
+    else
+        echo "Admin NIC is not in a default route, skipping." >> "$LOGFILE"
+    fi
+fi
 
 {% if omnia_share_option == "NFS" %}
 # Create omnia_path directory if it does not exist

--- a/discovery/roles/postscripts/common/templates/omnia_service_node_postboot.j2
+++ b/discovery/roles/postscripts/common/templates/omnia_service_node_postboot.j2
@@ -31,6 +31,8 @@ if [ $(ip route | grep default | wc -l) -gt 1 ]; then
     # Remove the admin nic as a default route if there are multiple default routes
     # Note: No need to restart network manager as it automatically removes any default routes associated with the NIC
     if ip route | grep default | grep -q {{ hostvars['omnia_provision']['admin_nic'] }}; then
+        CONNECTION_PROFILE=$(nmcli -f name,device connection show | grep -w {{ hostvars['omnia_provision']['admin_nic'] }} | cut -d' ' -f1 | head -n 1)
+        nmcli connection modify ${CONNECTION_PROFILE} ipv4.never-default yes >> "$LOGFILE"
         nmcli device modify {{ hostvars['omnia_provision']['admin_nic'] }} ipv4.never-default yes >> "$LOGFILE"
     else
         echo "Admin NIC is not in a default route, skipping." >> "$LOGFILE"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
In some instances, post provisioning due to autoconnect the admin nic and potentially an internet nic are assigned as default routes. The admin nic sometimes got priority over the internet nic, thus causing 0.0.0.0 routing to go through the admin nic and the internet to not be reachable. 

### Description of the Solution
If multiple default routes exist and one of them is the admin nic then we delete the admin nic default route. 

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@suman-square @abhishek-sa1 @priti-parate 