### PR TITLE
Adding fastapi as lint dependency

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible pylint kubernetes prettytable requests passlib
+          pip install ansible pylint kubernetes prettytable requests passlib fastapi
 
       - name: Get changed Python files (excluding deleted)
         id: changed-files


### PR DESCRIPTION
Using FastAPI in the REST apis but lint is giving error. hence adding into the lint dependencies.