### PR TITLE
Playbook watcher service on oim changes

### DIFF
--- a/build_stream/infra/repositories/nfs_playbook_queue_request_repository.py
+++ b/build_stream/infra/repositories/nfs_playbook_queue_request_repository.py
@@ -30,7 +30,7 @@ from core.localrepo.exceptions import QueueUnavailableError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_QUEUE_BASE = "/opt/omnia/build_stream/playbook_queue"
+DEFAULT_QUEUE_BASE = "/opt/omnia/playbook_queue"
 REQUEST_DIR_NAME = "requests"
 FILE_PERMISSIONS = stat.S_IRUSR | stat.S_IWUSR  # 600
 

--- a/build_stream/infra/repositories/nfs_playbook_queue_result_repository.py
+++ b/build_stream/infra/repositories/nfs_playbook_queue_result_repository.py
@@ -27,7 +27,7 @@ from core.localrepo.entities import PlaybookResult
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_QUEUE_BASE = "/opt/omnia/build_stream/playbook_queue"
+DEFAULT_QUEUE_BASE = "/opt/omnia/playbook_queue"
 RESULTS_DIR_NAME = "results"
 ARCHIVE_DIR_NAME = "archive/results"
 

--- a/build_stream/playbook-watcher/playbook_watcher_service.py
+++ b/build_stream/playbook-watcher/playbook_watcher_service.py
@@ -67,16 +67,16 @@ def log_secure_info(level: str, message: str, identifier: Optional[str] = None) 
     log_func(log_message)
 
 # Configuration
-QUEUE_BASE = Path(os.getenv("PLAYBOOK_QUEUE_BASE", "/opt/omnia/build_stream/playbook_queue"))
+QUEUE_BASE = Path(os.getenv("PLAYBOOK_QUEUE_BASE", ""))
 REQUESTS_DIR = QUEUE_BASE / "requests"
 RESULTS_DIR = QUEUE_BASE / "results"
 PROCESSING_DIR = QUEUE_BASE / "processing"
 ARCHIVE_DIR = QUEUE_BASE / "archive"
 
 # NFS shared path configuration
-NFS_SHARE_PATH = Path(os.getenv("NFS_SHARE_PATH", "/abc"))
-HOST_LOG_BASE_DIR = NFS_SHARE_PATH / "omnia" / "build_stream_logs"
-CONTAINER_LOG_BASE_DIR = Path("/opt/omnia/build_stream_logs")
+NFS_SHARE_PATH = Path(os.getenv("NFS_SHARE_PATH", ""))
+HOST_LOG_BASE_DIR = NFS_SHARE_PATH / "omnia" / "log" / "build_stream"
+CONTAINER_LOG_BASE_DIR = Path("/opt/omnia/log/build_stream")
 
 POLL_INTERVAL_SECONDS = int(os.getenv("POLL_INTERVAL_SECONDS", "2"))
 MAX_CONCURRENT_JOBS = int(os.getenv("MAX_CONCURRENT_JOBS", "5"))

