### PR TITLE
Defect fix for LDMS input validation

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -148,6 +148,13 @@ REPO_STORE_PATH_MSG = "Please provide a valid repo_store_path value."
 OMNIA_REPO_URL_MSG = "Repo urls are empty. Please provide a url and corresponding key."
 RHEL_OS_URL_MSG = "is empty. Please provide a rhel_os_url value."
 UBUNTU_OS_URL_MSG = "ubuntu_os_url is empty. Please provide a ubuntu_os_url value."
+LDMS_REQUIRES_SERVICE_K8S_MSG = (
+    "requires service_k8s to be present in the 'softwares' list in software_config.json."
+)
+
+LDMS_REQUIRES_SLURM_MSG = (
+    "requires Slurm package 'slurm_custom' to be present in the 'softwares' list in software_config.json."
+)
 
 # omnia_config.yml
 INVALID_PASSWORD_MSG = ("Provided password is invalid. Password must meet the specified "

--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -151,7 +151,6 @@ UBUNTU_OS_URL_MSG = "ubuntu_os_url is empty. Please provide a ubuntu_os_url valu
 LDMS_REQUIRES_SERVICE_K8S_MSG = (
     "requires service_k8s to be present in the 'softwares' list in software_config.json."
 )
-
 LDMS_REQUIRES_SLURM_MSG = (
     "requires Slurm package 'slurm_custom' to be present in the 'softwares' list in software_config.json."
 )

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -1374,6 +1374,38 @@ def validate_telemetry_config(
                 f"duplicate topics: {', '.join(set(duplicates))}",
                 "Each topic must be defined only once"
             ))
+
+    # Validate ldms_sampler_configurations - fail if it's None or empty array
+    ldms_sampler_configurations = data.get("ldms_sampler_configurations")
+
+    # Fail if ldms_sampler_configurations is None
+    if ldms_sampler_configurations is None:
+        errors.append(create_error_msg(
+            "ldms_sampler_configurations",
+            "null/None",
+            "ldms_sampler_configurations is required and cannot be null. Please provide valid sampler configurations with plugin names."
+        ))
+    # Fail if ldms_sampler_configurations is an empty array
+    elif isinstance(ldms_sampler_configurations, list):
+        if len(ldms_sampler_configurations) == 0:
+            errors.append(create_error_msg(
+                "ldms_sampler_configurations",
+                "empty array []",
+                "ldms_sampler_configurations cannot be an empty array. Please provide at least one valid sampler configuration with plugin names."
+            ))
+        else:
+            # Validate each sampler configuration for empty plugin_name
+            for idx, config in enumerate(ldms_sampler_configurations):
+                if not isinstance(config, dict):
+                    continue
+
+                plugin_name = config.get("plugin_name", "")
+                if not plugin_name or (isinstance(plugin_name, str) and plugin_name.strip() == ""):
+                    errors.append(create_error_msg(
+                        f"ldms_sampler_configurations[{idx}].plugin_name",
+                        f"'{plugin_name}'",
+                        "plugin_name cannot be empty. Must be one of: meminfo, procstat2, vmstat, loadavg, slurm_sampler, procnetdev2"
+                    ))
     
     return errors
 

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -221,7 +221,7 @@ def validate_software_config(
             )
         )
     # Ensure ldms is not configured without a Slurm cluster package in softwares
-    if "ldms" in software_names and not any(sw in software_names for sw in ["slurm"]):
+    if "ldms" in software_names and not any(sw in software_names for sw in ["slurm_custom"]):
         errors.append(
             create_error_msg(
                 "Validation Error: ",

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -1353,7 +1353,7 @@ def validate_telemetry_config(
                     "missing 'idrac' topic",
                     "idrac topic is required when idrac_telemetry_support is true and 'kafka' is in idrac_telemetry_collection_type"
                 ))
-        
+
         # If LDMS software is configured in software_config.json, ldms topic is required
         logger.info(f"Checking LDMS topic requirement - ldms_support_from_software_config: {ldms_support_from_software_config}")
         if ldms_support_from_software_config and 'ldms' not in present_topics:

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -211,6 +211,26 @@ def validate_software_config(
             )
         )
 
