### PR TITLE
input_validation for consistent cluster name

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -20,6 +20,13 @@ These messages are used to provide user-friendly error messages during configura
 
 MISSING_CLUSTER_NAME_MSG = "Cluster name is mandatory for all kubernetes roles."
 CLUSTER_NAME_OVERLAP_MSG = "The cluster name '{0}' cannot be shared between service and compute Kubernetes roles."
+CLUSTER_NAME_INCONSISTENT_MSG = (
+    "Inconsistent 'cluster_name' values found across Service or Compute Kubernetes roles. "
+    "Each of the following role sets must use the same 'cluster_name': "
+    "[service_kube_control_plane, service_kube_node, service_etcd] and "
+    "[kube_control_plane, kube_node, etcd].")
+CLUSTER_ROLE_MISSING_MSG = (
+    "Cluster '{0}' is missing the following required Kubernetes roles: {1}.")
 MAX_NUMBER_OF_ROLES_MSG = "A max of 100 roles can be supported."
 MIN_NUMBER_OF_GROUPS_MSG = "At least 1 group is required."
 MIN_NUMBER_OF_ROLES_MSG = "At least 1 role is required."

--- a/examples/rhel_software_config.json
+++ b/examples/rhel_software_config.json
@@ -7,7 +7,6 @@
         {"name": "amdgpu", "version": "6.3.1"},
         {"name": "cuda", "version": "12.8.0"},
         {"name": "ofed", "version": "24.10-1.1.4.0"},
-        {"name": "service_node" },
         {"name": "freeipa"},
         {"name": "openldap"},
         {"name": "secure_login_node"},

--- a/examples/software_config_template/template_rhel_9.6_software_config.json
+++ b/examples/software_config_template/template_rhel_9.6_software_config.json
@@ -6,7 +6,6 @@
         {"name": "amdgpu", "version": "6.3.1"},
         {"name": "cuda", "version": "12.8.0"},
         {"name": "ofed", "version": "24.10-1.1.4.0"},
-        {"name": "service_node" },
         {"name": "freeipa"},
         {"name": "openldap"},
         {"name": "secure_login_node"},


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
This pull request introduces validation logic to ensure that all Kubernetes roles belonging to the same cluster (either service or compute) share a consistent cluster_name. It also verifies that each cluster includes all required roles:

For service clusters: service_kube_control_plane, service_kube_node, and service_etcd
For compute clusters: kube_control_plane, kube_node, and etcd
If any roles are missing or if inconsistent cluster names are detected within a role set, appropriate error messages are generated. This improves input validation accuracy.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
