### PR TITLE
additional_software schema change and fix in software_update.yml 

### DIFF
--- a/common/library/module_utils/input_validation/schema/additional_software.json
+++ b/common/library/module_utils/input_validation/schema/additional_software.json
@@ -7,7 +7,7 @@
       "properties": {
         "cluster": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 0,
           "items": {
             "type": "object",
             "oneOf": [

--- a/utils/software_update/software_update.yml
+++ b/utils/software_update/software_update.yml
@@ -14,14 +14,6 @@
 ---
 # local_repo has to be run before software_update
 
-- name: Invoke get_config_credentials.yml
-  when: not config_file_status | default(false) | bool
-  ansible.builtin.import_playbook: ../credential_utility/get_config_credentials.yml
-
-- name: Include input project directory
-  when: not project_dir_status | default(false) | bool
-  ansible.builtin.import_playbook: ../include_input_dir.yml
-
 - name: Set_fact for fetch omnia config credentials
   hosts: localhost
   connection: local
@@ -34,6 +26,14 @@
 
 - name: Invoke validate_config.yml to perform L1 and L2 validations with additional_software tag
   ansible.builtin.import_playbook: ../../input_validation/validate_config.yml
+
+- name: Invoke get_config_credentials.yml
+  when: not config_file_status | default(false) | bool
+  ansible.builtin.import_playbook: ../credential_utility/get_config_credentials.yml
+
+- name: Include input project directory
+  when: not project_dir_status | default(false) | bool
+  ansible.builtin.import_playbook: ../include_input_dir.yml
 
 - name: Check for additional_software in software_config.json
   hosts: localhost


### PR DESCRIPTION
Fixes:
additional_software schema to allow empty cluster[] list, 
fixed software_update.yml to set omnia_run_tags as first task as get credentials is using omnia_run_tags, so the playbook should not prompt for unnecessary prompts