--- a/prepare_oim/roles/deploy_containers/build_stream/tasks/enable_watcher_service.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/tasks/enable_watcher_service.yml
@@ -1,0 +1,80 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+
+- name: Read oim metadata
+  ansible.builtin.slurp:
+    src: "{{ oim_metadata_file }}"
+  register: oim_metadata_raw
+  delegate_to: localhost
+  connection: local
+
+- name: debug oim_metadata_raw
+  ansible.builtin.debug:
+    var: oim_metadata_raw
+
+- name: Parse oim_shared_path
+  ansible.builtin.set_fact:
+    oim_shared_path: "{{ (oim_metadata_raw.content | b64decode | from_yaml).oim_shared_path }}"
+
+- name: debug oim_shared_path
+  ansible.builtin.debug:
+    var: oim_shared_path
+
+- name: Check build_stream directory exists in oim_shared_path
+  ansible.builtin.stat:
+    path: "{{ oim_shared_path }}/omnia/build_stream"
+  register: build_stream_stat
+
+
+- name: Fail if omnia directory missing
+  ansible.builtin.fail:
+    msg: "Directory {{ oim_shared_path }}/omnia/omnia is missing; ensure oim_shared_path is mounted and populated."
+  when: not build_stream_stat.stat.exists
+
+# - name: Copy watcher python file to service directory
+#   ansible.builtin.copy:
+#     src: "/omnia/build_stream/playbook-watcher/playbook_watcher_service.py"
+#     dest: "{{ oim_shared_path }}/omnia/build_stream/playbook-watcher/playbook_watcher_service.py"
+#     owner: root
+#     group: root
+#     mode: "0755"
+
+- name: Deploy playbook watcher systemd unit
+  ansible.builtin.template:
+    src: playbook_watcher.service.j2
+    dest: "{{ watcher_systemd_path }}/{{ watcher_service_name }}"
+    mode: "0644"
+  notify:
+    - Reload systemd
+
+- name: Apply systemd reload for watcher
+  ansible.builtin.meta: flush_handlers
+
+- name: Restart and enable playbook watcher service
+  ansible.builtin.systemd_service:
+    name: "{{ watcher_service_name }}"
+    enabled: true
+    state: restarted
+
+- name: Check watcher service status
+  ansible.builtin.command: "systemctl status {{ watcher_service_name | regex_replace('\\.service$', '') }} --no-pager"
+  register: watcher_status
+  changed_when: false
+
+- name: Show recent watcher logs
+  ansible.builtin.command: "journalctl -u {{ watcher_service_name | regex_replace('\\.service$', '') }} -n 10 --no-pager"
+  when: watcher_status.rc == 0
+  register: watcher_logs
+  changed_when: false

--- a/prepare_oim/roles/deploy_containers/build_stream/tasks/enable_watcher_service.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/tasks/enable_watcher_service.yml
@@ -20,42 +20,31 @@
   delegate_to: localhost
   connection: local
 
-- name: debug oim_metadata_raw
-  ansible.builtin.debug:
-    var: oim_metadata_raw
-
 - name: Parse oim_shared_path
   ansible.builtin.set_fact:
     oim_shared_path: "{{ (oim_metadata_raw.content | b64decode | from_yaml).oim_shared_path }}"
-
-- name: debug oim_shared_path
-  ansible.builtin.debug:
-    var: oim_shared_path
 
 - name: Check build_stream directory exists in oim_shared_path
   ansible.builtin.stat:
     path: "{{ oim_shared_path }}/omnia/build_stream"
   register: build_stream_stat
 
-
-- name: Fail if omnia directory missing
+- name: Fail if build_stream directory missing
   ansible.builtin.fail:
-    msg: "Directory {{ oim_shared_path }}/omnia/omnia is missing; ensure oim_shared_path is mounted and populated."
+    msg: "{{ build_stream_nfs_path_error_msg }}"
   when: not build_stream_stat.stat.exists
 
-# - name: Copy watcher python file to service directory
-#   ansible.builtin.copy:
-#     src: "/omnia/build_stream/playbook-watcher/playbook_watcher_service.py"
-#     dest: "{{ oim_shared_path }}/omnia/build_stream/playbook-watcher/playbook_watcher_service.py"
-#     owner: root
-#     group: root
-#     mode: "0755"
+- name: Create playbook_queue directory
+  ansible.builtin.file:
+    path: "{{ oim_shared_path }}/omnia/playbook_queue"
+    state: directory
+    mode: "{{ build_stream_dir_mode }}"
 
 - name: Deploy playbook watcher systemd unit
   ansible.builtin.template:
     src: playbook_watcher.service.j2
     dest: "{{ watcher_systemd_path }}/{{ watcher_service_name }}"
-    mode: "0644"
+    mode: "{{ build_stream_file_mode }}"
   notify:
     - Reload systemd
 
