### PR TITLE
Fix: removed space in 'admin_ip' key access

### DIFF
--- a/common/library/modules/telemetry_prom_config.py
+++ b/common/library/modules/telemetry_prom_config.py
@@ -62,7 +62,7 @@ def main():
             continue
         service_tag = node['service_tag']
         # service_node_name = node['hostname']
-        service_active_nic_ip = node['virtual_ip_address'] if node.get('enable_service_ha') else node[' admin_ip']
+        service_active_nic_ip = node['virtual_ip_address'] if node.get('enable_service_ha') else node['admin_ip']
 
         # # Create the node directories
         service_dir = os.path.join(base_dir, service_tag)


### PR DESCRIPTION
### Issues Resolved by this Pull Request
This PR fixes a minor bug in the logic by removing an unintended space in the dictionary key access.

Fixes #

### Description of the Solution
removed unintended space in the dictionary key access.

### Suggested Reviewers
@nethramg @priti-parate @suman-square Please review
