### PR TITLE
Implement OAuth2 client registration endpoint

### DIFF
--- a/build_stream/api/auth/__init__.py
+++ b/build_stream/api/auth/__init__.py
@@ -11,3 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""OAuth2 Authentication API module."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/build_stream/api/auth/password_handler.py
+++ b/build_stream/api/auth/password_handler.py
@@ -116,6 +116,6 @@ def generate_credentials() -> Tuple[str, str, str]:
     client_secret = generate_client_secret()
     hashed_secret = hash_password(client_secret)
 
-    logger.debug("Generated new client credentials for client_id: %s", client_id)
+    logger.debug("Generated new client credentials")
 
     return client_id, client_secret, hashed_secret

--- a/build_stream/api/auth/password_handler.py
+++ b/build_stream/api/auth/password_handler.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Password hashing utilities using Argon2id algorithm.
+
+This module provides secure password hashing following the OAuth2 Implementation Spec:
+- Algorithm: Argon2id
+- Memory Cost: 65536 KB (64 MB)
+- Time Cost: 3 iterations
+- Parallelism: 4 threads
+- Salt Length: 16 bytes
+- Hash Length: 32 bytes
+"""
+
+import logging
+import secrets
+from typing import Tuple
+
+from argon2 import PasswordHasher, Type
+from argon2.exceptions import InvalidHashError, VerifyMismatchError
+
+logger = logging.getLogger(__name__)
+
+_hasher = PasswordHasher(
+    time_cost=3,
+    memory_cost=65536,
+    parallelism=4,
+    hash_len=32,
+    salt_len=16,
+    type=Type.ID,
+)
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using Argon2id.
+
+    Args:
+        password: The plaintext password to hash.
+
+    Returns:
+        The hashed password in Argon2 PHC string format.
+    """
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Verify a password against its hash.
+
+    Args:
+        password: The plaintext password to verify.
+        hashed: The Argon2 hash to verify against.
+
+    Returns:
+        True if password matches, False otherwise.
+    """
+    try:
+        _hasher.verify(hashed, password)
+        return True
+    except (VerifyMismatchError, InvalidHashError):
+        return False
+
+
+def check_needs_rehash(hashed: str) -> bool:
+    """Check if a hash needs to be rehashed due to parameter changes.
+
+    Args:
+        hashed: The existing hash to check.
+
+    Returns:
+        True if rehashing is recommended, False otherwise.
+    """
+    try:
+        return _hasher.check_needs_rehash(hashed)
+    except InvalidHashError:
+        return True
+
+
+def generate_client_id() -> str:
+    """Generate a unique client ID.
+
+    Returns:
+        A client ID with 'bld_' prefix followed by 32 hex characters.
+    """
+    return f"bld_{secrets.token_hex(16)}"
+
+
+def generate_client_secret() -> str:
+    """Generate a cryptographically secure client secret.
+
+    Returns:
+        A client secret with 'bld_s_' prefix followed by URL-safe base64 characters.
+    """
+    return f"bld_s_{secrets.token_urlsafe(32)}"
+
+
+def generate_credentials() -> Tuple[str, str, str]:
+    """Generate a new client ID, secret, and hashed secret.
+
+    Returns:
+        Tuple of (client_id, client_secret, hashed_secret).
+        The client_secret is the plaintext to return to the client.
+        The hashed_secret is what should be stored in the vault.
+    """
+    client_id = generate_client_id()
+    client_secret = generate_client_secret()
+    hashed_secret = hash_password(client_secret)
+
+    logger.debug("Generated new client credentials for client_id: %s", client_id)
+
+    return client_id, client_secret, hashed_secret

--- a/build_stream/api/auth/routes.py
+++ b/build_stream/api/auth/routes.py
@@ -141,7 +141,7 @@ async def register_client(
     Raises:
         HTTPException: With appropriate status code on failure.
     """
