### PR TITLE
removed multiple login failure check and message

### DIFF
--- a/utils/roles/inventory_validation/tasks/slurm_validations.yml
+++ b/utils/roles/inventory_validation/tasks/slurm_validations.yml
@@ -43,7 +43,7 @@
      login_node_required: true
   when:
      - groups['login_node'] is defined
-     - "groups['login_node'] | length | int == 1"
+     - "groups['login_node'] | length | int >= 1"
 
 - name: Warning when login_node not provided
   ansible.builtin.pause:

--- a/utils/roles/inventory_validation/tasks/slurm_validations.yml
+++ b/utils/roles/inventory_validation/tasks/slurm_validations.yml
@@ -45,13 +45,6 @@
      - groups['login_node'] is defined
      - "groups['login_node'] | length | int == 1"
 
-- name: Fail when more than 1 login node provided
-  ansible.builtin.fail:
-     msg: "{{ multiple_login_node_fail_msg }}"
-  when:
-     - groups['login_node'] is defined
-     - "groups['login_node'] | length | int > 1"
-
 - name: Warning when login_node not provided
   ansible.builtin.pause:
      seconds: "{{ warning_wait_time }}"

--- a/utils/roles/inventory_validation/vars/main.yml
+++ b/utils/roles/inventory_validation/vars/main.yml
@@ -91,7 +91,6 @@ unreachable_slurm_control_node_fail_msg: |
   Re-run playbook with reachable slurm_control_node."
 slurm_control_node_in_login_fail_msg: "Failed. Node mentioned in slurm_control_node group should not be present in login_node group"
 slurm_control_node_in_node_fail_msg: "Failed. Node mentioned in slurm_control_node group should not be present in slurm_node group"
-multiple_login_node_fail_msg: "Failed. Currently only one login node supported in inventory"
 login_node_warning_msg: |
   "[WARNING] login_node group with ip for login_node not present in the inventory.
   Proceeding execution with provided nodes"


### PR DESCRIPTION
In order to support multiple login_nodes, removed the failure from validation when multiple login_nodes are configured
