### PR TITLE
OAuth2 Token Endpoint with PyJWT

### DIFF
--- a/build_stream/api/auth/jwt_handler.py
+++ b/build_stream/api/auth/jwt_handler.py
@@ -135,7 +135,7 @@ class JWTHandler:
                     f"JWT private key not found: {self.config.private_key_path}"
                 ) from None
             except IOError as e:
-                logger.error("Failed to read JWT private key: %s", str(e))
+                logger.error("Failed to read JWT private key")
                 raise JWTCreationError("Failed to read JWT private key") from None
         return self._private_key
 
@@ -158,7 +158,7 @@ class JWTHandler:
                     f"JWT public key not found: {self.config.public_key_path}"
                 ) from None
             except IOError as e:
-                logger.error("Failed to read JWT public key: %s", str(e))
+                logger.error("Failed to read JWT public key")
                 raise JWTValidationError("Failed to read JWT public key") from None
         return self._public_key
 
@@ -212,10 +212,10 @@ class JWTHandler:
                 algorithm=self.config.algorithm,
                 headers=headers,
             )
-            logger.info("Access token created for client: %s", client_id)
+            logger.info("Access token created for client: %s", client_id[:8] + "...")
             return token, int(expires_delta.total_seconds())
         except Exception as e:
-            logger.error("Failed to create access token: %s", str(e))
+            logger.error("Failed to create access token")
             raise JWTCreationError("Failed to create access token") from None
 
     def validate_token(self, token: str) -> TokenData:
@@ -254,14 +254,14 @@ class JWTHandler:
             logger.warning("Token has expired")
             raise JWTExpiredError("Token has expired") from None
         except (InvalidAudienceError, InvalidIssuerError) as e:
-            logger.warning("Invalid token claims: %s", str(e))
+            logger.warning("Invalid token claims")
             raise JWTValidationError("Invalid token claims") from None
         except InvalidSignatureError:
             logger.warning("Invalid token signature")
             raise JWTInvalidSignatureError("Invalid token signature") from None
         except DecodeError as e:
-            logger.warning("Invalid token format: %s", str(e))
-            raise JWTValidationError("Invalid token format") from None
+                logger.warning("Invalid token format")
+                raise JWTValidationError("Invalid token format") from None
         except Exception as e:
-            logger.error("Unexpected error validating token: %s", str(e))
-            raise JWTValidationError("Token validation failed") from None
+                logger.error("Unexpected error validating token")
+                raise JWTValidationError("Token validation failed") from None

