### PR TITLE
Fix host vs container paths for Omnia metadata/input and upgrade backups

### DIFF
--- a/prepare_oim/prepare_oim.yml
+++ b/prepare_oim/prepare_oim.yml
@@ -97,6 +97,17 @@
         name: deploy_containers/openchami  # noqa:role-name[path]
         tasks_from: verify_openchami.yml
 
+- name: OpenCHAMI deployment prereq
+  hosts: oim
+  connection: ssh
+  gather_facts: false
+  tags: openchami
+  tasks:
+    - name: Pull OpenCHAMI images
+      ansible.builtin.include_role:
+        name: deploy_containers/openchami  # noqa:role-name[path]
+        tasks_from: deployment_prereq.yml
+
 - name: Deploy the openchami container
   hosts: localhost
   connection: local

--- a/prepare_oim/roles/deploy_containers/openchami/tasks/deployment_prereq.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/deployment_prereq.yml
@@ -1,0 +1,30 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Pull OpenCHAMI images using Podman
+  ansible.builtin.command:
+    cmd: "podman pull {{ item }}"
+  loop: "{{ openchami_images }}"
+  register: pull_result
+  retries: "{{ pull_image_retries }}"
+  delay: "{{ pull_image_delay }}"
+  until: pull_result.rc == 0
+  changed_when: false
+
+- name: Fail if any OpenCHAMI image pull failed
+  ansible.builtin.fail:
+    msg: "Failed to pull OpenCHAMI image: {{ item.item }}. Error: {{ item.stderr }}"
+  loop: "{{ pull_result.results }}"
+  when: item.rc != 0

--- a/prepare_oim/roles/deploy_containers/openchami/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/vars/main.yml
@@ -36,5 +36,41 @@ data_oci_dir: "{{ oim_shared_path }}/omnia/openchami/s3/data/oci"
 data_s3_dir: "{{ oim_shared_path }}/omnia/openchami/s3/data/s3"
 s3_work_dir: "{{ oim_shared_path }}/omnia/openchami/s3"
 
+# Usage: deploy_openchami.yml - pull openchami images
+pull_image_retries: 5
+pull_image_delay: 10
+
+# OpenCHAMI image tags
+openchami_local_ca_tag: "v0.2.2"
+openchami_opaal_tag: "v0.3.10"
+openchami_smd_tag: "v2.18.0"
+openchami_bss_tag: "v1.32.0"
+openchami_cloud_init_tag: "v1.2.3"
+openchami_coredhcp_tag: "v0.3.0"
+# Third-party image tags for OpenCHAMI
+minio_tag: "latest"
+postgres_tag: "11.5-alpine"
+hydra_tag: "v2.3"
+haproxy_tag: "latest"
+registry_tag: "latest"
+curl_tag: "latest"
+acme_tag: "3.1.1"
+
+# OpenCHAMI images list for podman pull on OIM
+openchami_images:
+  - "ghcr.io/openchami/local-ca:{{ openchami_local_ca_tag }}"
+  - "ghcr.io/openchami/opaal:{{ openchami_opaal_tag }}"
+  - "ghcr.io/openchami/smd:{{ openchami_smd_tag }}"
+  - "ghcr.io/openchami/bss:{{ openchami_bss_tag }}"
+  - "ghcr.io/openchami/cloud-init:{{ openchami_cloud_init_tag }}"
+  - "ghcr.io/openchami/coredhcp:{{ openchami_coredhcp_tag }}"
+  - "docker.io/minio/minio:{{ minio_tag }}"
+  - "docker.io/library/postgres:{{ postgres_tag }}"
+  - "docker.io/oryd/hydra:{{ hydra_tag }}"
+  - "cgr.dev/chainguard/haproxy:{{ haproxy_tag }}"
+  - "docker.io/library/registry:{{ registry_tag }}"
+  - "cgr.dev/chainguard/curl:{{ curl_tag }}"
+  - "docker.io/neilpang/acme.sh:{{ acme_tag }}"
+
 # Usage: verify_openchami.yml
 cluster_env_key: "{{ oim_node_name | upper }}_ACCESS_TOKEN"

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/deployment_prereq.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/deployment_prereq.yml
@@ -38,6 +38,20 @@
   when: hostname_enabled
   no_log: true
 
+- name: Pull Pulp image using Podman
+  ansible.builtin.command:
+    cmd: "podman pull {{ pulp_image }}"
+  register: pulp_pull_result
+  retries: "{{ pull_image_retries }}"
+  delay: "{{ pull_image_delay }}"
+  until: pulp_pull_result is not failed
+  changed_when: false
+
+- name: Fail if Pulp image pull failed
+  ansible.builtin.fail:
+    msg: "Failed to pull Pulp image: {{ pulp_image }}. Error: {{ pulp_pull_result.stderr }}"
+  when: pulp_pull_result.rc != 0
+
 - name: Invoke Pulp Container Deployment Tasks for HTTP
   ansible.builtin.include_tasks: deploy_pulp_container_http.yml
   when: not pulp_protocol_https

--- a/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
@@ -27,6 +27,10 @@ pulp_protocol_https: true
 # Tag is fixed for the Pulp container image as of 10-06-2025
 pulp_image: "docker.io/pulp/pulp:3.80"
 
+# Usage: deployment_prereq.yml - pull image retries
+pull_image_retries: 5
+pull_image_delay: 10
+
 arg_list:
   - "-e PULP_WORKERS=10"
   - "-e PULP_API_WORKERS=10"


### PR DESCRIPTION
### Description of the Solution

- Split path constants into container-side (CONTAINER_*) and host-side (OMNIA_*) to avoid mixing mount paths.
- Dynamically initialize host paths after omnia_path is known; remove unused OMNIA_BASE_DIR.
- Ensure podman exec operations (metadata updates, backups) use container paths; host creations use host paths.
- Added explicit podman pulls for Pulp/OpenCHAMI before Quadlet creation

### Suggested Reviewers
@abhishek-sa1 Please Review