### PR TITLE
Changed input folder path for k8s_access

### DIFF
--- a/scheduler/k8s_access.yml
+++ b/scheduler/k8s_access.yml
@@ -13,6 +13,10 @@
 # limitations under the License.
 ---
 
+- name: Include input project directory
+  when: not project_dir_status | default(false) | bool
+  ansible.builtin.import_playbook: ../utils/include_input_dir.yml
+  
 - name: Update Inventory with ansible_host information
   ansible.builtin.import_playbook: ../utils/servicetag_host_mapping.yml
   when: not ( hostvars['127.0.0.1']['update_inventory_executed'] | default(false) | bool )

--- a/scheduler/roles/k8s_access/vars/main.yml
+++ b/scheduler/roles/k8s_access/vars/main.yml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+
 # fetch_user_input.yml
+input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
 user_confirmation: "No usernames defined in k8s_access_config.yml file."
-file_path: "{{ role_path }}/../../../input/k8s_access_config.yml"
+file_path: "{{ input_project_dir }}/k8s_access_config.yml"
 
 # generate_certificate.yml
 user_kube_path: "/home/{{ user }}"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
The input folder was pointing to the Omnia 1.7 path, but in Omnia 2.0, the location of the input folder has changed. So, I updated the input folder path accordingly.

Fixes #

### Description of the Solution
Updated input folder path for Omnia 2.0

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
