### PR TITLE
Remove extra space in variable assignment in omnia_startup.sh

### DIFF
--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -35,7 +35,7 @@ omnia_release=2.0.0.0
 core_container_status=false
 omnia_path=""
 hashed_passwd=""
-domain_name = ""
+domain_name=""
 
 is_local_ip() {
     local ip_to_check="$1"


### PR DESCRIPTION

### Issues Resolved by this Pull Request
This PR fixes a syntax error caused by an incorrect variable assignment in 'omnia_startup.sh', which could prevent the script from running properly.

Fixes #

### Description of the Solution
Removed the extra space in the variable assignment in omnia_startup.sh to fix the syntax error preventing proper execution of the script.

### Suggested Reviewers
@abhishek-sa1 @priti-parate @nethramg please review
