### PR TITLE
Add set -euo pipefail to doca-install script

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,6 +12,7 @@ on:
       - pub/ochami_aarch64
       - pub/k8s_telemetry
       - pub/ib_support
+      - pub/v2.1_rc1
 
 jobs:
   build:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,6 +11,7 @@ on:
       - pub/ochami_aarch64
       - pub/k8s_telemetry
       - pub/ib_support
+      - pub/v2.1_rc1
 
 jobs:
   build:

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -203,8 +203,7 @@
         - mount -a
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
         - /usr/local/bin/check_slurm_controller_status.sh
         - chown -R {{ slurm_user }}:{{ slurm_user }} /var/log/slurm

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -217,8 +217,7 @@
         - mount -a
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
         - /usr/local/bin/check_slurm_controller_status.sh
         - chown -R {{ slurm_user }}:{{ slurm_user }} /var/log/slurm

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -124,8 +124,7 @@
         - mount -a
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
         - /usr/local/bin/check_slurm_controller_status.sh
         - chown -R {{ slurm_user }}:{{ slurm_user }} /var/log/slurm

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -137,8 +137,7 @@
         - mount -a
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
         - /usr/local/bin/check_slurm_controller_status.sh
         - chown -R {{ slurm_user }}:{{ slurm_user }} /var/log/slurm

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -414,8 +414,7 @@
         - cp {{ k8s_client_mount_path }}/pulp_webserver.crt /etc/pki/ca-trust/source/anchors
         - update-ca-trust extract
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - systemctl start crio.service
         - systemctl enable crio.service
         - sudo systemctl enable --now kubelet

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2
@@ -322,8 +322,7 @@
         - cp {{ k8s_client_mount_path }}/pulp_webserver.crt /etc/pki/ca-trust/source/anchors
         - update-ca-trust extract
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - systemctl start crio.service
         - systemctl enable crio.service
         - sudo systemctl enable --now kubelet

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_node_x86_64.yaml.j2
@@ -225,8 +225,7 @@
         - cp {{ k8s_client_mount_path }}/pulp_webserver.crt /etc/pki/ca-trust/source/anchors
         - update-ca-trust extract
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - systemctl start crio.service
         - systemctl enable crio.service
         - sudo systemctl enable --now kubelet

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -285,8 +285,7 @@
          - mount -a
          - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
          - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-         - bash /usr/local/bin/doca-install.sh
-         - bash /usr/local/bin/configure-ib-network.sh
+         - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
 
          - chown -R {{ slurm_user }}:{{ slurm_user }} {{ home_dir }}
          - chmod {{ file_mode_755 }} {{ home_dir }}

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -395,8 +395,7 @@
         - /usr/local/bin/configure_dirs_and_mounts.sh
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - /usr/local/bin/configure_slurmd_setup.sh
         - /usr/local/bin/configure_munge_and_pam.sh
 

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -409,8 +409,7 @@
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
 
-        - bash /usr/local/bin/doca-install.sh
-        - bash /usr/local/bin/configure-ib-network.sh
+        - bash /usr/local/bin/doca-install.sh && bash /usr/local/bin/configure-ib-network.sh
         - /usr/local/bin/configure_slurmd_setup.sh
         - /usr/local/bin/configure_munge_and_pam.sh
 

--- a/discovery/roles/configure_ochami/templates/doca-ofed/doca-install.sh.j2
+++ b/discovery/roles/configure_ochami/templates/doca-ofed/doca-install.sh.j2
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 # Optimize firewall ports declaration later
 DOCA_FIREWALL_PORTS=(
   "18515-18520/tcp"


### PR DESCRIPTION
This PR adds set -o pipefail to the doca-install script so that the script exits on any command failure. It also ensures that configure_ib_network.sh does not run when such a failure occurs.