--- a/build_stream/api/auth/jwt_handler.py
+++ b/build_stream/api/auth/jwt_handler.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JWT token generation and validation utilities.
+
+This module provides JWT handling following the OAuth2 Implementation Spec:
+- Algorithm: RS256 (RSA signature with SHA-256)
+- Token Lifetime: 3600 seconds (1 hour)
+- Claims: iss, sub, aud, iat, exp, nbf, jti, scope, client_name
+"""
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+import jwt
+from jwt.exceptions import (
+    DecodeError,
+    ExpiredSignatureError,
+    InvalidAudienceError,
+    InvalidIssuerError,
+    InvalidSignatureError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class JWTHandlerError(Exception):
+    """Base exception for JWT operations."""
+
+
+class JWTCreationError(JWTHandlerError):
+    """Exception raised when JWT creation fails."""
+
+
+class JWTValidationError(JWTHandlerError):
+    """Exception raised when JWT validation fails."""
+
+
+class JWTExpiredError(JWTValidationError):
+    """Exception raised when JWT has expired."""
+
+
+class JWTInvalidSignatureError(JWTValidationError):
+    """Exception raised when JWT signature is invalid."""
+
+
+@dataclass
+class JWTConfig:
+    """Configuration for JWT token handling."""
+
+    private_key_path: str
+    public_key_path: str
+    algorithm: str = "RS256"
+    access_token_expire_minutes: int = 60
+    issuer: str = "build-stream-api"
+    audience: str = "build-stream-api"
+    key_id: str = "build-stream-key-2026-01"
+
+    @classmethod
+    def from_env(cls) -> "JWTConfig":
+        """Create JWTConfig from environment variables."""
+        return cls(
+            private_key_path=os.getenv(
+                "JWT_PRIVATE_KEY_PATH", "/etc/omnia/keys/jwt_private.pem"
+            ),
+            public_key_path=os.getenv(
+                "JWT_PUBLIC_KEY_PATH", "/etc/omnia/keys/jwt_public.pem"
+            ),
+            algorithm=os.getenv("JWT_ALGORITHM", "RS256"),
+            access_token_expire_minutes=int(
+                os.getenv("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+            ),
+            issuer=os.getenv("JWT_ISSUER", "build-stream-api"),
+            audience=os.getenv("JWT_AUDIENCE", "build-stream-api"),
+            key_id=os.getenv("JWT_KEY_ID", "build-stream-key-2026-01"),
+        )
+
+
+@dataclass
+class TokenData:
+    """Data class representing decoded JWT token claims."""
+
+    client_id: str
+    client_name: str
+    scopes: List[str]
+    issued_at: datetime
+    expires_at: datetime
+    token_id: str
+
+
+class JWTHandler:
+    """Handler for JWT token creation and validation."""
+
+    def __init__(self, config: Optional[JWTConfig] = None):
+        """Initialize the JWT handler.
+
+        Args:
+            config: Optional JWTConfig instance. Creates from env if not provided.
+        """
+        self.config = config or JWTConfig.from_env()
+        self._private_key: Optional[str] = None
+        self._public_key: Optional[str] = None
+
+    def _load_private_key(self) -> str:
+        """Load the RSA private key for signing tokens.
+
+        Returns:
+            Private key as string.
+
+        Raises:
+            JWTCreationError: If key file cannot be read.
+        """
+        if self._private_key is None:
+            try:
+                with open(self.config.private_key_path, "r", encoding="utf-8") as f:
+                    self._private_key = f.read()
+            except FileNotFoundError:
+                logger.error("JWT private key not found: %s", self.config.private_key_path)
+                raise JWTCreationError(
+                    f"JWT private key not found: {self.config.private_key_path}"
+                ) from None
+            except IOError as e:
+                logger.error("Failed to read JWT private key: %s", e)
+                raise JWTCreationError("Failed to read JWT private key") from None
+        return self._private_key
+
+    def _load_public_key(self) -> str:
+        """Load the RSA public key for verifying tokens.
+
+        Returns:
+            Public key as string.
+
+        Raises:
+            JWTValidationError: If key file cannot be read.
+        """
+        if self._public_key is None:
+            try:
+                with open(self.config.public_key_path, "r", encoding="utf-8") as f:
+                    self._public_key = f.read()
+            except FileNotFoundError:
+                logger.error("JWT public key not found: %s", self.config.public_key_path)
+                raise JWTValidationError(
+                    f"JWT public key not found: {self.config.public_key_path}"
+                ) from None
+            except IOError as e:
+                logger.error("Failed to read JWT public key: %s", e)
+                raise JWTValidationError("Failed to read JWT public key") from None
+        return self._public_key
+
+    def create_access_token(
+        self,
+        client_id: str,
+        client_name: str,
+        scopes: List[str],
+    ) -> tuple[str, int]:
+        """Create a JWT access token.
+
+        Args:
+            client_id: The client identifier (becomes 'sub' claim).
+            client_name: Human-readable client name.
+            scopes: List of granted scopes.
+
+        Returns:
+            Tuple of (access_token, expires_in_seconds).
+
+        Raises:
+            JWTCreationError: If token creation fails.
+        """
+        now = datetime.now(timezone.utc)
+        expires_delta = timedelta(minutes=self.config.access_token_expire_minutes)
+        expires_at = now + expires_delta
+        token_id = str(uuid.uuid4())
+
+        claims = {
+            "iss": self.config.issuer,
+            "sub": client_id,
+            "aud": self.config.audience,
+            "iat": int(now.timestamp()),
+            "exp": int(expires_at.timestamp()),
+            "nbf": int(now.timestamp()),
+            "jti": token_id,
+            "scope": " ".join(scopes),
+            "client_name": client_name,
+        }
+
+        headers = {
+            "alg": self.config.algorithm,
+            "typ": "JWT",
+            "kid": self.config.key_id,
+        }
+
+        try:
+            private_key = self._load_private_key()
+            token = jwt.encode(
+                claims,
+                private_key,
+                algorithm=self.config.algorithm,
+                headers=headers,
+            )
+            logger.info("Access token created for client: %s", client_id)
+            return token, int(expires_delta.total_seconds())
+        except Exception as e:
+            logger.error("Failed to create access token: %s", e)
+            raise JWTCreationError("Failed to create access token") from None
+
+    def validate_token(self, token: str) -> TokenData:
+        """Validate a JWT access token and extract claims.
+
+        Args:
+            token: The JWT token string.
+
+        Returns:
+            TokenData with decoded claims.
+
+        Raises:
+            JWTExpiredError: If token has expired.
+            JWTInvalidSignatureError: If signature is invalid.
+            JWTValidationError: If token is otherwise invalid.
+        """
+        try:
+            public_key = self._load_public_key()
+            payload = jwt.decode(
+                token,
+                public_key,
+                algorithms=[self.config.algorithm],
+                audience=self.config.audience,
+                issuer=self.config.issuer,
+            )
+
+            return TokenData(
+                client_id=payload["sub"],
+                client_name=payload.get("client_name", ""),
+                scopes=payload.get("scope", "").split(),
+                issued_at=datetime.fromtimestamp(payload["iat"], tz=timezone.utc),
+                expires_at=datetime.fromtimestamp(payload["exp"], tz=timezone.utc),
+                token_id=payload.get("jti", ""),
+            )
+        except ExpiredSignatureError:
+            logger.warning("Token has expired")
+            raise JWTExpiredError("Token has expired") from None
+        except (InvalidAudienceError, InvalidIssuerError) as e:
+            logger.warning("Invalid token claims: %s", e)
+            raise JWTValidationError(f"Invalid token claims: {e}") from None
+        except InvalidSignatureError:
+            logger.warning("Invalid token signature")
+            raise JWTInvalidSignatureError("Invalid token signature") from None
+        except DecodeError as e:
+            logger.warning("Invalid token format: %s", e)
+            raise JWTValidationError("Invalid token format") from None
+        except Exception as e:
+            logger.error("Unexpected error validating token: %s", e)
+            raise JWTValidationError("Token validation failed") from None

--- a/build_stream/api/auth/jwt_handler.py
+++ b/build_stream/api/auth/jwt_handler.py
@@ -135,7 +135,7 @@ class JWTHandler:
                     f"JWT private key not found: {self.config.private_key_path}"
                 ) from None
             except IOError as e:
-                logger.error("Failed to read JWT private key: %s", e)
+                logger.error("Failed to read JWT private key: %s", str(e))
                 raise JWTCreationError("Failed to read JWT private key") from None
         return self._private_key
 
@@ -158,7 +158,7 @@ class JWTHandler:
                     f"JWT public key not found: {self.config.public_key_path}"
                 ) from None
             except IOError as e:
-                logger.error("Failed to read JWT public key: %s", e)
+                logger.error("Failed to read JWT public key: %s", str(e))
                 raise JWTValidationError("Failed to read JWT public key") from None
         return self._public_key
 
@@ -215,7 +215,7 @@ class JWTHandler:
             logger.info("Access token created for client: %s", client_id)
             return token, int(expires_delta.total_seconds())
         except Exception as e:
-            logger.error("Failed to create access token: %s", e)
+            logger.error("Failed to create access token: %s", str(e))
             raise JWTCreationError("Failed to create access token") from None
 
     def validate_token(self, token: str) -> TokenData:
@@ -254,14 +254,14 @@ class JWTHandler:
             logger.warning("Token has expired")
             raise JWTExpiredError("Token has expired") from None
         except (InvalidAudienceError, InvalidIssuerError) as e:
-            logger.warning("Invalid token claims: %s", e)
-            raise JWTValidationError(f"Invalid token claims: {e}") from None
+            logger.warning("Invalid token claims: %s", str(e))
+            raise JWTValidationError("Invalid token claims") from None
         except InvalidSignatureError:
             logger.warning("Invalid token signature")
             raise JWTInvalidSignatureError("Invalid token signature") from None
         except DecodeError as e:
-            logger.warning("Invalid token format: %s", e)
+            logger.warning("Invalid token format: %s", str(e))
             raise JWTValidationError("Invalid token format") from None
         except Exception as e:
-            logger.error("Unexpected error validating token: %s", e)
+            logger.error("Unexpected error validating token: %s", str(e))
             raise JWTValidationError("Token validation failed") from None

--- a/build_stream/api/auth/password_handler.py
+++ b/build_stream/api/auth/password_handler.py
@@ -116,6 +116,5 @@ def generate_credentials() -> Tuple[str, str, str]:
     client_secret = generate_client_secret()
     hashed_secret = hash_password(client_secret)
 
-    logger.debug("Generated new client credentials")
 
     return client_id, client_secret, hashed_secret

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Authentication service for OAuth2 client registration."""
+"""Authentication service for OAuth2 client registration and token generation."""
 
 import logging
 import os
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import List, Optional
 
