### PR TITLE
Enhance Input Validation and Slurm Controller Cloud-Init for Powervault Configuration

### DIFF
--- a/common/library/module_utils/input_validation/schema/storage_config.json
+++ b/common/library/module_utils/input_validation/schema/storage_config.json
@@ -52,7 +52,7 @@
       },
       "powervault_config": {
         "type": "object",
-        "required": ["ip", "iscsi_initiators", "volume_id"],
+        "required": ["ip", "iscsi_initiator", "volume_id"],
         "properties": {
           "ip": {
             "description": "List of target controller IP addresses",
@@ -70,7 +70,7 @@
             "type": "integer"
           },
 
-          "iscsi_initiators": {
+          "iscsi_initiator": {
             "description": "iSCSI initiator IQN",
             "type": "string",
             "pattern": "^iqn\\.[a-zA-Z0-9.-]+(?::[a-zA-Z0-9._:-]+)?$"

--- a/common/library/module_utils/input_validation/schema/storage_config.json
+++ b/common/library/module_utils/input_validation/schema/storage_config.json
@@ -51,7 +51,8 @@
         "minItems": 1
       },
       "powervault_config": {
-        "required": ["ip", "isci_initiators", "volume_id"],
+        "type": "object",
+        "required": ["ip", "iscsi_initiators", "volume_id"],
         "properties": {
           "ip": {
             "description": "List of target controller IP addresses",
@@ -69,14 +70,16 @@
             "type": "integer"
           },
 
-          "isci_initiators": {
+          "iscsi_initiators": {
             "description": "iSCSI initiator IQN",
-            "type": "string"
+            "type": "string",
+            "pattern": "^iqn\\.[a-zA-Z0-9.-]+(?::[a-zA-Z0-9._:-]+)?$"
           },
 
           "volume_id": {
             "description": "Volume identifier (hex string)",
-            "type": "string"
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]+$"
           }
         }
       }

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -92,7 +92,7 @@
 
             PORTALS=({% for ip in powervault_config.ip %}"{{ ip }}" {% endfor %})
             PORT="{{ powervault_config.port | default(3260) }}"
-            INITIATOR_IQN="{{ powervault_config.isci_initiators | default('') }}"
+            INITIATOR_IQN="{{ powervault_config.iscsi_initiators | default('') }}"
             VOLUME_ID="{{ powervault_config.volume_id | default('') }}"
             FS_TYPE="{{ powervault_config.fs_type | default('xfs') }}"
             MOUNT_OPTS="{{ powervault_config.mount_options | default('defaults,_netdev,noatime') }}"

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -92,7 +92,7 @@
 
             PORTALS=({% for ip in powervault_config.ip %}"{{ ip }}" {% endfor %})
             PORT="{{ powervault_config.port | default(3260) }}"
-            INITIATOR_IQN="{{ powervault_config.iscsi_initiators | default('') }}"
+            INITIATOR_IQN="{{ powervault_config.iscsi_initiator | default('') }}"
             VOLUME_ID="{{ powervault_config.volume_id | default('') }}"
             FS_TYPE="{{ powervault_config.fs_type | default('xfs') }}"
             MOUNT_OPTS="{{ powervault_config.mount_options | default('defaults,_netdev,noatime') }}"

--- a/input/storage_config.yml
+++ b/input/storage_config.yml
@@ -19,28 +19,23 @@
 
 # -----------------------------Powervault-------------------------------------------
 # powervault_config
-# ip: ipv4
-# A list of PowerVault controller IP addresses used for iSCSI target discovery and login.
+# Mandatory when using PowerVault for persistent storage.
+# Below parameters are mandatory when powervault_config is defined
+    # ip: A list of PowerVault controller ipv4 addresses used for iSCSI target discovery and login.
+    # iscsi_initiators: Specifies the InitiatorName used by the host when connecting to the iSCSI target. This IQN uniquely identifies the host to the storage array.
+    # volume_id: This is the unique WWN/identifier for the specific volume that should be used for persistent storage. This value is used for multipath scanning to select the correct mapped device.
+
+# Below are the optional parameters when powervault_config is defined
+    # port: Defines the TCP port for the iSCSI target service. When port is not specified, default port used will be 3260
+
+# Below is an example on how to configure powervault_config
 # In this configuration, a single controller portal is provided.
-
-# port:
-# Defines the TCP port for the iSCSI target service.
-# Port 3260 is the standard port for iSCSI communication.
-
-# isci_initiators:
-# Specifies the InitiatorName used by the host when connecting to the iSCSI target.
-# This IQN uniquely identifies the host to the storage array.
-
-# volume_id:
-# This is the unique WWN/identifier for the
-# specific volume that should be used for persistent storage.
-# The script uses this value during multipath scanning to select the correct mapped device
 
 #powervault_config:
 #  ip:
 #    - 172.1.2.3
 #  port: 3260
-#  isci_initiators: iqn.initiator.com.example:7d7d7d7d7d7
+#  iscsi_initiators: iqn.initiator.com.example:7d7d7d7d7d7
 #  volume_id: 00c0ff4343f1f1f1001c8c4e6901000000
 
 

--- a/input/storage_config.yml
+++ b/input/storage_config.yml
@@ -22,7 +22,7 @@
 # Mandatory when using PowerVault for persistent storage.
 # Below parameters are mandatory when powervault_config is defined
     # ip: A list of PowerVault controller ipv4 addresses used for iSCSI target discovery and login.
-    # iscsi_initiators: Specifies the InitiatorName used by the host when connecting to the iSCSI target. This IQN uniquely identifies the host to the storage array.
+    # iscsi_initiator: Specifies the InitiatorName used by the host when connecting to the iSCSI target. This IQN uniquely identifies the host to the storage array.
     # volume_id: This is the unique WWN/identifier for the specific volume that should be used for persistent storage. This value is used for multipath scanning to select the correct mapped device.
 
 # Below are the optional parameters when powervault_config is defined
@@ -35,7 +35,7 @@
 #  ip:
 #    - 172.1.2.3
 #  port: 3260
-#  iscsi_initiators: iqn.initiator.com.example:7d7d7d7d7d7
+#  iscsi_initiator: iqn.initiator.com.example:7d7d7d7d7d7
 #  volume_id: 00c0ff4343f1f1f1001c8c4e6901000000
 
 

--- a/input/storage_config.yml
+++ b/input/storage_config.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/input/storage_config.yml
+++ b/input/storage_config.yml
@@ -35,7 +35,7 @@
 #  ip:
 #    - 172.1.2.3
 #  port: 3260
-#  iscsi_initiator: iqn.initiator.com.example:7d7d7d7d7d7
+#  iscsi_initiator: iqn.2025-01.com.dell:scontrol-node
 #  volume_id: 00c0ff4343f1f1f1001c8c4e6901000000
 
 


### PR DESCRIPTION
This PR includes fixes for:

- Input validation for iscsi_initiator property, required when powervault_config is defined in storage_config.yml
- Modify parameter name in slurm controller cloud init file