### PR TITLE
Remove inventory dependency for external kafka and victoria connect playbooks

### DIFF
--- a/utils/external_kafka_connect_details.yml
+++ b/utils/external_kafka_connect_details.yml
@@ -18,14 +18,43 @@
   connection: local
   gather_facts: false
   tasks:
-    - name: Fail if service_kube_control_plane group is missing or empty
+    - name: Load Kafka utility role variables
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/roles/external_kafka_connect_details/vars/main.yml"
+
+    - name: Include input directory
+      ansible.builtin.include_role:
+        name: include_input_dir
+
+    - name: Set HA config path
+      ansible.builtin.set_fact:
+        k8s_ha_config_path: "{{ input_project_dir }}/high_availability_config.yml"
+
+    - name: Load High Availability config
+      ansible.builtin.include_vars:
+        file: "{{ k8s_ha_config_path }}"
+        name: ha_config
+      failed_when: false
+      register: ha_config_load
+
+    - name: Fail when High Availability config cannot be loaded
       ansible.builtin.fail:
-        msg: >-
-          Inventory must define a 'service_kube_control_plane' group with exactly one host.
-          Provide either the service kube control plane VIP or one of the service kube control plane node IPs.
-          Run with '-i <inventory>' and ensure exactly one host is in that group.
-      when:
-        - groups['service_kube_control_plane'] is not defined or (groups['service_kube_control_plane'] | length) != 1
+        msg: "{{ kafka_preflight_err_ha_config_missing }}"
+      when: ha_config_load.failed
+
+    - name: Set service kube control plane VIP from HA config
+      ansible.builtin.set_fact:
+        kube_vip: "{{ ha_config.service_k8s_cluster_ha[0].virtual_ip_address | default('') }}"
+
+    - name: Fail when service kube control plane VIP is not available
+      ansible.builtin.fail:
+        msg: "{{ kafka_preflight_err_ha_vip_missing }}"
+      when: (kube_vip | trim | length) == 0
+
+    - name: Create service_kube_control_plane group from VIP
+      ansible.builtin.add_host:
+        name: "{{ kube_vip }}"
+        groups: service_kube_control_plane
 
 - name: Fetch external Kafka connection details
   hosts: service_kube_control_plane

--- a/utils/external_victoria_connect_details.yml
+++ b/utils/external_victoria_connect_details.yml
@@ -18,14 +18,43 @@
   connection: local
   gather_facts: false
   tasks:
-    - name: Fail if service_kube_control_plane group is missing or empty
+    - name: Load Victoria utility role variables
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/roles/external_victoria_connect_details/vars/main.yml"
+
+    - name: Include input directory
+      ansible.builtin.include_role:
+        name: include_input_dir
+
+    - name: Set HA config path
+      ansible.builtin.set_fact:
+        k8s_ha_config_path: "{{ input_project_dir }}/high_availability_config.yml"
+
+    - name: Load High Availability config
+      ansible.builtin.include_vars:
+        file: "{{ k8s_ha_config_path }}"
+        name: ha_config
+      failed_when: false
+      register: ha_config_load
+
+    - name: Fail when High Availability config cannot be loaded
       ansible.builtin.fail:
-        msg: >-
-          Inventory must define a 'service_kube_control_plane' group with exactly one host.
-          Provide either the service kube control plane VIP or one of the service kube control plane node IPs.
-          Run with '-i <inventory>' and ensure exactly one host is in that group.
-      when:
-        - groups['service_kube_control_plane'] is not defined or (groups['service_kube_control_plane'] | length) != 1
+        msg: "{{ victoria_preflight_err_ha_config_missing }}"
+      when: ha_config_load.failed
+
+    - name: Set service kube control plane VIP from HA config
+      ansible.builtin.set_fact:
+        kube_vip: "{{ ha_config.service_k8s_cluster_ha[0].virtual_ip_address | default('') }}"
+
+    - name: Fail when service kube control plane VIP is not available
+      ansible.builtin.fail:
+        msg: "{{ victoria_preflight_err_ha_vip_missing }}"
+      when: (kube_vip | trim | length) == 0
+
+    - name: Create service_kube_control_plane group from VIP
+      ansible.builtin.add_host:
+        name: "{{ kube_vip }}"
+        groups: service_kube_control_plane
 
 - name: Fetch external Victoria connection details
   hosts: service_kube_control_plane

--- a/utils/roles/external_kafka_connect_details/tasks/main.yml
+++ b/utils/roles/external_kafka_connect_details/tasks/main.yml
@@ -13,6 +13,16 @@
 #  limitations under the License.
 ---
 
+- name: Validate service k8s controller connectivity
+  block:
+    - name: Wait for service k8s controller connection
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+  rescue:
+    - name: Fail when service k8s controller is not reachable
+      ansible.builtin.fail:
+        msg: "{{ kafka_preflight_err_service_k8s_controller_unreachable }}"
+
 - name: Check kubectl presence
   ansible.builtin.command: kubectl version --client=true
   register: kubectl_check

--- a/utils/roles/external_kafka_connect_details/vars/main.yml
+++ b/utils/roles/external_kafka_connect_details/vars/main.yml
@@ -37,6 +37,10 @@ kafka_preflight_err_ha_vip_missing: >-
   Failed to determine the service Kubernetes control plane VIP from High Availability config.
   Ensure service_k8s_cluster_ha[0].virtual_ip_address is set in: {{ k8s_ha_config_path }}.
 
