### PR TITLE
Fix aarch64 base image fact name for package collection

### DIFF
--- a/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
+++ b/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
@@ -24,9 +24,9 @@
         software_config_path: "{{ software_config_file_path }}"
       register: base_image_output
 
-    - name: Set x86_64_base_image_packages
+    - name: Set aarch_64_base_image_packages
       ansible.builtin.set_fact:
-        x86_64_base_image_packages: "{{ base_image_output.base_image_packages }}"
+        aarch64_base_image_packages: "{{ base_image_output.base_image_packages }}"
 
     - name: Debug package aarch64_base_image_packages
       ansible.builtin.debug:


### PR DESCRIPTION
### Description of the Solution
 In the aarch64 fetch_packages task, the play set x86_64_base_image_packages, so aarch64_base_image_packages was never created. When rendering the base image template, Ansible hit “AnsibleUndefinedVariable: 'aarch64_base_image_packages' is undefined. So Updated build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml to set the correct fact name aarch64_base_image_packages from base_image_output.base_image_packages, ensuring the template receives the package list for aarch64 builds.
 

### Suggested Reviewers
@abhishek-sa1 Please review
