### PR TITLE
Openldap certificate storage on nfs 

### DIFF
--- a/security/roles/ldap_client/tasks/configure_ldap_client_redhat.yml
+++ b/security/roles/ldap_client/tasks/configure_ldap_client_redhat.yml
@@ -57,6 +57,6 @@
 
 - name: Copy the certificate to remote node
   ansible.builtin.copy:
-    src: "{{ tls_cert_path }}/{{ hostvars[groups['auth_server'][0]]['ldaptoolbox_openldap_olcTLSCACertificateFile'] | basename }}"
+    src: "{{ oim_certs_dir }}/{{ hostvars[groups['auth_server'][0]]['ldaptoolbox_openldap_olcTLSCACertificateFile'] | basename }}"
     dest: "{{ tls_cert_path }}"
     mode: "{{ file_mode }}"

--- a/security/roles/ldap_client/vars/main.yml
+++ b/security/roles/ldap_client/vars/main.yml
@@ -23,3 +23,4 @@ sasl_nacanon_replace2: "SASL_NOCANON\ton\nURI\tldap://{{ hostvars[groups['auth_s
 # sasl_nacanon_replace3: Defined in each compute os vars file
 sasl_nacanon_replace4: "SASL_NOCANON\ton\nURI\tldap://{{ hostvars[groups['auth_server'][0]]['ansible_env'].SSH_CONNECTION.split(' ')[2] }}:636"
 file_mode: "0644"
+oim_certs_dir: "/opt/omnia/security/certs/"

--- a/security/roles/ldap_server/tasks/ldap_prereq_redhat.yml
+++ b/security/roles/ldap_server/tasks/ldap_prereq_redhat.yml
@@ -44,7 +44,7 @@
     - name: Copy Certificate to Omnia Infrastructure Manager for client setup
       ansible.builtin.fetch:
         src: "{{ tls_certificates_directory_path }}/{{ rhel_cert_file }}"
-        dest: "{{ tls_cert_path }}"
+        dest: "{{ oim_certs_dir }}"
         flat: true
       when: not openldap_status
 
@@ -72,7 +72,7 @@
     - name: Copy Certificate to Omnia Infrastructure Manager for client setup
       ansible.builtin.copy:
         src: "{{ hostvars['127.0.0.1']['tls_ca_certificate'] }}"
-        dest: "{{ tls_cert_path }}"
+        dest: "{{ oim_certs_dir }}"
         mode: "{{ openldap_cert_permissions }}"
       delegate_to: localhost
       connection: local

--- a/security/roles/ldap_server/tasks/validate_openldap.yml
+++ b/security/roles/ldap_server/tasks/validate_openldap.yml
@@ -40,3 +40,15 @@
         - ansible_facts.services["slapd-ltb.service"] is defined
         - ansible_facts.services["slapd-ltb.service"].state == "running"
         - schema_output is search(schema_search_string)
+
+    - name: Check if Security Certs directory exists
+      ansible.builtin.stat:
+        path: "{{ oim_certs_dir }}"
+      register: certs_dir_stat
+
+    - name: Create Security Certs directory if missing
+      ansible.builtin.file:
+        path: "{{ oim_certs_dir }}"
+        state: directory
+        mode: "{{ dir_mode }}"
+      when: not certs_dir_stat.stat.exists

--- a/security/roles/ldap_server/vars/main.yml
+++ b/security/roles/ldap_server/vars/main.yml
@@ -19,6 +19,8 @@ ldaptoolbox_olcPasswordHash: "{SHA}" # noqa var-naming
 openldap_configuration_mode: "0600"
 openldap_config_permissions: "0600"
 openldap_cert_permissions: "0644"
+oim_certs_dir: "/opt/omnia/security/certs/"
+dir_mode: "0755"
 
 # Usage: set_domain.yml
 openldap_config_dest_dir: "/opt/ldap"

--- a/security/roles/ldap_server/vars/redhat.yml
+++ b/security/roles/ldap_server/vars/redhat.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 ---
 
+# Usage: ldap_prereq_redHat.yml
 tls_cert_path: "/etc/openldap/certs/"
 tls_cert_source: "/etc/pki/tls/certs"
 rhel_cert_file: "ldapserver.crt"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Security Playbook can configure ldap client on OIM HA nodes through these changes

### Description of the Solution
Certs not getting created on NFS share and were stored on OIM node. Not accessible from HA node.

### Suggested Reviewers
@suman-square @Kratika-P @Milisha-Gupta @Manasa-Hemmanur @priti-parate @nethramg @abhishek-sa1

