### PR TITLE
Retrieve images from Pulp using Apptainer support

### DIFF
--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -204,10 +204,7 @@
       runcmd:
         - /usr/local/bin/set-ssh.sh
         - /usr/local/bin/install_cuda_toolkit.sh
-
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools
-        - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages /hpc_tools
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm/epilog.d     /etc/slurm/epilog.d      nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -131,12 +131,6 @@
             rmdir /cuda-runfile 2>/dev/null
 
             echo "===== CUDA Toolkit installation completed ====="
-        
-        - path: /tmp/apptainer_mirror.conf
-          permissions: '0644'
-          content: |
-            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
-
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -71,7 +71,7 @@
 
             echo "[INFO] Mounting NFS runfile directory for CUDA toolkit..."
             mkdir -p /cuda-runfile
-            mount -t nfs {{ cloud_init_nfs_path }}/runfile /cuda-runfile
+            mount -t nfs {{ cloud_init_nfs_path }}/hpc_tools/runfile /cuda-runfile
 
             if [ $? -ne 0 ]; then
                 echo "[ERROR] Failed to mount NFS runfile share. Exiting."
@@ -119,7 +119,7 @@
             # Create shared directory for compute nodes to mount
             mkdir -p /shared-cuda-toolkit
             # Mount the shared NFS location where compute nodes will access the toolkit
-            mount -t nfs {{ cloud_init_nfs_path }}/cuda/ /shared-cuda-toolkit
+            mount -t nfs {{ cloud_init_nfs_path }}/hpc_tools/cuda/ /shared-cuda-toolkit
 
             echo "[INFO] Copying CUDA toolkit to shared location..."
             # Copy the installed CUDA toolkit to the shared location for compute nodes
@@ -131,6 +131,11 @@
             rmdir /cuda-runfile 2>/dev/null
 
             echo "===== CUDA Toolkit installation completed ====="
+        
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
 
 
 {% if hostvars['localhost']['openldap_support'] %}
@@ -168,13 +173,18 @@
           content: |
             {{ lookup('template', 'templates/slurm/check_slurm_controller_status.sh.j2') | indent(12) }}
 
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
+
       runcmd:
         - /usr/local/bin/set-ssh.sh
         - /usr/local/bin/install_cuda_toolkit.sh
         - groupadd -r {{ slurm_group_name }}
         - useradd -r -g {{ slurm_group_name }} -d {{ home_dir }} -s /sbin/nologin {{ user }}
 
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools
         - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -182,6 +192,7 @@
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_nfs_path}}/hpc_tools  /hpc_tools   nfs defaults,_netdev 0 0" >> /etc/fstab
         - chmod {{ file_mode }} /etc/fstab
         - mount -a
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
@@ -216,6 +227,8 @@
         - systemctl restart sshd
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+        - mkdir -p /etc/containers/registries.conf.d
+        - mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
 {% if hostvars['localhost']['openldap_support'] %}
         - /usr/local/bin/update_ldap_conf.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -133,11 +133,6 @@
 
             echo "===== CUDA Toolkit installation completed ====="
 
-        - path: /tmp/apptainer_mirror.conf
-          permissions: '0644'
-          content: |
-            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
-
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf
           owner: root:root

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -72,7 +72,7 @@
 
             echo "[INFO] Mounting NFS runfile directory for CUDA toolkit..."
             mkdir -p /cuda-runfile
-            mount -t nfs {{ cloud_init_nfs_path }}/runfile /cuda-runfile
+            mount -t nfs {{ cloud_init_nfs_path }}/hpc_tools/runfile /cuda-runfile
 
             if [ $? -ne 0 ]; then
                 echo "[ERROR] Failed to mount NFS runfile share. Exiting."
@@ -120,7 +120,7 @@
             # Create shared directory for compute nodes to mount
             mkdir -p /shared-cuda-toolkit
             # Mount the shared NFS location where compute nodes will access the toolkit
-            mount -t nfs {{ cloud_init_nfs_path }}/cuda/ /shared-cuda-toolkit
+            mount -t nfs {{ cloud_init_nfs_path }}/hpc_tools/cuda/ /shared-cuda-toolkit
 
             echo "[INFO] Copying CUDA toolkit to shared location..."
             # Copy the installed CUDA toolkit to the shared location for compute nodes
@@ -133,7 +133,10 @@
 
             echo "===== CUDA Toolkit installation completed ====="
 
