### PR TITLE
Handling Pulp Certificate Generation

### DIFF
--- a/prepare_oim/roles/deploy_containers/common/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/common/vars/main.yml
@@ -77,7 +77,7 @@ prepare_oim_completion_msg: |
   registry for the cluster nodes, please execute the playbook local_repo/local_repo.yml as the next step.
 
 # podman_login.yml
-login_cmd: "podman login -u {{ docker_username }} -p {{ docker_password }}"
+login_cmd: "podman login docker.io -u {{ docker_username }} -p {{ docker_password }}"
 retry_count: "5"
 delay_time: "10"
 podman_login_fail_msg: "Podman login failed. Please ensure the podman login credentials in the input/omnia_config_credentials.yml are valid.

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
@@ -51,7 +51,6 @@
     mode: "{{ logs_dir_permission }}"
     remote_src: true
 
-# Steps to decide crt generation
 - name: Run pulp status command on omnia_core container
   ansible.builtin.command: /usr/local/bin/pulp status
   changed_when: false

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
@@ -77,7 +77,7 @@
     (
       (pulp_status_output.rc != 0) and
       (not file_check.stat.exists)
-    )  
+    )
   block:
     - name: Set cert_san fact based on hostname
       ansible.builtin.set_fact:

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
@@ -55,6 +55,7 @@
   ansible.builtin.command: /usr/local/bin/pulp status
   changed_when: false
   register: pulp_status_output
+  failed_when: false
 
 - name: Check if track file exists
   ansible.builtin.stat:

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/create_pulp_config_https.yml
@@ -51,17 +51,85 @@
     mode: "{{ logs_dir_permission }}"
     remote_src: true
 
-- name: Set cert_san fact based on hostname
-  ansible.builtin.set_fact:
-    cert_san: subjectAltName=IP:{{ cert_san_ip }},DNS:{{ pulp_server_ip }},DNS:pulp,DNS:localhost
-  when: hostvars['oim']['hostname_enabled']
-  no_log: true
+# Steps to decide crt generation
+- name: Run pulp status command on omnia_core container
+  ansible.builtin.command: /usr/local/bin/pulp status
+  changed_when: false
+  register: pulp_status_output
 
-- name: Set cert_san fact based on IP
-  ansible.builtin.set_fact:
-    cert_san: subjectAltName=IP:{{ pulp_server_ip }},DNS:pulp,DNS:localhost
-  when: not hostvars['oim']['hostname_enabled']
-  no_log: true
+- name: Check if track file exists
+  ansible.builtin.stat:
+    path: "{{ track_file_path }}"
+  register: file_check
+
+- name: Tasks to generate pulp crt
+  when: >
+    (
+      (hostvars['oim']['pulp_container_status'] == 'running') and
+      (pulp_status_output.rc != 0) and
+      (not file_check.stat.exists)
+    ) or
+    (
+      (hostvars['oim']['pulp_container_status'] == 'running') and
+      (pulp_status_output.rc == 0) and
+      (not file_check.stat.exists)
+    ) or
+    (
+      (pulp_status_output.rc != 0) and
+      (not file_check.stat.exists)
+    )  
+  block:
+    - name: Set cert_san fact based on hostname
+      ansible.builtin.set_fact:
+        cert_san: subjectAltName=IP:{{ cert_san_ip }},DNS:{{ pulp_server_ip }},DNS:pulp,DNS:localhost
+      when: hostvars['oim']['hostname_enabled']
+      no_log: true
+
+    - name: Set cert_san fact based on IP
+      ansible.builtin.set_fact:
+        cert_san: subjectAltName=IP:{{ pulp_server_ip }},DNS:pulp,DNS:localhost
+      when: not hostvars['oim']['hostname_enabled']
+      no_log: true
+
+    - name: Generating Pulp SSL Certificate
+      ansible.builtin.command:
+        cmd: "{{ generate_cert_cmd }}"
+      changed_when: false
+
+    - name: Ensure the pulp group exists
+      ansible.builtin.group:
+        name: pulp
+        state: present
+
+    - name: Change group ownership of SSL certificate and key
+      ansible.builtin.file:
+        path: "{{ item }}"
+        group: pulp
+        state: file
+      loop: "{{ cert_items.values() }}"
+
+    - name: Copy Pulp crt to container trust
+      ansible.builtin.copy:
+        src: "{{ pulp_cert_src }}"
+        dest: "{{ ca_trust_path }}"
+        mode: "{{ logs_dir_permission }}"
+
+    - name: Add Pulp Certificate to TrustStore
+      ansible.builtin.command:
+        cmd: update-ca-trust extract
+      changed_when: false
+
+    - name: Create a track file
+      ansible.builtin.file:
+        path: "{{ track_file_path }}"
+        state: touch
+        mode: "{{ logs_dir_permission }}"
+
+    - name: Record current timestamp in track file
+      ansible.builtin.copy:
+        dest: "{{ track_file_path }}"
+        content: "Timestamp: {{ ansible_date_time.iso8601 }}"
+        mode: "{{ logs_dir_permission }}"
 
 # CERT GENERATION USING community.crypto x509_certificate MODULE
 # - name: Generate private key
