### PR TITLE
Fix auth_server and etcd overlap validation logic

### DIFF
--- a/utils/roles/inventory_validation/tasks/auth_server_validations.yml
+++ b/utils/roles/inventory_validation/tasks/auth_server_validations.yml
@@ -28,3 +28,4 @@
   ansible.builtin.assert:
     that: "groups['etcd'] | intersect(groups['auth_server']) | length == 0"
     fail_msg: "{{ auth_etcd_fail_msg }}"
+  when: "'etcd' in groups"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
This pull request improves the validation logic for the auth_server and etcd inventory groups.

Fixes #

### Description of the Solution
The validation for auth_server and etcd overlap always ran, even if the etcd group was not defined in inventory, which could lead to unnecessary errors. Now, the overlap validation is conditional — it only executes if the etcd group is defined in the inventory.

### Suggested Reviewers
@snarthan @priti-parate Please review