-    logger.info("Client registration request received for: %s", request.client_name)
+    logger.info("Client registration request received")
 
     try:
         registered_client = _auth_service.register_client(
@@ -150,11 +150,7 @@ async def register_client(
             allowed_scopes=request.allowed_scopes,
         )
 
-        logger.info(
-            "Client registered successfully: %s (client_id: %s)",
-            registered_client.client_name,
-            registered_client.client_id,
-        )
+        logger.info("Client registered successfully")
 
         return ClientRegistrationResponse(
             client_id=registered_client.client_id,
@@ -166,7 +162,7 @@ async def register_client(
         )
 
     except ClientExistsError:
-        logger.warning("Client registration failed - client exists: %s", request.client_name)
+        logger.warning("Client registration failed - client exists")
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={"error": "client_exists", "error_description": "Client name already registered"},

--- a/build_stream/api/auth/routes.py
+++ b/build_stream/api/auth/routes.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FastAPI routes for OAuth2 authentication endpoints."""
+
+import logging
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+from .schemas import (
+    AuthErrorResponse,
+    ClientRegistrationRequest,
+    ClientRegistrationResponse,
+)
+from .service import (
+    AuthenticationError,
+    AuthService,
+    ClientExistsError,
+    MaxClientsReachedError,
+    RegistrationDisabledError,
+)
+from .vault_client import VaultError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+security = HTTPBasic()
+
+_auth_service = AuthService()
+
+
+def _verify_basic_auth(
+    credentials: Annotated[HTTPBasicCredentials, Depends(security)],
+) -> HTTPBasicCredentials:
+    """Verify Basic Authentication credentials for registration.
+
+    Args:
+        credentials: HTTP Basic Auth credentials from request.
+
+    Returns:
+        Validated credentials.
+
+    Raises:
+        HTTPException: If authentication fails.
+    """
+    try:
+        _auth_service.verify_registration_credentials(
+            credentials.username,
+            credentials.password,
+        )
+        return credentials
+    except AuthenticationError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"error": "invalid_credentials", "error_description": "Invalid Basic Auth credentials"},
+            headers={"WWW-Authenticate": "Basic"},
+        ) from None
+    except RegistrationDisabledError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"error": "service_unavailable", "error_description": "Registration service is not available"},
+        ) from None
+
+
+@router.post(
+    "/register",
+    response_model=ClientRegistrationResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register a new OAuth client",
+    description="Register a new OAuth client using HTTP Basic Authentication. "
+    "Returns client_id and client_secret which must be securely stored.",
+    responses={
+        201: {
+            "description": "Client registered successfully",
+            "model": ClientRegistrationResponse,
+        },
+        400: {
+            "description": "Invalid request (missing or malformed request body)",
+            "model": AuthErrorResponse,
+        },
+        401: {
+            "description": "Invalid Basic Auth credentials",
+            "model": AuthErrorResponse,
+        },
+        409: {
+            "description": "Client name already registered",
+            "model": AuthErrorResponse,
+        },
+        422: {
+            "description": "Validation error (invalid field values)",
+            "model": AuthErrorResponse,
+        },
+        429: {
+            "description": "Rate limit exceeded",
+            "model": AuthErrorResponse,
+        },
+        500: {
+            "description": "Internal server error",
+            "model": AuthErrorResponse,
+        },
+        503: {
+            "description": "Registration service unavailable",
+            "model": AuthErrorResponse,
+        },
+    },
+)
+async def register_client(
+    request: ClientRegistrationRequest,
+    credentials: Annotated[HTTPBasicCredentials, Depends(_verify_basic_auth)],  # pylint: disable=unused-argument
+) -> ClientRegistrationResponse:
+    """Register a new OAuth client.
+
+    This endpoint requires HTTP Basic Authentication with pre-configured
+    registration credentials. On success, returns client_id and client_secret
+    which the client must securely store.
+
+    **Important:** The client_secret is shown only once during registration.
+
+    Args:
+        request: Client registration request containing client_name and optional fields.
+        credentials: Validated Basic Auth credentials (injected by dependency).
+
+    Returns:
+        ClientRegistrationResponse with client_id and client_secret.
+
+    Raises:
+        HTTPException: With appropriate status code on failure.
+    """
+    logger.info("Client registration request received for: %s", request.client_name)
+
+    try:
+        registered_client = _auth_service.register_client(
+            client_name=request.client_name,
+            description=request.description,
+            allowed_scopes=request.allowed_scopes,
+        )
+
+        logger.info(
+            "Client registered successfully: %s (client_id: %s)",
+            registered_client.client_name,
+            registered_client.client_id,
+        )
+
+        return ClientRegistrationResponse(
+            client_id=registered_client.client_id,
+            client_secret=registered_client.client_secret,
+            client_name=registered_client.client_name,
+            allowed_scopes=registered_client.allowed_scopes,
+            created_at=registered_client.created_at,
+            expires_at=registered_client.expires_at,
+        )
+
+    except ClientExistsError:
+        logger.warning("Client registration failed - client exists: %s", request.client_name)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": "client_exists", "error_description": "Client name already registered"},
+        ) from None
+
+    except MaxClientsReachedError:
+        logger.warning("Client registration failed - max clients reached")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "max_clients_reached",
+                "error_description": "Maximum number of clients (1) already registered"
+            },
+        ) from None
+
+    except VaultError:
+        logger.error("Client registration failed - vault error for: %s", request.client_name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "server_error", "error_description": "Failed to store client credentials"},
+        ) from None
+
+    except Exception:
+        logger.exception("Unexpected error during client registration: %s", request.client_name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "server_error", "error_description": "An unexpected error occurred"},
+        ) from None

--- a/build_stream/api/auth/schemas.py
+++ b/build_stream/api/auth/schemas.py
@@ -95,9 +95,9 @@ class ClientRegistrationResponse(BaseModel):  # pylint: disable=too-few-public-m
         "json_schema_extra": {
             "examples": [
                 {
-                    "client_id": "bld_c1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6",
-                    "client_secret": "bld_s_7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8",
-                    "client_name": "omnia-controller-node-01",
+                    "client_id": "bld_<32_hex_characters>",
+                    "client_secret": "bld_s_<base64_url_safe_characters>",
+                    "client_name": "example-client-name",
                     "allowed_scopes": ["catalog:read", "catalog:write"],
                     "created_at": "2026-01-21T07:31:00Z",
                     "expires_at": None,

--- a/build_stream/api/auth/schemas.py
+++ b/build_stream/api/auth/schemas.py
@@ -96,7 +96,7 @@ class ClientRegistrationResponse(BaseModel):  # pylint: disable=too-few-public-m
             "examples": [
                 {
                     "client_id": "bld_<32_hex_characters>",
-                    "client_secret": "bld_s_<base64_url_safe_characters>",
+                    "client_secret": "********",
                     "client_name": "example-client-name",
                     "allowed_scopes": ["catalog:read", "catalog:write"],
                     "created_at": "2026-01-21T07:31:00Z",

--- a/build_stream/api/auth/schemas.py
+++ b/build_stream/api/auth/schemas.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic schemas for OAuth2 authentication API request and response models."""
+
+import re
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ClientRegistrationRequest(BaseModel):  # pylint: disable=too-few-public-methods
+    """Request model for client registration."""
+
+    client_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Unique identifier for the client (alphanumeric, hyphens, max 64 chars)",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        max_length=256,
+        description="Human-readable description (max 256 chars)",
+    )
+    allowed_scopes: Optional[List[str]] = Field(
+        default=None,
+        description="Requested OAuth scopes (default: ['catalog:read'])",
+    )
+
+    @field_validator("client_name")
+    @classmethod
+    def validate_client_name(cls, v: str) -> str:
+        """Validate client_name contains only allowed characters."""
+        if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$", v):
+            raise ValueError(
+                "client_name must start with alphanumeric and contain only "
+                "alphanumeric characters, hyphens, and underscores"
+            )
+        return v
+
+    @field_validator("allowed_scopes")
+    @classmethod
+    def validate_scopes(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        """Validate that requested scopes are valid."""
+        valid_scopes = {"catalog:read", "catalog:write", "admin:read", "admin:write"}
+        if v is not None:
+            for scope in v:
+                if scope not in valid_scopes:
+                    raise ValueError(f"Invalid scope: {scope}")
+        return v
+
+
+class ClientRegistrationResponse(BaseModel):  # pylint: disable=too-few-public-methods
+    """Response model for successful client registration."""
+
+    client_id: str = Field(
+        ...,
+        description="Unique client identifier (prefix: bld_)",
+    )
+    client_secret: str = Field(
+        ...,
+        description="Client secret (prefix: bld_s_) - shown only once",
+    )
+    client_name: str = Field(
+        ...,
+        description="The registered client name",
+    )
+    allowed_scopes: List[str] = Field(
+        ...,
+        description="Granted OAuth scopes",
+    )
+    created_at: datetime = Field(
+        ...,
+        description="Registration timestamp",
+    )
+    expires_at: Optional[datetime] = Field(
+        default=None,
+        description="Credential expiration (null = no expiry)",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "client_id": "bld_c1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6",
+                    "client_secret": "bld_s_7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8",
+                    "client_name": "omnia-controller-node-01",
+                    "allowed_scopes": ["catalog:read", "catalog:write"],
+                    "created_at": "2026-01-21T07:31:00Z",
+                    "expires_at": None,
+                }
+            ]
+        }
+    }
+
+
+class AuthErrorResponse(BaseModel):  # pylint: disable=too-few-public-methods
+    """OAuth2 error response model following RFC 6749."""
+
+    error: str = Field(
+        ...,
+        description="Error code (machine-readable)",
+    )
+    error_description: str = Field(
+        ...,
+        description="Human-readable error description",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "error": "invalid_credentials",
+                    "error_description": "Invalid Basic Auth credentials",
+                },
+                {
+                    "error": "client_exists",
+                    "error_description": "Client name already registered",
+                },
+            ]
+        }
+    }