+kafka_preflight_err_service_k8s_controller_unreachable: >-
+  Service Kubernetes controller is not reachable over SSH: {{ ansible_host | default(inventory_hostname) }}.
+  Ensure the service Kubernetes VIP is reachable and resolvable from the OIM host.
+
 kafka_ome_ui_navigation_line1: "Configuration -> Remote Connectivity"
 kafka_ome_ui_enable_label: "Enable Kafka Connectivity"
 kafka_ome_auth_mode_value: "SSL"

--- a/utils/roles/external_kafka_connect_details/vars/main.yml
+++ b/utils/roles/external_kafka_connect_details/vars/main.yml
@@ -29,6 +29,14 @@ kafka_err_external_ip_missing: >-
   Failed to fetch Kafka LoadBalancer external IP. Ensure service '{{ kafka_lb_service_name }}'
   exists in namespace '{{ kafka_namespace }}' and has an external IP assigned.
 
+kafka_preflight_err_ha_config_missing: >-
+  Failed to load High Availability config file: {{ k8s_ha_config_path }}.
+  Provide a valid HA config so the service Kubernetes VIP can be used.
+
+kafka_preflight_err_ha_vip_missing: >-
+  Failed to determine the service Kubernetes control plane VIP from High Availability config.
+  Ensure service_k8s_cluster_ha[0].virtual_ip_address is set in: {{ k8s_ha_config_path }}.
+
 kafka_ome_ui_navigation_line1: "Configuration -> Remote Connectivity"
 kafka_ome_ui_enable_label: "Enable Kafka Connectivity"
 kafka_ome_auth_mode_value: "SSL"

--- a/utils/roles/external_victoria_connect_details/tasks/main.yml
+++ b/utils/roles/external_victoria_connect_details/tasks/main.yml
@@ -174,7 +174,6 @@
     vminsert_port: "{{ (vminsert_lb_port.stdout | trim) | default('') }}"
     vmselect_port: "{{ (vmselect_lb_port.stdout | trim) | default('') }}"
     victoria_tls_ca: "{{ victoria_tls_cert_dir }}/ca.crt"
-    
 
 - name: Fail when LoadBalancer IPs are not available
   ansible.builtin.fail:

--- a/utils/roles/external_victoria_connect_details/tasks/main.yml
+++ b/utils/roles/external_victoria_connect_details/tasks/main.yml
@@ -13,6 +13,16 @@
 #  limitations under the License.
 ---
 
+- name: Validate service k8s controller connectivity
+  block:
+    - name: Wait for service k8s controller connection
+      ansible.builtin.wait_for_connection:
+        timeout: 30
+  rescue:
+    - name: Fail when service k8s controller is not reachable
+      ansible.builtin.fail:
+        msg: "{{ victoria_preflight_err_service_k8s_controller_unreachable }}"
+
 - name: Check kubectl presence
   ansible.builtin.command: kubectl version --client=true
   register: kubectl_check

--- a/utils/roles/external_victoria_connect_details/vars/main.yml
+++ b/utils/roles/external_victoria_connect_details/vars/main.yml
@@ -38,6 +38,10 @@ victoria_preflight_err_ha_vip_missing: >-
   Failed to determine the service Kubernetes control plane VIP from High Availability config.
   Ensure service_k8s_cluster_ha[0].virtual_ip_address is set in: {{ k8s_ha_config_path }}.
 
+victoria_preflight_err_service_k8s_controller_unreachable: >-
+  Service Kubernetes controller is not reachable over SSH: {{ ansible_host | default(inventory_hostname) }}.
+  Ensure the service Kubernetes VIP is reachable and resolvable from the OIM host.
+
 victoria_sfm_ui_navigation: "Observability -> Settings -> Prometheus Remote Write"
 victoria_sfm_remote_write_target_name: "victoria"
 victoria_sfm_remote_write_message_version: "v1"

--- a/utils/roles/external_victoria_connect_details/vars/main.yml
+++ b/utils/roles/external_victoria_connect_details/vars/main.yml
@@ -30,6 +30,14 @@ victoria_err_lb_missing: >-
   Failed to fetch Victoria LoadBalancer IP(s). Ensure services 'vminsert' and 'vmselect'
   exist in namespace '{{ victoria_namespace }}' and have external IPs assigned.
 
+victoria_preflight_err_ha_config_missing: >-
+  Failed to load High Availability config file: {{ k8s_ha_config_path }}.
+  Provide a valid HA config so the service Kubernetes VIP can be used.
+
+victoria_preflight_err_ha_vip_missing: >-
+  Failed to determine the service Kubernetes control plane VIP from High Availability config.
+  Ensure service_k8s_cluster_ha[0].virtual_ip_address is set in: {{ k8s_ha_config_path }}.
+
 victoria_sfm_ui_navigation: "Observability -> Settings -> Prometheus Remote Write"
 victoria_sfm_remote_write_target_name: "victoria"
 victoria_sfm_remote_write_message_version: "v1"


### PR DESCRIPTION
1. Remove inventory dependency for external kafka and victoria connect playbooks by reading dynamically from HA configuration