### PR TITLE
Timezone Fix

### DIFF
--- a/discovery/discovery.yml
+++ b/discovery/discovery.yml
@@ -66,6 +66,15 @@
   roles:
     - discovery_validations
 
+- name: Validate OIM timezone
+  hosts: oim
+  connection: ssh
+  tasks:
+    - name: Validate OIM timezone has not changed
+      ansible.builtin.include_role:
+        name: discovery_validations
+        tasks_from: validate_oim_timezone.yml
+
 - name: Validate discovery parameters
   hosts: oim
   connection: ssh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-common.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-common.yaml.j2
@@ -16,7 +16,7 @@
           permissions: '0755'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             localectl set-locale LANG={{ hostvars['localhost']['language'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -22,7 +22,7 @@
           permissions: '0755'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -22,7 +22,7 @@
           permissions: '0755'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '{{ file_mode_755 }}'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             localectl set-locale LANG={{ hostvars['localhost']['language'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '{{ file_mode_755 }}'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             localectl set-locale LANG={{ hostvars['localhost']['language'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '0755'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '0755'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_node_x86_64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '0755'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -23,7 +23,7 @@
         - path: /usr/local/bin/set-ssh.sh
           permissions: '{{ file_mode_755 }}'
           content: |
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '{{ file_mode_755 }}'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -24,7 +24,7 @@
           permissions: '{{ file_mode_755 }}'
           content: |
             #!/bin/bash
-            timedatectl set-timezone {{ hostvars['localhost']['oim_timezone'] }}
+            timedatectl set-timezone {{ hostvars['oim']['oim_timezone'] }}
             sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
             sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
             sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/50-cloud-init.conf

--- a/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
+++ b/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
@@ -38,22 +38,19 @@
     stored_oim_timezone: "{{ oim_metadata.oim_timezone | default('') }}"
     current_oim_timezone: "{{ current_oim_tz_cmd.stdout | default('') }}"
 
-- name: Warn if OIM timezone changed after omnia_core deployment
-  ansible.builtin.pause:
-    seconds: "{{ pause_time_15 }}"
-    prompt: "{{ oim_timezone_changed_warning_msg }}"
-  when:
-    - stored_oim_timezone | length > 0
-    - current_oim_timezone | length > 0
-    - (stored_oim_timezone | trim | lower)
-      != (current_oim_timezone | trim | lower)
+- name: Handle OIM timezone change
+  block:
+    - name: Warn if OIM timezone changed after omnia_core deployment
+      ansible.builtin.pause:
+        seconds: "{{ pause_time_15 }}"
+        prompt: "{{ oim_timezone_changed_warning_msg }}"
 
-- name: Update OIM metadata timezone if changed
-  ansible.builtin.lineinfile:
-    path: "{{ oim_metadata_file_path }}"
-    regexp: '^oim_timezone:'
-    line: "oim_timezone: {{ current_oim_timezone | trim }}"
-    create: false
+    - name: Update OIM metadata timezone if changed
+      ansible.builtin.lineinfile:
+        path: "{{ oim_metadata_file_path }}"
+        regexp: '^oim_timezone:'
+        line: "oim_timezone: {{ current_oim_timezone | trim }}"
+        create: false
   when:
     - stored_oim_timezone | length > 0
     - current_oim_timezone | length > 0

--- a/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
+++ b/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
@@ -39,10 +39,28 @@
     current_oim_timezone: "{{ current_oim_tz_cmd.stdout | default('') }}"
 
 - name: Warn if OIM timezone changed after omnia_core deployment
-  ansible.builtin.debug:
-    msg: "{{ oim_timezone_changed_warning_msg }}"
+  ansible.builtin.pause:
+    seconds: "{{ pause_time_15 }}"
+    prompt: "{{ oim_timezone_changed_warning_msg }}"
   when:
     - stored_oim_timezone | length > 0
     - current_oim_timezone | length > 0
     - (stored_oim_timezone | trim | lower)
       != (current_oim_timezone | trim | lower)
+
+- name: Update OIM metadata timezone if changed
+  ansible.builtin.lineinfile:
+    path: "{{ oim_metadata_file_path }}"
+    regexp: '^oim_timezone:'
+    line: "oim_timezone: {{ current_oim_timezone | trim }}"
+    create: false
+  when:
+    - stored_oim_timezone | length > 0
+    - current_oim_timezone | length > 0
+    - (stored_oim_timezone | trim | lower)
+      != (current_oim_timezone | trim | lower)
+
+- name: Update OIM metadata vars
+  ansible.builtin.include_vars: "{{ oim_metadata_file_path }}"
+  register: include_oim_metadata
+  no_log: true

--- a/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
+++ b/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
@@ -57,7 +57,6 @@
         line: "oim_timezone: {{ current_oim_timezone | trim }}"
         create: false
 
-
 - name: Update OIM metadata vars
   ansible.builtin.include_vars: "{{ oim_metadata_file_path }}"
   register: include_oim_metadata

--- a/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
+++ b/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
@@ -39,6 +39,11 @@
     current_oim_timezone: "{{ current_oim_tz_cmd.stdout | default('') }}"
 
 - name: Handle OIM timezone change
+  when:
+    - stored_oim_timezone | length > 0
+    - current_oim_timezone | length > 0
+    - (stored_oim_timezone | trim | lower)
+      != (current_oim_timezone | trim | lower)
   block:
     - name: Warn if OIM timezone changed after omnia_core deployment
       ansible.builtin.pause:
@@ -51,11 +56,7 @@
         regexp: '^oim_timezone:'
         line: "oim_timezone: {{ current_oim_timezone | trim }}"
         create: false
-  when:
-    - stored_oim_timezone | length > 0
-    - current_oim_timezone | length > 0
-    - (stored_oim_timezone | trim | lower)
-      != (current_oim_timezone | trim | lower)
+
 
 - name: Update OIM metadata vars
   ansible.builtin.include_vars: "{{ oim_metadata_file_path }}"

--- a/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
+++ b/discovery/roles/discovery_validations/tasks/validate_oim_timezone.yml
@@ -1,0 +1,48 @@
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Get current OIM timezone
+  ansible.builtin.command: >
+    timedatectl show -p Timezone --value
+  register: current_oim_tz_cmd
+  changed_when: false
+  failed_when: false
+
+- name: Read OIM metadata file
+  ansible.builtin.slurp:
+    path: "{{ oim_metadata_file_path }}"
+  register: oim_metadata_raw
+  failed_when: false
+
+- name: Parse OIM metadata YAML
+  ansible.builtin.set_fact:
+    oim_metadata: >-
+      {{ (oim_metadata_raw.content | default('') | b64decode | from_yaml)
+         if oim_metadata_raw is defined and oim_metadata_raw.content is defined
+         else {} }}
+
+- name: Extract stored and current OIM timezone
+  ansible.builtin.set_fact:
+    stored_oim_timezone: "{{ oim_metadata.oim_timezone | default('') }}"
+    current_oim_timezone: "{{ current_oim_tz_cmd.stdout | default('') }}"
+
+- name: Warn if OIM timezone changed after omnia_core deployment
+  ansible.builtin.debug:
+    msg: "{{ oim_timezone_changed_warning_msg }}"
+  when:
+    - stored_oim_timezone | length > 0
+    - current_oim_timezone | length > 0
+    - (stored_oim_timezone | trim | lower)
+      != (current_oim_timezone | trim | lower)

--- a/discovery/roles/discovery_validations/vars/main.yml
+++ b/discovery/roles/discovery_validations/vars/main.yml
@@ -74,6 +74,5 @@ bmc_group_data_filename: "/opt/omnia/telemetry/bmc_group_data.csv"
 # Usage: validate_oim_timezone.yml
 oim_timezone_changed_warning_msg: |
   WARNING: OIM timezone has changed from '{{ stored_oim_timezone }}' to '{{ current_oim_timezone }}' after omnia_core container was deployed.
-  Please change it back to the initial value stored in oim_metadata.yml.
 
 oim_metadata_file_path: "/opt/omnia/.data/oim_metadata.yml"

--- a/discovery/roles/discovery_validations/vars/main.yml
+++ b/discovery/roles/discovery_validations/vars/main.yml
@@ -70,3 +70,10 @@ warning_idrac_telemetry_support_true: |
   Also, ensure that the firmware version is greater than 4 for iDRAC9 or greater than 1 for iDRAC10."
 pause_time_15: 15
 bmc_group_data_filename: "/opt/omnia/telemetry/bmc_group_data.csv"
+
+# Usage: validate_oim_timezone.yml
+oim_timezone_changed_warning_msg: |
+  WARNING: OIM timezone has changed from '{{ stored_oim_timezone }}' to '{{ current_oim_timezone }}' after omnia_core container was deployed.
+  Please change it back to the initial value stored in oim_metadata.yml.
+
+oim_metadata_file_path: "/opt/omnia/.data/oim_metadata.yml"

--- a/discovery/roles/discovery_validations/vars/main.yml
+++ b/discovery/roles/discovery_validations/vars/main.yml
@@ -73,6 +73,10 @@ bmc_group_data_filename: "/opt/omnia/telemetry/bmc_group_data.csv"
 
 # Usage: validate_oim_timezone.yml
 oim_timezone_changed_warning_msg: |
-  WARNING: OIM timezone has changed from '{{ stored_oim_timezone }}' to '{{ current_oim_timezone }}' after omnia_core container was deployed.
+  WARNING: OIM timezone has changed from '{{ stored_oim_timezone }}' to '{{ current_oim_timezone }}'
+  after omnia_core container was deployed. Omnia will now proceed using the UPDATED timezone value
+  and update the metadata accordingly. If this change was not intentional, please revert the
+  OIM host timezone back to the original value, else REPROVISION THE ENTIRE CLUSTER to avoid
+  inconsistent behavior.
 
 oim_metadata_file_path: "/opt/omnia/.data/oim_metadata.yml"


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Detects and surfaces OIM timezone drift between the host and oim_metadata.yml, updating metadata to stay consistent with the current host timezone.
Validates that the timezone matches the OIM host timezone, preventing misconfigured provisioning runs.


### Description of the Solution
Add robust OIM timezone validation and metadata handling: detect host/metadata timezone drift during discovery, warn the user, update oim_metadata.yml to the current timezone, and validate that timezone matches the OIM host to prevent inconsistent deployments.