--- a/build_stream/api/auth/schemas.py
+++ b/build_stream/api/auth/schemas.py
@@ -96,7 +96,7 @@ class ClientRegistrationResponse(BaseModel):  # pylint: disable=too-few-public-m
             "examples": [
                 {
                     "client_id": "bld_<32_hex_characters>",
-                    "client_secret": "********",
+                    #"client_secret": "", #Commented out for security
                     "client_name": "example-client-name",
                     "allowed_scopes": ["catalog:read", "catalog:write"],
                     "created_at": "2026-01-21T07:31:00Z",

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -139,9 +139,7 @@ class AuthService:  # pylint: disable=too-few-public-methods
         """
         active_count = self.vault_client.get_active_client_count()
         if active_count >= 1:
-            logger.warning(
-                "Max client limit reached. Active clients: %d", active_count
-            )
+            logger.warning("Max client limit reached")
             raise MaxClientsReachedError(
                 "Maximum number of clients (1) already registered. "
                 "Only one active client is supported."

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -113,7 +113,7 @@ class AuthService:  # pylint: disable=too-few-public-methods
             logger.warning("Invalid registration password attempted")
             raise AuthenticationError("Invalid credentials")
 
-        logger.info("Registration credentials verified for user: %s", username)
+        logger.info("Registration credentials verified successfully")
         return True
 
     def register_client(
@@ -148,8 +148,8 @@ class AuthService:  # pylint: disable=too-few-public-methods
             )
 
         if self.vault_client.client_exists(client_name):
-            logger.warning("Attempted to register existing client: %s", client_name)
-            raise ClientExistsError(f"Client '{client_name}' already exists")
+            logger.warning("Attempted to register existing client")
+            raise ClientExistsError("Client already exists")
 
         scopes = allowed_scopes if allowed_scopes else DEFAULT_SCOPES
         client_id, client_secret, hashed_secret = generate_credentials()
@@ -170,11 +170,7 @@ class AuthService:  # pylint: disable=too-few-public-methods
             logger.error("Failed to save client to vault: %s", client_name)
             raise
 
-        logger.info(
-            "Client registered successfully: %s (client_id: %s)",
-            client_name,
-            client_id,
-        )
+        logger.info("Client registered successfully")
 
         return RegisteredClient(
             client_id=client_id,

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Authentication service for OAuth2 client registration."""
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from .password_handler import generate_credentials, verify_password
+from .vault_client import VaultClient, VaultDecryptError, VaultError, VaultNotFoundError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SCOPES = ["catalog:read"]
+
+
+class AuthenticationError(Exception):
+    """Exception raised when authentication fails."""
+
+
+class ClientExistsError(Exception):
+    """Exception raised when client name already exists."""
+
+
+class MaxClientsReachedError(Exception):
+    """Exception raised when maximum number of clients is already registered."""
+
+
+class RegistrationDisabledError(Exception):
+    """Exception raised when registration is disabled or misconfigured."""
+
+
+@dataclass
+class RegisteredClient:
+    """Data class representing a registered OAuth client."""
+
+    client_id: str
+    client_secret: str
+    client_name: str
+    allowed_scopes: List[str]
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+
+
+class AuthService:  # pylint: disable=too-few-public-methods
+    """Service for handling OAuth2 authentication operations."""
+
+    def __init__(self, vault_client: Optional[VaultClient] = None):
+        """Initialize the authentication service.
+
+        Args:
+            vault_client: Optional VaultClient instance. Creates default if not provided.
+        """
+        self.vault_client = vault_client or VaultClient()
+        self._registration_username = os.getenv("AUTH_REGISTRATION_USERNAME")
+
+    def verify_registration_credentials(self, username: str, password: str) -> bool:
+        """Verify the Basic Auth credentials for registration endpoint.
+
+        Args:
+            username: The provided username.
+            password: The provided password.
+
+        Returns:
+            True if credentials are valid.
+
+        Raises:
+            AuthenticationError: If credentials are invalid.
+            RegistrationDisabledError: If registration is not configured.
+        """
+        try:
+            auth_config = self.vault_client.get_auth_config()
+        except VaultNotFoundError:
+            logger.error("Auth configuration vault not found")
+            raise RegistrationDisabledError(
+                "Registration is not configured"
+            ) from None
+        except VaultDecryptError:
+            logger.error("Failed to decrypt auth configuration")
+            raise RegistrationDisabledError(
+                "Registration configuration error"
+            ) from None
+
+        registration_config = auth_config.get("auth_registration", {})
+        stored_username = registration_config.get("username")
+        stored_password_hash = registration_config.get("password_hash")
+
+        if not stored_username or not stored_password_hash:
+            logger.error("Registration credentials not configured in vault")
+            raise RegistrationDisabledError(
+                "Registration is not configured"
+            ) from None
+
+        if username != stored_username:
+            logger.warning("Invalid registration username attempted")
+            raise AuthenticationError("Invalid credentials")
+
+        if not verify_password(password, stored_password_hash):
+            logger.warning("Invalid registration password attempted")
+            raise AuthenticationError("Invalid credentials")
+
+        logger.info("Registration credentials verified for user: %s", username)
+        return True
+
+    def register_client(
+        self,
+        client_name: str,
+        description: Optional[str] = None,
+        allowed_scopes: Optional[List[str]] = None,
+    ) -> RegisteredClient:
+        """Register a new OAuth client.
+
+        Args:
+            client_name: Unique name for the client.
+            description: Optional description of the client.
+            allowed_scopes: List of OAuth scopes to grant.
+
+        Returns:
+            RegisteredClient with credentials (secret shown only once).
+
+        Raises:
+            ClientExistsError: If client_name is already registered.
+            MaxClientsReachedError: If maximum client limit (1) is reached.
+            VaultError: If vault operations fail.
+        """
+        active_count = self.vault_client.get_active_client_count()
+        if active_count >= 1:
+            logger.warning(
+                "Max client limit reached. Active clients: %d", active_count
+            )
+            raise MaxClientsReachedError(
+                "Maximum number of clients (1) already registered. "
+                "Only one active client is supported."
+            )
+
+        if self.vault_client.client_exists(client_name):
+            logger.warning("Attempted to register existing client: %s", client_name)
+            raise ClientExistsError(f"Client '{client_name}' already exists")
+
+        scopes = allowed_scopes if allowed_scopes else DEFAULT_SCOPES
+        client_id, client_secret, hashed_secret = generate_credentials()
+        created_at = datetime.now(timezone.utc)
+
+        client_data = {
+            "client_name": client_name,
+            "client_secret_hash": hashed_secret,
+            "description": description,
+            "allowed_scopes": scopes,
+            "created_at": created_at.isoformat(),
+            "is_active": True,
+        }
+
+        try:
+            self.vault_client.save_oauth_client(client_id, client_data)
+        except VaultError as e:
+            logger.error("Failed to save client to vault: %s", client_name)
+            raise
+
+        logger.info(
+            "Client registered successfully: %s (client_id: %s)",
+            client_name,
+            client_id,
+        )
+
+        return RegisteredClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            client_name=client_name,
+            allowed_scopes=scopes,
+            created_at=created_at,
+            expires_at=None,
+        )

--- a/build_stream/api/auth/vault_client.py
+++ b/build_stream/api/auth/vault_client.py
@@ -69,6 +69,8 @@ class VaultClient:  # pylint: disable=too-few-public-methods
             "/etc/omnia/input/project_default/build_stream_oauth_credentials.yml"
         )
 