-
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf
@@ -170,13 +173,18 @@
           content: |
             {{ lookup('template', 'templates/slurm/check_slurm_controller_status.sh.j2') | indent(12) }}
 
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
+
       runcmd:
         - /usr/local/bin/set-ssh.sh
         - /usr/local/bin/install_cuda_toolkit.sh
         - groupadd -r {{ slurm_group_name }}
         - useradd -r -g {{ slurm_group_name }} -d {{ home_dir }} -s /sbin/nologin {{ user }}
 
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools
         - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -184,6 +192,7 @@
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_nfs_path}}/hpc_tools  /hpc_tools   nfs defaults,_netdev 0 0" >> /etc/fstab
         - chmod {{ file_mode }} /etc/fstab
         - mount -a
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
@@ -218,6 +227,8 @@
         - systemctl restart sshd
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+        - mkdir -p /etc/containers/registries.conf.d
+        - mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
 {% if hostvars['localhost']['openldap_support'] %}
         - /usr/local/bin/update_ldap_conf.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -214,9 +214,7 @@
 
         # Ensure Slurm NFS root is mounted at client_mount_path (e.g. /share_omnia)
         - mkdir -p {{ client_mount_path }}/slurm/ssh 
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages
-
-        - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages /hpc_tools
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm/epilog.d     /etc/slurm/epilog.d      nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -91,12 +91,17 @@
           content: |
             {{ lookup('template', 'templates/slurm/check_slurm_controller_status.sh.j2') | indent(12) }}
 
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
+
       runcmd:
         - /usr/local/bin/set-ssh.sh
         - groupadd -r {{ slurm_group_name }}
         - useradd -r -g {{ slurm_group_name }} -d {{ home_dir }} -s /sbin/nologin {{ user }}
 
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
         - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -104,6 +109,8 @@
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_nfs_path}}/hpc_tools/container_images  /hpc_tools/container_images   nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_nfs_path}}/hpc_tools/scripts  /hpc_tools/scripts   nfs defaults,_netdev 0 0" >> /etc/fstab
         - chmod {{ file_mode }} /etc/fstab
         - mount -a
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
@@ -138,6 +145,8 @@
         - systemctl restart sshd
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+        - mkdir -p /etc/containers/registries.conf.d
+        - mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
 {% if hostvars['localhost']['openldap_support'] %}
         - /usr/local/bin/update_ldap_conf.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -116,9 +116,7 @@
       runcmd:
         - /usr/local/bin/set-ssh.sh
 
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
-        - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages /hpc_tools/container_images /hpc_tools/scripts
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm/epilog.d     /etc/slurm/epilog.d      nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -90,12 +90,17 @@
           content: |
             {{ lookup('template', 'templates/slurm/check_slurm_controller_status.sh.j2') | indent(12) }}
 
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
+
       runcmd:
         - /usr/local/bin/set-ssh.sh
         - groupadd -r {{ slurm_group_name }}
         - useradd -r -g {{ slurm_group_name }} -d {{ home_dir }} -s /sbin/nologin {{ user }}
 
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
         - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -103,6 +108,8 @@
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_nfs_path}}/hpc_tools/container_images  /hpc_tools/container_images   nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_nfs_path}}/hpc_tools/scripts  /hpc_tools/scripts   nfs defaults,_netdev 0 0" >> /etc/fstab
         - chmod {{ file_mode }} /etc/fstab
         - mount -a
         - yes | cp /etc/slurm/epilog.d/slurmd.service /usr/lib/systemd/system/
@@ -137,6 +144,8 @@
         - systemctl restart sshd
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+        - mkdir -p /etc/containers/registries.conf.d
+        - mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
 {% if hostvars['localhost']['openldap_support'] %}
         - /usr/local/bin/update_ldap_conf.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -121,12 +121,9 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
-
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
-        
         # Ensure Slurm NFS root is mounted at client_mount_path (e.g. /share_omnia)
         - mkdir -p {{ client_mount_path }}/slurm/ssh
-        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages
+        - mkdir -p /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages /hpc_tools/container_images /hpc_tools/scripts
         - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
         - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -236,6 +236,11 @@
               sleep 5
             done
 
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
+
       runcmd:
          - /usr/local/bin/set-ssh.sh
          - useradd -mG wheel -p '$6$VHdSKZNm$O3iFYmRiaFQCemQJjhfrpqqV7DdHBi5YpY6Aq06JSQpABPw.3d8PQ8bNY9NuZSmDv7IL/TsrhRJ6btkgKaonT.' testuser # Required??
@@ -243,7 +248,7 @@
          - useradd -r -g {{ slurm_group_name }} -d {{ home_dir }} -s /sbin/nologin {{ user }}
 
         # Create directories for nfs and mount all
-         - mkdir -p /var/log/slurm /etc/slurm {{ home_dir }} /etc/my.cnf.d /etc/munge /var/lib/mysql /var/log/mariadb /cert /var/log/track
+         - mkdir -p /var/log/slurm /etc/slurm {{ home_dir }} /etc/my.cnf.d /etc/munge /var/lib/mysql /var/log/mariadb /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
          - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
          - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm      /etc/slurm       nfs defaults,_netdev 0 0" >> /etc/fstab
          - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/my.cnf.d   /etc/my.cnf.d    nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -253,6 +258,8 @@
          - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
          - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
          - echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+         - echo "{{ cloud_init_nfs_path}}/hpc_tools/container_images  /hpc_tools/container_images   nfs defaults,_netdev 0 0" >> /etc/fstab
+         - echo "{{ cloud_init_nfs_path}}/hpc_tools/scripts  /hpc_tools/scripts   nfs defaults,_netdev 0 0" >> /etc/fstab
          - chmod {{ file_mode }} /etc/fstab
          - mount -a
 
