### PR TITLE
Update to openldap configs

### DIFF
--- a/security/roles/ldap_server/tasks/ldap_common.yml
+++ b/security/roles/ldap_server/tasks/ldap_common.yml
@@ -18,4 +18,6 @@
     ldaptoolbox_openldap_config_olcRootPW_hash: "{{ hostvars['127.0.0.1']['openldap_config_password_hash'] }}" # noqa var-naming
     ldaptoolbox_openldap_database_olcRootPW_hash: "{{ hostvars['127.0.0.1']['openldap_db_password_hash'] }}" # noqa var-naming
     ldaptoolbox_openldap_monitor_olcRootPW_hash: "{{ hostvars['127.0.0.1']['openldap_monitor_password_hash'] }}" # noqa var-naming
+    ldaptoolbox_openldap_config_olcRootDN: "cn={{ hostvars['127.0.0.1']['openldap_config_username'] }},cn=config" # noqa var-naming
+    ldaptoolbox_openldap_database_olcRootDN: "cn={{ hostvars['127.0.0.1']['openldap_db_username'] }},{{ ldaptoolbox_openldap_suffix }}" # noqa var-naming
   no_log: true

--- a/security/roles/ldap_server/vars/main.yml
+++ b/security/roles/ldap_server/vars/main.yml
@@ -14,8 +14,6 @@
 ---
 
 # Usage: ldap_prereq_Redhat.yml
-ldaptoolbox_openldap_config_olcRootDN: "cn={{ hostvars['127.0.0.1']['openldap_config_username'] }},cn=config" # noqa var-naming
-ldaptoolbox_openldap_database_olcRootDN: "cn={{ hostvars['127.0.0.1']['openldap_db_username'] }},{{ ldaptoolbox_openldap_suffix }}" # noqa var-naming
 ldaptoolbox_openldap_monitor_olcRootDN: "cn=monitor" # noqa var-naming
 ldaptoolbox_olcPasswordHash: "{SHA}" # noqa var-naming
 openldap_configuration_mode: "0600"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Openldap configs set by Omnia were not correctly being passed forward to the openldap-ltb playbook. 

Fixes #
Moved config variables to the correct location so that they could be used by the openldap ltb playbook. 

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@abhishek-sa1 @priti-parate 