@@ -71,6 +60,12 @@
 - name: Check watcher service status
   ansible.builtin.command: "systemctl status {{ watcher_service_name | regex_replace('\\.service$', '') }} --no-pager"
   register: watcher_status
+  changed_when: false
+
+- name: Show recent watcher logs
+  ansible.builtin.command: "journalctl -u {{ watcher_service_name | regex_replace('\\.service$', '') }} -n 10 --no-pager"
+  when: watcher_status.rc == 0
+  register: watcher_logs
   changed_when: false
 
 - name: Show recent watcher logs

--- a/prepare_oim/roles/deploy_containers/build_stream/tasks/main.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/tasks/main.yml
@@ -13,6 +13,8 @@
 #  limitations under the License.
 
 ---
+- name: Enable playbook watcher service
+  ansible.builtin.include_tasks: enable_watcher_service.yml
 
 - name: Deploy omnia_build_stream container
   ansible.builtin.include_tasks: deploy_build_stream.yml

--- a/prepare_oim/roles/deploy_containers/build_stream/templates/playbook_watcher.service.j2
+++ b/prepare_oim/roles/deploy_containers/build_stream/templates/playbook_watcher.service.j2
@@ -1,17 +1,3 @@
-# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 [Unit]
 Description=Omnia Playbook Watcher Service for Build Stream
 Documentation=https://github.com/dell/omnia

--- a/prepare_oim/roles/deploy_containers/build_stream/templates/playbook_watcher.service.j2
+++ b/prepare_oim/roles/deploy_containers/build_stream/templates/playbook_watcher.service.j2
@@ -17,33 +17,32 @@ Description=Omnia Playbook Watcher Service for Build Stream
 Documentation=https://github.com/dell/omnia
 After=network.target
 
-
 [Service]
 Type=simple
 User=root
-WorkingDirectory=/opt/omnia/build_stream
-ExecStart=/usr/bin/python3 /opt/omnia/build_stream/playbook-watcher/playbook_watcher_service.py
+WorkingDirectory={{ oim_shared_path }}/omnia/build_stream
+ExecStart={{ build_stream_watcher_exec }}
 Restart=always
-RestartSec=5
+RestartSec={{ watcher_restart_sec }}
 StandardOutput=journal
 StandardError=journal
 
 # Environment variables
-Environment="PLAYBOOK_QUEUE_BASE=/opt/omnia/build_stream/playbook_queue"
-Environment="NFS_SHARE_PATH=/abc"
-Environment="POLL_INTERVAL_SECONDS=2"
-Environment="MAX_CONCURRENT_JOBS=5"
-Environment="DEFAULT_TIMEOUT_MINUTES=30"
-Environment="LOG_LEVEL=INFO"
+Environment="PLAYBOOK_QUEUE_BASE={{ build_stream_watcher_playbook_queue_base }}"
+Environment="NFS_SHARE_PATH={{ oim_shared_path }}"
+Environment="POLL_INTERVAL_SECONDS={{ watcher_poll_interval_seconds }}"
+Environment="MAX_CONCURRENT_JOBS={{ watcher_max_concurrent_jobs }}"
+Environment="DEFAULT_TIMEOUT_MINUTES={{ watcher_default_timeout_minutes }}"
+Environment="LOG_LEVEL={{ watcher_log_level }}"
 
 # Security hardening
-NoNewPrivileges=true
-PrivateTmp=true
+NoNewPrivileges={{ watcher_no_new_privileges | lower }}
+PrivateTmp={{ watcher_private_tmp | lower }}
 
 # Resource limits
-LimitNOFILE=4096
-MemoryMax=512M
-CPUQuota=50%
+LimitNOFILE={{ watcher_limit_nofile }}
+MemoryMax={{ watcher_memory_max }}
+CPUQuota={{ watcher_cpu_quota }}
 
 [Install]
 WantedBy=multi-user.target

