### PR TITLE
fix(schema): replace 'login_node' with 'login' in Roles enum

### DIFF
--- a/common/library/module_utils/input_validation/schema/roles_config.json
+++ b/common/library/module_utils/input_validation/schema/roles_config.json
@@ -83,7 +83,7 @@
               "slurm_control_node",
               "slurm_node",
               "slurm_dbd",
-              "login_node",
+              "login",
               "auth_server",
               "compiler_node"
             ]


### PR DESCRIPTION
### Issues Resolved by this Pull Request
This pull request resolves an inconsistency in role naming between the input validation and the rest of the playbook logic.
Previously, input validation only accepted login_node as a valid role, while the rest of the code consistently used login. This mismatch caused the playbook to fail during validation when using login, and prevented proper node discovery when using login_node.

Fixes #
Removed login_node and added login to the list of accepted roles in the input validation logic.

### Suggested Reviewers
@abhishek-sa1 @nethramg @priti-parate  Please review
