### PR TITLE
Update image-build to use custom Dell HPC image (image-build-el10:1.0)

### DIFF
--- a/build_image_x86_64/roles/image_creation/tasks/build_image_tag.yml
+++ b/build_image_x86_64/roles/image_creation/tasks/build_image_tag.yml
@@ -13,9 +13,9 @@
 #  limitations under the License.
 ---
 
-- name: Pull specific OpenCHAMI image by version tag
+- name: Pull image-build image
   ansible.builtin.command:
-    cmd: "podman pull {{ openchami_image_sha }}"
+    cmd: "podman pull {{ image_build_el10 }}"
   register: pull_result
   changed_when: "'Image is up to date' not in pull_result.stdout"
 
@@ -23,11 +23,3 @@
   ansible.builtin.fail:
     msg: "{{ pull_result.stdout }}"
   when: pull_result.rc != 0
-
-- name: Tagging OpenCHAMI image with stable name
-  ansible.builtin.command:
-    cmd: "{{ ochami_stable_image_tag }}"
-  args:
-    creates: "{{ ochami_stable_image_path }}"
-  register: tag_result
-  changed_when: "'Tagged' in tag_result.stdout"

--- a/build_image_x86_64/roles/image_creation/tasks/build_image_tag.yml
+++ b/build_image_x86_64/roles/image_creation/tasks/build_image_tag.yml
@@ -17,6 +17,9 @@
   ansible.builtin.command:
     cmd: "podman pull {{ image_build_el10 }}"
   register: pull_result
+  retries: "{{ pull_image_retries }}"
+  delay: "{{ pull_image_delay }}"
+  until: pull_result.rc == 0
   changed_when: "'Image is up to date' not in pull_result.stdout"
 
 - name: Fail if image not pulled successfully

--- a/build_image_x86_64/roles/image_creation/vars/main.yml
+++ b/build_image_x86_64/roles/image_creation/vars/main.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-openchami_image_sha: "ghcr.io/openchami/image-build@sha256:52dd9d546951ce4f2f6f9febd08a228cfcb5b9e8e204ca4f5ee232f6be65d3a4"
+image_build_el10: "docker.io/dellhpcomniaaisolution/image-build-el10:1.0"
 input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
 omnia_metadata_file: "/opt/omnia/.data/oim_metadata.yml"
 dir_permissions_644: "0644"
@@ -33,7 +33,7 @@ ochami_compute_mounts:
 
 ochami_x86_64_image:
   - --entrypoint /bin/bash
-  - ghcr.io/openchami/image-build:stable
+  - docker.io/dellhpcomniaaisolution/image-build-el10:1.0
 ochami_base_command:
   - -c 'update-ca-trust extract && image-build --config /home/builder/config.yaml --log-level DEBUG'
 
@@ -52,7 +52,3 @@ compute_image_failure_msg: |
 # build_compute_image.yml
 openchami_compute_image_vars_template: "{{ role_path }}/templates/compute_images_templates.j2"
 openchami_compute_image_vars_path: "/opt/omnia/openchami/compute_images_template.yaml"
-
-# build_image_tag.yml
-ochami_stable_image_tag: "podman tag {{ openchami_image_sha }} ghcr.io/openchami/image-build:stable"
-ochami_stable_image_path: "/var/lib/containers/storage/overlay-images/{{ openchami_image_sha }}"

--- a/build_image_x86_64/roles/image_creation/vars/main.yml
+++ b/build_image_x86_64/roles/image_creation/vars/main.yml
@@ -13,6 +13,8 @@
 # limitations under the License.
 ---
 image_build_el10: "docker.io/dellhpcomniaaisolution/image-build-el10:1.0"
+pull_image_retries: "3"
+pull_image_delay: "10"
 input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
 omnia_metadata_file: "/opt/omnia/.data/oim_metadata.yml"
 dir_permissions_644: "0644"

--- a/common/vars/openchami_image_cmd.yml
+++ b/common/vars/openchami_image_cmd.yml
@@ -20,8 +20,6 @@ rhel_aarch64_base_image_name: "rhel-aarch64_base"
 base_image_commands:
   - "dracut --add 'dmsquash-live livenet network-manager' --install '/usr/lib/systemd/systemd-sysroot-fstab-check' --kver $(basename /lib/modules/*) -N -f --logfile /tmp/dracut.log 2>/dev/null"   # noqa: yaml[line-length]
   - "echo DRACUT LOG:; cat /tmp/dracut.log"
-  - "rm -f /var/lib/rpm/__db*"
-  - "rpmdb --rebuilddb"
 
 #  x86_64 compute commands
 default_x86_64_compute_commands:


### PR DESCRIPTION
This PR updates the x86_64 image build process to use the custom image with AlmaLinux 10 image instead of the OpenCHAMI image.
The previous OpenCHAMI stable image was based on AlmaLinux 8.8, which is incompatible with our target cluster OS (RHEL 10). To support RHEL 10 compute nodes, we built a new image based on AlmaLinux 10 using the same OpenCHAMI code with necessary modifications.

@abhishek-sa1 please review