+from .jwt_handler import JWTCreationError, JWTHandler
 from .password_handler import generate_credentials, verify_password
 from .vault_client import VaultClient, VaultDecryptError, VaultError, VaultNotFoundError
 
@@ -44,6 +45,22 @@ class RegistrationDisabledError(Exception):
     """Exception raised when registration is disabled or misconfigured."""
 
 
+class InvalidClientError(Exception):
+    """Exception raised when client credentials are invalid."""
+
+
+class ClientDisabledError(Exception):
+    """Exception raised when client account is disabled."""
+
+
+class InvalidScopeError(Exception):
+    """Exception raised when requested scope is not allowed."""
+
+
+class TokenCreationError(Exception):
+    """Exception raised when token creation fails."""
+
+
 @dataclass
 class RegisteredClient:
     """Data class representing a registered OAuth client."""
@@ -56,16 +73,32 @@ class RegisteredClient:
     expires_at: Optional[datetime] = None
 
 
-class AuthService:  # pylint: disable=too-few-public-methods
+@dataclass
+class TokenResult:
+    """Data class representing a token generation result."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    scope: str
+
+
+class AuthService:
     """Service for handling OAuth2 authentication operations."""
 
-    def __init__(self, vault_client: Optional[VaultClient] = None):
+    def __init__(
+        self,
+        vault_client: Optional[VaultClient] = None,
+        jwt_handler: Optional[JWTHandler] = None,
+    ):
         """Initialize the authentication service.
 
         Args:
             vault_client: Optional VaultClient instance. Creates default if not provided.