@@ -100,31 +168,3 @@
 #     selfsigned_version: 3
 #     selfsigned_create_subject_key_identifier: always_create
 #     return_content: true
-
-- name: Generating Pulp SSL Certificate
-  ansible.builtin.command:
-    cmd: "{{ generate_cert_cmd }}"
-  changed_when: false
-
-- name: Ensure the pulp group exists
-  ansible.builtin.group:
-    name: pulp
-    state: present
-
-- name: Change group ownership of SSL certificate and key
-  ansible.builtin.file:
-    path: "{{ item }}"
-    group: pulp
-    state: file
-  loop: "{{ cert_items.values() }}"
-
-- name: Copy Pulp crt to container trust
-  ansible.builtin.copy:
-    src: "{{ pulp_cert_src }}"
-    dest: "{{ ca_trust_path }}"
-    mode: "{{ logs_dir_permission }}"
-
-- name: Add Pulp Certificate to TrustStore
-  ansible.builtin.command:
-    cmd: update-ca-trust extract
-  changed_when: false

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/deploy_pulp_container_https.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/deploy_pulp_container_https.yml
@@ -71,6 +71,10 @@
       ansible.builtin.fail:
         msg: "{{ pulp_deployed_fail_msg }}"
 
+- name: Set fact for container status
+  ansible.builtin.set_fact:
+    pulp_container_status: "{{ pulp_container_status.containers[0].State.Status }}"
+
 - name: Reset Pulp Password
   containers.podman.podman_container_exec:
     name: "{{ pulp_container_name }}"

--- a/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
@@ -113,6 +113,7 @@ pulp_config_cmd_overwrite_https: "pulp config create --username admin  --base-ur
 pulp_config_filepath: "{{ pulp_ha_dir }}/cli.toml"
 config_default_dir: "/root/.config/pulp/"
 config_default_loc: "{{ config_default_dir }}/cli.toml"
+track_file_path: /opt/omnia/pulp/pulp_crt_track.txt
 cert_san_ip: 0.0.0.0
 cert_validity_days: 365
 cert_items:

--- a/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
@@ -36,10 +36,9 @@ pulp_deployed_fail_msg:
   The deployment of the {{ pulp_container_name }} container has failed. To resolve this issue,
   please run the utility/oim_cleanup.yml playbook to clean up any existing OIM resources.
   After the cleanup, you can re-run the original playbook to deploy the {{ pulp_container_name }} container successfully.
-retries_var: 6
-delay_var: 20
-delay_var_five: 5
-delay_var_sixty: 20
+retries_var: 8
+delay_var: 30
+delay_var_sixty: 30
 timeout_var: 60
 reset_password_cmd: bash -c "pulpcore-manager reset-admin-password --password {{ pulp_password }}"
 
@@ -133,7 +132,7 @@ ca_trust_path: "/etc/pki/ca-trust/source/anchors/"
 
 # Usage: reload_pulp_nginx.yml
 nginx_reload_cmd: "nginx -s reload"
-nginx_retries_var: 10
+nginx_retries_var: 11
 omnia_container_name: "omnia_core"
 pulp_status_url: "https://{{ pulp_server_ip }}:{{ pulp_container_port_https }}/pulp/api/v3/status/"
 endpoint_retries: 10


### PR DESCRIPTION
Added logic and conditions to create a track file during Pulp certificate generation. This ensures that the certificate is not regenerated on subsequent runs of unless the specified conditions are met and the track file is absent.