### PR TITLE
 Skip podman pulls when images already exist for Pulp and OpenCHAMI

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/tasks/deployment_prereq.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/deployment_prereq.yml
@@ -13,18 +13,29 @@
 # limitations under the License.
 ---
 
-- name: Pull OpenCHAMI images using Podman
+- name: Check if OpenCHAMI images already exist
   ansible.builtin.command:
-    cmd: "podman pull {{ item }}"
+    cmd: "podman image exists {{ item }}"
   loop: "{{ openchami_images }}"
+  register: openchami_image_exists
+  changed_when: false
+  failed_when: false
+
+- name: Pull OpenCHAMI images using Podman when missing
+  ansible.builtin.command:
+    cmd: "podman pull {{ item.item }}"
+  loop: "{{ openchami_image_exists.results }}"
+  loop_control:
+    label: "{{ item.item }}"
   register: pull_result
   retries: "{{ pull_image_retries }}"
   delay: "{{ pull_image_delay }}"
   until: pull_result.rc == 0
   changed_when: false
+  when: item.rc != 0
 
 - name: Fail if any OpenCHAMI image pull failed
   ansible.builtin.fail:
     msg: "Failed to pull OpenCHAMI image: {{ item.item }}. Error: {{ item.stderr }}"
-  loop: "{{ pull_result.results }}"
-  when: item.rc != 0
+  loop: "{{ pull_result.results | default([]) }}"
+  when: item.rc is defined and item.rc != 0

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/deployment_prereq.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/deployment_prereq.yml
@@ -38,7 +38,14 @@
   when: hostname_enabled
   no_log: true
 
-- name: Pull Pulp image using Podman
+- name: Check if Pulp image already exists
+  ansible.builtin.command:
+    cmd: "podman image exists {{ pulp_image }}"
+  register: pulp_image_exists
+  changed_when: false
+  failed_when: false
+
+- name: Pull Pulp image using Podman when missing
   ansible.builtin.command:
     cmd: "podman pull {{ pulp_image }}"
   register: pulp_pull_result
@@ -46,11 +53,15 @@
   delay: "{{ pull_image_delay }}"
   until: pulp_pull_result is not failed
   changed_when: false
+  when: pulp_image_exists.rc != 0
 
 - name: Fail if Pulp image pull failed
   ansible.builtin.fail:
     msg: "Failed to pull Pulp image: {{ pulp_image }}. Error: {{ pulp_pull_result.stderr }}"
-  when: pulp_pull_result.rc != 0
+  when:
+    - pulp_image_exists.rc != 0
+    - pulp_pull_result.rc is defined
+    - pulp_pull_result.rc != 0
 
 - name: Invoke Pulp Container Deployment Tasks for HTTP
   ansible.builtin.include_tasks: deploy_pulp_container_http.yml


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
Add podman image exists guard so Pulp image pulls only run when missing, and fail task only triggers after an attempted pull failure.
Add the same idempotent guard for all OpenCHAMI images; skip pulls for images already present and fail only on actual pull errors.

### Suggested Reviewers
@abhishek-sa1 Please review