### PR TITLE
Update image-builder version to 1.1

### DIFF
--- a/build_image_aarch64/roles/prepare_arm_node/tasks/main.yml
+++ b/build_image_aarch64/roles/prepare_arm_node/tasks/main.yml
@@ -167,7 +167,7 @@
 
 - name: Build full Podman image path
   ansible.builtin.set_fact:
-    pulp_aarch_image: "{{ hostvars['localhost']['oim_pxe_ip'] }}:2225/dellhpcomniaaisolution/image-build-aarch64:1.0"
+    pulp_aarch_image: "{{ hostvars['localhost']['oim_pxe_ip'] }}:2225/dellhpcomniaaisolution/image-build-aarch64:1.1"
 
 - name: Pull aarch64 image using Podman
   ansible.builtin.command:

--- a/input/config/aarch64/rhel/10.0/default_packages.json
+++ b/input/config/aarch64/rhel/10.0/default_packages.json
@@ -59,7 +59,7 @@
       {"package": "kexec-tools", "type": "rpm", "repo_name": "aarch64_baseos"},
       {"package": "which", "type": "rpm", "repo_name": "aarch64_baseos"},
       {"package": "iperf3", "type": "rpm", "repo_name": "aarch64_appstream"},
-      { "package": "docker.io/dellhpcomniaaisolution/image-build-aarch64", "tag": "1.0", "type": "image" }
+      { "package": "docker.io/dellhpcomniaaisolution/image-build-aarch64", "tag": "1.1", "type": "image" }
     ]
   }
 }


### PR DESCRIPTION
### Description of the Solution
The older image-builder image (version 1.0) had vulnerabilities. After fixing them, created a new tag (version 1.1). In the omnia repo, updated the image-builder tag in default_packages.json to download the new image, and in the build_image_aarch64.yml playbook, updated the same tag to pull the image.

### Suggested Reviewers
@abhishek-sa1  please review