@@ -279,6 +286,8 @@
 
          - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
          - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
+         - mkdir -p /etc/containers/registries.conf.d
+         - mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
 {% if hostvars['localhost']['openldap_support'] %}
          - /usr/local/bin/update_ldap_conf.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -469,8 +469,7 @@
 
         # slurm user and group created in the users module
         # Create directories for nfs and mount all
-         - mkdir -p /var/log/slurm /etc/slurm {{ home_dir }} /etc/my.cnf.d /etc/munge /var/lib/mysql /var/log/mariadb /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
-         - mkdir -p /var/log/slurm /etc/slurm {{ home_dir }} /etc/my.cnf.d /etc/munge /var/lib/mysql /var/log/mariadb /cert /var/log/track /var/lib/packages
+         - mkdir -p /var/log/slurm /etc/slurm {{ home_dir }} /etc/my.cnf.d /etc/munge /var/lib/mysql /var/log/mariadb /cert /var/log/track /var/lib/packages /hpc_tools/container_images /hpc_tools/scripts
          - echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
          - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm      /etc/slurm       nfs defaults,_netdev 0 0" >> /etc/fstab
          - echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/my.cnf.d   /etc/my.cnf.d    nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -79,7 +79,7 @@
             else
                 echo "[INFO] Mounting NFS runfile directory for driver installation..."
                 mkdir -p /gpu-runfile
-                mount -t nfs {{ cloud_init_nfs_path }}/runfile /gpu-runfile
+                mount -t nfs {{ cloud_init_nfs_path }}/hpc_tools/runfile /gpu-runfile
 
                 if [ $? -ne 0 ]; then
                     echo "[ERROR] Failed to mount NFS runfile share. Exiting."
@@ -220,7 +220,7 @@
             echo "[INFO] ===== Starting directory creation and NFS mounts for Pulp cert, Slurm and Munge (aarch64) ====="
 
             echo "[INFO] Creating base directories for Pulp cert, Slurm and Munge"
-            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track
+            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
 
             echo "[INFO] Updating /etc/fstab with NFS entries for Pulp cert, Slurm and Munge paths"
             echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -230,10 +230,14 @@
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+            echo "{{ cloud_init_nfs_path}}/hpc_tools/container_images  /hpc_tools/container_images   nfs defaults,_netdev 0 0" >> /etc/fstab
+            echo "{{ cloud_init_nfs_path}}/hpc_tools/scripts  /hpc_tools/scripts   nfs defaults,_netdev 0 0" >> /etc/fstab
             chmod {{ file_mode }} /etc/fstab
 
             echo "[INFO] Mounting all NFS entries from /etc/fstab"
             mount -av
+            mkdir -p /etc/containers/registries.conf.d
+            mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
             echo "[INFO] ===== Completed directory creation and NFS mounts for Slurm and Munge (aarch64) ====="
 
@@ -368,6 +372,11 @@
           permissions: '{{ file_mode_755 }}'
           content: |
             {{ lookup('template', 'templates/slurm/check_slurm_controller_status.sh.j2') | indent(12) }}
+
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
 
       runcmd:
         - /usr/local/bin/set-ssh.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -236,13 +236,10 @@
 
             echo "[INFO] ===== Starting directory creation and NFS mounts for Pulp cert, Slurm and Munge (aarch64) ====="
 
-            echo "[INFO] Creating base directories for Pulp cert, Slurm and Munge"
-            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
             echo "[INFO] Creating base directories for Slurm and Munge"
-            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages
+            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages /hpc_tools/container_images /hpc_tools/scripts
 
             echo "[INFO] Updating /etc/fstab with NFS entries for Pulp cert, Slurm and Munge paths"
-            echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/log/slurm  /var/log/slurm   nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/var/spool      /var/spool       nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm/epilog.d     /etc/slurm/epilog.d      nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -79,7 +79,7 @@
             else
                 echo "[INFO] Mounting NFS runfile directory for driver installation..."
                 mkdir -p /gpu-runfile
-                mount -t nfs {{ cloud_init_nfs_path }}/runfile /gpu-runfile
+                mount -t nfs {{ cloud_init_nfs_path }}/hpc_tools/runfile /gpu-runfile
 
                 if [ $? -ne 0 ]; then
                     echo "[ERROR] Failed to mount NFS runfile share. Exiting."
@@ -229,7 +229,7 @@
             echo "[INFO] ===== Starting directory creation and NFS mounts for Pulp cert, Slurm and Munge ====="
 
             echo "[INFO] Creating base directories for Pulp cert, Slurm and Munge"
-            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track
+            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
 
             echo "[INFO] Updating /etc/fstab with NFS entries for Pulp cert, Slurm and Munge paths"
             echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -238,10 +238,14 @@
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/slurm/epilog.d     /etc/slurm/epilog.d      nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ cloud_init_nfs_path }}/$(hostname -s)/etc/munge      /etc/munge       nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ trackfile_nfs_path }}    /var/log/track       nfs defaults,_netdev 0 0" >> /etc/fstab
+            echo "{{ cloud_init_nfs_path}}/hpc_tools/container_images  /hpc_tools/container_images   nfs defaults,_netdev 0 0" >> /etc/fstab
+            echo "{{ cloud_init_nfs_path}}/hpc_tools/scripts  /hpc_tools/scripts   nfs defaults,_netdev 0 0" >> /etc/fstab
             chmod {{ file_mode }} /etc/fstab
 
             echo "[INFO] Mounting all NFS entries from /etc/fstab"
             mount -av