+            jwt_handler: Optional JWTHandler instance. Creates default if not provided.
         """
         self.vault_client = vault_client or VaultClient()
+        self.jwt_handler = jwt_handler or JWTHandler()
         self._registration_username = os.getenv("AUTH_REGISTRATION_USERNAME")
 
     def verify_registration_credentials(self, username: str, password: str) -> bool:
@@ -164,7 +197,7 @@ class AuthService:  # pylint: disable=too-few-public-methods
 
         try:
             self.vault_client.save_oauth_client(client_id, client_data)
-        except VaultError as e:
+        except VaultError:
             logger.error("Failed to save client to vault: %s", client_name)
             raise
 
@@ -177,4 +210,106 @@ class AuthService:  # pylint: disable=too-few-public-methods
             allowed_scopes=scopes,
             created_at=created_at,
             expires_at=None,
+        )
+
+    def verify_client_credentials(
+        self,
+        client_id: str,
+        client_secret: str,
+    ) -> dict:
+        """Verify client credentials for token endpoint.
+
+        Args:
+            client_id: The client identifier.
+            client_secret: The client secret.
+
+        Returns:
+            Client data dictionary if credentials are valid.
+
+        Raises:
+            InvalidClientError: If client_id is unknown or secret is invalid.
+            ClientDisabledError: If client account is disabled.
+        """
+        try:
+            oauth_clients = self.vault_client.get_oauth_clients()
+        except (VaultNotFoundError, VaultDecryptError):
+            logger.error("Failed to load OAuth clients from vault")
+            raise InvalidClientError("Client authentication failed") from None
+
+        if client_id not in oauth_clients:
+            logger.warning("Unknown client_id attempted: %s", client_id[:8] + "...")
+            raise InvalidClientError("Client authentication failed")
+
+        client_data = oauth_clients[client_id]
+
+        if not client_data.get("is_active", False):
+            logger.warning("Disabled client attempted token request: %s", client_id[:8] + "...")
+            raise ClientDisabledError("Client account is disabled")
+
+        stored_hash = client_data.get("client_secret_hash")
+        if not stored_hash or not verify_password(client_secret, stored_hash):
+            logger.warning("Invalid client secret for: %s", client_id[:8] + "...")
+            raise InvalidClientError("Client authentication failed")
+
+        logger.info("Client credentials verified: %s", client_id[:8] + "...")
+        return client_data
+
+    def generate_token(
+        self,
+        client_id: str,
+        client_secret: str,
+        requested_scope: Optional[str] = None,
+    ) -> TokenResult:
+        """Generate a JWT access token for authenticated client.
+
+        Args:
+            client_id: The client identifier.
+            client_secret: The client secret.
+            requested_scope: Optional space-separated list of requested scopes.
+
+        Returns:
+            TokenResult with access token and metadata.
+
+        Raises:
+            InvalidClientError: If client credentials are invalid.
+            ClientDisabledError: If client account is disabled.
+            InvalidScopeError: If requested scope is not allowed.
+            TokenCreationError: If token creation fails.
+        """
+        client_data = self.verify_client_credentials(client_id, client_secret)
+
+        allowed_scopes = client_data.get("allowed_scopes", DEFAULT_SCOPES)
+        client_name = client_data.get("client_name", "")
+
+        if requested_scope:
+            requested_scopes = requested_scope.split()
+            for scope in requested_scopes:
+                if scope not in allowed_scopes:
+                    logger.warning(
+                        "Client %s requested unauthorized scope: %s",
+                        client_id[:8] + "...",
+                        scope,
+                    )
+                    raise InvalidScopeError(f"Scope '{scope}' is not allowed for this client")
+            granted_scopes = requested_scopes
+        else:
+            granted_scopes = allowed_scopes
+
+        try:
+            access_token, expires_in = self.jwt_handler.create_access_token(
+                client_id=client_id,
+                client_name=client_name,
+                scopes=granted_scopes,
+            )
+        except JWTCreationError as e:
+            logger.error("Failed to create access token: %s", e)
+            raise TokenCreationError("Failed to create access token") from None
+
+        logger.info("Token generated for client: %s", client_id[:8] + "...")
+
+        return TokenResult(
+            access_token=access_token,
+            token_type="Bearer",
+            expires_in=expires_in,
+            scope=" ".join(granted_scopes),
         )

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -118,12 +118,10 @@ class AuthService:
         try:
             auth_config = self.vault_client.get_auth_config()
         except VaultNotFoundError:
-            logger.error("Auth configuration vault not found")
             raise RegistrationDisabledError(
                 "Registration is not configured"
             ) from None
         except VaultDecryptError:
-            logger.error("Failed to decrypt auth configuration")
             raise RegistrationDisabledError(
                 "Registration configuration error"
             ) from None
@@ -133,20 +131,16 @@ class AuthService:
         stored_password_hash = registration_config.get("password_hash")
 
         if not stored_username or not stored_password_hash:
-            logger.error("Registration credentials not configured in vault")
             raise RegistrationDisabledError(
                 "Registration is not configured"
             ) from None
 
         if username != stored_username:
-            logger.warning("Invalid registration username attempted")
             raise AuthenticationError("Invalid credentials")
 
         if not verify_password(password, stored_password_hash):
-            logger.warning("Invalid registration password attempted")
             raise AuthenticationError("Invalid credentials")
 
-        logger.info("Registration credentials verified successfully")
         return True
 
     def register_client(
@@ -172,14 +166,12 @@ class AuthService:
         """
         active_count = self.vault_client.get_active_client_count()
         if active_count >= 1:
