### PR TITLE
Support additional RPM packages via additional_packages.json

### DIFF
--- a/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
+++ b/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
+++ b/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
@@ -13,21 +13,19 @@
 # limitations under the License.
 ---
 
-- name: Fetch aarch64 default_packages.json software packages
+- name: Fetch aarch64 default_packages.json and additional_packages.json software packages
   when: fg_aarch64
   block:
-    - name: Load default_packages.json
-      ansible.builtin.include_vars:
-        file: "{{ default_json_path }}"
-        name: default_packages_json
+    - name: Collect base image RPM packages (default + additional)
+      base_image_package_collector:
+        default_json_path: "{{ default_json_path }}"
+        additional_json_path: "{{ additional_json_path | default('') }}"
+        software_config_path: "{{ software_config_file_path }}"
+      register: base_image_output
 
-    - name: Extract rpm packages
+    - name: Set x86_64_base_image_packages
       ansible.builtin.set_fact:
-        aarch64_base_image_packages: >-
-          {{ default_packages_json.default_packages.cluster
-            | selectattr('type', 'equalto', 'rpm')
-            | map(attribute='package')
-            | list }}
+        x86_64_base_image_packages: "{{ base_image_output.base_image_packages }}"
 
     - name: Debug package aarch64_base_image_packages
       ansible.builtin.debug:

--- a/build_image_aarch64/roles/fetch_packages/vars/main.yml
+++ b/build_image_aarch64/roles/fetch_packages/vars/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/build_image_aarch64/roles/fetch_packages/vars/main.yml
+++ b/build_image_aarch64/roles/fetch_packages/vars/main.yml
@@ -22,6 +22,7 @@ input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
 functional_groups_file_path: "{{ hostvars['localhost']['functional_groups_config_path'] }}"
 software_config_file_path: "{{ input_project_dir }}/software_config.json"
 default_json_path: "{{ input_project_dir }}/config/aarch64/rhel/10.0/default_packages.json"
+additional_json_path: "{{ input_project_dir }}/config/aarch64/rhel/10.0/additional_packages.json"
 aarch64_build_image_completion_msg: |
   The playbook build_image_aarch64.yml has been completed successfully.
   To boot x86_64 and aarch64 nodes execute discovery/discovery.yml playbook.

--- a/build_image_x86_64/roles/fetch_packages/tasks/fetch_packages.yml
+++ b/build_image_x86_64/roles/fetch_packages/tasks/fetch_packages.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/build_image_x86_64/roles/fetch_packages/tasks/fetch_packages.yml
+++ b/build_image_x86_64/roles/fetch_packages/tasks/fetch_packages.yml
@@ -13,21 +13,19 @@
 #  limitations under the License.
 ---
 
-- name: Fetch x86_64 default_packages.json software packages
+- name: Fetch x86_64 default_packages.json and additional_packages.json software packages
   when: fg_x86_64
   block:
-    - name: Load default_packages.json
-      ansible.builtin.include_vars:
-        file: "{{ default_json_path }}"
-        name: default_package_json
+    - name: Collect base image RPM packages (default + additional)
+      base_image_package_collector:
+        default_json_path: "{{ default_json_path }}"
+        additional_json_path: "{{ additional_json_path | default('') }}"
+        software_config_path: "{{ software_config_file_path }}"
+      register: base_image_output
 
-    - name: Extract rpm packages
+    - name: Set x86_64_base_image_packages
       ansible.builtin.set_fact:
-        x86_64_base_image_packages: >-
-          {{ default_package_json.default_packages.cluster
-            | selectattr('type', 'equalto', 'rpm')
-            | map(attribute='package')
-            | list }}
+        x86_64_base_image_packages: "{{ base_image_output.base_image_packages }}"
 
     - name: Debug package x86_64_base_image_packages
       ansible.builtin.debug:
@@ -39,6 +37,7 @@
         functional_groups_file: "{{ functional_groups_file_path }}"
         software_config_file: "{{ software_config_file_path }}"
         input_project_dir: "{{ input_project_dir }}"
+        additional_json_path: "{{ additional_json_path }}"
       register: compute_images_output
 
     - name: Save packages for x86_64 keys in compute_images_dict

--- a/build_image_x86_64/roles/fetch_packages/vars/main.yml
+++ b/build_image_x86_64/roles/fetch_packages/vars/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/build_image_x86_64/roles/fetch_packages/vars/main.yml
+++ b/build_image_x86_64/roles/fetch_packages/vars/main.yml
@@ -22,6 +22,7 @@ input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
 functional_groups_file_path: "{{ hostvars['localhost']['functional_groups_config_path'] }}"
 software_config_file_path: "{{ input_project_dir }}/software_config.json"
 default_json_path: "{{ input_project_dir }}/config/x86_64/rhel/10.0/default_packages.json"
+additional_json_path: "{{ input_project_dir }}/config/x86_64/rhel/10.0/additional_packages.json"
 x86_64_build_image_completion_msg: |
   The playbook build_image_x86_64.yml has been completed successfully.
   To boot x86_64 nodes execute discovery/discovery.yml playbook.

