### PR TITLE
Input validation changes for additional_packages

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,11 +6,7 @@ on:
       - main
       - staging
       - release_1.7.1
-      - pub/local_repo_arch
-      - pub/provision_arch
-      - pub/ochami
-      - pub/ochami_aarch64
-      - pub/k8s_telemetry
+      - pub/q1_dev
 
 jobs:
   build:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,13 +3,10 @@ name: Pylint
 on:
   pull_request:
     branches:
+      - main
       - staging
       - release_1.7.1
-      - pub/local_repo_arch
-      - pub/provision_arch
-      - pub/ochami
-      - pub/ochami_aarch64
-      - pub/k8s_telemetry
+      - pub/q1_dev
 
 jobs:
   build:

--- a/common/library/module_utils/input_validation/common_utils/validation_utils.py
+++ b/common/library/module_utils/input_validation/common_utils/validation_utils.py
@@ -732,7 +732,7 @@ def validate_cluster_items(cluster_items, json_file_path):
         if is_additional_packages and item_type not in allowed_types_for_additional:
             failures.append(
                 f"Failed. Type '{item_type}' is not allowed in '{json_file_path}'. "
-                f"Only 'rpm' and 'image' types are permitted.")
+                f"Only 'rpm' and 'image' types are permitted in this file.")
             continue
 
         required_fields = config.TYPE_REQUIREMENTS.get(item_type)

--- a/common/library/module_utils/input_validation/common_utils/validation_utils.py
+++ b/common/library/module_utils/input_validation/common_utils/validation_utils.py
@@ -723,8 +723,18 @@ def validate_cluster_items(cluster_items, json_file_path):
     failures = []
     successes = []
 
+    is_additional_packages = json_file_path.endswith('additional_packages.json')
+    allowed_types_for_additional = {'rpm', 'image'}
+
     for item in cluster_items:
         item_type = item.get('type')
+
+        if is_additional_packages and item_type not in allowed_types_for_additional:
+            failures.append(
+                f"Failed. Type '{item_type}' is not allowed in '{json_file_path}'. "
+                f"Only 'rpm' and 'image' types are permitted.")
+            continue
+
         required_fields = config.TYPE_REQUIREMENTS.get(item_type)
 
         if not required_fields:
@@ -780,7 +790,7 @@ def validate_softwaresubgroup_entries(
                 cluster_items = json_data[software_name]['cluster']
                 item_successes, item_failures = validate_cluster_items(cluster_items, json_path)
                 if item_failures:
-                    failures.append(f"{item_failures}")
+                    failures.extend(item_failures)
             else:
                 failures.append(
                     f"Failed. Invalid JSON format for: '{software_name}'"

--- a/examples/rhel_software_config.json
+++ b/examples/rhel_software_config.json
@@ -11,7 +11,7 @@
         {"name": "openmpi", "version": "5.0.8", "arch": ["x86_64","aarch64"]},
         {"name": "csi_driver_powerscale", "version":"v2.15.0", "arch": ["x86_64"]},
         {"name": "ldms", "arch": ["x86_64","aarch64"]},
-        {"name": "additional_packages", "arch": ["x86_64,aarch64"]}
+        {"name": "additional_packages", "arch": ["x86_64","aarch64"]}
     ],
     "slurm_custom": [
         {"name": "slurm_control_node"},

--- a/examples/rhel_software_config.json
+++ b/examples/rhel_software_config.json
@@ -10,7 +10,8 @@
         {"name": "ucx", "version": "1.19.0", "arch": ["x86_64","aarch64"]},
         {"name": "openmpi", "version": "5.0.8", "arch": ["x86_64","aarch64"]},
         {"name": "csi_driver_powerscale", "version":"v2.15.0", "arch": ["x86_64"]},
-        {"name": "ldms", "arch": ["x86_64","aarch64"]}
+        {"name": "ldms", "arch": ["x86_64","aarch64"]},
+        {"name": "additional_packages", "arch": ["x86_64,aarch64"]}
     ],
     "slurm_custom": [
         {"name": "slurm_control_node"},
@@ -22,6 +23,15 @@
         {"name": "service_kube_control_plane_first"},
         {"name": "service_kube_control_plane"},
         {"name": "service_kube_node"}
+    ],
+    "additional_packages": [
+        {"name": "slurm_control_node"},
+        {"name": "slurm_node"},
+        {"name": "login_node"},
+        {"name": "login_compiler_node"},
+        {"name": "service_kube_control_plane_first"},
+        {"name": "service_kube_control_plane"},
+        {"name": "service_kube_node"}        
     ]
-
 }
+

--- a/input/config/aarch64/rhel/10.0/additional_packages.json
+++ b/input/config/aarch64/rhel/10.0/additional_packages.json
@@ -1,0 +1,7 @@
+{
+    "additional_packages": {
+        "cluster": [
+
+        ]
+    }
+}

--- a/input/config/x86_64/rhel/10.0/additional_packages.json
+++ b/input/config/x86_64/rhel/10.0/additional_packages.json
@@ -1,0 +1,7 @@
+{
+    "additional_packages": {
+        "cluster": [
+
+        ]
+    }
+}


### PR DESCRIPTION
### Description of the Solution
**Created additional_packages.json skeleton files for RHEL 10.0 (x86_64 and aarch64).**
**Added input validation for additional_packages.json files to restrict types to rpm and image only.**

### Suggested Reviewers
@abhishek-sa1 @Milisha-Gupta @priti-parate
