### PR TITLE
Fix incorrect network_gateway validation

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/validation_utils.py
+++ b/common/library/module_utils/input_validation/common_utils/validation_utils.py
@@ -483,6 +483,22 @@ def key_value_exists(list_of_dicts, key, value) -> bool:
             return True
     return False
 
+def validate_ipv4(ip: str) -> bool:
+    """
+    Validates if the given IP is a valid IPv4 address.
+
+    Args:
+        ip (str): The given IP address to be validated
+
+    Returns:
+        bool: True if valid IPv4 address, False otherwise.
+    """
+    try:
+        ipaddress.IPv4Address(ip)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
 def validate_ipv4_range(ip_range) -> bool:
     """
     Validates if the given IP range is a valid IPv4 range.

--- a/common/library/module_utils/input_validation/validation_flows/provision_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/provision_validation.py
@@ -194,7 +194,7 @@ def _validate_admin_network(network):
     # Validate network gateway
     if "network_gateway" in admin_net and admin_net["network_gateway"]:
         gateway = admin_net["network_gateway"]
-        if not validation_utils.validate_ipv4_range(gateway):
+        if not validation_utils.validate_ipv4(gateway):
             errors.append(
                 create_error_msg(
                     "admin_network.network_gateway",
@@ -252,7 +252,7 @@ def _validate_bmc_network(network):
     # Validate network gateway
     if bmc_net.get("network_gateway"):
         gateway = bmc_net["network_gateway"]
-        if not validation_utils.validate_ipv4_range(gateway):
+        if not validation_utils.validate_ipv4(gateway):
             errors.append(
                 create_error_msg(
                     "bmc_network.network_gateway",


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
Previously, the validation logic for network_gateway incorrectly used the validate_ipv4_range function, which is designed to validate IP ranges in the format "start_ip-end_ip" (e.g., "10.5.0.1-10.5.0.254"). Since network_gateway is expected to be a single IP address (e.g., "10.5.0.11"), passing it to validate_ipv4_range caused a ValueError due to the missing - delimiter, resulting in a failed validation.

To resolve this, a new function validate_ipv4 was introduced.

### Suggested Reviewers
@abhishek-sa1 @priti-parate Please review
