### PR TITLE
Add input validation for service_k8s roles and package presence

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -66,9 +66,13 @@ SERVICE_NODE_ENTRY_MISSING_ROLES_CONFIG_MSG = ("The role service_node defined in
     " but service_node entry missing in sofware_config.json, "
     "Please rerun local repo with service_node entry in software_config.json "
     "to deploy service nodes successfully")
+SERVICE_K8S_ENTRY_MISSING_SOFTWARE_CONFIG_MSG = ("The role service_kube_control_plane is defined in roles_config.yml, "
+    "but the service_k8s package entry is missing in software_config.json. "
+    "To deploy Kubernetes in the service_k8s cluster, the package must be added to software_config.json.")
 SERVICE_NODE_ENTRY_INVALID_ROLES_CONFIG_MSG = ("The 'service_node' role defined in roles_config.yml"
     " is not currently supported and is reserved for future use. Please remove or update this role"
     " to avoid configuration errors.")
+
 # provision_config.yml
 DEFAULT_LEASE_TIME_FAIL_MSG = "Please provide a valid default_lease_time."
 TIMEZONE_FAIL_MSG = ("Unsupported Timezone. Please check the timezone.txt file "

--- a/common/library/module_utils/input_validation/validation_flows/roles_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/roles_validation.py
@@ -209,6 +209,23 @@ def validate_service_node_in_software_config(input_file_path):
         return True
     return False
 
+# Below function will be used to validate service_k8s entry in software_config
+def validate_service_k8s_in_software_config(input_file_path):
+    """
+    verifies service_k8s entry present in sofwate config.json
+
+    Returns:
+        True if service_k8s entry is present
+        False if no entry
+    """
+    # verify service_k8s  with sofwate config json
+    software_config_file_path = create_file_path(input_file_path, file_names["software_config"])
+    software_config_json = json.load(open(software_config_file_path, "r"))
+    softwares = software_config_json["softwares"]
+    if validation_utils.contains_software(softwares, "service_k8s"):
+        return True
+    return False
+
 # Validate that service cluster K8s roles do not overlap with non-service k8s roles
 def validate_cluster_name_overlap(roles, groups):
     """
@@ -404,6 +421,27 @@ def validate_roles_config(
                                     None,
                                     f"An error occurred while validating software_config.json: {str(e)}"))
 
+    # Role service_kube_control_plane is defined in roles_config.yml,
+    # verify service_k8s package entry is present in software_config.json
+    # If no entry is present, then fail the input validator
+    if validation_utils.key_value_exists(roles, name, "service_kube_control_plane"):
+        try:
+            if not validate_service_k8s_in_software_config(input_file_path):
+                errors.append(
+                    create_error_msg(
+                        "software_config.json",
+                        None,
+                        en_us_validation_msg.SERVICE_K8S_ENTRY_MISSING_SOFTWARE_CONFIG_MSG
+                    )
+                )
+        except Exception as e:
+            errors.append(
+                create_error_msg(
+                    "software_config.json",
+                    None,
+                    f"An error occurred while validating software_config.json: {str(e)}"
+                )
+            )
 
     if len(errors) <= 0:
         # List of groups which need to have their resource_mgr_id set


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
This pull request addresses an issue where input validation was incorrectly passing when the user defined service_k8s cluster roles in the roles_config.yml but did not provide the service_k8s package in the software_config.json.

The solution ensures that input validation fails if the user has defined service_kube_control_plane in the roles_config.yml but did not include the service_k8s package in the software_config.json.

### Suggested Reviewers
@abhishek-sa1 @nethramg @priti-parate Please review
