### PR TITLE
Input validation tags

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -161,9 +161,9 @@ def validate_usernames(input_file_path, data, logger, module, omnia_base_dir, mo
     errors = []
 
     k8s_access_config_file_path = create_file_path(input_file_path, file_names["k8s_access_config"])
-    k8s_access_config_json = validation_utils.load_yaml_as_json(k8s_access_config_file_path, omnia_base_dir, module_utils_base, project_name, logger, module)
+    k8s_access_config_json = validation_utils.load_yaml_as_json(k8s_access_config_file_path, omnia_base_dir, project_name, logger, module)
     passwordless_ssh_config_file_path = create_file_path(input_file_path, file_names["passwordless_ssh_config"])
-    passwordless_ssh_config_json = validation_utils.load_yaml_as_json(passwordless_ssh_config_file_path, omnia_base_dir, module_utils_base, project_name, logger, module)
+    passwordless_ssh_config_json = validation_utils.load_yaml_as_json(passwordless_ssh_config_file_path, omnia_base_dir, project_name, logger, module)
 
     k8s_user_name = k8s_access_config_json["user_name"]
     pw_ssh_user_name = passwordless_ssh_config_json["user_name"]

--- a/input_validation/roles/validate_input/tasks/main.yml
+++ b/input_validation/roles/validate_input/tasks/main.yml
@@ -23,8 +23,8 @@
 
 - name: Validate omnia input config
   vars:
-    # Note: When running a specific playbook without tags ansible run tags will default to ["all"], thus if more than two tags are present
-    # the "all" tag should be removed so that only the config files related to that playbook are validated.
+    # Note: When running a specific playbook without tags ansible run tags will default to ["all"], thus if two or more tags are present
+    # then the "all" tag should be removed so that only the config files related to that playbook are validated.
     input_validate_tags: "{{ omnia_run_tags | default([]) | difference(['all']) if (omnia_run_tags | length) >= 2
       else omnia_run_tags | default([]) }}"
   validate_input:

--- a/input_validation/roles/validate_input/tasks/main.yml
+++ b/input_validation/roles/validate_input/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Validate omnia input config
   vars:
-    input_validate_tags: "{{ omnia_run_tags | default([]) | difference(['all']) if (omnia_run_tags | length) >= 2 
+    input_validate_tags: "{{ omnia_run_tags | default([]) | difference(['all']) if (omnia_run_tags | length) >= 2
       else omnia_run_tags | default([]) }}"
   validate_input:
     omnia_base_dir: "{{ input_dir }}/../"

--- a/input_validation/roles/validate_input/tasks/main.yml
+++ b/input_validation/roles/validate_input/tasks/main.yml
@@ -23,7 +23,8 @@
 
 - name: Validate omnia input config
   vars:
-    input_validate_tags: "{{ omnia_run_tags | default([]) | difference(['all']) }}"
+    input_validate_tags: "{{ omnia_run_tags | default([]) | difference(['all']) if (omnia_run_tags | length) >= 2 
+      else omnia_run_tags | default([]) }}"
   validate_input:
     omnia_base_dir: "{{ input_dir }}/../"
     project_name: "{{ project_name }}"

--- a/input_validation/roles/validate_input/tasks/main.yml
+++ b/input_validation/roles/validate_input/tasks/main.yml
@@ -23,6 +23,8 @@
 
 - name: Validate omnia input config
   vars:
+    # Note: When running a specific playbook without tags ansible run tags will default to ["all"], thus if more than two tags are present
+    # the "all" tag should be removed so that only the config files related to that playbook are validated.
     input_validate_tags: "{{ omnia_run_tags | default([]) | difference(['all']) if (omnia_run_tags | length) >= 2
       else omnia_run_tags | default([]) }}"
   validate_input:


### PR DESCRIPTION
### Issues Resolved by this Pull Request
-Adding logic to allow for an "all" tag to be passed to the input validation to validate all input files. 
-Fixed incorrect function call in the common validation file

### Description of the Solution
ansible_run_tags defaults to "all"; however, this "all" tag was being removed. Logic was added to remove the "all" tag if there is more than one other tag specific, that way individual input validation tags can still be called without validating all input files. 

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@priti-parate @abhishek-sa1 @youngjae-hur7