--- a/common/library/modules/base_image_package_collector.py
+++ b/common/library/modules/base_image_package_collector.py
@@ -1,0 +1,195 @@
+#!/usr/bin/python
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Ansible module to collect RPM packages from default_packages.json and additional_packages.json.
+Returns a flat list of package names for base image building.
+"""
+
+import os
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+
+ROLE_SPECIFIC_KEYS = [
+    "slurm_control_node",
+    "slurm_node",
+    "login_node",
+    "login_compiler_node",
+    "service_kube_control_plane_first",
+    "service_kube_control_plane",
+    "service_kube_node"
+]
+
+
+def load_json_file(path, module):
+    """
+    Load a JSON file safely.
+
+    Args:
+        path (str): Path to the JSON file.
+        module (AnsibleModule): The Ansible module instance.
+
+    Returns:
+        dict or None: Parsed JSON content if successful, otherwise None.
+    """
+    if not os.path.isfile(path):
+        module.log(f"File not found: {path}")
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        module.log(f"Failed to read JSON file {path}: {e}")
+        return None
+
+
+def extract_rpm_package_names(cluster_items):
+    """
+    Extract RPM package names from a cluster list.
+
+    Args:
+        cluster_items (list): List of package items.
+
+    Returns:
+        list: List of package names (strings) where type is 'rpm'.
+    """
+    if not cluster_items or not isinstance(cluster_items, list):
+        return []
+    return [
+        item.get('package') for item in cluster_items
+        if item.get('type') == 'rpm' and item.get('package')
+    ]
+
+
+def collect_default_packages(json_path, module):
+    """
+    Collect RPM package names from default_packages.json.
+
+    Args:
+        json_path (str): Path to default_packages.json.
+        module (AnsibleModule): The Ansible module instance.
+
+    Returns:
+        list: List of package names.
+    """
+    data = load_json_file(json_path, module)
+    if not data:
+        return []
+
+    default_packages = data.get('default_packages', {})
+    cluster_items = default_packages.get('cluster', [])
+    return extract_rpm_package_names(cluster_items)
+
+
+def collect_additional_global_packages(json_path, module):
+    """
+    Collect ONLY global RPM package names from additional_packages.json.
+    Role-specific packages are handled by image_package_collector.py.
+
+    Args:
+        json_path (str): Path to additional_packages.json.
+        module (AnsibleModule): The Ansible module instance.
+
+    Returns:
+        list: List of global package names.
+    """
+    data = load_json_file(json_path, module)
+    if not data:
+        return []
+
+    # Only global RPMs from additional_packages.cluster[]
+    additional_packages = data.get('additional_packages', {})
+    global_cluster = additional_packages.get('cluster', [])
+    return extract_rpm_package_names(global_cluster)
+
+
+def is_additional_packages_enabled(software_config):
+    """
+    Check if additional_packages is defined in softwares array of software_config.json.
+
+    Args:
+        software_config (dict): Parsed software_config.json content.
+
+    Returns:
+        bool: True if additional_packages is in softwares array.
+    """
+    if not software_config:
+        return False
+    softwares = software_config.get('softwares', [])
+    return any(sw.get('name') == 'additional_packages' for sw in softwares)
+
+
+
+
+def run_module():
+    """
+    Run the Ansible module.
+
+    Collects RPM packages from default_packages.json and additional_packages.json,
+    returns a combined flat list of unique package names.
+    """
+    module_args = dict(
+        default_json_path=dict(type="str", required=True),
+        additional_json_path=dict(type="str", required=False, default=""),
+        software_config_path=dict(type="str", required=True),
+    )
+
+    result = dict(
+        changed=False,
+        base_image_packages=[],
+        default_packages=[],
+        additional_packages=[]
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    default_json_path = module.params["default_json_path"]
+    additional_json_path = module.params["additional_json_path"]
+    software_config_path = module.params["software_config_path"]
+
+    # Load software_config.json
+    software_config = load_json_file(software_config_path, module)
+
+    # Collect from default_packages.json
+    default_pkgs = collect_default_packages(default_json_path, module)
+    result["default_packages"] = default_pkgs
+
+    # Collect ONLY global packages from additional_packages.json if enabled
+    # Role-specific packages are handled by image_package_collector.py
+    additional_pkgs = []
+    if additional_json_path and is_additional_packages_enabled(software_config):
+        additional_pkgs = collect_additional_global_packages(additional_json_path, module)
+    result["additional_packages"] = additional_pkgs
+
+    # Combine and deduplicate while preserving order
+    combined = default_pkgs + additional_pkgs
+    seen = set()
+    unique_packages = []
+    for pkg in combined:
+        if pkg not in seen:
+            unique_packages.append(pkg)
+            seen.add(pkg)
+
+    result["base_image_packages"] = unique_packages
+    module.exit_json(**result)
+
+
+def main():
+    """Main entry point."""
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/common/library/modules/base_image_package_collector.py
+++ b/common/library/modules/base_image_package_collector.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# pylint: disable=import-error,no-name-in-module
+#!/usr/bin/python
+
 """
 Ansible module to collect RPM packages from default_packages.json and additional_packages.json.
 Returns a flat list of package names for base image building.

