### PR TITLE
Defect-fix: omnia_startup.sh failed to bring up omnia_core container

### DIFF
--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -600,6 +600,41 @@ validate_oim() {
     echo -e "${GREEN} Podman socket has been enabled and started.${NC}"
 }
 
+# Checks if the required directories for Omnia are present.
+# This function iterates over a list of required directories and checks if each one exists.
+# Returns: None (exits the script if a directory is not found)
+check_required_directories() {
+    required_paths=(
+        "$omnia_path/omnia"
+        "$omnia_path/omnia/ssh_config/.ssh"
+        "$omnia_path/omnia/log/core/container"
+        "$omnia_path/omnia/hosts"
+        "$omnia_path/omnia/pulp/pulp_ha"
+    )
+
+    missing_paths=()
+
+    for path in "${required_paths[@]}"; do
+        if [ ! -e "$path" ]; then  # Checks both files and directories
+            missing_paths+=("$path")
+        fi
+    done
+
+    if [ "${#missing_paths[@]}" -ne 0 ]; then
+        echo -e "${RED}Error: The following required files or directories are missing:${NC}"
+        echo -e "${RED}${missing_paths[*]}${NC}"
+        echo -e "User can not Retain Existing configuration"
+        echo
+        echo -e "${YELLOW}Instructions:${NC}"
+        echo -e "${YELLOW}* Backup any existing files if required${NC}"
+        echo -e "${YELLOW}* Run ./omnia_startup.sh and choose:${NC}"
+        echo -e "${YELLOW}    Options:${NC}"
+        echo -e "${YELLOW}      -> Reinstall the container${NC}"
+        echo -e "${YELLOW}      -> Overwrite and create new configuration${NC}"
+        exit 1
+    fi
+}
+
 # Sets up the Omnia core container.
 # This function pulls the Omnia core Docker image and runs the container.
 # It defines the container options and runs the container.
@@ -852,6 +887,7 @@ main() {
                 # If the user wants to retain existing configuration, call the remove_container function
                 if [ "$choice" = "1" ]; then
                     fetch_config
+                    check_required_directories
                     remove_container
                     setup_container
                     init_ssh_config

--- a/omnia_startup.sh
+++ b/omnia_startup.sh
@@ -601,8 +601,7 @@ validate_oim() {
 }
 
 # Checks if the required directories for Omnia are present.
-# This function iterates over a list of required directories and checks if each one exists.
-# Returns: None (exits the script if a directory is not found)
+# This function iterates over a list of required directories/files and checks if each one exists.
 check_required_directories() {
     required_paths=(
         "$omnia_path/omnia"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
omnia_startup.sh failed to bring up omnia_core container when mount files or directories are missing in the existing configuration, because of which the omnia_core container creation fails.

Fixes #
Added a block to check if all mount directories or file exists, when user selecting retain existing configuration option

### Suggested Reviewers
@abhishek-sa1 @priti-parate @Aditya-DP @Milisha-Gupta @nethramg 