### PR TITLE
Enable service node firewalld ports

### DIFF
--- a/telemetry/roles/service_node_config/tasks/firewall_settings.yml
+++ b/telemetry/roles/service_node_config/tasks/firewall_settings.yml
@@ -1,0 +1,37 @@
+#  Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+
+- name: Add iDRAC-telemetry related ports on service_nodes firewalld
+  ansible.posix.firewalld:
+    port: "{{ item }}"
+    state: enabled
+    permanent: true
+  loop: "{{ idrac_firewall_ports }}"
+
+- name: Add prometheus and prometheus_pump related ports on service_nodes firewalld
+  ansible.posix.firewalld:
+    port: "{{ item }}"
+    state: enabled
+    permanent: true
+  loop: "{{ prometheus_firewall_ports }}"
+  when: hostvars['localhost']['idrac_telemetry_collection_type'] == "prometheus"
+
+- name: Reload firewalld to apply changes
+  ansible.builtin.command: firewall-cmd --reload
+  changed_when: true
+
+- name: Display open ports for verification
+  ansible.builtin.command: firewall-cmd --list-all
+  changed_when: true

--- a/telemetry/roles/service_node_config/tasks/main.yml
+++ b/telemetry/roles/service_node_config/tasks/main.yml
@@ -18,6 +18,9 @@
     - hostvars['localhost']['idrac_telemetry_support']
     - hostvars['localhost']['federated_idrac_telemetry_collection']
   block:
+    - name: Export firewall ports on servie_nodes
+      ansible.builtin.include_tasks: firewall_settings.yml
+
     - name: Include tasks for podman secrets
       ansible.builtin.include_tasks: create_podman_secrets.yml
 

--- a/telemetry/roles/service_node_config/vars/main.yml
+++ b/telemetry/roles/service_node_config/vars/main.yml
@@ -12,6 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ---
+# Usage:firewall_settings.yml
+idrac_firewall_ports:
+  - "61613/tcp"
+  - "8161/tcp"
+  - "3306/tcp"
+  - "3000/tcp"
+
+prometheus_firewall_ports:
+  - "2112/tcp"
+  - "9090/tcp"
 
 # Usage: create_podman_secrets.yml
 mysql_root_password: "mysql_root_password"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Enable firewall ports on **service nodes** for telemetry flow

Fixes #

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
@abhishek-sa1 @priti-parate @suman-square @Milisha-Gupta @Aditya-DP 