--- a/prepare_oim/roles/deploy_containers/build_stream/templates/playbook_watcher.service.j2
+++ b/prepare_oim/roles/deploy_containers/build_stream/templates/playbook_watcher.service.j2
@@ -1,3 +1,17 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [Unit]
 Description=Omnia Playbook Watcher Service for Build Stream
 Documentation=https://github.com/dell/omnia

--- a/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
@@ -30,6 +30,27 @@ build_stream_image_tag: "1.0"
 build_stream_port: "{{ hostvars['localhost']['build_stream_port'] | default('443') }}"
 build_stream_log_dir: "{{ omnia_path }}/log/build_stream"
 
+omnia_default_dir: "/omnia"
+# Build Stream watcher service
+watcher_service_name: "playbook_watcher.service"
+watcher_service_src_path: "templates/playbook_watcher.service.j2"
+watcher_systemd_path: "/etc/systemd/system"
+# build_stream_watcher_unit_path: "{{ build_stream_watcher_unit_dir }}/{{ build_stream_watcher_service_name }}"
+build_stream_watcher_exec: "/usr/bin/python3 {{ oim_shared_path }}/omnia/build_stream/playbook-watcher/playbook_watcher_service.py"
+watcher_restart_sec: 5
+watcher_no_new_privileges: true
+watcher_private_tmp: true
+watcher_limit_nofile: 4096
+watcher_memory_max: "512M"
+watcher_cpu_quota: "50%"
+
+# Watcher environment variables
+build_stream_watcher_playbook_queue_base: "{{ oim_shared_path }}/omnia/playbook_queue"
+watcher_poll_interval_seconds: 2
+watcher_max_concurrent_jobs: 5
+watcher_default_timeout_minutes: 30
+watcher_log_level: "INFO"
+
 # Directory & File Modes
 build_stream_dir_mode: "0755"
 build_stream_jwt_script_mode: "0755"

--- a/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
@@ -29,13 +29,12 @@ build_stream_image_tag: "1.0"
 # Ports & Logs
 build_stream_port: "{{ hostvars['localhost']['build_stream_port'] | default('443') }}"
 build_stream_log_dir: "{{ omnia_path }}/log/build_stream"
-
+build_stream_nfs_path_error_msg: "Directory {{ oim_shared_path }}/omnia/build_stream is missing; ensure oim_shared_path is mounted and populated correctly."
 omnia_default_dir: "/omnia"
 # Build Stream watcher service
 watcher_service_name: "playbook_watcher.service"
 watcher_service_src_path: "templates/playbook_watcher.service.j2"
 watcher_systemd_path: "/etc/systemd/system"
-# build_stream_watcher_unit_path: "{{ build_stream_watcher_unit_dir }}/{{ build_stream_watcher_service_name }}"
 build_stream_watcher_exec: "/usr/bin/python3 {{ oim_shared_path }}/omnia/build_stream/playbook-watcher/playbook_watcher_service.py"
 watcher_restart_sec: 5
 watcher_no_new_privileges: true
@@ -43,8 +42,6 @@ watcher_private_tmp: true
 watcher_limit_nofile: 4096
 watcher_memory_max: "512M"
 watcher_cpu_quota: "50%"
-
-# Watcher environment variables
 build_stream_watcher_playbook_queue_base: "{{ oim_shared_path }}/omnia/playbook_queue"
 watcher_poll_interval_seconds: 2
 watcher_max_concurrent_jobs: 5
@@ -52,6 +49,7 @@ watcher_default_timeout_minutes: 30
 watcher_log_level: "INFO"
 
 # Directory & File Modes
+build_stream_file_mode: "0644"
 build_stream_dir_mode: "0755"
 build_stream_jwt_script_mode: "0755"
 


### PR DESCRIPTION
### Description of the Solution
Prepare OIM to install and enable the playbook watcher service, So that the OIM host is ready to process build stream playbook requests

### Suggested Reviewers

@priti-parate @Rajeshkumar-s2 @Venu-p1 @abhishek-sa1 