### PR TITLE
Add  API layer with generic API responsibilities and implement ParseCatalog endpoint

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible pylint kubernetes prettytable requests passlib
+          pip install ansible pylint kubernetes prettytable requests passlib fastapi uvicorn
 
       - name: Get changed Python files (excluding deleted)
         id: changed-files

--- a/build_stream/api/parse_catalog/__init__.py
+++ b/build_stream/api/parse_catalog/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ParseCatalog API module."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/build_stream/api/parse_catalog/routes.py
+++ b/build_stream/api/parse_catalog/routes.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FastAPI routes for ParseCatalog API."""
+
+import logging
+
+from fastapi import APIRouter, File, HTTPException, UploadFile, status
+
+from .schemas import ErrorResponse, ParseCatalogResponse, ParseCatalogStatus
+from .service import (
+    CatalogParseError,
+    InvalidFileFormatError,
+    InvalidJSONError,
+    ParseCatalogService,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/parse-catalog", tags=["Catalog Parsing"])
+
+_service = ParseCatalogService()
+
+
+@router.post(
+    "",
+    response_model=ParseCatalogResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Parse a catalog file",
+    description="Upload a catalog JSON file to parse and generate output files.",
+    responses={
+        200: {
+            "description": "Catalog parsed successfully",
+            "model": ParseCatalogResponse,
+        },
+        400: {
+            "description": "Invalid request (bad file format or JSON)",
+            "model": ErrorResponse,
+        },
+        422: {
+            "description": "Validation error",
+            "model": ErrorResponse,
+        },
+        500: {
+            "description": "Internal server error during processing",
+            "model": ErrorResponse,
+        },
+    },
+)
+async def parse_catalog(
+    file: UploadFile = File(..., description="The catalog JSON file to parse"),
+) -> ParseCatalogResponse:
+    """Parse a catalog from an uploaded JSON file.
+
+    This endpoint accepts a catalog JSON file, validates its format and content,
+    then processes it to generate the required output files.
+
+    Args:
+        file: The uploaded JSON file containing catalog data.
+
+    Returns:
+        ParseCatalogResponse with status and message.
+
+    Raises:
+        HTTPException: With appropriate status code on failure.
+    """
+    logger.info("Received parse catalog request for file: %s", file.filename)
+
+    try:
+        contents = await file.read()
+        result = await _service.parse_catalog(
+            filename=file.filename or "unknown.json",
+            contents=contents,
+        )
+
+        return ParseCatalogResponse(
+            status=ParseCatalogStatus.SUCCESS,
+            message=result.message,
+            output_path=result.output_path,
+        )
+
+    except InvalidFileFormatError as e:
+        logger.warning("Invalid file format: %s", file.filename)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+    except InvalidJSONError as e:
+        logger.warning("Invalid JSON content in file: %s", file.filename)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+    except CatalogParseError as e:
+        logger.error("Catalog parsing failed for file: %s", file.filename)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
+
+    except Exception as e:
+        logger.exception("Unexpected error processing file: %s", file.filename)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An unexpected error occurred",
+        ) from e

--- a/build_stream/api/parse_catalog/schemas.py
+++ b/build_stream/api/parse_catalog/schemas.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic schemas for ParseCatalog API request and response models."""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ParseCatalogStatus(str, Enum):
+    """Status enum for ParseCatalog API responses."""
+
+    SUCCESS = "success"
+    ERROR = "error"
+
+
+class ParseCatalogResponse(BaseModel):
+    """Response model for ParseCatalog API."""
+
+    status: ParseCatalogStatus = Field(
+        ...,
+        description="Status of the catalog parsing operation",
+    )
+    message: str = Field(
+        ...,
+        description="Human-readable message describing the result",
+    )
+    output_path: Optional[str] = Field(
+        default=None,
+        description="Path to the generated output files (only on success)",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "status": "success",
+                    "message": "Catalog parsed successfully",
+                    "output_path": "out/generator",
+                },
+                {
+                    "status": "error",
+                    "message": "Invalid file format. Only JSON files are accepted.",
+                    "output_path": None,
+                },
+            ]
+        }
+    }
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response model."""
+
+    status: ParseCatalogStatus = ParseCatalogStatus.ERROR
+    message: str = Field(..., description="Error message describing what went wrong")
+    detail: Optional[str] = Field(
+        default=None,
+        description="Additional error details (only in non-production environments)",
+    )

--- a/build_stream/api/parse_catalog/schemas.py
+++ b/build_stream/api/parse_catalog/schemas.py
@@ -27,7 +27,7 @@ class ParseCatalogStatus(str, Enum):
     ERROR = "error"
 
 
-class ParseCatalogResponse(BaseModel):
+class ParseCatalogResponse(BaseModel):  # pylint: disable=too-few-public-methods
     """Response model for ParseCatalog API."""
 
     status: ParseCatalogStatus = Field(
@@ -61,7 +61,7 @@ class ParseCatalogResponse(BaseModel):
     }
 
 
-class ErrorResponse(BaseModel):
+class ErrorResponse(BaseModel):  # pylint: disable=too-few-public-methods
     """Standard error response model."""
 
     status: ParseCatalogStatus = ParseCatalogStatus.ERROR

--- a/build_stream/api/parse_catalog/service.py
+++ b/build_stream/api/parse_catalog/service.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Business logic service for ParseCatalog API."""
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Optional
+
+from core.catalog.generator import generate_root_json_from_catalog
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogParseError(Exception):
+    """Exception raised when catalog parsing fails."""
+
+    pass
+
+
+class InvalidFileFormatError(CatalogParseError):
+    """Exception raised when the uploaded file has an invalid format."""
+
+    pass
+
+
+class InvalidJSONError(CatalogParseError):
+    """Exception raised when the JSON content is invalid."""
+
+    pass
+
+
+@dataclass
+class ParseResult:
+    """Result of a catalog parse operation."""
+
+    success: bool
+    message: str
+    output_path: Optional[str] = None
+
+
+class ParseCatalogService:
+    """Service for parsing catalog files."""
+
+    DEFAULT_OUTPUT_ROOT = "out/generator"
+
+    def __init__(self, output_root: Optional[str] = None):
+        """Initialize the ParseCatalog service.
+
+        Args:
+            output_root: Root directory for generated output files.
+        """
+        self.output_root = output_root or self.DEFAULT_OUTPUT_ROOT
+
+    async def parse_catalog(
+        self,
+        filename: str,
+        contents: bytes,
+    ) -> ParseResult:
+        """Parse a catalog from uploaded file contents.
+
+        Args:
+            filename: Name of the uploaded file.
+            contents: Raw bytes content of the uploaded file.
+
+        Returns:
+            ParseResult containing the operation status and details.
+
+        Raises:
+            InvalidFileFormatError: If file is not a JSON file.
+            InvalidJSONError: If JSON content is malformed or not a dict.
+            CatalogParseError: If catalog processing fails.
+        """
+        logger.info("Starting catalog parse for file: %s", filename)
+
+        self._validate_file_format(filename)
+        json_data = self._parse_json_content(contents)
+        self._validate_json_structure(json_data)
+
+        return await self._process_catalog(json_data)
+
+    def _validate_file_format(self, filename: str) -> None:
+        """Validate that the file has a .json extension."""
+        if not filename.endswith(".json"):
+            logger.warning("Invalid file format received: %s", filename)
+            raise InvalidFileFormatError(
+                "Invalid file format. Only JSON files are accepted."
+            )
+
+    def _parse_json_content(self, contents: bytes) -> dict:
+        """Parse JSON content from bytes."""
+        try:
+            return json.loads(contents.decode("utf-8"))
+        except json.JSONDecodeError as e:
+            logger.error("Failed to parse JSON content")
+            raise InvalidJSONError(f"Invalid JSON data: {e.msg}") from e
+        except UnicodeDecodeError as e:
+            logger.error("Failed to decode file content as UTF-8")
+            raise InvalidJSONError("File content is not valid UTF-8 text") from e
+
+    def _validate_json_structure(self, json_data: object) -> None:
+        """Validate that JSON data is a dictionary."""
+        if not isinstance(json_data, dict):
+            logger.warning("JSON data is not a dictionary")
+            raise InvalidJSONError(
+                "Invalid JSON data. The data must be a dictionary."
+            )
+
+    async def _process_catalog(self, json_data: dict) -> ParseResult:
+        """Process the catalog data and generate output files.
+
+        Args:
+            json_data: Validated catalog data as a dictionary.
+
+        Returns:
+            ParseResult with success status and output path.
+
+        Raises:
+            CatalogParseError: If processing fails.
+        """
+        temp_file_path = None
+        try:
+            temp_file_path = self._write_temp_file(json_data)
+            logger.debug("Wrote catalog to temporary file: %s", temp_file_path)
+
+            generate_root_json_from_catalog(
+                catalog_path=temp_file_path,
+                output_root=self.output_root,
+            )
+
+            logger.info("Catalog parsed successfully, output at: %s", self.output_root)
+            return ParseResult(
+                success=True,
+                message="Catalog parsed successfully",
+                output_path=self.output_root,
+            )
+
+        except FileNotFoundError as e:
+            logger.error("Required file not found during processing")
+            raise CatalogParseError("Required file not found during processing") from e
+        except Exception as e:
+            logger.error("Catalog processing failed")
+            raise CatalogParseError("Failed to process catalog") from e
+        finally:
+            if temp_file_path and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+                logger.debug("Cleaned up temporary file: %s", temp_file_path)
+
+    def _write_temp_file(self, json_data: dict) -> str:
+        """Write JSON data to a temporary file.
+
+        Args:
+            json_data: Data to write to the file.
+
+        Returns:
+            Path to the temporary file.
+        """
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".json",
+            delete=False,
+            encoding="utf-8",
+        ) as f:
+            json.dump(json_data, f)
+            return f.name

