### PR TITLE
Enhance iDRAC Pod Assignment & Add Dynamic Telemetry Grouping

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install Ansible and Ansible Lint
         run: |

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Install Ansible and Ansible Lint
         run: |

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Install Ansible and Ansible Lint
         run: |
-          python --version
           python -m pip install --upgrade pip
           pip install ansible
 

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -34,6 +34,6 @@ jobs:
           ansible-galaxy collection install -r .config/requirements.yml --force
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@latest
         with:
           args: --config=.config/ansible-lint.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install Ansible and Ansible Lint
         run: |
+          python --version
           python -m pip install --upgrade pip
           pip install ansible
 
@@ -34,6 +35,6 @@ jobs:
           ansible-galaxy collection install -r .config/requirements.yml --force
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@latest
+        uses: ansible/ansible-lint@main
         with:
           args: --config=.config/ansible-lint.yml

--- a/common/library/modules/get_service_cluster_info.py
+++ b/common/library/modules/get_service_cluster_info.py
@@ -50,7 +50,8 @@ def get_service_cluster_node_details():
             'admin_ip': admin_ip,
             'service_tag': service_tag,
             'node': node,
-            'cluster_name': cluster_name
+            'cluster_name': cluster_name,
+            'role': role
         }
 
         data[service_tag]['parent_status'] = 'service_kube_control_plane' in role

--- a/telemetry/roles/idrac_telemetry/tasks/main.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/main.yml
@@ -18,6 +18,8 @@
   block:
     - name: Collect iDRAC IP and initiate telemetry collection
       ansible.builtin.include_tasks: initiate_telemetry.yml
+      when: not hostvars['localhost']['federated_idrac_telemetry_collection']
 
     - name: Generete telemetry report
       ansible.builtin.include_tasks: create_telemetry_report.yml
+      when: not hostvars['localhost']['federated_idrac_telemetry_collection']

--- a/telemetry/roles/service_k8s_telemetry/tasks/update_metadata_file.yml
+++ b/telemetry/roles/service_k8s_telemetry/tasks/update_metadata_file.yml
@@ -31,17 +31,43 @@
 
 - name: Get service cluster node details
   ansible.builtin.set_fact:
-    kube_cp_node: "{{ service_cluster_metadata | dict2items | selectattr('value.child_groups', 'undefined') | list }}"
-    kube_compute_nodes: "{{ service_cluster_metadata | dict2items | selectattr('value.child_groups', 'defined') | list }}"
+    kube_cp_node: >-
+      {{ service_cluster_metadata | dict2items
+         | selectattr('value.role', 'search', '(^|,)service_kube_control_plane(,|$)')
+         | list }}
+    kube_compute_nodes: >-
+      {{ service_cluster_metadata | dict2items
+         | rejectattr('value.role', 'search', '(^|,)service_kube_control_plane(,|$)')
+         | list }}
 
-- name: Build updated metadata with idrac telemetry pods
+- name: Identify unassigned service nodes and idrac-telemetry pods
   ansible.builtin.set_fact:
-    updated_metadata_items: "{{ updated_metadata_items | default([]) + [ { item.0.key: item.0.value | combine({ 'idrac_podname': item.1 }) } ] }}"
-  loop: "{{ (kube_cp_node + kube_compute_nodes) | zip(idrac_telemetry_pods) | list }}"
+    unassigned_nodes: >-
+      {{ (kube_cp_node + kube_compute_nodes)
+         | rejectattr('value.idrac_podname', 'defined')
+         | list }}
+    assigned_pods: >-
+      {{ (kube_cp_node + kube_compute_nodes)
+         | map(attribute='value.idrac_podname')
+         | select('defined') | list | default([]) }}
 
-- name: Append pod details in service_cluster metadata
+- name: Identify unassigned telemetry pods
   ansible.builtin.set_fact:
-    service_cluster_metadata: "{{ service_cluster_metadata | combine(updated_metadata_items | combine, recursive=True) }}"
+    unassigned_pods: >-
+      {{ idrac_telemetry_pods | difference(assigned_pods) }}
+
+- name: Build new pod assignments for unassigned nodes
+  ansible.builtin.set_fact:
+    new_metadata_items: "{{ new_metadata_items | default([]) + [
+        {
+          item.0.key: item.0.value | combine({ 'idrac_podname': item.1 })
+        }
+      ] }}"
+  loop: "{{ unassigned_nodes | zip(unassigned_pods) | list }}"
+
+- name: Append new pod details in service_cluster metadata
+  ansible.builtin.set_fact:
+    service_cluster_metadata: "{{ service_cluster_metadata | combine(new_metadata_items | combine, recursive=True) }}"
 
 - name: Update service_cluster metadata file
   ansible.builtin.copy:

--- a/telemetry/roles/service_k8s_telemetry/templates/idrac_telemetry_statefulset.yml.j2
+++ b/telemetry/roles/service_k8s_telemetry/templates/idrac_telemetry_statefulset.yml.j2
@@ -42,6 +42,16 @@ spec:
           hostnames:
             - "mysqldb"
 
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 5
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 5
+
       containers:
         - name: mysqldb
           image: {{ mysql_image }}