-            logger.warning("Max client limit reached")
             raise MaxClientsReachedError(
                 "Maximum number of clients (1) already registered. "
                 "Only one active client is supported."
             )
 
         if self.vault_client.client_exists(client_name):
-            logger.warning("Attempted to register existing client")
             raise ClientExistsError("Client already exists")
 
         scopes = allowed_scopes if allowed_scopes else DEFAULT_SCOPES
@@ -198,10 +190,7 @@ class AuthService:
         try:
             self.vault_client.save_oauth_client(client_id, client_data)
         except VaultError:
-            logger.error("Failed to save client to vault")
             raise
-
-        logger.info("Client registered successfully")
 
         return RegisteredClient(
             client_id=client_id,

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -198,7 +198,7 @@ class AuthService:
         try:
             self.vault_client.save_oauth_client(client_id, client_data)
         except VaultError:
-            logger.error("Failed to save client to vault: %s", client_name)
+            logger.error("Failed to save client to vault")
             raise
 
         logger.info("Client registered successfully")
@@ -302,7 +302,7 @@ class AuthService:
                 scopes=granted_scopes,
             )
         except JWTCreationError as e:
-            logger.error("Failed to create access token: %s", str(e))
+            logger.error("Failed to create access token")
             raise TokenCreationError("Failed to create access token") from None
 
         logger.info("Token generated for client: %s", client_id[:8] + "...")

--- a/build_stream/api/auth/service.py
+++ b/build_stream/api/auth/service.py
@@ -302,7 +302,7 @@ class AuthService:
                 scopes=granted_scopes,
             )
         except JWTCreationError as e:
-            logger.error("Failed to create access token: %s", e)
+            logger.error("Failed to create access token: %s", str(e))
             raise TokenCreationError("Failed to create access token") from None
 
         logger.info("Token generated for client: %s", client_id[:8] + "...")

--- a/build_stream/api/auth/vault_client.py
+++ b/build_stream/api/auth/vault_client.py
@@ -205,8 +205,7 @@ class VaultClient:  # pylint: disable=too-few-public-methods
             os.chmod(vault_path, 0o600)
             logger.debug("Vault written successfully")
 
-        except subprocess.CalledProcessError as e:
-            logger.error("Failed to encrypt vault. Return code: %d", e.returncode)
+        except subprocess.CalledProcessError:
             raise VaultEncryptError("Failed to encrypt vault") from None
         except subprocess.TimeoutExpired:
             logger.error("Vault encryption timed out")