+    _ALLOWED_VAULT_COMMANDS = frozenset({"view", "encrypt", "decrypt"})
+
     def _run_vault_command(
         self,
         command: str,
@@ -80,16 +82,20 @@ class VaultClient:  # pylint: disable=too-few-public-methods
         Args:
             command: The vault command (view, encrypt, decrypt).
             vault_path: Path to the vault file.
-            input_data: Optional input data for stdin.
+            input_data: Optional input data for stdin (passed to process stdin, not shell).
 
         Returns:
             Command output as string.
 
         Raises:
+            VaultError: If command is not in allowlist.
             VaultNotFoundError: If vault file doesn't exist.
             VaultDecryptError: If decryption fails.
             VaultEncryptError: If encryption fails.
         """
+        if command not in self._ALLOWED_VAULT_COMMANDS:
+            raise VaultError("Invalid vault command")
+
         if command == "view" and not os.path.exists(vault_path):
             raise VaultNotFoundError(f"Vault file not found: {vault_path}")
 

--- a/build_stream/api/auth/vault_client.py
+++ b/build_stream/api/auth/vault_client.py
@@ -1,0 +1,280 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ansible Vault client for secure credential storage and retrieval."""
+
+import logging
+import os
+import subprocess
+import tempfile
+from typing import Any, Dict, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class VaultError(Exception):
+    """Base exception for vault operations."""
+
+
+class VaultDecryptError(VaultError):
+    """Exception raised when vault decryption fails."""
+
+
+class VaultEncryptError(VaultError):
+    """Exception raised when vault encryption fails."""
+
+
+class VaultNotFoundError(VaultError):
+    """Exception raised when vault file is not found."""
+
+
+class VaultClient:  # pylint: disable=too-few-public-methods
+    """Client for interacting with Ansible Vault encrypted files."""
+
+    def __init__(
+        self,
+        vault_password_file: Optional[str] = None,
+        oauth_clients_vault_path: Optional[str] = None,
+        auth_config_vault_path: Optional[str] = None,
+    ):
+        """Initialize the Vault client.
+
+        Args:
+            vault_password_file: Path to the Ansible Vault password file.
+            oauth_clients_vault_path: Path to the OAuth clients vault file.
+            auth_config_vault_path: Path to the auth configuration vault file.
+        """
+        self.vault_password_file = vault_password_file or os.getenv(
+            "ANSIBLE_VAULT_PASSWORD_FILE", "/etc/omnia/.vault_pass"
+        )
+        self.oauth_clients_vault_path = oauth_clients_vault_path or os.getenv(
+            "OAUTH_CLIENTS_VAULT_PATH",
+            "/etc/omnia/input/project_default/build_stream_oauth_credentials.yml"
+        )
+        self.auth_config_vault_path = auth_config_vault_path or os.getenv(
+            "AUTH_CONFIG_VAULT_PATH",
+            "/etc/omnia/input/project_default/build_stream_oauth_credentials.yml"
+        )
+
+    def _run_vault_command(
+        self,
+        command: str,
+        vault_path: str,
+        input_data: Optional[str] = None,
+    ) -> str:
+        """Run an ansible-vault command.
+
+        Args:
+            command: The vault command (view, encrypt, decrypt).
+            vault_path: Path to the vault file.
+            input_data: Optional input data for stdin.
+
+        Returns:
+            Command output as string.
+
+        Raises:
+            VaultNotFoundError: If vault file doesn't exist.
+            VaultDecryptError: If decryption fails.
+            VaultEncryptError: If encryption fails.
+        """
+        if command == "view" and not os.path.exists(vault_path):
+            raise VaultNotFoundError(f"Vault file not found: {vault_path}")
+
+        if not os.path.exists(self.vault_password_file):
+            raise VaultError(f"Vault password file not found: {self.vault_password_file}")
+
+        cmd = [
+            "ansible-vault",
+            command,
+            vault_path,
+            "--vault-password-file",
+            self.vault_password_file,
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                input=input_data,
+                check=True,
+                timeout=30,
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            logger.error("Vault command failed: %s", command)
+            if command == "view":
+                raise VaultDecryptError("Failed to decrypt vault") from None
+            raise VaultEncryptError("Failed to encrypt vault") from None
+        except subprocess.TimeoutExpired:
+            logger.error("Vault command timed out: %s", command)
+            raise VaultError("Vault operation timed out") from None
+
+    def read_vault(self, vault_path: str) -> Dict[str, Any]:
+        """Read and decrypt a vault file.
+
+        Args:
+            vault_path: Path to the vault file.
+
+        Returns:
+            Decrypted vault contents as dictionary.
+
+        Raises:
+            VaultNotFoundError: If vault file doesn't exist.
+            VaultDecryptError: If decryption fails.
+        """
+        logger.debug("Reading vault: %s", vault_path)
+        output = self._run_vault_command("view", vault_path)
+        try:
+            return yaml.safe_load(output) or {}
+        except yaml.YAMLError as e:
+            logger.error("Failed to parse vault YAML")
+            raise VaultDecryptError("Invalid vault content format") from None
+
+    def write_vault(self, vault_path: str, data: Dict[str, Any]) -> None:
+        """Write data to an encrypted vault file.
+
+        Args:
+            vault_path: Path to the vault file.
+            data: Data to encrypt and store.
+
+        Raises:
+            VaultEncryptError: If encryption fails.
+        """
+        logger.debug("Writing vault: %s", vault_path)
+
+        yaml_content = yaml.safe_dump(data, default_flow_style=False)
+
+        vault_dir = os.path.dirname(vault_path)
+        if vault_dir and not os.path.exists(vault_dir):
+            os.makedirs(vault_dir, mode=0o700, exist_ok=True)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".yml",
+            delete=False,
+            encoding="utf-8",
+        ) as temp_file:
+            temp_file.write(yaml_content)
+            temp_path = temp_file.name
+
+        try:
+            encrypt_cmd = [
+                "ansible-vault",
+                "encrypt",
+                temp_path,
+                "--vault-password-file",
+                self.vault_password_file,
+            ]
+            subprocess.run(encrypt_cmd, check=True, capture_output=True, timeout=30)
+
+            with open(temp_path, "r", encoding="utf-8") as f:
+                encrypted_content = f.read()
+
+            with open(vault_path, "w", encoding="utf-8") as f:
+                f.write(encrypted_content)
+
+            os.chmod(vault_path, 0o600)
+            logger.info("Vault written successfully: %s", vault_path)
+
+        except subprocess.CalledProcessError:
+            logger.error("Failed to encrypt vault")
+            raise VaultEncryptError("Failed to encrypt vault") from None
+        except subprocess.TimeoutExpired:
+            logger.error("Vault encryption timed out")
+            raise VaultError("Vault operation timed out") from None
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    def get_auth_config(self) -> Dict[str, Any]:
+        """Get authentication configuration from vault.
+
+        Returns:
+            Auth configuration dictionary containing registration credentials.
+
+        Raises:
+            VaultNotFoundError: If auth config vault doesn't exist.
+            VaultDecryptError: If decryption fails.
+        """
+        return self.read_vault(self.auth_config_vault_path)
+
+    def get_oauth_clients(self) -> Dict[str, Any]:
+        """Get OAuth clients from vault.
+
+        Returns:
+            Dictionary of registered OAuth clients.
+
+        Raises:
+            VaultNotFoundError: If OAuth clients vault doesn't exist.
+            VaultDecryptError: If decryption fails.
+        """
+        try:
+            data = self.read_vault(self.oauth_clients_vault_path)
+            return data.get("oauth_clients", {})
+        except VaultNotFoundError:
+            return {}
+
+    def save_oauth_client(
+        self,
+        client_id: str,
+        client_data: Dict[str, Any],
+    ) -> None:
+        """Save a new OAuth client to vault.
+
+        Args:
+            client_id: The client identifier.
+            client_data: Client data including hashed secret and metadata.
+
+        Raises:
+            VaultEncryptError: If encryption fails.
+        """
+        try:
+            existing_data = self.read_vault(self.oauth_clients_vault_path)
+        except VaultNotFoundError:
+            existing_data = {"oauth_clients": {}}
+
+        if "oauth_clients" not in existing_data:
+            existing_data["oauth_clients"] = {}
+
+        existing_data["oauth_clients"][client_id] = client_data
+
+        self.write_vault(self.oauth_clients_vault_path, existing_data)
+        logger.info("OAuth client saved: %s", client_id)
+
+    def get_active_client_count(self) -> int:
+        """Get the count of active registered clients.
+
+        Returns:
+            Number of active clients.
+        """
+        clients = self.get_oauth_clients()
+        return sum(1 for c in clients.values() if c.get("is_active", True))
+
+    def client_exists(self, client_name: str) -> bool:
+        """Check if a client with the given name already exists.
+
+        Args:
+            client_name: The client name to check.
+
+        Returns:
+            True if client exists, False otherwise.
+        """
+        clients = self.get_oauth_clients()
+        for client_data in clients.values():
+            if client_data.get("client_name") == client_name:
+                return True
+        return False

--- a/build_stream/api/auth/vault_client.py
+++ b/build_stream/api/auth/vault_client.py
@@ -75,14 +75,12 @@ class VaultClient:  # pylint: disable=too-few-public-methods
         self,
         command: str,
         vault_path: str,
-        input_data: Optional[str] = None,
     ) -> str:
         """Run an ansible-vault command.
 
         Args:
             command: The vault command (view, encrypt, decrypt).
             vault_path: Path to the vault file.
-            input_data: Optional input data for stdin (passed to process stdin, not shell).
 
         Returns:
             Command output as string.
@@ -115,7 +113,6 @@ class VaultClient:  # pylint: disable=too-few-public-methods
                 cmd,
                 capture_output=True,
                 text=True,
-                input=input_data,
                 check=True,
                 timeout=30,
             )

--- a/build_stream/api/parse_catalog/routes.py
+++ b/build_stream/api/parse_catalog/routes.py
@@ -28,13 +28,13 @@ from .service import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/parse-catalog", tags=["Catalog Parsing"])
+router = APIRouter(prefix="/jobs", tags=["Catalog Parsing"])
 
 _service = ParseCatalogService()
 
 
 @router.post(
-    "",
+    "/{jobId}/stages/parse-catalog",
     response_model=ParseCatalogResponse,
     status_code=status.HTTP_200_OK,
     summary="Parse a catalog file",
@@ -59,6 +59,7 @@ _service = ParseCatalogService()
     },
 )
 async def parse_catalog(
+    jobId: str,
     file: UploadFile = File(..., description="The catalog JSON file to parse"),
 ) -> ParseCatalogResponse:
     """Parse a catalog from an uploaded JSON file.