@@ -132,7 +142,7 @@ spec:
     - metadata:
         name: mysqldb-pvc
       spec:
-        accessModes: ["ReadWriteOnce"]
+        accessModes: ["ReadWriteMany"]
         resources:
           requests:
             storage: {{ mysqldb_storage }}

--- a/telemetry/roles/telemetry_validation/tasks/add_host_goups.yml
+++ b/telemetry/roles/telemetry_validation/tasks/add_host_goups.yml
@@ -72,3 +72,10 @@
     groups: "active_oim_node"
   when:
     - enable_oim_ha
+
+- name: Create telemetry group
+  ansible.builtin.add_host:
+    hostname: "{{ item }}"
+    groups: "{{ telemetry_host_group }}"
+    ansible_connection: "{{ 'local' if item == 'localhost' else 'ssh' }}"
+  loop: "{{ telemetry_host }}"

--- a/telemetry/roles/telemetry_validation/vars/main.yml
+++ b/telemetry/roles/telemetry_validation/vars/main.yml
@@ -117,6 +117,12 @@ invalid_parent_tags_message: |
   If service nodes are not provisioned or compute node provisioning not initiated,
   please run discovery_provision.yml to provision service nodes and compute nodes from service nodes.
   And then run `telemetry.yml` playbook again.
+telemetry_host_group: "telemetry_group"
+telemetry_host: >-
+  {{ groups['kube_control_plane']
+     if federated_idrac_telemetry_collection | default(false)
+     else ['localhost']
+  }}
 
 # Usage: include_high_availability_config.yml
 high_availability_config_path: "{{ input_project_dir }}/high_availability_config.yml"

--- a/telemetry/telemetry.yml
+++ b/telemetry/telemetry.yml
@@ -168,8 +168,7 @@
         name: k8s_prometheus
 
 - name: Enable idrac telemetry in OIM
-  hosts: localhost
-  connection: local
+  hosts: telemetry_group
   gather_facts: false
   tasks:
     - name: Enable idrac telemetry
@@ -186,6 +185,7 @@
         name: idrac_telemetry
         tasks_from: trigger_telemetry_collection.yml
       when:
+        - not hostvars['localhost']['federated_idrac_telemetry_collection']
         - hostvars['localhost']['telemetry_idrac'] is defined
         - (hostvars['localhost']['telemetry_idrac'] | length > 0)
 
@@ -262,7 +262,9 @@
     - name: Telemetry Report Overview
       ansible.builtin.debug:
         msg: "{{ telemetry_report.splitlines() }}"
-      when: hostvars['localhost']['idrac_telemetry_support']
+      when: 
+        - hostvars['localhost']['idrac_telemetry_support']
+        - not hostvars['localhost']['federated_idrac_telemetry_collection']
 
 - name: Detailed Telemetry Report
   hosts: localhost
@@ -274,4 +276,6 @@
     - name: Detailed Telemetry Report
       ansible.builtin.debug:
         msg: "Check the file at {{ telemetry_report_path_oim }} in omnia_core container for detailed telemetry report."
-      when: hostvars['localhost']['idrac_telemetry_support']
+      when: 
+        - hostvars['localhost']['idrac_telemetry_support']
+        - not hostvars['localhost']['federated_idrac_telemetry_collection']

--- a/telemetry/telemetry.yml
+++ b/telemetry/telemetry.yml
@@ -262,7 +262,7 @@
     - name: Telemetry Report Overview
       ansible.builtin.debug:
         msg: "{{ telemetry_report.splitlines() }}"
-      when: 
+      when:
         - hostvars['localhost']['idrac_telemetry_support']
         - not hostvars['localhost']['federated_idrac_telemetry_collection']
 
@@ -276,6 +276,6 @@
     - name: Detailed Telemetry Report
       ansible.builtin.debug:
         msg: "Check the file at {{ telemetry_report_path_oim }} in omnia_core container for detailed telemetry report."
-      when: 
+      when:
         - hostvars['localhost']['idrac_telemetry_support']
         - not hostvars['localhost']['federated_idrac_telemetry_collection']


### PR DESCRIPTION
Pod Assignment Stability:
Existing idrac_podname mappings are now preserved across runs, ensuring consistent pod-node bindings.

Selective Assignment:
Only unassigned service nodes receive new iDRAC pods, making the system more idempotent and scalable.

Safe First-Time Deployment:
Handled edge cases where metadata or pod assignments are initially empty, avoiding task failures.

Dynamic Inventory Integration:
Added a add_host task to dynamically group telemetry nodes, supporting flexible role targeting and orchestration.

Minimal Metadata Overwrites:
Metadata updates are cleanly merged, preventing overwrites of unrelated keys.

### Suggested Reviewers
@abhishek-sa1 @nethramg @priti-parate 