--- a/build_stream/api/auth/vault_client.py
+++ b/build_stream/api/auth/vault_client.py
@@ -206,11 +206,7 @@ class VaultClient:  # pylint: disable=too-few-public-methods
             logger.debug("Vault written successfully")
 
         except subprocess.CalledProcessError as e:
-            logger.error(
-                "Failed to encrypt vault. Return code: %d, stderr: %s",
-                e.returncode,
-                e.stderr,
-            )
+            logger.error("Failed to encrypt vault. Return code: %d", e.returncode)
             raise VaultEncryptError("Failed to encrypt vault") from None
         except subprocess.TimeoutExpired:
             logger.error("Vault encryption timed out")
@@ -272,7 +268,7 @@ class VaultClient:  # pylint: disable=too-few-public-methods
         existing_data["oauth_clients"][client_id] = client_data
 
         self.write_vault(self.oauth_clients_vault_path, existing_data)
-        logger.info("OAuth client saved: %s", client_id)
+        logger.info("OAuth client saved: %s", client_id[:8] + "...")
 
     def get_active_client_count(self) -> int:
         """Get the count of active registered clients.

--- a/build_stream/requirements-dev.txt
+++ b/build_stream/requirements-dev.txt
@@ -1,0 +1,15 @@
+# Development and testing dependencies for Build Stream API
+# Install with: pip install -r requirements-dev.txt
+
+# Testing framework
+pytest>=7.4.0
+pytest-asyncio>=0.21.0
+pytest-cov>=4.1.0
+
+# HTTP client for FastAPI testing
+httpx>=0.25.0
+
+# Code quality
+pylint>=3.0.0
+black>=23.0.0
+isort>=5.12.0

--- a/build_stream/requirements.txt
+++ b/build_stream/requirements.txt
@@ -1,0 +1,25 @@
+# Core dependencies for Build Stream API
+# Install with: pip install -r requirements.txt
+
+# Web framework
+fastapi>=0.104.0
+uvicorn>=0.24.0
+pydantic>=2.5.0
+
+# Authentication
+PyJWT>=2.8.0
+cryptography>=41.0.0
+argon2-cffi>=23.1.0
+
+# Vault integration
+pyyaml>=6.0.0
+ansible>=8.0.0
+
+# Form data handling
+python-multipart>=0.0.6
+
+# HTTP client
+httpx>=0.25.0
+
+# JSON Schema validation
+jsonschema>=4.20.0

--- a/build_stream/scripts/generate_jwt_keys.sh
+++ b/build_stream/scripts/generate_jwt_keys.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate RSA key pair for JWT signing
+#
+# This script generates a 4096-bit RSA key pair for signing JWT tokens.
+# The keys are stored in the specified directory with appropriate permissions.
+#
+# Usage:
+#   ./generate_jwt_keys.sh [output_directory]
+#
+# Default output directory: /etc/omnia/keys
+
+set -euo pipefail
+
+# Configuration
+KEY_SIZE=4096
+PRIVATE_KEY_NAME="jwt_private.pem"
+PUBLIC_KEY_NAME="jwt_public.pem"
+DEFAULT_OUTPUT_DIR="/etc/omnia/keys"
+
+# Parse arguments
+OUTPUT_DIR="${1:-$DEFAULT_OUTPUT_DIR}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if openssl is available
+if ! command -v openssl &> /dev/null; then
+    log_error "openssl is required but not installed."
+    exit 1
+fi
+
+# Create output directory if it doesn't exist
+if [ ! -d "$OUTPUT_DIR" ]; then
+    log_info "Creating output directory: $OUTPUT_DIR"
+    mkdir -p "$OUTPUT_DIR"
+fi
+
+PRIVATE_KEY_PATH="$OUTPUT_DIR/$PRIVATE_KEY_NAME"
+PUBLIC_KEY_PATH="$OUTPUT_DIR/$PUBLIC_KEY_NAME"
+
+# Check if keys already exist
+if [ -f "$PRIVATE_KEY_PATH" ] || [ -f "$PUBLIC_KEY_PATH" ]; then
+    log_warn "JWT keys already exist in $OUTPUT_DIR"
+    read -p "Do you want to overwrite them? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        log_info "Key generation cancelled."
+        exit 0
+    fi
+    log_warn "Overwriting existing keys..."
+fi
+
+log_info "Generating $KEY_SIZE-bit RSA private key..."
+openssl genrsa -out "$PRIVATE_KEY_PATH" "$KEY_SIZE" 2>/dev/null
+
+if [ $? -ne 0 ]; then
+    log_error "Failed to generate private key"
+    exit 1
+fi
+
+log_info "Extracting public key..."
+openssl rsa -in "$PRIVATE_KEY_PATH" -pubout -out "$PUBLIC_KEY_PATH" 2>/dev/null
+
+if [ $? -ne 0 ]; then
+    log_error "Failed to extract public key"
+    rm -f "$PRIVATE_KEY_PATH"
+    exit 1
+fi
+
+# Set secure permissions
+log_info "Setting secure permissions..."
+chmod 600 "$PRIVATE_KEY_PATH"  # Owner read/write only
+chmod 644 "$PUBLIC_KEY_PATH"   # Owner read/write, others read
+
+# Verify the keys
+log_info "Verifying key pair..."
+VERIFY_RESULT=$(openssl rsa -in "$PRIVATE_KEY_PATH" -check 2>&1)
+if echo "$VERIFY_RESULT" | grep -q "RSA key ok"; then
+    log_info "Key verification successful"
+else
+    log_error "Key verification failed"
+    exit 1
+fi
+
+# Display key information
+log_info "JWT keys generated successfully!"
+echo ""
+echo "Key Details:"
+echo "  Private Key: $PRIVATE_KEY_PATH"
+echo "  Public Key:  $PUBLIC_KEY_PATH"
+echo "  Key Size:    $KEY_SIZE bits"
+echo "  Algorithm:   RS256 (RSA with SHA-256)"
+echo ""
+echo "Environment Variables (add to your configuration):"
+echo "  export JWT_PRIVATE_KEY_PATH=\"$PRIVATE_KEY_PATH\""
+echo "  export JWT_PUBLIC_KEY_PATH=\"$PUBLIC_KEY_PATH\""
+echo ""
+echo "Key Rotation Recommendations:"
+echo "  - Rotate keys every 365 days for production environments"
+echo "  - Keep backup of old public key for token validation during rotation"
+echo "  - Update JWT_KEY_ID environment variable when rotating keys"
+echo ""
+log_warn "IMPORTANT: Keep the private key secure and never commit it to version control!"

--- a/build_stream/scripts/generate_jwt_keys.sh
+++ b/build_stream/scripts/generate_jwt_keys.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 KEY_SIZE=4096
 PRIVATE_KEY_NAME="jwt_private.pem"
 PUBLIC_KEY_NAME="jwt_public.pem"
-DEFAULT_OUTPUT_DIR="/etc/omnia/keys"
+DEFAULT_OUTPUT_DIR="/opt/omnia/build_stream/api/auth/keys"
 
 # Parse arguments
 OUTPUT_DIR="${1:-$DEFAULT_OUTPUT_DIR}"

--- a/build_stream/tests/integration/conftest.py
+++ b/build_stream/tests/integration/conftest.py
@@ -205,6 +205,7 @@ class ServerManager:
         "fastapi",
         "uvicorn",
         "pydantic",
+        "PyJWT",
         "argon2-cffi",
         "pyyaml",
         "httpx",


### PR DESCRIPTION
### Description of the Solution
Implemented OAuth2 client_credentials flow token endpoint for Build Stream API Server with JWT token generation and validation using PyJWT.

Key Changes:
New Features:

Added POST /api/v1/auth/token endpoint for JWT token generation
Implemented OAuth2 client_credentials grant type
JWT tokens with RS256 algorithm using 4096-bit RSA keys
Client credential verification against Ansible Vault storage
Scope validation for requested permissions
Implementation:

api/auth/jwt_handler.py - JWT token creation/validation with PyJWT
api/auth/service.py - Extended AuthService with token generation methods
api/auth/schemas.py - Token request/response Pydantic models
api/auth/routes.py - Token endpoint with comprehensive error handling
scripts/generate_jwt_keys.sh - Secure RSA key generation script
Dependencies:

Replaced python-jose with PyJWT>=2.8.0 and cryptography>=41.0.0
Added python-multipart>=0.0.6 for form data handling


### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.

@priti-parate @Venu-p1 @abhishek-sa1 @Kratika-P @Milisha-Gupta 

### Checkmarx

IT is run successfully without any new vulnerabilities. Will share the developer testing report shortly.

### UT Results

```
(.venv) root@rajeshkumars:~/Documents/omnia/build_stream# pytest tests/ -v
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/Documents/omnia/build_stream
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 53 items                                                                                                                                        

tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_valid_credentials_returns_201 PASSED                                           [  1%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_minimal_request_returns_201 PASSED                                             [  3%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_invalid_auth_returns_401 PASSED                                                [  5%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_missing_auth_returns_401 PASSED                                                [  7%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_max_clients_reached_returns_409 PASSED                                         [  9%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_duplicate_client_name_returns_409 PASSED                                       [ 11%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_invalid_client_name_returns_422 PASSED                                         [ 13%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_empty_client_name_returns_422 PASSED                                           [ 15%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_missing_client_name_returns_422 PASSED                                         [ 16%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_invalid_scope_returns_422 PASSED                                               [ 18%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_client_name_too_long_returns_422 PASSED                                        [ 20%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_response_contains_all_fields PASSED                                            [ 22%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_client_id_format PASSED                                                        [ 24%]
tests/api/auth/test_register.py::TestRegisterEndpoint::test_register_client_secret_format PASSED                                                    [ 26%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_valid_credentials_returns_201 PASSED                                 [ 28%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_minimal_request_returns_201 PASSED                                   [ 30%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_max_clients_reached_returns_409 PASSED                               [ 32%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_invalid_auth_returns_401 PASSED                                      [ 33%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_missing_auth_returns_401 PASSED                                      [ 35%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_invalid_client_name_returns_422 PASSED                               [ 37%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_empty_client_name_returns_422 PASSED                                 [ 39%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_missing_client_name_returns_422 PASSED                               [ 41%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_invalid_scope_returns_422 PASSED                                     [ 43%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_client_name_too_long_returns_422 PASSED                              [ 45%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_response_contains_all_fields PASSED                                  [ 47%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_client_id_format PASSED                                              [ 49%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_client_secret_format PASSED                                          [ 50%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_malformed_json_returns_422 PASSED                                    [ 52%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_wrong_content_type_returns_422 PASSED                                [ 54%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_malformed_basic_auth_returns_401 PASSED                              [ 56%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_bearer_auth_returns_401 PASSED                                       [ 58%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_special_characters_in_client_name PASSED                             [ 60%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_description_with_unicode PASSED                                      [ 62%]
tests/integration/test_register_e2e.py::TestRegisterEndpointE2E::test_register_all_valid_scopes PASSED                                              [ 64%]
tests/unit/auth/test_password_handler.py::TestPasswordHashing::test_hash_password_returns_argon2_hash PASSED                                        [ 66%]
tests/unit/auth/test_password_handler.py::TestPasswordHashing::test_hash_password_different_for_same_input PASSED                                   [ 67%]
tests/unit/auth/test_password_handler.py::TestPasswordHashing::test_verify_password_correct_password PASSED                                         [ 69%]
tests/unit/auth/test_password_handler.py::TestPasswordHashing::test_verify_password_incorrect_password PASSED                                       [ 71%]
tests/unit/auth/test_password_handler.py::TestPasswordHashing::test_verify_password_invalid_hash PASSED                                             [ 73%]
tests/unit/auth/test_password_handler.py::TestPasswordHashing::test_generated_password_strength PASSED                                              [ 75%]
tests/unit/auth/test_password_handler.py::TestCredentialGeneration::test_generate_client_id_format PASSED                                           [ 77%]
tests/unit/auth/test_password_handler.py::TestCredentialGeneration::test_generate_client_id_unique PASSED                                           [ 79%]
tests/unit/auth/test_password_handler.py::TestCredentialGeneration::test_generate_client_secret_format PASSED                                       [ 81%]
tests/unit/auth/test_password_handler.py::TestCredentialGeneration::test_generate_client_secret_unique PASSED                                       [ 83%]
tests/unit/auth/test_password_handler.py::TestCredentialGeneration::test_generate_credentials_returns_tuple PASSED                                  [ 84%]
tests/unit/auth/test_password_handler.py::TestCredentialGeneration::test_generate_credentials_secret_verifiable PASSED                              [ 86%]
tests/unit/auth/test_service.py::TestAuthServiceCredentialVerification::test_verify_valid_credentials PASSED                                        [ 88%]
tests/unit/auth/test_service.py::TestAuthServiceCredentialVerification::test_verify_invalid_username PASSED                                         [ 90%]
tests/unit/auth/test_service.py::TestAuthServiceCredentialVerification::test_verify_invalid_password PASSED                                         [ 92%]
tests/unit/auth/test_service.py::TestAuthServiceClientRegistration::test_register_client_success PASSED                                             [ 94%]
tests/unit/auth/test_service.py::TestAuthServiceClientRegistration::test_register_client_default_scopes PASSED                                      [ 96%]
tests/unit/auth/test_service.py::TestAuthServiceClientRegistration::test_register_client_max_clients_reached PASSED                                 [ 98%]
tests/unit/auth/test_service.py::TestAuthServiceClientRegistration::test_register_client_duplicate_name PASSED                                      [100%]

============================================================== 53 passed in 91.28s (0:01:31) ==============================================================
(.venv) root@rajeshkumars:~/Documents/omnia/build_stream# 
(.venv) root@rajeshkumars:~/Documents/omnia/build_stream# 