+    # Ensure ldms is not configured without service_k8s in softwares
+    if "ldms" in software_names and "service_k8s" not in software_names:
+        errors.append(
+            create_error_msg(
+                "Validation Error: ",
+                "ldms",
+                "requires service_k8s to be present in the 'softwares' list in software_config.json."
+            )
+        )
+
+    # Ensure ldms is not configured without a Slurm cluster package in softwares
+    if "ldms" in software_names and not any(sw in software_names for sw in ["slurm", "slurm_custom"]):
+        errors.append(
+            create_error_msg(
+                "Validation Error: ",
+                "ldms",
+                "requires a Slurm package ('slurm' or 'slurm_custom') to be present in the 'softwares' list in software_config.json."
+            )
+        )
+
     for software_pkg in data['softwares']:
         software = software_pkg['name']
         arch_list = software_pkg.get('arch')
@@ -1354,38 +1374,6 @@ def validate_telemetry_config(
                 f"duplicate topics: {', '.join(set(duplicates))}",
                 "Each topic must be defined only once"
             ))
-    
-    # Validate ldms_sampler_configurations - fail if it's None or empty array
-    ldms_sampler_configurations = data.get("ldms_sampler_configurations")
-    
-    # Fail if ldms_sampler_configurations is None
-    if ldms_sampler_configurations is None:
-        errors.append(create_error_msg(
-            "ldms_sampler_configurations",
-            "null/None",
-            "ldms_sampler_configurations is required and cannot be null. Please provide valid sampler configurations with plugin names."
-        ))
-    # Fail if ldms_sampler_configurations is an empty array
-    elif isinstance(ldms_sampler_configurations, list):
-        if len(ldms_sampler_configurations) == 0:
-            errors.append(create_error_msg(
-                "ldms_sampler_configurations",
-                "empty array []",
-                "ldms_sampler_configurations cannot be an empty array. Please provide at least one valid sampler configuration with plugin names."
-            ))
-        else:
-            # Validate each sampler configuration for empty plugin_name
-            for idx, config in enumerate(ldms_sampler_configurations):
-                if not isinstance(config, dict):
-                    continue
-                
-                plugin_name = config.get("plugin_name", "")
-                if not plugin_name or (isinstance(plugin_name, str) and plugin_name.strip() == ""):
-                    errors.append(create_error_msg(
-                        f"ldms_sampler_configurations[{idx}].plugin_name",
-                        f"'{plugin_name}'",
-                        "plugin_name cannot be empty. Must be one of: meminfo, procstat2, vmstat, loadavg, slurm_sampler, procnetdev2"
-                    ))
     
     return errors
 

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -217,17 +217,16 @@ def validate_software_config(
             create_error_msg(
                 "Validation Error: ",
                 "ldms",
-                "requires service_k8s to be present in the 'softwares' list in software_config.json."
+                en_us_validation_msg.LDMS_REQUIRES_SERVICE_K8S_MSG
             )
         )
-
     # Ensure ldms is not configured without a Slurm cluster package in softwares
-    if "ldms" in software_names and not any(sw in software_names for sw in ["slurm", "slurm_custom"]):
+    if "ldms" in software_names and not any(sw in software_names for sw in ["slurm"]):
         errors.append(
             create_error_msg(
                 "Validation Error: ",
                 "ldms",
-                "requires a Slurm package ('slurm' or 'slurm_custom') to be present in the 'softwares' list in software_config.json."
+                en_us_validation_msg.LDMS_REQUIRES_SLURM_MSG
             )
         )
 


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Add input validation so that ldms in software_config.json  is only allowed when both service_k8s and a Slurm package (slurm or slurm_custom) are also configured, preventing invalid LDMS-only setups.