--- a/common/library/modules/image_package_collector.py
+++ b/common/library/modules/image_package_collector.py
@@ -6,6 +6,17 @@ import yaml
 
 from ansible.module_utils.basic import AnsibleModule
 
+ROLE_SPECIFIC_KEYS = [
+    "slurm_control_node",
+    "slurm_node",
+    "login_node",
+    "login_compiler_node",
+    "service_kube_control_plane_first",
+    "service_kube_control_plane",
+    "service_kube_node"
+]
+
+
 def load_yaml_file(path, module):
     """
     Load a YAML file safely.
@@ -38,12 +49,65 @@ def load_json_file(path, module):
     Returns:
         dict or None: Parsed JSON content if successful, otherwise None.
     """
+    if not os.path.isfile(path):
+        module.log(f"File not found: {path}")
+        return None
     try:
         with open(path, "r") as f:
             return json.load(f)
     except Exception as e:
         module.log(f"Failed to read JSON file {path}: {e}")
         return None
+
+
+def is_additional_packages_enabled(software_config):
+    """
+    Check if additional_packages is defined in softwares array of software_config.json.
+    """
+    if not software_config:
+        return False
+    softwares = software_config.get('softwares', [])
+    return any(sw.get('name') == 'additional_packages' for sw in softwares)
+
+
+def get_allowed_additional_subgroups(software_config):
+    """
+    Get list of allowed subgroups from additional_packages array in software_config.json.
+    """
+    if not software_config:
+        return []
+    additional_packages_list = software_config.get('additional_packages', [])
+    return [item.get('name') for item in additional_packages_list if item.get('name')]
+
+
+def get_additional_packages_for_role(additional_json_path, role_name, module):
+    """
+    Get RPM packages for a specific role from additional_packages.json.
+
+    Args:
+        additional_json_path (str): Path to additional_packages.json.
+        role_name (str): Role name (e.g., 'slurm_control_node').
+        module: Ansible module instance.
+
+    Returns:
+        list: List of RPM package names for the role.
+    """
+    if not additional_json_path or role_name not in ROLE_SPECIFIC_KEYS:
+        return []
+
+    data = load_json_file(additional_json_path, module)
+    if not data or role_name not in data:
+        return []
+
+    role_data = data.get(role_name, {})
+    cluster_items = role_data.get('cluster', [])
+
+    packages = []
+    for item in cluster_items:
+        if item.get('type') == 'rpm' and item.get('package'):
+            packages.append(item['package'])
+
+    return packages
 
 
 def collect_packages_from_json(sw_data, fg_name=None, slurm_defined=False, service_k8s_defined=False):
@@ -204,6 +268,7 @@ def run_module():
         functional_groups_file=dict(type="str", required=True),
         software_config_file=dict(type="str", required=True),
         input_project_dir=dict(type="str", required=True),
+        additional_json_path=dict(type="str", required=False, default=""),
     )
 
     result = dict(changed=False, compute_images_dict={})
@@ -212,6 +277,7 @@ def run_module():
     functional_groups_file = module.params["functional_groups_file"]
     software_config_file = module.params["software_config_file"]
     input_project_dir = module.params["input_project_dir"]
+    additional_json_path = module.params["additional_json_path"]
 
     # Load configs
     functional_groups = load_yaml_file(functional_groups_file, module)
@@ -223,6 +289,10 @@ def run_module():
 
     # Build list of allowed softwares (from software_config.json)
     allowed_softwares = {sw["name"] for sw in software_config.get("softwares", [])}
+
+    # Check if additional_packages is enabled and get allowed subgroups
+    additional_enabled = is_additional_packages_enabled(software_config)
+    allowed_additional_subgroups = get_allowed_additional_subgroups(software_config) if additional_enabled else []
 
     # pylint: disable=line-too-long
     # Functional group → json files mapping
@@ -260,6 +330,22 @@ def run_module():
             fg_name, base_name, arch, os_version, input_project_dir,
             software_map, allowed_softwares, module
         )
+
+        # Add role-specific packages from additional_packages.json if enabled
+        if additional_enabled and base_name in allowed_additional_subgroups:
+            additional_role_pkgs = get_additional_packages_for_role(
+                additional_json_path, base_name, module
+            )
+            packages.extend(additional_role_pkgs)
+
+            # Deduplicate while preserving order
+            seen = set()
+            unique_packages = []
+            for pkg in packages:
+                if pkg not in seen:
+                    unique_packages.append(pkg)
+                    seen.add(pkg)
+            packages = unique_packages
 
         compute_images_dict[fg_name] = {
             "functional_group": fg_name,

--- a/common/library/modules/image_package_collector.py
+++ b/common/library/modules/image_package_collector.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=import-error,no-name-in-module
 #!/usr/bin/python
 
 import os


### PR DESCRIPTION
Support additional RPM packages via additional_packages.json, so that users can extend the base OS image without modifying Omnia defaults.