### PR TITLE
Kafka Log segment byte config

### DIFF
--- a/common/library/module_utils/input_validation/schema/telemetry_config.json
+++ b/common/library/module_utils/input_validation/schema/telemetry_config.json
@@ -76,6 +76,9 @@
               "log_retention_bytes": {
                 "type": "integer"
               },
+              "log_segment_bytes": {
+                "type": "integer"
+              },
               "topic_partitions": {
                 "type": "integer",
                 "minimum": 1
@@ -85,6 +88,7 @@
               "persistence_size",
               "log_retention_hours",
               "log_retention_bytes",
+              "log_segment_bytes",
               "topic_partitions"
             ]
           }

--- a/input/telemetry_config.yml
+++ b/input/telemetry_config.yml
@@ -66,7 +66,7 @@ kafka_configurations:
   log_retention_bytes: -1
 
   # The maximum size of Kafka log segments (in bytes) before they are deleted.
-  # Default: 104857600 (1 GB)
+  # Default: 1073741824 (1 GB)
   log_segment_bytes: 1073741824
 
   # The number of partitions for each Kafka topic.

--- a/input/telemetry_config.yml
+++ b/input/telemetry_config.yml
@@ -66,8 +66,8 @@ kafka_configurations:
   log_retention_bytes: -1
 
   # The maximum size of Kafka log segments (in bytes) before they are deleted.
-  # Default: 104857600 (100 MB)
-  log_segment_bytes: 104857600
+  # Default: 104857600 (1 GB)
+  log_segment_bytes: 1073741824
 
   # The number of partitions for each Kafka topic.
   # Increasing this can improve throughput but also increases storage/overhead.

--- a/input/telemetry_config.yml
+++ b/input/telemetry_config.yml
@@ -65,6 +65,10 @@ kafka_configurations:
   # Default: -1 (unlimited)
   log_retention_bytes: -1
 
+  # The maximum size of Kafka log segments (in bytes) before they are deleted.
+  # Default: 104857600 (100 MB)
+  log_segment_bytes: 104857600
+
   # The number of partitions for each Kafka topic.
   # Increasing this can improve throughput but also increases storage/overhead.
   # Default: 1

--- a/telemetry/roles/service_k8s_telemetry/templates/kafka-statefulset.yaml.j2
+++ b/telemetry/roles/service_k8s_telemetry/templates/kafka-statefulset.yaml.j2
@@ -128,6 +128,8 @@ spec:
               value: "/bitnami/kafka/config/certs/kafka.truststore.pem"
             - name: KAFKA_TLS_CLIENT_AUTH
               value: "none"
+            - name: KAFKA_CFG_LOG_SEGMENT_BYTES
+              value: "{{ hostvars['localhost']['kafka_configurations']['log_segment_bytes'] }}"
             - name: KAFKA_CFG_LOG_RETENTION_HOURS
               value: "{{ hostvars['localhost']['kafka_configurations']['log_retention_hours'] }}"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES


### PR DESCRIPTION
## Summary
This PR adds support for configuring Kafka log segment size via environment variables.

## Changes
- Added log_segment_bytes in telemetry input config
- Added `KAFKA_CFG_LOG_SEGMENT_BYTES` to the container environment
- Defaulted to 1GB (1073741824bytes)

## Motivation
Kafka was using the default 1GB segment size, which was too large for our retention policy. Smaller segments allow for more frequent cleanup and better disk usage.
