### PR TITLE
Refine telemetry status messages to indicate latest run context

### DIFF
--- a/telemetry/roles/idrac_telemetry/vars/main.yml
+++ b/telemetry/roles/idrac_telemetry/vars/main.yml
@@ -76,8 +76,8 @@ telemetry_report_sn: |
     - {{ item }}
   {% endfor %}
 
-  IPs with Telemetry Initiated: {{ telemetry_idrac_count }}
-  IPs List (Telemetry Activated):
+  IPs with Telemetry Initiated in latest run: {{ telemetry_idrac_count }}
+  IPs List (Telemetry Activated in latest run):
   {% for item in telemetry_idrac %}
     - {{ item }}
   {% endfor %}


### PR DESCRIPTION
### Issues Resolved by this Pull Request
This pull request resolves an inconsistency in the telemetry report formatting between OIM and SVC node sections.
Previously, the SVC node section used generic labels for telemetry data, which did not align with the "latest run" context used in the OIM section.
This could cause confusion when comparing telemetry statuses across different node groups.

The fix ensures both sections now follow a consistent format, improving report clarity and user understanding.


### Description of the Solution
Standardized telemetry report format across OIM and SVC node sections by aligning field names to clearly indicate the latest run context.

### Suggested Reviewers
@abhishek-sa1 @priti-parate @nethramg please review
