### PR TITLE
Implement adapter policy module

### DIFF
--- a/automation-suite/poc/milestone-1/catalog_parser/ADAPTER_POLICY_GUIDE.md
+++ b/automation-suite/poc/milestone-1/catalog_parser/ADAPTER_POLICY_GUIDE.md
@@ -1,0 +1,242 @@
+# Adapter Policy Guide
+
+This guide explains how to write the **adapter policy file** (`adapter_policy_default.json`) to generate adapter config JSONs.
+
+The adapter policy file lets you:
+
+- Pull one or more **roles** (top-level keys) from one or more **source JSON files** into a **target JSON file**.
+- Optionally **rename** roles while pulling.
+- Optionally **filter** packages while pulling (currently substring match).
+- Create a **derived role** that contains **common packages** across multiple roles.
+- Remove those common packages from the source roles so packages do not appear twice.
+
+---
+
+## 1. What the generator expects
+
+### 1.1 Source files
+
+The generator reads source files from the `--input-dir` directory, for each architecture/OS/version:
+
+```text
+<input-dir>/<arch>/<os_family>/<os_version>/
+  base_os.json
+  functional_layer.json
+  infrastructure.json
+  miscellaneous.json
+  ...
+```
+
+Each source file is expected to be an object where each top-level key is a **role** or **feature**, e.g. `"K8S Controller"`, `"K8S Worker"`, etc.
+
+Each role has a `packages` list:
+
+```json
+{
+  "K8S Controller": {
+    "packages": [
+      {"package": "kubeadm-v1.31.4-amd64", "type": "tarball", "uri": "..."}
+    ]
+  }
+}
+```
+
+### 1.2 Output files
+
+The mapping adapter writes target files under `--output-dir`:
+
+```text
+<output-dir>/<arch>/<os_family>/<os_version>/
+  service_k8s.json
+  slurm_custom.json
+  default_packages.json
+  ...
+```
+
+Each target file is an object of roles where each role contains a `cluster` list:
+
+```json
+{
+  "service_kube_node": {
+    "cluster": [
+      {"package": "vim", "type": "rpm", "repo_name": "x86_64_appstream"}
+    ]
+  }
+}
+```
+
+---
+
+## 2. Adapter policy file structure
+
+The adapter policy file is a JSON object with this shape:
+
+- `version`: schema version (use `"2.0.0"`)
+- `description`: human-readable
+- `targets`: mapping of **target filename** -> **target specification**
+
+At a high level:
+
+```json
+{
+  "version": "2.0.0",
+  "description": "...",
+  "targets": {
+    "service_k8s.json": {
+      "transform": {"exclude_fields": ["architecture"]},
+      "sources": [ ... ],
+      "derived": [ ... ]
+    }
+  }
+}
+```
+
+---
+
+## 3. Target spec
+
+A target spec describes how to build a single target file.
+
+### 3.1 `transform` (optional)
+
+Applied to all packages written in this target, unless overridden per pull.
+
+Currently supported:
+
+- `exclude_fields`: removes keys from each package object (commonly `architecture`).
+- `rename_fields`: renames keys inside each package object.
+
+### 3.2 `sources` (required)
+
+A list of source specs. Each source spec pulls one or more roles from a single source file.
+
+Each `source` has:
+
+- `source_file`: e.g. `functional_layer.json`
+- `pulls`: list of roles to pull
+
+Each `pull` has:
+
+- `source_key`: the role name in the source file
+- `target_key` (optional): rename the role in the output. If omitted, the role name is unchanged.
+- `filter` (optional): filter packages while pulling
+- `transform` (optional): per-role transform override
+
+### 3.3 `derived` (optional)
+
+Defines derived roles that are computed from roles already pulled into the target.
+
+Currently supported derived operation:
+
+- `extract_common`
+  - Computes packages that appear in `min_occurrences` or more of the `from_keys` roles
+  - Writes them into `target_key`
+  - If `remove_from_sources=true`, those common packages are removed from each role in `from_keys`
+
+---
+
+## 4. Fully worked example: `service_k8s.json`
+
+Goal:
+
+- Pull two roles from `functional_layer.json`
+  - `K8S Controller` -> `service_kube_control_plane`
+  - `K8S Worker` -> `service_kube_node`
+- Derive a new role called `service_k8s` containing packages common to both pulled roles
+- Remove those common packages from `service_kube_control_plane` and `service_kube_node`
+
+```json
+{
+  "version": "2.0.0",
+  "description": "Example mapping: build service_k8s.json from functional_layer.json",
+  "targets": {
+    "service_k8s.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "functional_layer.json",
+          "pulls": [
+            {
+              "source_key": "K8S Controller",
+              "target_key": "service_kube_control_plane"
+            },
+            {
+              "source_key": "K8S Worker",
+              "target_key": "service_kube_node"
+            }
+          ]
+        }
+      ],
+      "derived": [
+        {
+          "target_key": "service_k8s",
+          "operation": {
+            "type": "extract_common",
+            "from_keys": ["service_kube_control_plane", "service_kube_node"],
+            "min_occurrences": 2,
+            "remove_from_sources": true
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Resulting output file (`service_k8s.json`) will contain:
+
+- `service_kube_control_plane`: only control-plane-unique packages
+- `service_kube_node`: only node-unique packages
+- `service_k8s`: the common packages extracted from both
+
+---
+
+## 5. Example: substring filtering (e.g., `nfs.json`)
+
+Goal:
+
+- Pull `Base OS` packages from `base_os.json`
+- Only keep packages whose `package` contains substring `"nfs"`
+
+```json
+{
+  "version": "2.0.0",
+  "description": "Example mapping: build nfs.json from base_os.json",
+  "targets": {
+    "nfs.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "base_os.json",
+          "pulls": [
+            {
+              "source_key": "Base OS",
+              "target_key": "nfs",
+              "filter": {
+                "type": "substring",
+                "field": "package",
+                "values": ["nfs"],
+                "case_sensitive": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+
+## 6. Tips and common mistakes
+
+- **Role names must match exactly**: `source_key` must exist in the source JSON.
+- **Derived roles operate on target role names**: `from_keys` refers to the names after renaming (`target_key`).
+- If you set `remove_from_sources=true`, verify you included the right keys in `from_keys`.
+- Filters apply *before* transforms.

--- a/automation-suite/poc/milestone-1/catalog_parser/adapter.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/adapter.py
@@ -39,10 +39,9 @@ from .generator import (
     _filter_featurelist_for_arch,
     _discover_arch_os_version_from_catalog,
     _package_common_dict,
-    _configure_logging,
     _validate_catalog_and_schema_paths,
 )
-
+from .utils import _configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/automation-suite/poc/milestone-1/catalog_parser/adapter_policy.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/adapter_policy.py
@@ -1,0 +1,549 @@
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter to generate Omnia input JSONs from policy.
+
+Transforms root JSONs from the main directory into target adapter config JSONs
+using a declarative adapter policy file.
+"""
+
+import json
+import os
+import argparse
+import logging
+from typing import Dict, List, Any, Optional, Tuple
+from collections import Counter
+
+from jsonschema import ValidationError, validate
+
+from .utils import load_json_file
+from . import adapter_policy_schema_consts as schema
+
+logger = logging.getLogger(__name__)
+
+_BASE_DIR = os.path.dirname(__file__)
+_DEFAULT_POLICY_PATH = os.path.join(_BASE_DIR, "resources", "adapter_policy_default.json")
+_DEFAULT_SCHEMA_PATH = os.path.join(_BASE_DIR, "resources", "AdapterPolicySchema.json")
+
+
+def validate_policy_config(policy_config: Any, schema_config: Any, policy_path: str, schema_path: str) -> None:
+    """Validate the adapter policy JSON against the schema."""
+    try:
+        validate(instance=policy_config, schema=schema_config)
+    except ValidationError as exc:
+        loc = "/".join(str(p) for p in exc.absolute_path) if exc.absolute_path else "<root>"
+        raise ValueError(
+            "Adapter policy validation failed.\n"
+            f"Policy: {policy_path}\n"
+            f"Schema: {schema_path}\n"
+            f"At: {loc}\n"
+            f"Error: {exc.message}"
+        ) from exc
+
+
+def discover_architectures(input_dir: str) -> List[str]:
+    """Discover available architectures from input directory structure."""
+    archs = []
+    if os.path.isdir(input_dir):
+        for item in os.listdir(input_dir):
+            item_path = os.path.join(input_dir, item)
+            if os.path.isdir(item_path):
+                archs.append(item)
+    return archs
+
+
+def discover_os_versions(input_dir: str, arch: str) -> List[tuple]:
+    """Discover OS families and versions for a given architecture.
+
+    Returns list of (os_family, version) tuples.
+    """
+    results = []
+    arch_path = os.path.join(input_dir, arch)
+    if not os.path.isdir(arch_path):
+        return results
+
+    for os_family in os.listdir(arch_path):
+        os_family_path = os.path.join(arch_path, os_family)
+        if os.path.isdir(os_family_path):
+            for version in os.listdir(os_family_path):
+                version_path = os.path.join(os_family_path, version)
+                if os.path.isdir(version_path):
+                    results.append((os_family, version))
+    return results
+
+
+def _package_key(pkg: Dict) -> Tuple[str, str, str]:
+    """Generate a stable key for a package.
+
+    For v2 derived operations (common package extraction), we want equivalence based on
+    the full package definition except architecture. This avoids collisions for tarballs
+    where repo_name is absent and uri differs.
+    """
+
+    def _hashable(v: Any) -> Any:
+        if isinstance(v, (dict, list)):
+            return json.dumps(v, sort_keys=True)
+        return v
+
+    return tuple(
+        sorted(
+            (k, _hashable(v))
+            for k, v in pkg.items()
+            if k != "architecture"
+        )
+    )
+
+
+def transform_package(pkg: Dict, transform_config: Optional[Dict]) -> Dict:
+    """Apply transformation rules to a package dict (excluding filter)."""
+    if not transform_config:
+        return pkg.copy()
+
+    result = pkg.copy()
+
+    exclude_fields = transform_config.get(schema.EXCLUDE_FIELDS, [])
+    for field in exclude_fields:
+        result.pop(field, None)
+
+    rename_fields = transform_config.get(schema.RENAME_FIELDS, {})
+    for old_name, new_name in rename_fields.items():
+        if old_name in result:
+            result[new_name] = result.pop(old_name)
+
+    return result
+
+
+def apply_substring_filter(
+    packages: List[Dict],
+    filter_config: Dict
+) -> List[Dict]:
+    """Filter packages by substring matching on a specified field."""
+    field = filter_config.get(schema.FIELD, "package")
+    values = filter_config.get(schema.VALUES, [])
+    case_sensitive = filter_config.get(schema.CASE_SENSITIVE, False)
+
+    if not values:
+        return packages
+
+    filtered = []
+    for pkg in packages:
+        field_value = pkg.get(field, "")
+        if not case_sensitive:
+            field_value = field_value.lower()
+            check_values = [v.lower() for v in values]
+        else:
+            check_values = values
+
+        if any(v in field_value for v in check_values):
+            filtered.append(pkg)
+
+    return filtered
+
+
+def compute_common_packages(
+    source_data: Dict,
+    compare_keys: List[str],
+    min_occurrences: int = 2
+) -> Tuple[set, Dict[Tuple, Dict]]:
+    """Compute packages that appear in multiple source keys.
+
+    Returns:
+        - Set of common package keys
+        - Dict mapping package key to package dict
+    """
+    key_counts: Counter = Counter()
+    key_to_pkg: Dict[Tuple, Dict] = {}
+
+    for source_key in compare_keys:
+        if source_key not in source_data:
+            continue
+
+        feature = source_data[source_key]
+        packages = feature.get(schema.PACKAGES, [])
+
+        seen_in_this_key: set = set()
+        for pkg in packages:
+            k = _package_key(pkg)
+            key_to_pkg.setdefault(k, pkg)
+            if k not in seen_in_this_key:
+                seen_in_this_key.add(k)
+                key_counts[k] += 1
+
+    common_keys = {k for k, count in key_counts.items() if count >= min_occurrences}
+    return common_keys, key_to_pkg
+
+
+def apply_extract_common_filter(
+    packages: List[Dict],
+    source_data: Dict,
+    filter_config: Dict
+) -> List[Dict]:
+    """Extract packages that are common across multiple source keys."""
+    compare_keys = filter_config.get(schema.COMPARE_KEYS, [])
+    min_occurrences = filter_config.get(schema.MIN_OCCURRENCES, 2)
+
+    if not compare_keys:
+        return packages
+
+    common_keys, key_to_pkg = compute_common_packages(source_data, compare_keys, min_occurrences)
+
+    # Return common packages in deterministic order
+    result = []
+    seen = set()
+    for k, pkg in key_to_pkg.items():
+        if k in common_keys and k not in seen:
+            seen.add(k)
+            result.append(pkg)
+
+    return result
+
+
+def apply_extract_unique_filter(
+    packages: List[Dict],
+    source_data: Dict,
+    _source_key: str,
+    filter_config: Dict
+) -> List[Dict]:
+    """Extract packages unique to the current source key (not common with others)."""
+    compare_keys = filter_config.get(schema.COMPARE_KEYS, [])
+    min_occurrences = filter_config.get(schema.MIN_OCCURRENCES, 2)
+
+    if not compare_keys:
+        return packages
+
+    common_keys, _ = compute_common_packages(source_data, compare_keys, min_occurrences)
+
+    # Return packages from current source_key that are NOT in common
+    return [pkg for pkg in packages if _package_key(pkg) not in common_keys]
+
+
+def apply_filter(
+    packages: List[Dict],
+    _source_data: Dict,
+    _source_key: str,
+    filter_config: Optional[Dict]
+) -> List[Dict]:
+    """Apply filter based on filter type."""
+    if not filter_config:
+        return packages
+
+    filter_type = filter_config.get(schema.TYPE)
+
+    if filter_type == schema.SUBSTRING_FILTER:
+        return apply_substring_filter(packages, filter_config)
+
+    logger.warning("Unknown/unsupported filter type in v2: %s", filter_type)
+    return packages
+
+
+def merge_transform(base: Optional[Dict], override: Optional[Dict]) -> Optional[Dict]:
+    """Merge two transform dicts where override wins."""
+    if not base and not override:
+        return None
+    if not base:
+        return override
+    if not override:
+        return base
+    merged = base.copy()
+    merged.update(override)
+    return merged
+
+
+def compute_common_keys_from_roles(
+    roles: Dict[str, List[Dict]],
+    from_keys: List[str],
+    min_occurrences: int
+) -> set:
+    """Compute package keys that are common across the given target roles."""
+    key_counts: Counter = Counter()
+    for role_key in from_keys:
+        pkgs = roles.get(role_key, [])
+        seen_in_role: set = set()
+        for pkg in pkgs:
+            k = _package_key(pkg)
+            if k not in seen_in_role:
+                seen_in_role.add(k)
+                key_counts[k] += 1
+    return {k for k, count in key_counts.items() if count >= min_occurrences}
+
+
+def derive_common_role(
+    target_roles: Dict[str, List[Dict]],
+    derived_key: str,
+    from_keys: List[str],
+    min_occurrences: int = 2,
+    remove_from_sources: bool = True
+) -> None:
+    """Derive a common role and optionally remove common packages from source roles."""
+    common_keys = compute_common_keys_from_roles(target_roles, from_keys, min_occurrences)
+
+    common_pkgs: List[Dict] = []
+    seen: set = set()
+    for role_key in from_keys:
+        for pkg in target_roles.get(role_key, []):
+            k = _package_key(pkg)
+            if k in common_keys and k not in seen:
+                seen.add(k)
+                common_pkgs.append(pkg)
+
+    target_roles[derived_key] = common_pkgs
+
+    if remove_from_sources:
+        for role_key in from_keys:
+            target_roles[role_key] = [
+                pkg for pkg in target_roles.get(role_key, [])
+                if _package_key(pkg) not in common_keys
+            ]
+
+
+def check_conditions(
+    conditions: Optional[Dict],
+    arch: str,
+    os_family: str,
+    os_version: str
+) -> bool:
+    """Check if mapping conditions are satisfied."""
+    if not conditions:
+        return True
+
+    if schema.ARCHITECTURES in conditions:
+        if arch not in conditions[schema.ARCHITECTURES]:
+            return False
+
+    if schema.OS_FAMILIES in conditions:
+        if os_family not in conditions[schema.OS_FAMILIES]:
+            return False
+
+    if schema.OS_VERSIONS in conditions:
+        if os_version not in conditions[schema.OS_VERSIONS]:
+            return False
+
+    return True
+
+
+def process_target_spec(
+    target_file: str,
+    target_spec: Dict,
+    source_files: Dict[str, Dict],
+    target_configs: Dict[str, Dict],
+    arch: str,
+    os_family: str,
+    os_version: str
+) -> None:
+    """Build a single target file config using v2 target-centric spec."""
+    conditions = target_spec.get(schema.CONDITIONS)
+    if not check_conditions(conditions, arch, os_family, os_version):
+        logger.debug("Skipping target %s (conditions not met)", target_file)
+        return
+
+    target_level_transform = target_spec.get(schema.TRANSFORM)
+
+    target_roles: Dict[str, List[Dict]] = {}
+
+    for source_spec in target_spec.get(schema.SOURCES, []):
+        source_file = source_spec.get(schema.SOURCE_FILE)
+        if not source_file or source_file not in source_files:
+            logger.debug("Source file %s not loaded/available", source_file)
+            continue
+
+        source_data = source_files[source_file]
+
+        for pull in source_spec.get(schema.PULLS, []):
+            source_key = pull.get(schema.SOURCE_KEY)
+            if not source_key or source_key not in source_data:
+                logger.debug("Source key '%s' not found in %s", source_key, source_file)
+                continue
+
+            target_key = pull.get(schema.TARGET_KEY) or source_key
+            filter_config = pull.get(schema.FILTER)
+            pull_transform = merge_transform(target_level_transform, pull.get(schema.TRANSFORM))
+
+            packages = source_data[source_key].get(schema.PACKAGES, [])
+            packages = apply_filter(packages, source_data, source_key, filter_config)
+            packages = [transform_package(pkg, pull_transform) for pkg in packages]
+
+            target_roles[target_key] = packages
+
+    for derived in target_spec.get(schema.DERIVED, []) or []:
+        derived_key = derived.get(schema.TARGET_KEY)
+        operation = derived.get(schema.OPERATION, {})
+        op_type = operation.get(schema.TYPE)
+        if op_type != schema.EXTRACT_COMMON_OPERATION:
+            logger.warning("Unsupported derived operation type: %s", op_type)
+            continue
+
+        from_keys = operation.get(schema.FROM_KEYS, [])
+        min_occurrences = operation.get(schema.MIN_OCCURRENCES, 2)
+        remove_from_sources = operation.get(schema.REMOVE_FROM_SOURCES, True)
+
+        if derived_key and from_keys:
+            derive_common_role(
+                target_roles=target_roles,
+                derived_key=derived_key,
+                from_keys=from_keys,
+                min_occurrences=min_occurrences,
+                remove_from_sources=remove_from_sources
+            )
+
+    if target_roles:
+        target_configs[target_file] = {
+            role_key: {schema.CLUSTER: pkgs}
+            for role_key, pkgs in target_roles.items()
+        }
+
+
+def write_config_file(file_path: str, config: Dict) -> None:
+    """Write a config JSON file with proper formatting."""
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+    with open(file_path, "w", encoding="utf-8") as out_file:
+        out_file.write("{\n")
+
+        items = list(config.items())
+        for i, (top_key, body) in enumerate(items):
+            out_file.write(f'  "{top_key}": {{\n')
+            out_file.write(f'    "{schema.CLUSTER}": [\n')
+
+            pkgs = body.get(schema.CLUSTER, [])
+            for j, pkg in enumerate(pkgs):
+                line = "      " + json.dumps(pkg, separators=(", ", ": "))
+                if j < len(pkgs) - 1:
+                    line += ","
+                out_file.write(line + "\n")
+
+            out_file.write("    ]\n")
+            out_file.write("  }")
+            if i < len(items) - 1:
+                out_file.write(",\n")
+            else:
+                out_file.write("\n")
+
+        out_file.write("}\n")
+
+
+def generate_configs_from_policy(
+    input_dir: str,
+    output_dir: str,
+    policy_path: str = _DEFAULT_POLICY_PATH,
+    schema_path: str = _DEFAULT_SCHEMA_PATH
+) -> None:
+    """Main function to generate adapter configs using adapter policy.
+
+    Args:
+        input_dir: Path to input directory (e.g., poc/milestone-1/out1/main)
+        output_dir: Path to output directory (e.g., poc/milestone-1/out1/adapter/input/config)
+        policy_path: Path to adapter policy JSON file
+    """
+    policy_config = load_json_file(policy_path)
+    schema_config = load_json_file(schema_path)
+    validate_policy_config(policy_config, schema_config, policy_path=policy_path, schema_path=schema_path)
+    targets = policy_config.get(schema.TARGETS, {})
+
+    logger.info("Loaded %d target(s) from %s", len(targets), policy_path)
+
+    architectures = discover_architectures(input_dir)
+    logger.info("Discovered architectures: %s", architectures)
+
+    for arch in architectures:
+        os_versions = discover_os_versions(input_dir, arch)
+
+        for os_family, version in os_versions:
+            logger.info("Processing: arch=%s, os=%s, version=%s", arch, os_family, version)
+
+            source_dir = os.path.join(input_dir, arch, os_family, version)
+            target_dir = os.path.join(output_dir, arch, os_family, version)
+
+            source_files: Dict[str, Dict] = {}
+            for filename in os.listdir(source_dir):
+                if filename.endswith(".json"):
+                    file_path = os.path.join(source_dir, filename)
+                    source_files[filename] = load_json_file(file_path)
+                    logger.debug("Loaded source file: %s", filename)
+
+            target_configs: Dict[str, Dict] = {}
+
+            for target_file, target_spec in targets.items():
+                process_target_spec(
+                    target_file=target_file,
+                    target_spec=target_spec,
+                    source_files=source_files,
+                    target_configs=target_configs,
+                    arch=arch,
+                    os_family=os_family,
+                    os_version=version
+                )
+
+            for target_file, data in target_configs.items():
+                if data:
+                    file_path = os.path.join(target_dir, target_file)
+                    write_config_file(file_path, data)
+                    logger.info("Written: %s", file_path)
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Generate adapter configs from input JSONs using adapter policy"
+    )
+    parser.add_argument(
+        "--input-dir",
+        required=True,
+        help="Path to input directory containing source JSONs (e.g., out1/main)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Path to output directory for generated configs (e.g., out1/adapter/input/config)"
+    )
+    parser.add_argument(
+        "--policy",
+        default=_DEFAULT_POLICY_PATH,
+        help="Path to adapter policy JSON file"
+    )
+    parser.add_argument(
+        "--schema",
+        default=_DEFAULT_SCHEMA_PATH,
+        help="Path to adapter policy schema JSON file"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level"
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    logger.info("Starting adapter policy generation")
+    logger.info("Input directory: %s", args.input_dir)
+    logger.info("Output directory: %s", args.output_dir)
+    logger.info("Policy file: %s", args.policy)
+
+    generate_configs_from_policy(
+        input_dir=args.input_dir,
+        output_dir=args.output_dir,
+        policy_path=args.policy,
+        schema_path=args.schema
+    )
+
+    logger.info("Adapter config generation completed")
+
+
+if __name__ == "__main__":
+    main()

--- a/automation-suite/poc/milestone-1/catalog_parser/adapter_policy_schema_consts.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/adapter_policy_schema_consts.py
@@ -18,6 +18,9 @@ PACKAGES = "packages"
 TYPE = "type"
 
 SUBSTRING_FILTER = "substring"
+ALLOWLIST_FILTER = "allowlist"
+FIELD_IN_FILTER = "field_in"
+ANY_OF_FILTER = "any_of"
 EXTRACT_COMMON_OPERATION = "extract_common"
 
 CLUSTER = "cluster"
@@ -28,6 +31,7 @@ RENAME_FIELDS = "rename_fields"
 FIELD = "field"
 VALUES = "values"
 CASE_SENSITIVE = "case_sensitive"
+FILTERS = "filters"
 COMPARE_KEYS = "compare_keys"
 
 ARCHITECTURES = "architectures"

--- a/automation-suite/poc/milestone-1/catalog_parser/adapter_policy_schema_consts.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/adapter_policy_schema_consts.py
@@ -1,0 +1,35 @@
+TARGETS = "targets"
+SOURCES = "sources"
+SOURCE_FILE = "source_file"
+PULLS = "pulls"
+SOURCE_KEY = "source_key"
+TARGET_KEY = "target_key"
+FILTER = "filter"
+TRANSFORM = "transform"
+CONDITIONS = "conditions"
+DERIVED = "derived"
+OPERATION = "operation"
+FROM_KEYS = "from_keys"
+MIN_OCCURRENCES = "min_occurrences"
+REMOVE_FROM_SOURCES = "remove_from_sources"
+
+PACKAGES = "packages"
+
+TYPE = "type"
+
+SUBSTRING_FILTER = "substring"
+EXTRACT_COMMON_OPERATION = "extract_common"
+
+CLUSTER = "cluster"
+
+EXCLUDE_FIELDS = "exclude_fields"
+RENAME_FIELDS = "rename_fields"
+
+FIELD = "field"
+VALUES = "values"
+CASE_SENSITIVE = "case_sensitive"
+COMPARE_KEYS = "compare_keys"
+
+ARCHITECTURES = "architectures"
+OS_FAMILIES = "os_families"
+OS_VERSIONS = "os_versions"

--- a/automation-suite/poc/milestone-1/catalog_parser/adapter_policy_schema_consts.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/adapter_policy_schema_consts.py
@@ -1,3 +1,19 @@
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""String constants for adapter policy schema keys."""
+
 TARGETS = "targets"
 SOURCES = "sources"
 SOURCE_FILE = "source_file"

--- a/automation-suite/poc/milestone-1/catalog_parser/generator.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/generator.py
@@ -30,7 +30,7 @@ from jsonschema import ValidationError, validate
 
 from .models import Catalog
 from .parser import ParseCatalog
-from .utils import load_json_file
+from .utils import _configure_logging, load_json_file
 
 logger = logging.getLogger(__name__)
 
@@ -44,30 +44,6 @@ ERROR_CODE_PROCESSING_ERROR = 3
 # This code generates JSON files
 # i.e baseos.json, infrastructure.json, functional_layer.json, miscellaneous.json
 # for a given catalog
-
-def _configure_logging(log_file: Optional[str] = None, log_level: int = logging.INFO) -> None:
-    """Configure root logging for the catalog generator.
-
-    If log_file is provided, logs are written to that file and the directory is
-    created if needed; otherwise logs go to stderr.
-    """
-
-    if log_file:
-        log_dir = os.path.dirname(log_file)
-        if log_dir:
-            os.makedirs(log_dir, exist_ok=True)
-        logging.basicConfig(
-            level=log_level,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            filename=log_file,
-            encoding="utf-8",
-        )
-    else:
-        logging.basicConfig(
-            level=log_level,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        )
-
 
 def _validate_catalog_and_schema_paths(catalog_path: str, schema_path: str) -> None:
     """Validate that the catalog and schema paths exist.

--- a/automation-suite/poc/milestone-1/catalog_parser/resources/AdapterPolicySchema.json
+++ b/automation-suite/poc/milestone-1/catalog_parser/resources/AdapterPolicySchema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "AdapterPolicySchema.json",
+  "title": "Target-Centric Mapping Schema",
+  "description": "Schema defining how to build target config JSON files from one or more source JSON files, including derived roles.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version for future compatibility"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of this mapping configuration"
+    },
+    "architectures": {
+      "type": "array",
+      "description": "List of supported architectures",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "targets": {
+      "type": "object",
+      "description": "Target files to generate (filename -> target spec)",
+      "additionalProperties": {
+        "$ref": "#/definitions/targetSpec"
+      }
+    }
+  },
+  "required": ["version", "targets"],
+  "definitions": {
+    "targetSpec": {
+      "type": "object",
+      "description": "Specification for building a single target file",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "description": "Source files and roles to pull into this target",
+          "items": {
+            "$ref": "#/definitions/sourceSpec"
+          }
+        },
+        "derived": {
+          "type": "array",
+          "description": "Derived roles computed from pulled roles",
+          "items": {
+            "$ref": "#/definitions/derivedSpec"
+          }
+        },
+        "transform": {
+          "$ref": "#/definitions/transform",
+          "description": "Transform applied to all packages in this target (unless overridden per pull)"
+        },
+        "conditions": {
+          "$ref": "#/definitions/conditions",
+          "description": "Optional conditions for when this target applies"
+        }
+      },
+      "required": ["sources"]
+    },
+    "sourceSpec": {
+      "type": "object",
+      "description": "Defines which roles (keys) to pull from a given source file",
+      "properties": {
+        "source_file": {
+          "type": "string",
+          "description": "Input file name (without path, e.g., 'functional_layer.json')"
+        },
+        "pulls": {
+          "type": "array",
+          "description": "Roles to pull from the source file",
+          "items": {
+            "$ref": "#/definitions/pullSpec"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["source_file", "pulls"]
+    },
+    "pullSpec": {
+      "type": "object",
+      "description": "Pull a role from a source file into the target file, optionally renaming and filtering",
+      "properties": {
+        "source_key": {
+          "type": "string",
+          "description": "Role/key in the source file"
+        },
+        "target_key": {
+          "type": "string",
+          "description": "Role/key to write into the target file; defaults to source_key if omitted"
+        },
+        "filter": {
+          "$ref": "#/definitions/filter",
+          "description": "Optional filter for this role"
+        },
+        "transform": {
+          "$ref": "#/definitions/transform",
+          "description": "Optional per-role transform override"
+        }
+      },
+      "required": ["source_key"]
+    },
+    "derivedSpec": {
+      "type": "object",
+      "description": "A derived role definition",
+      "properties": {
+        "target_key": {
+          "type": "string",
+          "description": "Role/key to create in the target file"
+        },
+        "operation": {
+          "$ref": "#/definitions/operation"
+        }
+      },
+      "required": ["target_key", "operation"]
+    },
+    "operation": {
+      "type": "object",
+      "description": "Operation to derive a role and remove common packages from source roles",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["extract_common"],
+          "description": "Currently supported derived operation types"
+        },
+        "from_keys": {
+          "type": "array",
+          "description": "Target roles to compare",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2
+        },
+        "min_occurrences": {
+          "type": "integer",
+          "description": "Minimum occurrences across from_keys to be considered common",
+          "default": 2
+        },
+        "remove_from_sources": {
+          "type": "boolean",
+          "description": "If true, common packages are removed from each role in from_keys",
+          "default": true
+        }
+      },
+      "required": ["type", "from_keys"]
+    },
+    "conditions": {
+      "type": "object",
+      "description": "Conditions that determine when a mapping rule applies",
+      "properties": {
+        "architectures": {
+          "type": "array",
+          "description": "Limit this mapping to specific architectures. If omitted, applies to all.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "os_versions": {
+          "type": "array",
+          "description": "Limit this mapping to specific OS versions (e.g., ['10.0', '9.0'])",
+          "items": {
+            "type": "string"
+          }
+        },
+        "os_families": {
+          "type": "array",
+          "description": "Limit this mapping to specific OS families (e.g., ['rhel', 'ubuntu'])",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "transform": {
+      "type": "object",
+      "description": "Transformation rules to apply when writing package objects",
+      "properties": {
+        "exclude_fields": {
+          "type": "array",
+          "description": "Fields to exclude from package objects",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rename_fields": {
+          "type": "object",
+          "description": "Field renaming map (old_name -> new_name)",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "filter": {
+      "type": "object",
+      "description": "Filter rules to select specific packages from source",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of filter to apply",
+          "enum": ["substring"]
+        },
+        "field": {
+          "type": "string",
+          "description": "Field to apply filter on (for substring filter)",
+          "default": "package"
+        },
+        "values": {
+          "type": "array",
+          "description": "Values to match against (for substring filter)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "case_sensitive": {
+          "type": "boolean",
+          "description": "Whether substring matching is case-sensitive",
+          "default": false
+        }
+      },
+      "required": ["type"]
+    }
+  }
+}

--- a/automation-suite/poc/milestone-1/catalog_parser/resources/AdapterPolicySchema.json
+++ b/automation-suite/poc/milestone-1/catalog_parser/resources/AdapterPolicySchema.json
@@ -201,7 +201,7 @@
         "type": {
           "type": "string",
           "description": "Type of filter to apply",
-          "enum": ["substring"]
+          "enum": ["substring", "allowlist", "field_in", "any_of"]
         },
         "field": {
           "type": "string",
@@ -219,8 +219,22 @@
           "type": "boolean",
           "description": "Whether substring matching is case-sensitive",
           "default": false
+        },
+        "filters": {
+          "type": "array",
+          "description": "Sub-filters for composite any_of filter",
+          "items": {
+            "$ref": "#/definitions/filter"
+          },
+          "minItems": 1
         }
       },
+      "allOf": [
+        {
+          "if": {"properties": {"type": {"const": "any_of"}}},
+          "then": {"required": ["filters"]}
+        }
+      ],
       "required": ["type"]
     }
   }

--- a/automation-suite/poc/milestone-1/catalog_parser/resources/adapter_policy_default.json
+++ b/automation-suite/poc/milestone-1/catalog_parser/resources/adapter_policy_default.json
@@ -1,0 +1,149 @@
+{
+  "version": "2.0.0",
+  "description": "Target-centric mapping spec: pull roles into each target file, then derive common roles and remove duplicates.",
+  "architectures": ["aarch64", "x86_64"],
+  "targets": {
+    "default_packages.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "base_os.json",
+          "pulls": [
+            {"source_key": "Base OS", "target_key": "default_packages"}
+          ]
+        }
+      ]
+    },
+    "nfs.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "base_os.json",
+          "pulls": [
+            {
+              "source_key": "Base OS",
+              "target_key": "nfs",
+              "filter": {"type": "substring", "field": "package", "values": ["nfs"], "case_sensitive": false}
+            }
+          ]
+        }
+      ]
+    },
+    "openldap.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "base_os.json",
+          "pulls": [
+            {
+              "source_key": "Base OS",
+              "target_key": "openldap",
+              "filter": {"type": "substring", "field": "package", "values": ["ldap"], "case_sensitive": false}
+            }
+          ]
+        }
+      ]
+    },
+    "openmpi.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "base_os.json",
+          "pulls": [
+            {
+              "source_key": "Base OS",
+              "target_key": "openmpi",
+              "filter": {"type": "substring", "field": "package", "values": ["openmpi"], "case_sensitive": false}
+            }
+          ]
+        }
+      ]
+    },
+    "service_k8s.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "functional_layer.json",
+          "pulls": [
+            {"source_key": "K8S Controller", "target_key": "service_kube_control_plane"},
+            {"source_key": "K8S Worker", "target_key": "service_kube_node"}
+          ]
+        }
+      ],
+      "derived": [
+        {
+          "target_key": "service_k8s",
+          "operation": {
+            "type": "extract_common",
+            "from_keys": ["service_kube_control_plane", "service_kube_node"],
+            "min_occurrences": 2,
+            "remove_from_sources": true
+          }
+        }
+      ]
+    },
+    "slurm_custom.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "functional_layer.json",
+          "pulls": [
+            {"source_key": "Login Node", "target_key": "login_node"},
+            {"source_key": "Compiler", "target_key": "login_compiler_node"},
+            {"source_key": "Slurm Controller", "target_key": "slurm_control_node"},
+            {"source_key": "Slurm Worker", "target_key": "slurm_node"}
+          ]
+        }
+      ],
+      "derived": [
+        {
+          "target_key": "slurms_custom",
+          "operation": {
+            "type": "extract_common",
+            "from_keys": ["login_node", "login_compiler_node", "slurm_control_node", "slurm_node"],
+            "min_occurrences": 2,
+            "remove_from_sources": true
+          }
+        }
+      ]
+    },
+    "csi_driver_powerscale.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "infrastructure.json",
+          "pulls": [
+            {"source_key": "csi", "target_key": "csi_driver_powerscale"}
+          ]
+        }
+      ]
+    },
+    "miscellaneous.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "miscellaneous.json",
+          "pulls": [
+            {"source_key": "Miscellaneous", "target_key": "miscellaneous"}
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/automation-suite/poc/milestone-1/catalog_parser/resources/adapter_policy_default.json
+++ b/automation-suite/poc/milestone-1/catalog_parser/resources/adapter_policy_default.json
@@ -44,7 +44,29 @@
             {
               "source_key": "Base OS",
               "target_key": "openldap",
-              "filter": {"type": "substring", "field": "package", "values": ["ldap"], "case_sensitive": false}
+              "filter": {
+                "type": "any_of",
+                "filters": [
+                  {
+                    "type": "allowlist",
+                    "field": "package",
+                    "values": ["openldap", "openldap-clients", "openldap-servers"],
+                    "case_sensitive": false
+                  },
+                  {
+                    "type": "field_in",
+                    "field": "feature",
+                    "values": ["openldap"],
+                    "case_sensitive": false
+                  },
+                  {
+                    "type": "substring",
+                    "field": "package",
+                    "values": ["ldap", "openldap", "slapd"],
+                    "case_sensitive": false
+                  }
+                ]
+              }
             }
           ]
         }

--- a/automation-suite/poc/milestone-1/catalog_parser/test_fixtures/adapter_policy_test.json
+++ b/automation-suite/poc/milestone-1/catalog_parser/test_fixtures/adapter_policy_test.json
@@ -1,0 +1,72 @@
+{
+  "version": "2.0.0",
+  "description": "Test fixture for v2 target-centric mapping spec.",
+  "architectures": ["aarch64", "x86_64"],
+  "targets": {
+    "default_packages.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "base_os.json",
+          "pulls": [
+            {"source_key": "Base OS", "target_key": "default_packages"}
+          ]
+        }
+      ]
+    },
+    "service_k8s.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "functional_layer.json",
+          "pulls": [
+            {"source_key": "K8S Controller", "target_key": "service_kube_control_plane"},
+            {"source_key": "K8S Worker", "target_key": "service_kube_node"}
+          ]
+        }
+      ],
+      "derived": [
+        {
+          "target_key": "service_k8s",
+          "operation": {
+            "type": "extract_common",
+            "from_keys": ["service_kube_control_plane", "service_kube_node"],
+            "min_occurrences": 2,
+            "remove_from_sources": true
+          }
+        }
+      ]
+    },
+    "slurm_custom.json": {
+      "transform": {
+        "exclude_fields": ["architecture"]
+      },
+      "sources": [
+        {
+          "source_file": "functional_layer.json",
+          "pulls": [
+            {"source_key": "Login Node", "target_key": "login_node"},
+            {"source_key": "Compiler", "target_key": "login_compiler_node"},
+            {"source_key": "Slurm Controller", "target_key": "slurm_control_node"},
+            {"source_key": "Slurm Worker", "target_key": "slurm_node"}
+          ]
+        }
+      ],
+      "derived": [
+        {
+          "target_key": "slurms_custom",
+          "operation": {
+            "type": "extract_common",
+            "from_keys": ["login_node", "login_compiler_node", "slurm_control_node", "slurm_node"],
+            "min_occurrences": 2,
+            "remove_from_sources": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/automation-suite/poc/milestone-1/catalog_parser/tests/sample.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/tests/sample.py
@@ -23,12 +23,15 @@ import os
 
 from catalog_parser.generator import generate_root_json_from_catalog, get_functional_layer_roles_from_file, get_package_list
 from catalog_parser.adapter import generate_omnia_json_from_catalog
+from catalog_parser.adapter_policy import generate_configs_from_policy
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 CATALOG_PARSER_DIR = os.path.join(BASE_DIR, "")
 CATALOG_PATH = os.path.join(CATALOG_PARSER_DIR, "test_fixtures", "catalog_rhel.json")
 SCHEMA_PATH = os.path.join(CATALOG_PARSER_DIR, "resources", "CatalogSchema.json")
 FUNCTIONAL_LAYER_PATH = os.path.join(CATALOG_PARSER_DIR, "test_fixtures", "functional_layer.json")
+ADAPTER_POLICY_PATH = os.path.join(CATALOG_PARSER_DIR, "resources", "adapter_policy_default.json")
+ADAPTER_POLICY_SCHEMA_PATH = os.path.join(CATALOG_PARSER_DIR, "resources", "AdapterPolicySchema.json")
 
 try:
     generate_root_json_from_catalog(
@@ -49,9 +52,18 @@ try:
         log_level=logging.INFO,
     )
 
+    generate_configs_from_policy(
+        input_dir="out/generator2",
+        output_dir="out/adapter_policy/config2",
+        policy_path=ADAPTER_POLICY_PATH,
+        schema_path=ADAPTER_POLICY_SCHEMA_PATH,
+        configure_logging=True,
+        log_file="logs/adapter_policy.log",
+        log_level=logging.INFO,
+    )
+
     roles = get_functional_layer_roles_from_file(FUNCTIONAL_LAYER_PATH)
     print(f"Functional layer roles: {roles}")
-
 
     # Get packages for a specific role
     result = get_package_list(FUNCTIONAL_LAYER_PATH, role="K8S Controller")

--- a/automation-suite/poc/milestone-1/catalog_parser/tests/test_adapter_policy.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/tests/test_adapter_policy.py
@@ -1,0 +1,634 @@
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for adapter_policy module."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(__file__)
+CATALOG_PARSER_DIR = os.path.dirname(HERE)
+PROJECT_ROOT = os.path.dirname(CATALOG_PARSER_DIR)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from catalog_parser.adapter_policy import (
+    validate_policy_config,
+    discover_architectures,
+    discover_os_versions,
+    transform_package,
+    apply_substring_filter,
+    compute_common_packages,
+    apply_extract_common_filter,
+    apply_extract_unique_filter,
+    apply_filter,
+    merge_transform,
+    compute_common_keys_from_roles,
+    derive_common_role,
+    check_conditions,
+    process_target_spec,
+    write_config_file,
+    generate_configs_from_policy,
+    _DEFAULT_POLICY_PATH,
+    _DEFAULT_SCHEMA_PATH,
+)
+from catalog_parser import adapter_policy_schema_consts as schema
+
+
+class TestValidatePolicyConfig(unittest.TestCase):
+    """Tests for validate_policy_config function."""
+
+    def setUp(self):
+        self.valid_policy = {
+            "version": "2.0.0",
+            "targets": {
+                "test.json": {
+                    "sources": [
+                        {
+                            "source_file": "source.json",
+                            "pulls": [{"source_key": "role1"}]
+                        }
+                    ]
+                }
+            }
+        }
+        self.schema_path = _DEFAULT_SCHEMA_PATH
+        with open(self.schema_path, "r", encoding="utf-8") as f:
+            self.schema_config = json.load(f)
+
+    def test_valid_policy_passes_validation(self):
+        """Valid policy should not raise any exception."""
+        validate_policy_config(
+            self.valid_policy,
+            self.schema_config,
+            policy_path="test_policy.json",
+            schema_path=self.schema_path
+        )
+
+    def test_missing_version_raises_error(self):
+        """Policy missing required 'version' field should raise ValueError."""
+        invalid_policy = {"targets": {}}
+        with self.assertRaises(ValueError) as ctx:
+            validate_policy_config(
+                invalid_policy,
+                self.schema_config,
+                policy_path="test_policy.json",
+                schema_path=self.schema_path
+            )
+        self.assertIn("Adapter policy validation failed", str(ctx.exception))
+        self.assertIn("version", str(ctx.exception))
+
+    def test_missing_targets_raises_error(self):
+        """Policy missing required 'targets' field should raise ValueError."""
+        invalid_policy = {"version": "2.0.0"}
+        with self.assertRaises(ValueError) as ctx:
+            validate_policy_config(
+                invalid_policy,
+                self.schema_config,
+                policy_path="test_policy.json",
+                schema_path=self.schema_path
+            )
+        self.assertIn("Adapter policy validation failed", str(ctx.exception))
+        self.assertIn("targets", str(ctx.exception))
+
+    def test_invalid_target_spec_raises_error(self):
+        """Target spec missing 'sources' should raise ValueError."""
+        invalid_policy = {
+            "version": "2.0.0",
+            "targets": {
+                "test.json": {}
+            }
+        }
+        with self.assertRaises(ValueError) as ctx:
+            validate_policy_config(
+                invalid_policy,
+                self.schema_config,
+                policy_path="test_policy.json",
+                schema_path=self.schema_path
+            )
+        self.assertIn("Adapter policy validation failed", str(ctx.exception))
+
+
+class TestDiscoverArchitectures(unittest.TestCase):
+    """Tests for discover_architectures function."""
+
+    def test_discovers_architecture_directories(self):
+        """Should return list of subdirectory names."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "x86_64"))
+            os.makedirs(os.path.join(tmpdir, "aarch64"))
+            # Create a file (should be ignored)
+            with open(os.path.join(tmpdir, "readme.txt"), "w") as f:
+                f.write("test")
+
+            archs = discover_architectures(tmpdir)
+            self.assertEqual(sorted(archs), ["aarch64", "x86_64"])
+
+    def test_returns_empty_for_nonexistent_dir(self):
+        """Should return empty list for non-existent directory."""
+        archs = discover_architectures("/nonexistent/path")
+        self.assertEqual(archs, [])
+
+    def test_returns_empty_for_empty_dir(self):
+        """Should return empty list for empty directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archs = discover_architectures(tmpdir)
+            self.assertEqual(archs, [])
+
+
+class TestDiscoverOsVersions(unittest.TestCase):
+    """Tests for discover_os_versions function."""
+
+    def test_discovers_os_and_versions(self):
+        """Should return list of (os_family, version) tuples."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "x86_64", "rhel", "9.0"))
+            os.makedirs(os.path.join(tmpdir, "x86_64", "rhel", "8.0"))
+            os.makedirs(os.path.join(tmpdir, "x86_64", "ubuntu", "22.04"))
+
+            results = discover_os_versions(tmpdir, "x86_64")
+            self.assertEqual(len(results), 3)
+            self.assertIn(("rhel", "9.0"), results)
+            self.assertIn(("rhel", "8.0"), results)
+            self.assertIn(("ubuntu", "22.04"), results)
+
+    def test_returns_empty_for_nonexistent_arch(self):
+        """Should return empty list for non-existent architecture."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            results = discover_os_versions(tmpdir, "nonexistent")
+            self.assertEqual(results, [])
+
+
+class TestTransformPackage(unittest.TestCase):
+    """Tests for transform_package function."""
+
+    def test_no_transform_returns_copy(self):
+        """No transform config should return a copy of the package."""
+        pkg = {"name": "test", "version": "1.0"}
+        result = transform_package(pkg, None)
+        self.assertEqual(result, pkg)
+        self.assertIsNot(result, pkg)
+
+    def test_exclude_fields(self):
+        """Should exclude specified fields."""
+        pkg = {"name": "test", "version": "1.0", "architecture": "x86_64"}
+        transform = {schema.EXCLUDE_FIELDS: ["architecture"]}
+        result = transform_package(pkg, transform)
+        self.assertEqual(result, {"name": "test", "version": "1.0"})
+
+    def test_rename_fields(self):
+        """Should rename specified fields."""
+        pkg = {"name": "test", "ver": "1.0"}
+        transform = {schema.RENAME_FIELDS: {"ver": "version"}}
+        result = transform_package(pkg, transform)
+        self.assertEqual(result, {"name": "test", "version": "1.0"})
+
+    def test_exclude_and_rename_combined(self):
+        """Should apply both exclude and rename."""
+        pkg = {"name": "test", "ver": "1.0", "arch": "x86_64"}
+        transform = {
+            schema.EXCLUDE_FIELDS: ["arch"],
+            schema.RENAME_FIELDS: {"ver": "version"}
+        }
+        result = transform_package(pkg, transform)
+        self.assertEqual(result, {"name": "test", "version": "1.0"})
+
+
+class TestApplySubstringFilter(unittest.TestCase):
+    """Tests for apply_substring_filter function."""
+
+    def test_filters_by_substring(self):
+        """Should filter packages by substring match."""
+        packages = [
+            {"package": "kubernetes-client"},
+            {"package": "kubernetes-server"},
+            {"package": "docker-ce"},
+        ]
+        filter_config = {
+            schema.FIELD: "package",
+            schema.VALUES: ["kubernetes"]
+        }
+        result = apply_substring_filter(packages, filter_config)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all("kubernetes" in p["package"] for p in result))
+
+    def test_case_insensitive_by_default(self):
+        """Should be case-insensitive by default."""
+        packages = [
+            {"package": "Kubernetes-Client"},
+            {"package": "docker-ce"},
+        ]
+        filter_config = {
+            schema.FIELD: "package",
+            schema.VALUES: ["kubernetes"]
+        }
+        result = apply_substring_filter(packages, filter_config)
+        self.assertEqual(len(result), 1)
+
+    def test_case_sensitive_when_specified(self):
+        """Should be case-sensitive when specified."""
+        packages = [
+            {"package": "Kubernetes-Client"},
+            {"package": "kubernetes-server"},
+        ]
+        filter_config = {
+            schema.FIELD: "package",
+            schema.VALUES: ["kubernetes"],
+            schema.CASE_SENSITIVE: True
+        }
+        result = apply_substring_filter(packages, filter_config)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["package"], "kubernetes-server")
+
+    def test_empty_values_returns_all(self):
+        """Empty values list should return all packages."""
+        packages = [{"package": "test1"}, {"package": "test2"}]
+        filter_config = {schema.FIELD: "package", schema.VALUES: []}
+        result = apply_substring_filter(packages, filter_config)
+        self.assertEqual(result, packages)
+
+
+class TestComputeCommonPackages(unittest.TestCase):
+    """Tests for compute_common_packages function."""
+
+    def test_finds_common_packages(self):
+        """Should find packages common across multiple keys."""
+        source_data = {
+            "role1": {schema.PACKAGES: [
+                {"name": "common-pkg", "version": "1.0"},
+                {"name": "unique1", "version": "1.0"},
+            ]},
+            "role2": {schema.PACKAGES: [
+                {"name": "common-pkg", "version": "1.0"},
+                {"name": "unique2", "version": "1.0"},
+            ]},
+        }
+        common_keys, key_to_pkg = compute_common_packages(
+            source_data, ["role1", "role2"], min_occurrences=2
+        )
+        self.assertEqual(len(common_keys), 1)
+
+    def test_respects_min_occurrences(self):
+        """Should respect min_occurrences threshold."""
+        source_data = {
+            "role1": {schema.PACKAGES: [{"name": "pkg1"}]},
+            "role2": {schema.PACKAGES: [{"name": "pkg1"}]},
+            "role3": {schema.PACKAGES: [{"name": "pkg2"}]},
+        }
+        common_keys, _ = compute_common_packages(
+            source_data, ["role1", "role2", "role3"], min_occurrences=3
+        )
+        self.assertEqual(len(common_keys), 0)
+
+
+class TestMergeTransform(unittest.TestCase):
+    """Tests for merge_transform function."""
+
+    def test_none_inputs_return_none(self):
+        """Both None should return None."""
+        self.assertIsNone(merge_transform(None, None))
+
+    def test_base_only(self):
+        """Only base should return base."""
+        base = {schema.EXCLUDE_FIELDS: ["arch"]}
+        self.assertEqual(merge_transform(base, None), base)
+
+    def test_override_only(self):
+        """Only override should return override."""
+        override = {schema.EXCLUDE_FIELDS: ["arch"]}
+        self.assertEqual(merge_transform(None, override), override)
+
+    def test_override_wins(self):
+        """Override values should win."""
+        base = {schema.EXCLUDE_FIELDS: ["arch"]}
+        override = {schema.EXCLUDE_FIELDS: ["version"]}
+        result = merge_transform(base, override)
+        self.assertEqual(result[schema.EXCLUDE_FIELDS], ["version"])
+
+
+class TestCheckConditions(unittest.TestCase):
+    """Tests for check_conditions function."""
+
+    def test_no_conditions_returns_true(self):
+        """No conditions should always return True."""
+        self.assertTrue(check_conditions(None, "x86_64", "rhel", "9.0"))
+
+    def test_architecture_condition(self):
+        """Should check architecture condition."""
+        conditions = {schema.ARCHITECTURES: ["x86_64"]}
+        self.assertTrue(check_conditions(conditions, "x86_64", "rhel", "9.0"))
+        self.assertFalse(check_conditions(conditions, "aarch64", "rhel", "9.0"))
+
+    def test_os_family_condition(self):
+        """Should check OS family condition."""
+        conditions = {schema.OS_FAMILIES: ["rhel"]}
+        self.assertTrue(check_conditions(conditions, "x86_64", "rhel", "9.0"))
+        self.assertFalse(check_conditions(conditions, "x86_64", "ubuntu", "22.04"))
+
+    def test_os_version_condition(self):
+        """Should check OS version condition."""
+        conditions = {schema.OS_VERSIONS: ["9.0"]}
+        self.assertTrue(check_conditions(conditions, "x86_64", "rhel", "9.0"))
+        self.assertFalse(check_conditions(conditions, "x86_64", "rhel", "8.0"))
+
+    def test_multiple_conditions_all_must_pass(self):
+        """All conditions must pass."""
+        conditions = {
+            schema.ARCHITECTURES: ["x86_64"],
+            schema.OS_FAMILIES: ["rhel"],
+            schema.OS_VERSIONS: ["9.0"]
+        }
+        self.assertTrue(check_conditions(conditions, "x86_64", "rhel", "9.0"))
+        self.assertFalse(check_conditions(conditions, "aarch64", "rhel", "9.0"))
+
+
+class TestDeriveCommonRole(unittest.TestCase):
+    """Tests for derive_common_role function."""
+
+    def test_derives_common_packages(self):
+        """Should derive common packages into new role."""
+        target_roles = {
+            "role1": [{"name": "common"}, {"name": "unique1"}],
+            "role2": [{"name": "common"}, {"name": "unique2"}],
+        }
+        derive_common_role(
+            target_roles,
+            derived_key="common_role",
+            from_keys=["role1", "role2"],
+            min_occurrences=2,
+            remove_from_sources=True
+        )
+        self.assertIn("common_role", target_roles)
+        self.assertEqual(len(target_roles["common_role"]), 1)
+        self.assertEqual(target_roles["common_role"][0]["name"], "common")
+
+    def test_removes_from_sources_when_specified(self):
+        """Should remove common packages from source roles."""
+        target_roles = {
+            "role1": [{"name": "common"}, {"name": "unique1"}],
+            "role2": [{"name": "common"}, {"name": "unique2"}],
+        }
+        derive_common_role(
+            target_roles,
+            derived_key="common_role",
+            from_keys=["role1", "role2"],
+            min_occurrences=2,
+            remove_from_sources=True
+        )
+        self.assertEqual(len(target_roles["role1"]), 1)
+        self.assertEqual(target_roles["role1"][0]["name"], "unique1")
+
+    def test_keeps_sources_when_not_removing(self):
+        """Should keep source packages when remove_from_sources=False."""
+        target_roles = {
+            "role1": [{"name": "common"}, {"name": "unique1"}],
+            "role2": [{"name": "common"}, {"name": "unique2"}],
+        }
+        derive_common_role(
+            target_roles,
+            derived_key="common_role",
+            from_keys=["role1", "role2"],
+            min_occurrences=2,
+            remove_from_sources=False
+        )
+        self.assertEqual(len(target_roles["role1"]), 2)
+
+
+class TestWriteConfigFile(unittest.TestCase):
+    """Tests for write_config_file function."""
+
+    def test_writes_valid_json(self):
+        """Should write valid JSON file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "subdir", "test.json")
+            config = {
+                "role1": {schema.CLUSTER: [{"name": "pkg1"}]},
+                "role2": {schema.CLUSTER: [{"name": "pkg2"}]},
+            }
+            write_config_file(file_path, config)
+
+            self.assertTrue(os.path.exists(file_path))
+            with open(file_path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded["role1"][schema.CLUSTER][0]["name"], "pkg1")
+
+    def test_creates_parent_directories(self):
+        """Should create parent directories if they don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "a", "b", "c", "test.json")
+            config = {"role1": {schema.CLUSTER: []}}
+            write_config_file(file_path, config)
+            self.assertTrue(os.path.exists(file_path))
+
+
+class TestGenerateConfigsFromPolicy(unittest.TestCase):
+    """Tests for generate_configs_from_policy function."""
+
+    def setUp(self):
+        self.test_fixtures_dir = os.path.join(CATALOG_PARSER_DIR, "test_fixtures")
+        self.test_policy_path = os.path.join(self.test_fixtures_dir, "adapter_policy_test.json")
+
+    def test_generates_output_files(self):
+        """Should generate output JSON files from valid policy."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create input directory structure
+            input_dir = os.path.join(tmpdir, "input")
+            output_dir = os.path.join(tmpdir, "output")
+            os.makedirs(os.path.join(input_dir, "x86_64", "rhel", "9.0"))
+
+            # Create source file
+            source_data = {
+                "Base OS": {
+                    schema.PACKAGES: [
+                        {"package": "test-pkg", "version": "1.0"}
+                    ]
+                }
+            }
+            with open(os.path.join(input_dir, "x86_64", "rhel", "9.0", "base_os.json"), "w") as f:
+                json.dump(source_data, f)
+
+            # Create minimal policy
+            policy = {
+                "version": "2.0.0",
+                "targets": {
+                    "output.json": {
+                        "sources": [{
+                            "source_file": "base_os.json",
+                            "pulls": [{"source_key": "Base OS", "target_key": "base_role"}]
+                        }]
+                    }
+                }
+            }
+            policy_path = os.path.join(tmpdir, "policy.json")
+            with open(policy_path, "w") as f:
+                json.dump(policy, f)
+
+            generate_configs_from_policy(
+                input_dir=input_dir,
+                output_dir=output_dir,
+                policy_path=policy_path,
+                schema_path=_DEFAULT_SCHEMA_PATH
+            )
+
+            output_file = os.path.join(output_dir, "x86_64", "rhel", "9.0", "output.json")
+            self.assertTrue(os.path.exists(output_file))
+
+    def test_invalid_policy_raises_error(self):
+        """Should raise ValueError for invalid policy."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = os.path.join(tmpdir, "input")
+            output_dir = os.path.join(tmpdir, "output")
+            os.makedirs(input_dir)
+
+            # Create invalid policy (missing version)
+            invalid_policy = {"targets": {}}
+            policy_path = os.path.join(tmpdir, "invalid_policy.json")
+            with open(policy_path, "w") as f:
+                json.dump(invalid_policy, f)
+
+            with self.assertRaises(ValueError) as ctx:
+                generate_configs_from_policy(
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    policy_path=policy_path,
+                    schema_path=_DEFAULT_SCHEMA_PATH
+                )
+            self.assertIn("Adapter policy validation failed", str(ctx.exception))
+
+
+class TestDefaultPaths(unittest.TestCase):
+    """Tests for default path constants."""
+
+    def test_default_policy_path_exists(self):
+        """Default policy path should point to existing file."""
+        self.assertTrue(
+            os.path.exists(_DEFAULT_POLICY_PATH),
+            f"Default policy file not found: {_DEFAULT_POLICY_PATH}"
+        )
+
+    def test_default_schema_path_exists(self):
+        """Default schema path should point to existing file."""
+        self.assertTrue(
+            os.path.exists(_DEFAULT_SCHEMA_PATH),
+            f"Default schema file not found: {_DEFAULT_SCHEMA_PATH}"
+        )
+
+    def test_default_policy_validates_against_schema(self):
+        """Default policy should validate against default schema."""
+        with open(_DEFAULT_POLICY_PATH, "r", encoding="utf-8") as f:
+            policy = json.load(f)
+        with open(_DEFAULT_SCHEMA_PATH, "r", encoding="utf-8") as f:
+            schema_config = json.load(f)
+
+        # Should not raise
+        validate_policy_config(
+            policy,
+            schema_config,
+            policy_path=_DEFAULT_POLICY_PATH,
+            schema_path=_DEFAULT_SCHEMA_PATH
+        )
+
+
+class TestProcessTargetSpec(unittest.TestCase):
+    """Tests for process_target_spec function."""
+
+    def test_processes_simple_target(self):
+        """Should process a simple target specification."""
+        source_files = {
+            "source.json": {
+                "role1": {schema.PACKAGES: [{"name": "pkg1"}]}
+            }
+        }
+        target_spec = {
+            "sources": [{
+                "source_file": "source.json",
+                "pulls": [{"source_key": "role1", "target_key": "output_role"}]
+            }]
+        }
+        target_configs = {}
+
+        process_target_spec(
+            target_file="output.json",
+            target_spec=target_spec,
+            source_files=source_files,
+            target_configs=target_configs,
+            arch="x86_64",
+            os_family="rhel",
+            os_version="9.0"
+        )
+
+        self.assertIn("output.json", target_configs)
+        self.assertIn("output_role", target_configs["output.json"])
+
+    def test_skips_when_conditions_not_met(self):
+        """Should skip target when conditions are not met."""
+        source_files = {"source.json": {"role1": {schema.PACKAGES: []}}}
+        target_spec = {
+            "conditions": {schema.ARCHITECTURES: ["aarch64"]},
+            "sources": [{
+                "source_file": "source.json",
+                "pulls": [{"source_key": "role1"}]
+            }]
+        }
+        target_configs = {}
+
+        process_target_spec(
+            target_file="output.json",
+            target_spec=target_spec,
+            source_files=source_files,
+            target_configs=target_configs,
+            arch="x86_64",
+            os_family="rhel",
+            os_version="9.0"
+        )
+
+        self.assertNotIn("output.json", target_configs)
+
+    def test_applies_transform(self):
+        """Should apply transform to packages."""
+        source_files = {
+            "source.json": {
+                "role1": {schema.PACKAGES: [
+                    {"name": "pkg1", "architecture": "x86_64"}
+                ]}
+            }
+        }
+        target_spec = {
+            "transform": {schema.EXCLUDE_FIELDS: ["architecture"]},
+            "sources": [{
+                "source_file": "source.json",
+                "pulls": [{"source_key": "role1", "target_key": "output_role"}]
+            }]
+        }
+        target_configs = {}
+
+        process_target_spec(
+            target_file="output.json",
+            target_spec=target_spec,
+            source_files=source_files,
+            target_configs=target_configs,
+            arch="x86_64",
+            os_family="rhel",
+            os_version="9.0"
+        )
+
+        pkgs = target_configs["output.json"]["output_role"][schema.CLUSTER]
+        self.assertNotIn("architecture", pkgs[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automation-suite/poc/milestone-1/catalog_parser/tests/test_adapter_policy.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/tests/test_adapter_policy.py
@@ -509,6 +509,54 @@ class TestGenerateConfigsFromPolicy(unittest.TestCase):
                 )
             self.assertIn("Adapter policy validation failed", str(ctx.exception))
 
+    def test_missing_input_dir_raises_file_not_found(self):
+        """Should raise FileNotFoundError if input_dir does not exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = os.path.join(tmpdir, "output")
+            missing_input_dir = os.path.join(tmpdir, "does_not_exist")
+
+            with self.assertRaises(FileNotFoundError):
+                generate_configs_from_policy(
+                    input_dir=missing_input_dir,
+                    output_dir=output_dir,
+                    policy_path=_DEFAULT_POLICY_PATH,
+                    schema_path=_DEFAULT_SCHEMA_PATH,
+                )
+
+    def test_missing_policy_file_raises_file_not_found(self):
+        """Should raise FileNotFoundError if policy_path does not exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = os.path.join(tmpdir, "input")
+            output_dir = os.path.join(tmpdir, "output")
+            os.makedirs(input_dir)
+
+            missing_policy_path = os.path.join(tmpdir, "missing_policy.json")
+
+            with self.assertRaises(FileNotFoundError):
+                generate_configs_from_policy(
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    policy_path=missing_policy_path,
+                    schema_path=_DEFAULT_SCHEMA_PATH,
+                )
+
+    def test_missing_schema_file_raises_file_not_found(self):
+        """Should raise FileNotFoundError if schema_path does not exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = os.path.join(tmpdir, "input")
+            output_dir = os.path.join(tmpdir, "output")
+            os.makedirs(input_dir)
+
+            missing_schema_path = os.path.join(tmpdir, "missing_schema.json")
+
+            with self.assertRaises(FileNotFoundError):
+                generate_configs_from_policy(
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    policy_path=_DEFAULT_POLICY_PATH,
+                    schema_path=missing_schema_path,
+                )
+
 
 class TestDefaultPaths(unittest.TestCase):
     """Tests for default path constants."""

--- a/automation-suite/poc/milestone-1/catalog_parser/tests/test_generator_roles.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/tests/test_generator_roles.py
@@ -47,7 +47,6 @@ class TestGetFunctionalLayerRolesFromFile(unittest.TestCase):
             "Login Node",
             "Slurm Controller",
             "Slurm Worker",
-            "service_etcd",
         ]
 
         self.assertCountEqual(roles, expected_roles)

--- a/automation-suite/poc/milestone-1/catalog_parser/utils.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/utils.py
@@ -15,7 +15,33 @@
 """Utility functions for the catalog parser package."""
 
 import json
-from typing import Any
+import logging
+import os
+from typing import Any, Optional
+
+
+def _configure_logging(log_file: Optional[str] = None, log_level: int = logging.INFO) -> None:
+    """Configure root logging.
+
+    If log_file is provided, logs are written to that file and the directory is
+    created if needed; otherwise logs go to stderr.
+    """
+
+    if log_file:
+        log_dir = os.path.dirname(log_file)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+        logging.basicConfig(
+            level=log_level,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            filename=log_file,
+            encoding="utf-8",
+        )
+    else:
+        logging.basicConfig(
+            level=log_level,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
 
 
 def load_json_file(file_path: str) -> Any:

--- a/automation-suite/poc/milestone-1/catalog_parser/utils.py
+++ b/automation-suite/poc/milestone-1/catalog_parser/utils.py
@@ -25,7 +25,16 @@ def _configure_logging(log_file: Optional[str] = None, log_level: int = logging.
 
     If log_file is provided, logs are written to that file and the directory is
     created if needed; otherwise logs go to stderr.
+
+    Note: This function clears existing handlers before configuring, allowing
+    multiple calls with different log files to work correctly.
     """
+    root_logger = logging.getLogger()
+
+    # Remove existing handlers to allow reconfiguration
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()
 
     if log_file:
         log_dir = os.path.dirname(log_file)
@@ -36,11 +45,13 @@ def _configure_logging(log_file: Optional[str] = None, log_level: int = logging.
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             filename=log_file,
             encoding="utf-8",
+            force=True,
         )
     else:
         logging.basicConfig(
             level=log_level,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            force=True,
         )
 
 


### PR DESCRIPTION
## Title
**Implement adapter policy module**

---

## Description

### Summary
This PR implements the adapter policy module that generates adapter input configuration files from source JSONs using a declarative policy file. The policy file is validated against a JSON schema before processing to ensure correctness.

### Changes

#### New Features
- **JSON Schema Validation**: Policy files are validated against `AdapterPolicySchema.json` before processing
- **CLI & module**: Added support to invoke as CLI or as a module

#### Documentation
- Provided `ADAPTER_POLICY_GUIDE.md` for users on how to create a policy file with examples

#### Other Enhancements
- **Centralized Logging config**: Moved `_configure_logging` to `utils.py` for reuse across modules