--- a/build_stream/api/router.py
+++ b/build_stream/api/router.py
@@ -16,8 +16,10 @@
 
 from fastapi import APIRouter
 
+from .auth import router as auth_router
 from .parse_catalog import router as parse_catalog_router
 
 api_router = APIRouter(prefix="/api/v1")
 
+api_router.include_router(auth_router)
 api_router.include_router(parse_catalog_router)


### PR DESCRIPTION
### Description of the Solution
Add /api/v1/auth/register endpoint for OAuth2 client credentials flow:
 
- Add vault_client.py for Ansible Vault interaction (read/write/encrypt)
- Add password_handler.py with Argon2id hashing (64MB, 3 iterations)
- Add schemas.py with Pydantic request/response models
- Add service.py with registration business logic
- Add routes.py with POST /auth/register endpoint
- Enforce single active client limit (max 1 client)
- Store credentials in build_stream vault file.
 
Features:
- HTTP Basic Auth for registration endpoint protection
- Cryptographically secure client_id/client_secret generation
- Argon2id password hashing for stored secrets
- Comprehensive error responses (401, 409, 422, 500, 503)
 
Documentation:
- Add REGISTER_IMPLEMENTATION_SPEC.md with sequence/flow diagrams
### Suggested Reviewers
@abhishek-sa1 @priti-parate @venu-p1

If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