--- a/build_stream/api/parse_catalog/service.py
+++ b/build_stream/api/parse_catalog/service.py
@@ -29,19 +29,13 @@ logger = logging.getLogger(__name__)
 class CatalogParseError(Exception):
     """Exception raised when catalog parsing fails."""
 
-    pass
-
 
 class InvalidFileFormatError(CatalogParseError):
     """Exception raised when the uploaded file has an invalid format."""
 
-    pass
-
 
 class InvalidJSONError(CatalogParseError):
     """Exception raised when the JSON content is invalid."""
-
-    pass
 
 
 @dataclass
@@ -53,7 +47,7 @@ class ParseResult:
     output_path: Optional[str] = None
 
 
-class ParseCatalogService:
+class ParseCatalogService:  # pylint: disable=too-few-public-methods
     """Service for parsing catalog files."""
 
     DEFAULT_OUTPUT_ROOT = "out/generator"

--- a/build_stream/api/router.py
+++ b/build_stream/api/router.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API router that aggregates all API modules."""
+
+from fastapi import APIRouter
+
+from .parse_catalog import router as parse_catalog_router
+
+api_router = APIRouter(prefix="/api/v1")
+
+api_router.include_router(parse_catalog_router)

--- a/build_stream/core/catalog/parser.py
+++ b/build_stream/core/catalog/parser.py
@@ -48,17 +48,12 @@ def ParseCatalog(file_path: str, schema_path: str = _DEFAULT_SCHEMA_PATH) -> Cat
     logger.debug("Validating catalog JSON against schema")
     try:
         validate(instance=catalog_json, schema=schema)
-    except ValidationError as exc:
-        path = ".".join(str(p) for p in exc.path) or "<root>"
+    except ValidationError:
         logger.error(
             "Catalog validation failed for %s",
             file_path,
         )
-        logger.debug(
-            "Catalog validation failed at path: %s",
-            path,
-        )
-        raise ValueError("Catalog validation failed") from None
+        raise
     data = catalog_json["Catalog"]
 
     functional_packages = [

--- a/build_stream/core/catalog/parser.py
+++ b/build_stream/core/catalog/parser.py
@@ -58,7 +58,7 @@ def ParseCatalog(file_path: str, schema_path: str = _DEFAULT_SCHEMA_PATH) -> Cat
             "Catalog validation failed at path: %s",
             path,
         )
-        raise
+        raise ValueError("Catalog validation failed") from None
     data = catalog_json["Catalog"]
 
     functional_packages = [

--- a/build_stream/main.py
+++ b/build_stream/main.py
@@ -83,7 +83,7 @@ async def health_check() -> dict:
 
 
 @app.exception_handler(Exception)
-async def global_exception_handler(request, exc):
+async def global_exception_handler(request, exc):  # pylint: disable=unused-argument
     """Global exception handler for unhandled exceptions."""
     logger.exception("Unhandled exception occurred")
     return JSONResponse(

--- a/build_stream/main.py
+++ b/build_stream/main.py
@@ -11,3 +11,93 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Build Stream API Server.
+
+Main entry point for the Build Stream API application.
+This module initializes the FastAPI application and is invoked from the Dockerfile.
+
+Usage:
+    uvicorn main:app --host 0.0.0.0 --port 443
+"""
+
+import logging
+import os
+
+from fastapi import FastAPI, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from api.router import api_router
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Build Stream API",
+    description="RESTful API for the Omnia Build Stream application",
+    version="1.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.getenv("CORS_ORIGINS", "*").split(","),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(api_router)
+
+
+@app.get(
+    "/",
+    summary="Root endpoint",
+    description="Returns a welcome message and API documentation URL.",
+)
+async def root() -> dict:
+    """Root endpoint returning welcome message."""
+    return {
+        "message": "Welcome to Build Stream API",
+        "docs": "/docs",
+        "version": "1.0.0",
+    }
+
+
+@app.get(
+    "/health",
+    summary="Health check",
+    description="Returns the health status of the API server.",
+    status_code=status.HTTP_200_OK,
+)
+async def health_check() -> dict:
+    """Health check endpoint for container orchestration."""
+    return {"status": "healthy"}
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request, exc):
+    """Global exception handler for unhandled exceptions."""
+    logger.exception("Unhandled exception occurred")
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        content={"status": "error", "message": "An internal server error occurred"},
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "443"))
+    reload = os.getenv("RELOAD", "false").lower() == "true"
+
+    logger.info("Starting Build Stream API server on %s:%d", host, port)
+    uvicorn.run("main:app", host=host, port=port, reload=reload)


### PR DESCRIPTION


### Description of the Solution
- Add FastAPI application entry point (main.py) with CORS, health check, global exception handler
- Create modular API structure under api/ with versioned router (/api/v1)
- Implement ParseCatalog API module with routes, service layer, and Pydantic schemas
- Separate HTTP concerns from business logic for testability and maintainability

### Suggested Reviewers
@abhishek-sa1 @priti-parate 
