### PR TITLE
Fix for return status in execute command for file type

### DIFF
--- a/common/library/module_utils/local_repo/parse_and_download.py
+++ b/common/library/module_utils/local_repo/parse_and_download.py
@@ -85,7 +85,7 @@ def execute_command(cmd_string, logger, type_json=False):
                 return False
 
         logger.info(f"Command succeeded: {cmd_string}")
-        return True
+        return status
     except subprocess.CalledProcessError as e:
         logger.error(f"Command failed: {cmd_string} - {e}")
         return False


### PR DESCRIPTION
This PR fixes "bool is not scriptable" issue in return status for packages of type=file