### PR TITLE
Custom slurm confs paths now read from omnia_core rather than oim

### DIFF
--- a/discovery/roles/slurm_config/tasks/confs.yml
+++ b/discovery/roles/slurm_config/tasks/confs.yml
@@ -27,7 +27,8 @@
 - name: Slurm dbd opts
   ansible.builtin.set_fact:
     apply_config: "{{ apply_config | default({})
-     | combine({'slurmdbd': (apply_config['slurmdbd'] | combine({'DbdHost': ctld_list[0], 'StorageHost': ctld_list[0]}))}) }}"
+     | combine({'slurmdbd': (apply_config['slurmdbd']
+     | combine({'DbdHost': ctld_list[0], 'StorageHost': ctld_list[0]}))}) }}"
   when: ctld_list
 
 - name: Check .conf files existence
@@ -37,21 +38,52 @@
   loop: "{{ ctld_list | product(conf_files | default([])) }}"
   register: ctld_conf_files
 
+- name: Parse configs_input files from localhost (if they are paths)
+  slurm_conf:
+    op: parse
+    conf_name: "{{ item.key }}"
+    path: "{{ item.value }}"
+  delegate_to: localhost
+  loop: "{{ configs_input | default({}) | dict2items }}"
+  register: parsed_configs_input_results
+  when:
+    - configs_input is defined
+    - configs_input
+    - item.value is abs
+
+- name: Build parsed_configs_input dictionary from parsed files
+  ansible.builtin.set_fact:
+    parsed_configs_input: "{{ parsed_configs_input | default({}) | combine({item.item.key: item.conf_dict}) }}"
+  loop: "{{ parsed_configs_input_results.results }}"
+  when:
+    - parsed_configs_input_results is defined
+    - not parsed_configs_input_results.skipped | default(false)
+
+- name: Add configs_input dicts that are already parsed
+  ansible.builtin.set_fact:
+    parsed_configs_input: "{{ parsed_configs_input | default({}) | combine({item.key: item.value}) }}"
+  loop: "{{ configs_input | default({}) | dict2items }}"
+  when:
+    - configs_input is defined
+    - configs_input
+    - item.value is mapping
+
 - name: Create lists for conf_merge
   ansible.builtin.set_fact:
     conf_merge_dict: "{{
         conf_merge_dict | default({})
         | combine({
-            conf_set.item.1: (
-              [apply_config[conf_set.item.1]]
-              + ([conf_set.stat.path] if conf_set.stat.exists else [])
-              + ([configs_input.get(conf_set.item.1)] if configs_input.get(conf_set.item.1) else [])
+            existing_conf_set.item.1: (
+              [apply_config[existing_conf_set.item.1]]
+              + ([existing_conf_set.stat.path] if existing_conf_set.stat.exists else [])
+              + ([parsed_configs_input.get(existing_conf_set.item.1)]
+               if parsed_configs_input is defined and parsed_configs_input.get(existing_conf_set.item.1) else [])
             )
           })
       }}"
   loop: "{{ ctld_conf_files.results }}"
   loop_control:
-    loop_var: conf_set
+    loop_var: existing_conf_set
   register: prepared_conf_lists
 
 - name: Prepend ClusterName and SlurmctldHost to slurm conf sources

--- a/discovery/roles/slurm_config/tasks/confs.yml
+++ b/discovery/roles/slurm_config/tasks/confs.yml
@@ -49,7 +49,7 @@
   when:
     - configs_input is defined
     - configs_input
-    - item.value is abs
+    - item.value is string
 
 - name: Build parsed_configs_input dictionary from parsed files
   ansible.builtin.set_fact:
@@ -57,7 +57,7 @@
   loop: "{{ parsed_configs_input_results.results }}"
   when:
     - parsed_configs_input_results is defined
-    - not parsed_configs_input_results.skipped | default(false)
+    - not item.skipped | default(false)
 
 - name: Add configs_input dicts that are already parsed
   ansible.builtin.set_fact:

--- a/input/omnia_config.yml
+++ b/input/omnia_config.yml
@@ -32,13 +32,12 @@
 # <conf name>: 
 #    <mapping> or <filepath>
 # <mapping> Supply the configuration values directly as a key–value map
-# <filepath> Supply the absolute path to a custom configuration file on the OIM server
+# <filepath> Supply the absolute path to a custom configuration file
 # The conf files supported by slurm are
 # slurm
 # cgroup
 # slurmdbd
 # gres
-# mpi
 # Thes files will be written into the slurm_config directory with .conf suffix
 
 slurm_cluster:
@@ -62,7 +61,6 @@ slurm_cluster:
     #   cgroup: /path/to/custom_cgroup.conf
     #   slurmdbd: /path/to/custom_slurmdbd.conf
     #   gres: /path/to/custom_gres.conf
-    #   mpi: /path/to/custom_mpi.conf
   
 # ----------------------------SERVICE K8S------------------------------------------------------
 # For service k8s cluster below parameters are required,(List)


### PR DESCRIPTION
Previously the slurm conf paths were considered to be present on OIM.
This PR contains changes to read from core_container