+            mkdir -p /etc/containers/registries.conf.d
+            mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
             echo "[INFO] ===== Completed directory creation and NFS mounts for Slurm and Munge ====="
 
@@ -370,6 +374,11 @@
           permissions: '{{ file_mode_755 }}'
           content: |
             {{ lookup('template', 'templates/slurm/check_slurm_controller_status.sh.j2') | indent(12) }}
+
+        - path: /tmp/apptainer_mirror.conf
+          permissions: '0644'
+          content: |
+            {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
 
       runcmd:
         - /usr/local/bin/set-ssh.sh

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -256,8 +256,7 @@
             # Ensure Slurm NFS root is mounted at client_mount_path (e.g. /share_omnia)
             mkdir -p {{ client_mount_path }}/slurm/ssh
             echo "[INFO] Creating base directories for Pulp cert, Slurm and Munge"
-            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /hpc_tools/container_images /hpc_tools/scripts
-            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages
+            mkdir -pv /var/log/slurm /var/run/slurm /var/spool /var/lib/slurm /etc/slurm/epilog.d /etc/munge /cert /var/log/track /var/lib/packages /hpc_tools/container_images /hpc_tools/scripts
 
             echo "[INFO] Updating /etc/fstab with NFS entries for Pulp cert, Slurm and Munge paths"
             echo "{{ cloud_init_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab

--- a/discovery/roles/configure_ochami/templates/nodes/apptainer_mirror.conf.j2
+++ b/discovery/roles/configure_ochami/templates/nodes/apptainer_mirror.conf.j2
@@ -1,0 +1,43 @@
+unqualified-search-registries = ["{{ pulp_mirror }}"]
+
+[[registry]]
+prefix = "docker.io"
+location = "registry-1.docker.io"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"
+
+[[registry]]
+prefix = "ghcr.io"
+location = "ghcr.io"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"
+
+[[registry]]
+prefix = "quay.io"
+location = "quay.io"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"
+
+[[registry]]
+prefix = "registry.k8s.io"
+location = "registry.k8s.io"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"
+
+[[registry]]
+prefix = "nvcr.io"
+location = "nvcr.io"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"
+
+[[registry]]
+prefix = "public.ecr.aws"
+location = "public.ecr.aws"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"
+
+[[registry]]
+prefix = "gcr.io"
+location = "gcr.io"
+[[registry.mirror]]
+location = "{{ pulp_mirror }}"

--- a/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
+++ b/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
@@ -103,8 +103,8 @@
     mode: "{{ file_mode }}"
   become: true
 
-- name: Create cuda dirs
-  ansible.builtin.include_tasks: cuda.yml
+- name: Create hpc tools dirs
+  ansible.builtin.include_tasks: hpc_tools.yml
 
 - name: Check if munge key exists top level
   ansible.builtin.stat:

--- a/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
+++ b/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -136,14 +136,6 @@
   ansible.builtin.set_fact:
     pulp_mirror: "{{ hostvars['localhost']['admin_nic_ip'] }}:2225"
 
-# - name: Deploy apptainer_mirror.conf to NFS share
-#   ansible.builtin.template:
-#     src: "apptainer_mirror.conf.j2"
-#     dest: "{{ apptainer_mirror_conf_path }}"
-#     owner: "{{ root_user }}"
-#     group: "{{ root_group }}"
-#     mode: "0644"
-
 - name: Set NFS info fact
   ansible.builtin.set_fact:
     oim_shared_path: "{{ hostvars['localhost']['oim_shared_path'] }}"
@@ -162,7 +154,7 @@
 - name: Copy cuda run file using copy module for aarch64
   ansible.builtin.copy:
     src: "{{ oim_shared_path }}/omnia/offline_repo/cluster/aarch64/rhel/10.0/iso/cuda-run/"
-    dest: "{{ slurm_config_path }}/runfile/"
+    dest: "{{ slurm_config_path }}/hpc_tools/runfile/"
     mode: '0755'
     owner: root
     group: root

--- a/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
+++ b/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
@@ -103,21 +103,46 @@
     mode: "{{ file_mode }}"
   become: true
 
-- name: Create the cuda directory on share
+- name: Create HPC tools directories on share
   ansible.builtin.file:
-    path: "{{ slurm_config_path }}/cuda"
+    path: "{{ slurm_config_path }}/hpc_tools/{{ item }}"
     state: directory
     owner: root
     group: root
     mode: "{{ common_mode }}"
+  loop:
+    - cuda
+    - runfile
+    - scripts
+    - container_images
 
-- name: Create the runfile directory on share
-  ansible.builtin.file:
-    path: "{{ slurm_config_path }}/runfile"
-    state: directory
-    owner: root
-    group: root
-    mode: "{{ common_mode }}"
+- name: Deploy download_container_image.sh to NFS share
+  ansible.builtin.template:
+    src: "download_container_image.sh.j2"
+    dest: "{{ download_container_image_path }}"
+    owner: "{{ root_user }}"
+    group: "{{ root_group }}"
+    mode: "0755"
+
+- name: Deploy container_image.list to NFS share
+  ansible.builtin.template:
+    src: "container_image.list.j2"
+    dest: "{{ container_image_list_path }}"
+    owner: "{{ root_user }}"
+    group: "{{ root_group }}"
+    mode: "0644"
+
+- name: Set fact for pulp mirror
+  ansible.builtin.set_fact:
+    pulp_mirror: "{{ hostvars['localhost']['admin_nic_ip'] }}:2225"
+
+# - name: Deploy apptainer_mirror.conf to NFS share
+#   ansible.builtin.template:
+#     src: "apptainer_mirror.conf.j2"
+#     dest: "{{ apptainer_mirror_conf_path }}"
+#     owner: "{{ root_user }}"
+#     group: "{{ root_group }}"
+#     mode: "0644"
 
 - name: Set NFS info fact
   ansible.builtin.set_fact:
@@ -148,7 +173,7 @@
 - name: Copy cuda run file using copy module for x86_64
   ansible.builtin.copy:
     src: "{{ oim_shared_path }}/omnia/offline_repo/cluster/x86_64/rhel/10.0/iso/cuda-run/"
-    dest: "{{ slurm_config_path }}/runfile/"
+    dest: "{{ slurm_config_path }}/hpc_tools/runfile/"
     mode: '0755'
     owner: root
     group: root

--- a/discovery/roles/slurm_config/tasks/hpc_tools.yml
+++ b/discovery/roles/slurm_config/tasks/hpc_tools.yml
@@ -12,14 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# Move to packages directory moving forward
-- name: Create the cuda directory on share
+
+- name: Create HPC tools directories on share
   ansible.builtin.file:
-    path: "{{ slurm_config_path }}/cuda"
+    path: "{{ slurm_config_path }}/hpc_tools/{{ item }}"
     state: directory
     owner: root
     group: root
     mode: "{{ common_mode }}"
+  loop:
+    - cuda
+    - runfile
+    - scripts
+    - container_images
+
+- name: Deploy download_container_image.sh to NFS share
+  ansible.builtin.template:
+    src: "download_container_image.sh.j2"
+    dest: "{{ download_container_image_path }}"
+    owner: "{{ root_user }}"
+    group: "{{ root_group }}"
+    mode: "0755"
+
+- name: Deploy container_image.list to NFS share
+  ansible.builtin.template:
+    src: "container_image.list.j2"
+    dest: "{{ container_image_list_path }}"
+    owner: "{{ root_user }}"
+    group: "{{ root_group }}"
+    mode: "0644"
+
+- name: Set fact for pulp mirror
+  ansible.builtin.set_fact:
+    pulp_mirror: "{{ hostvars['localhost']['admin_nic_ip'] }}:2225"
 
 - name: Create x86_64 package base directory
   ansible.builtin.file:
@@ -93,14 +118,6 @@
     - item.item.source_path | length > 0
     - item.item.dest_path | length > 0
 
-- name: Create the runfile directory on share
-  ansible.builtin.file:
-    path: "{{ slurm_config_path }}/runfile"
-    state: directory
-    owner: root
-    group: root
-    mode: "{{ common_mode }}"
-
 - name: Set NFS info fact
   ansible.builtin.set_fact:
     oim_shared_path: "{{ hostvars['localhost']['oim_shared_path'] }}"
@@ -118,7 +135,7 @@
 - name: Copy cuda run file using copy module for aarch64
   ansible.builtin.copy:
     src: "{{ oim_shared_path }}/omnia/offline_repo/cluster/aarch64/rhel/10.0/iso/cuda-run/"
-    dest: "{{ slurm_config_path }}/runfile/"
+    dest: "{{ slurm_config_path }}/hpc_tools/runfile/"
     mode: '0755'
     owner: root
     group: root
@@ -129,7 +146,7 @@
 - name: Copy cuda run file using copy module for x86_64
   ansible.builtin.copy:
     src: "{{ oim_shared_path }}/omnia/offline_repo/cluster/x86_64/rhel/10.0/iso/cuda-run/"
-    dest: "{{ slurm_config_path }}/runfile/"
+    dest: "{{ slurm_config_path }}/hpc_tools/runfile/"
     mode: '0755'
     owner: root
     group: root

--- a/discovery/roles/slurm_config/templates/container_image.list.j2
+++ b/discovery/roles/slurm_config/templates/container_image.list.j2
@@ -1,0 +1,13 @@
+# Container Image List
+# This file contains container images to be downloaded as SIF files
+# Format: <registry>/<namespace>/<image>:<tag>
+# Lines starting with # are comments and will be ignored
+# Empty lines are also ignored
+#
+# Examples:
+#   nvcr.io/nvidia/hpc-benchmarks:25.09
+#   docker.io/library/ubuntu:22.04
+#   ghcr.io/apptainer/apptainer:latest
+
+# Default HPC Benchmarks image
+nvcr.io/nvidia/hpc-benchmarks:25.09

--- a/discovery/roles/slurm_config/templates/download_container_image.sh.j2
+++ b/discovery/roles/slurm_config/templates/download_container_image.sh.j2
@@ -120,17 +120,28 @@ while IFS= read -r line || [ -n "$line" ]; do
 
         # Pull from Pulp only
         echo "Trying: PULP ($PULP_IMAGE)" >> /var/log/apptainer_pull.log
-        apptainer pull --disable-cache --name "$CONTAINER_IMAGE" --dir "$DOWNLOAD_DIR" --tmpdir "$DOWNLOAD_DIR" "$PULP_IMAGE" 2>&1 | tee -a /var/log/apptainer_pull.log
+        echo "[INFO] Starting pull (this may take several minutes for large images)..."
 
-        if [ $? -eq 0 ] && [ -f "$CONTAINER_IMAGE" ]; then
+        # Use timeout to prevent hanging (30 minutes)
+        timeout 1800 apptainer pull --disable-cache --name "$CONTAINER_IMAGE" --dir "$DOWNLOAD_DIR" --tmpdir "$DOWNLOAD_DIR" "$PULP_IMAGE" 2>&1 | tee -a /var/log/apptainer_pull.log
+        PULL_EXIT_CODE=$?
+
+        # Check the actual exit code from timeout command
+        if [ $PULL_EXIT_CODE -eq 124 ]; then
+            echo "[ERROR] Pull timed out after 30 minutes."
+            echo "[INFO] Large images may require more time. Try pulling manually or increase timeout."
+            echo "Result: TIMEOUT" >> /var/log/apptainer_pull.log
+            ((FAILED_COUNT++))
+            FAILED_IMAGES="${FAILED_IMAGES}\n  - ${line} (TIMEOUT)"
+        elif [ $PULL_EXIT_CODE -eq 0 ] && [ -f "$CONTAINER_IMAGE" ]; then
             echo "[SUCCESS] Container image pulled successfully from Pulp mirror"
             echo "[SOURCE] Downloaded from: PULP MIRROR ($PULP_SERVER)"
             echo "Result: SUCCESS (PULP)" >> /var/log/apptainer_pull.log
             ls -lh "$CONTAINER_IMAGE"
             ((SUCCESS_COUNT++))
         else
-            echo "[ERROR] Failed to pull container image from Pulp mirror."
-            echo "[INFO] Image may not be available in Pulp. Please sync it first."
+            echo "[ERROR] Failed to pull container image from Pulp mirror (exit code: $PULL_EXIT_CODE)."
+            echo "[INFO] Image may not be available in Pulp or download was interrupted."
             echo "Result: FAILED" >> /var/log/apptainer_pull.log
             ((FAILED_COUNT++))
             FAILED_IMAGES="${FAILED_IMAGES}\n  - ${line}"

--- a/discovery/roles/slurm_config/templates/download_container_image.sh.j2
+++ b/discovery/roles/slurm_config/templates/download_container_image.sh.j2
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Generic container image download script (SIF format) - Pulp only
+# Deployed via NFS share for all nodes
+# Reads container images from container_image.list file and downloads them as SIF files
+# Downloads from Pulp mirror only (no internet fallback)
+# Usage: download_container_image.sh
+
+LOGFILE="/var/log/container_image_download.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER_IMAGE_LIST="${SCRIPT_DIR}/container_image.list"
+DOWNLOAD_DIR="/hpc_tools/container_images"
+PULP_SERVER="{{ hostvars['localhost']['admin_nic_ip'] }}:2225"
+
+echo "===== Starting Container Image Download Script (Pulp Only) ====="
+echo "[INFO] Timestamp: $(date)"
+
+# Check if Apptainer is installed
+echo "[INFO] Checking Apptainer installation..."
+if ! command -v apptainer &>/dev/null; then
+    echo "[ERROR] Apptainer is not installed. Please install Apptainer first."
+    exit 1
+fi
+echo "[SUCCESS] Apptainer is installed."
+apptainer --version
+
+# Check if container image list file exists
+if [ ! -f "$CONTAINER_IMAGE_LIST" ]; then
+    echo "[ERROR] Container image list file not found: $CONTAINER_IMAGE_LIST"
+    echo "[INFO] Please create the file with one image URI per line."
+    echo "[INFO] Example format: nvcr.io/nvidia/hpc-benchmarks:25.09"
+    exit 1
+fi
+
+# Navigate to download directory
+mkdir -p "$DOWNLOAD_DIR"
+
+echo "[INFO] Download directory: $DOWNLOAD_DIR"
+
+if [ ! -d "$DOWNLOAD_DIR" ]; then
+    echo "[ERROR] Download directory does not exist: $DOWNLOAD_DIR"
+    exit 1
+fi
+
+cd "$DOWNLOAD_DIR" || {
+    echo "[ERROR] Failed to change directory to $DOWNLOAD_DIR"
+    exit 1
+}
+
+# Clear pull log at start of run
+echo "===== Container Image Pull Log =====" > /var/log/apptainer_pull.log
+echo "Started: $(date)" >> /var/log/apptainer_pull.log
+
+echo "[INFO] Processing images from list file: $CONTAINER_IMAGE_LIST"
+
+TOTAL_IMAGES=0
+SUCCESS_COUNT=0
+FAILED_COUNT=0
+FAILED_IMAGES=""
+
+while IFS= read -r line || [ -n "$line" ]; do
+    # Skip empty lines and comments
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    
+    # Trim whitespace
+    line=$(echo "$line" | xargs)
+    
+    # Add docker:// prefix if not present
+    if [[ ! "$line" =~ ^docker:// ]]; then
+        CONTAINER_REGISTRY="docker://$line"
+    else
+        CONTAINER_REGISTRY="$line"
+    fi
+    
+    # Auto-generate SIF filename from image URI
+    TAG=$(echo "$CONTAINER_REGISTRY" | grep -oP '(?<=:)[^:]+$' || echo "latest")
+    IMAGE_NAME=$(echo "$CONTAINER_REGISTRY" | sed 's|docker://||' | rev | cut -d'/' -f1 | rev | cut -d':' -f1)
+    CONTAINER_IMAGE="${IMAGE_NAME}_${TAG}.sif"
+    
+    ((TOTAL_IMAGES++))
+    
+    echo ""
+    echo "===== Processing Image $TOTAL_IMAGES: $line ====="
+    echo "[INFO] Image URI: $CONTAINER_REGISTRY"
+    echo "[INFO] Output file: $CONTAINER_IMAGE"
+    echo "[INFO] Destination: $DOWNLOAD_DIR/$CONTAINER_IMAGE"
+    
+    # Pull container image from Pulp mirror only
+    echo "[INFO] Pulling container image from Pulp mirror..."
+    echo "[INFO] Pulp mirror: $PULP_SERVER"
+
+    if [ -f "$DOWNLOAD_DIR/$CONTAINER_IMAGE" ]; then
+        echo "[WARN] Container image already exists: $CONTAINER_IMAGE"
+        echo "[INFO] Skipping download. Remove the file to re-download."
+        ((SUCCESS_COUNT++))
+    else
+        # Append separator and timestamp to pull log
+        echo "" >> /var/log/apptainer_pull.log
+        echo "========================================" >> /var/log/apptainer_pull.log
+        echo "Image: $line" >> /var/log/apptainer_pull.log
+        echo "Timestamp: $(date)" >> /var/log/apptainer_pull.log
+        echo "========================================" >> /var/log/apptainer_pull.log
+
+        # Extract registry and path from image URI
+        # e.g., docker://nvcr.io/nvidia/hpc-benchmarks:25.09 -> nvcr.io/nvidia/hpc-benchmarks:25.09
+        IMAGE_PATH="${CONTAINER_REGISTRY#docker://}"
+
+        # Strip registry prefix (e.g., nvcr.io/, ghcr.io/, docker.io/) for Pulp URL
+        # Pulp stores images without the registry prefix
+        # e.g., nvcr.io/nvidia/hpc-benchmarks:25.09 -> nvidia/hpc-benchmarks:25.09
+        IMAGE_PATH_NO_REGISTRY=$(echo "$IMAGE_PATH" | sed 's|^[^/]*/||')
+
+        # Construct Pulp mirror URL (without registry prefix)
+        PULP_IMAGE="docker://${PULP_SERVER}/${IMAGE_PATH_NO_REGISTRY}"
+
+        echo "[INFO] Pulling from Pulp mirror..."
+        echo "[INFO] Pulp URL: $PULP_IMAGE"
+
+        # Pull from Pulp only
+        echo "Trying: PULP ($PULP_IMAGE)" >> /var/log/apptainer_pull.log
+        apptainer pull --disable-cache --name "$CONTAINER_IMAGE" --dir "$DOWNLOAD_DIR" --tmpdir "$DOWNLOAD_DIR" "$PULP_IMAGE" 2>&1 | tee -a /var/log/apptainer_pull.log
+
+        if [ $? -eq 0 ] && [ -f "$CONTAINER_IMAGE" ]; then
+            echo "[SUCCESS] Container image pulled successfully from Pulp mirror"
+            echo "[SOURCE] Downloaded from: PULP MIRROR ($PULP_SERVER)"
+            echo "Result: SUCCESS (PULP)" >> /var/log/apptainer_pull.log
+            ls -lh "$CONTAINER_IMAGE"
+            ((SUCCESS_COUNT++))
+        else
+            echo "[ERROR] Failed to pull container image from Pulp mirror."
+            echo "[INFO] Image may not be available in Pulp. Please sync it first."
+            echo "Result: FAILED" >> /var/log/apptainer_pull.log
+            ((FAILED_COUNT++))
+            FAILED_IMAGES="${FAILED_IMAGES}\n  - ${line}"
+        fi
+    fi
+done < "$CONTAINER_IMAGE_LIST"
+
+echo ""
+echo "===== Container Image Download Summary ====="
+echo "[INFO] Total images processed: $TOTAL_IMAGES"
+echo "[INFO] Successful downloads: $SUCCESS_COUNT"
+echo "[INFO] Failed downloads: $FAILED_COUNT"
+
+if [ $FAILED_COUNT -gt 0 ]; then
+    echo -e "[ERROR] Failed images:$FAILED_IMAGES"
+    EXIT_CODE=1
+else
+    EXIT_CODE=0
+fi
+
+echo ""
+echo "===== Container Image Download Completed ====="
+exit ${EXIT_CODE:-0}

--- a/discovery/roles/slurm_config/vars/main.yml
+++ b/discovery/roles/slurm_config/vars/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/discovery/roles/slurm_config/vars/main.yml
+++ b/discovery/roles/slurm_config/vars/main.yml
@@ -103,3 +103,6 @@ auth_tls_certs_path: "/opt/omnia/auth/tls_certs/ldapserver.crt"
 slurm_installation_type: configless
 pulp_webserver_cert_path: "/opt/omnia/pulp/settings/certs/pulp_webserver.crt"
 controller_empty_msg: "Slurm controller functional group is missing from PXE mapping file. Please update the file and rerun discovery.yml."
+download_container_image_path: "{{ slurm_config_path }}/hpc_tools/scripts/download_container_image.sh"
+container_image_list_path: "{{ slurm_config_path }}/hpc_tools/scripts/container_image.list"
+pulp_mirror: "{{ hostvars['localhost']['admin_nic_ip'] }}:2225"

--- a/input/config/aarch64/rhel/10.0/slurm_custom.json
+++ b/input/config/aarch64/rhel/10.0/slurm_custom.json
@@ -8,7 +8,6 @@
             {"package": "pmix", "type": "rpm", "repo_name": "aarch64_appstream"},
             {"package": "pmix-devel", "type": "rpm", "repo_name": "aarch64_appstream"},
             {"package": "nvcr.io/nvidia/hpc-benchmarks", "tag": "25.09", "type": "image"},
-            {"package": "apptainer", "type": "rpm", "repo_name": "epel"}
             {"package": "apptainer", "type": "rpm", "repo_name": "epel" },
             {"package": "doca-ofed",
              "type": "iso",

--- a/input/config/aarch64/rhel/10.0/slurm_custom.json
+++ b/input/config/aarch64/rhel/10.0/slurm_custom.json
@@ -6,7 +6,9 @@
             {"package": "firewalld", "type": "rpm", "repo_name": "aarch64_baseos"},
             {"package": "python3-firewall", "type": "rpm", "repo_name": "aarch64_baseos"},
             {"package": "pmix", "type": "rpm", "repo_name": "aarch64_appstream"},
-            {"package": "pmix-devel", "type": "rpm", "repo_name": "aarch64_appstream"}
+            {"package": "pmix-devel", "type": "rpm", "repo_name": "aarch64_appstream"},
+            {"package": "nvcr.io/nvidia/hpc-benchmarks", "tag": "25.09", "type": "image"},
+            {"package": "apptainer", "type": "rpm", "repo_name": "epel"}
         ]
     },
     "slurm_control_node": {

--- a/input/config/x86_64/rhel/10.0/slurm_custom.json
+++ b/input/config/x86_64/rhel/10.0/slurm_custom.json
@@ -4,7 +4,9 @@
             {"package": "munge", "type": "rpm", "repo_name": "x86_64_appstream"},
             {"package": "firewalld", "type": "rpm", "repo_name": "x86_64_baseos"},
             {"package": "python3-firewall", "type": "rpm", "repo_name": "x86_64_baseos"},
-            {"package": "pmix", "type": "rpm", "repo_name": "x86_64_appstream"}
+            {"package": "pmix", "type": "rpm", "repo_name": "x86_64_appstream"},
+            {"package": "nvcr.io/nvidia/hpc-benchmarks", "tag": "25.09", "type": "image"},
+            {"package": "apptainer", "type": "rpm", "repo_name": "epel"}
         ]
     },
     "slurm_control_node": {

--- a/input/config/x86_64/rhel/10.0/slurm_custom.json
+++ b/input/config/x86_64/rhel/10.0/slurm_custom.json
@@ -6,7 +6,6 @@
             {"package": "python3-firewall", "type": "rpm", "repo_name": "x86_64_baseos"},
             {"package": "pmix", "type": "rpm", "repo_name": "x86_64_appstream"},
             {"package": "nvcr.io/nvidia/hpc-benchmarks", "tag": "25.09", "type": "image"},
-            {"package": "apptainer", "type": "rpm", "repo_name": "epel"}
             {"package": "apptainer", "type": "rpm", "repo_name": "epel" },
             {"package": "doca-ofed",
              "type": "iso",


### PR DESCRIPTION
The Apptainer container download process reads image URIs from container_image.list (located in the script directory), pulls each image from the Pulp mirror using apptainer pull, and saves them as .sif files in /hpc_tools/container_images/. The SIF filename is auto-generated as {image_name}_{tag}.sif (e.g., hpc-benchmarks_25.09.sif). 