### PR TITLE
updated nfs mount point variable for ucx and mpi mount

### DIFF
--- a/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
+++ b/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
@@ -269,3 +269,4 @@
 - name: NFS path for ucx, openmpi and ldms cloud init
   ansible.builtin.set_fact:
     cloud_init_slurm_nfs_path: "{{ nfs_server_ip }}:{{ nfs_server_path }}"
+    client_mount_path: "{{ share_path }}"


### PR DESCRIPTION
### RCA
The variable client_mount_path used to mount in cloud init part of  is part of looping variable used in nfs_client code. so was picking the last nfs block in the storage_config.yml. 

### Resolution
Updated the variable client_mount_path later in slurm_config of discovery.yml while creating nfs directories for slurm
