### PR TITLE
Enhance Kubernetes StatefulSet configurations for idrac and kafka templates

### DIFF
--- a/telemetry/roles/service_k8s_telemetry/templates/idrac_telemetry_statefulset.yml.j2
+++ b/telemetry/roles/service_k8s_telemetry/templates/idrac_telemetry_statefulset.yml.j2
@@ -42,6 +42,7 @@ spec:
           hostnames:
             - "mysqldb"
 
+      terminationGracePeriodSeconds: 3
       tolerations:
       - effect: NoExecute
         key: node.kubernetes.io/not-ready
@@ -59,6 +60,10 @@ spec:
           volumeMounts:
             - name: mysqldb-pvc
               mountPath: /var/lib/mysql/
+          lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sh", "-c", "mysqladmin shutdown -uroot -p${MYSQL_ROOT_PASSWORD}"]
           env:
             - name: MYSQL_DATABASE
               value: {{ mysqldb_name }}

--- a/telemetry/roles/service_k8s_telemetry/templates/kafka-statefulset.yaml.j2
+++ b/telemetry/roles/service_k8s_telemetry/templates/kafka-statefulset.yaml.j2
@@ -46,10 +46,22 @@ spec:
                       values:
                         - {{ kafka.app_name }}
                 topologyKey: "kubernetes.io/hostname"
-      tolerations:
-        - key: "node-role.kubernetes.io/control-plane"
-          operator: "Exists"
-          effect: "NoSchedule"
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoExecute
+            tolerationSeconds: 5
+          - key: node.kubernetes.io/not-ready
+            operator: Exists
+            effect: NoExecute
+            tolerationSeconds: 5
+          - key: node.kubernetes.io/unreachable
+            operator: Exists
+            effect: NoExecute
+            tolerationSeconds: 5
       containers:
         - name: {{ kafka.container_name }}
           image: {{ kafka.image }}


### PR DESCRIPTION
- Added terminationGracePeriodSeconds to idrac telemetry StatefulSet.
- Implemented preStop lifecycle hook for graceful shutdown in idrac telemetry.
- Updated tolerations in kafka StatefulSet to include NoExecute effects with tolerationSeconds.

### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
