### PR TITLE
Add appropriate pythonpath to ensure pylint import errors fixed

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,14 +22,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible pylint kubernetes prettytable requests passlib fastapi uvicorn sqlalchemy pytest httpx argon2
+          pip install ansible pylint kubernetes prettytable requests passlib fastapi uvicorn sqlalchemy pytest httpx argon2-cffi pyyaml cryptography dependency-injector python-dotenv
 
       - name: Get changed Python files (excluding deleted)
         id: changed-files
@@ -58,7 +58,9 @@ jobs:
           FILES=$(echo "${{ steps.changed-files.outputs.files }}" | tr ' ' '\n' | grep -v '^discovery/roles/telemetry/files/nersc-ldms-aggr/' | xargs)
 
           if [ -n "$FILES" ]; then
-            pylint $FILES --fail-under=${PYLINT_THRESHOLD}
+            # Set PYTHONPATH to include build_stream directory for proper import resolution
+            # This allows pylint to resolve both relative imports in build_stream and regular imports elsewhere
+            PYTHONPATH=.:./build_stream pylint $FILES --fail-under=${PYLINT_THRESHOLD}
           else
             echo "No files to lint after filtering."
           fi

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -22,14 +22,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible pylint kubernetes prettytable requests passlib fastapi uvicorn sqlalchemy pytest httpx argon2-cffi pyyaml cryptography dependency-injector python-dotenv
+          pip install ansible pylint kubernetes prettytable requests passlib fastapi uvicorn sqlalchemy pytest httpx argon2-cffi pyyaml dependency-injector
 
       - name: Get changed Python files (excluding deleted)
         id: changed-files


### PR DESCRIPTION

### Description of the Solution
Add appropriate pythonpath to ensure pylint import errors fixed for build_stream directory.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@priti-parate @Venu-p1 @abhishek-sa1 
