### PR TITLE
Defect Fix - discovery.yml failed for slurm_config tasks when only service_k8s is enabled in software_config.json

### DIFF
--- a/discovery/roles/slurm_config/tasks/main.yml
+++ b/discovery/roles/slurm_config/tasks/main.yml
@@ -28,6 +28,6 @@
 # This does not consider hierarchy of slurm nodes
 - name: Entering the slurm configuration only if slurm in nodes.yaml
   ansible.builtin.include_tasks: create_slurm_dir.yml
-  when: 
+  when:
     - slurm_support
     - ctld_list or (cmpt_list or login_list or compiler_login_list)

--- a/discovery/roles/slurm_config/tasks/main.yml
+++ b/discovery/roles/slurm_config/tasks/main.yml
@@ -23,8 +23,11 @@
 
 - name: Get the slurm hostnames
   ansible.builtin.include_tasks: read_slurm_hostnames.yml
+  when: slurm_support
 
 # This does not consider hierarchy of slurm nodes
 - name: Entering the slurm configuration only if slurm in nodes.yaml
   ansible.builtin.include_tasks: create_slurm_dir.yml
-  when: ctld_list or (cmpt_list or login_list or compiler_login_list) and slurm_support
+  when: 
+    - slurm_support
+    - ctld_list or (cmpt_list or login_list or compiler_login_list)

--- a/discovery/roles/slurm_config/tasks/read_slurm_hostnames.yml
+++ b/discovery/roles/slurm_config/tasks/read_slurm_hostnames.yml
@@ -65,6 +65,14 @@
                    | selectattr('key', 'match', '^login_compiler_node_')
                    | map(attribute='value') | list | flatten }}"
 
+- name: Fail if Slurm controller list is empty
+  ansible.builtin.fail:
+    msg: "{{ controller_empty_msg }}"
+  when:
+    - ctld_list | length == 0
+
 - name: Extract slurm controller IP
   ansible.builtin.set_fact:
-    controller_ip: "{{ ip_name_map[grouped_nodes.slurm_control_node_x86_64 | first] }}"
+    controller_ip: "{{ ip_name_map[ctld_list | first] }}"
+  when: ctld_list | length > 0
+

--- a/discovery/roles/slurm_config/tasks/read_slurm_hostnames.yml
+++ b/discovery/roles/slurm_config/tasks/read_slurm_hostnames.yml
@@ -75,4 +75,3 @@
   ansible.builtin.set_fact:
     controller_ip: "{{ ip_name_map[ctld_list | first] }}"
   when: ctld_list | length > 0
-

--- a/discovery/roles/slurm_config/vars/main.yml
+++ b/discovery/roles/slurm_config/vars/main.yml
@@ -102,3 +102,4 @@ omnia_run_tags: "{{ hostvars['localhost']['omnia_run_tags'] }}"
 auth_tls_certs_path: "/opt/omnia/auth/tls_certs/ldapserver.crt"
 slurm_installation_type: configless
 pulp_webserver_cert_path: "/opt/omnia/pulp/settings/certs/pulp_webserver.crt"
+controller_empty_msg: "Slurm controller functional group is missing from PXE mapping file. Please update the file and rerun discovery.yml."


### PR DESCRIPTION
This PR addresses fix for the defect -> When only service_k8s is present in software_config.json, discovery.yml was failing for some tasks in slurm_config role.
Added appropriate checks to run slurm-related tasks only when slurm_support is true (slurm_custom is present in software_config)