### PR TITLE
Fix for local_repo.yml allows passes even with invalid package names in JSON files

### DIFF
--- a/common/library/module_utils/local_repo/config.py
+++ b/common/library/module_utils/local_repo/config.py
@@ -64,6 +64,10 @@ DNF_COMMANDS = {
     "x86_64": ["dnf", "download", "--resolve", "--alldeps", "--arch=x86_64,noarch"],
     "aarch64": ["dnf", "download", "--forcearch", "aarch64", "--resolve", "--alldeps", "--exclude=*.x86_64"]
 }
+DNF_INFO_COMMANDS = {
+    "x86_64": ["dnf", "info", "--quiet"],
+    "aarch64": ["dnf", "info", "--quiet", "--forcearch=aarch64"]
+}
 
 # ----------------------------
 # Used by download_common.py
@@ -222,7 +226,7 @@ CLEANUP_LOG_FILE_PATH = "/opt/omnia/log/local_repo/cleanup.log"
 # Naming convention: <arch>_omnia-additional to match existing filter patterns
 # ----------------------------
 ADDITIONAL_REPOS_KEY = "additional_repos"
-AGGREGATED_REPO_NAME_TEMPLATE = "{arch}_omnia-additional-repo"
+AGGREGATED_REPO_NAME_TEMPLATE = "{arch}_omnia-additional"
 AGGREGATED_REMOTE_NAME_TEMPLATE = "{arch}_omnia-additional-{name}"
 AGGREGATED_DISTRIBUTION_NAME_TEMPLATE = "{arch}_omnia-additional"
 AGGREGATED_BASE_PATH_TEMPLATE = "opt/omnia/offline_repo/cluster/{arch}/rhel/10.0/rpms/omnia-additional"

--- a/common/library/module_utils/local_repo/container_repo_utils.py
+++ b/common/library/module_utils/local_repo/container_repo_utils.py
@@ -13,6 +13,13 @@
 # limitations under the License.
 #pylint: disable=import-error,no-name-in-module
 
+"""
+Container repository utilities for Pulp operations.
+
+This module provides functions for creating, syncing, and managing
+container repositories and distributions in Pulp.
+"""
+
 import multiprocessing
 from ansible.module_utils.local_repo.parse_and_download import execute_command
 from ansible.module_utils.local_repo.config import (
@@ -114,109 +121,119 @@ def sync_container_repository(repo_name, remote_name, package_content, logger, t
         logger.info(f"Getting repository version before sync for {repo_name}")
         verify_command = pulp_container_commands["show_container_repo"] % repo_name
         verify_result_before = execute_command(verify_command, logger, type_json=True)
-        
+
         version_before = None
-        if verify_result_before and isinstance(verify_result_before, dict) and "stdout" in verify_result_before:
+        if (verify_result_before and isinstance(verify_result_before, dict) and 
+                "stdout" in verify_result_before):
             repo_data_before = verify_result_before["stdout"]
             if isinstance(repo_data_before, dict):
                 version_before = repo_data_before.get("latest_version_href")
                 logger.info(f"Repository version before sync: {version_before}")
-        
+
         command = pulp_container_commands["sync_container_repository"] % (repo_name, remote_name)
         result = execute_command(command,logger)
         if result is False or (isinstance(result, dict) and result.get("returncode", 1) != 0):
             logger.error(f"Sync command failed for repository {repo_name}")
             return False
-        
+
         logger.info(f"Validating sync result for repository {repo_name}")
         verify_result_after = execute_command(verify_command, logger, type_json=True)
-        
-        if verify_result_after and isinstance(verify_result_after, dict) and "stdout" in verify_result_after:
+
+        if (verify_result_after and isinstance(verify_result_after, dict) and 
+                "stdout" in verify_result_after):
             repo_data_after = verify_result_after["stdout"]
             if isinstance(repo_data_after, dict):
                 version_after = repo_data_after.get("latest_version_href")
                 logger.info(f"Repository version after sync: {version_after}")
-                
+
                 if not version_after or version_after.endswith("/versions/0/"):
                     logger.error(f"Sync completed but no content was downloaded for {repo_name}. "
                                f"The specified image tag likely does not exist in the upstream registry.")
                     return False
-                
+
                 if version_before and version_after and version_before == version_after:
                     # Check if tag actually exists using precise Pulp commands
                     try:
                         # Step 1: Get distribution to find repository href
                         dist_command = f"pulp container distribution show --name {repo_name}"
                         dist_result = execute_command(dist_command, logger, type_json=True)
-                        
+
                         if not dist_result or not isinstance(dist_result, dict) or "stdout" not in dist_result:
-                            logger.error(f"Failed to get distribution info for {repo_name}. Assuming tag doesn't exist.")
-                            return False
-                        
-                        dist_data = dist_result["stdout"]
-                        if not isinstance(dist_data, dict) or "repository" not in dist_data:
-                            logger.error(f"Invalid distribution data for {repo_name}. Assuming tag doesn't exist.")
-                            return False
-                        
-                        repo_href = dist_data["repository"]
-                        logger.info(f"Found repository href: {repo_href}")
-                        
-                        # Step 2: Get repository version href
-                        repo_command = f"pulp container repository show --href {repo_href}"
-                        repo_result = execute_command(repo_command, logger, type_json=True)
-                        
-                        if not repo_result or not isinstance(repo_result, dict) or "stdout" not in repo_result:
-                            logger.error(f"Failed to get repository info for {repo_href}. Assuming tag doesn't exist.")
-                            return False
-                        
-                        repo_data = repo_result["stdout"]
-                        if not isinstance(repo_data, dict) or "latest_version_href" not in repo_data:
-                            logger.error(f"Invalid repository data for {repo_href}. Assuming tag doesn't exist.")
-                            return False
-                        
-                        repo_ver_href = repo_data["latest_version_href"]
-                        logger.info(f"Found repository version href: {repo_ver_href}")
-                        
-                        # Step 3: Check if tag exists in content
-                        tags_command = f"pulp show --href '/pulp/api/v3/content/container/tags/?repository_version={repo_ver_href}'"
-                        tags_result = execute_command(tags_command, logger, type_json=True)
-                        
-                        if not tags_result or not isinstance(tags_result, dict) or "stdout" not in tags_result:
-                            logger.error(f"Failed to get content tags for {repo_ver_href}. Assuming tag doesn't exist.")
-                            return False
-                        
-                        tags_data = tags_result["stdout"]
-                        if not isinstance(tags_data, dict) or "results" not in tags_data:
-                            logger.error(f"Invalid tags data for {repo_ver_href}. Assuming tag doesn't exist.")
-                            return False
-                        
-                        tags = tags_data["results"]
-                        tag_exists = False
-                        
-                        # Use the tag parameter if provided, otherwise fall back to checking package_content
-                        tag_to_check = tag if tag else package_content
-                        
-                        for tag_item in tags:
-                            if isinstance(tag_item, dict) and "name" in tag_item and tag_item["name"] == tag_to_check:
-                                tag_exists = True
-                                break
-                        
-                        if tag_exists:
-                            logger.info(f"Tag '{tag_to_check}' already exists in Pulp repository {repo_name}. No sync needed - image is already available.")
+                            logger.info(f"Distribution {repo_name} does not exist yet - skipping tag validation, will create distribution")
+                        # Skip tag validation but continue to create distribution at line 221
                         else:
-                            logger.error(f"Sync completed but repository version did not change for {repo_name}. "
-                                       f"Version remained at {version_after}. "
-                                       f"Tag '{tag_to_check}' does not exist in Pulp repository content. "
-                                       f"This indicates the tag likely does not exist in the upstream registry.")
-                            return False
+                            # Distribution exists, validate the tag
+                            dist_data = dist_result["stdout"]
+                            if not isinstance(dist_data, dict) or "repository" not in dist_data:
+                                logger.error(f"Invalid distribution data for {repo_name}. Assuming tag doesn't exist.")
+                                return False
+                            repo_href = dist_data["repository"]
+                            logger.info(f"Found repository href: {repo_href}")
+
+                            # Step 2: Get repository version href
+                            repo_command = f"pulp container repository show --href {repo_href}"
+                            repo_result = execute_command(repo_command, logger, type_json=True)
+
+                            if not repo_result or not isinstance(repo_result, dict) or "stdout" not in repo_result:
+                                logger.error(f"Failed to get repository info for {repo_href}. Assuming tag doesn't exist.")
+                                return False
+
+                            repo_data = repo_result["stdout"]
+                            if not isinstance(repo_data, dict) or "latest_version_href" not in repo_data:
+                                logger.error(f"Invalid repository data for {repo_href}. Assuming tag doesn't exist.")
+                                return False
+
+                            repo_ver_href = repo_data["latest_version_href"]
+                            logger.info(f"Found repository version href: {repo_ver_href}")
+
+                            # Step 3: Check if tag exists in content
+                            tags_command = (
+                                f"pulp show --href "
+                                f"'/pulp/api/v3/content/container/tags/"
+                                f"?repository_version={repo_ver_href}'"
+                            )
+                            tags_result = execute_command(tags_command, logger, type_json=True)
+
+                            if not tags_result or not isinstance(tags_result, dict) or "stdout" not in tags_result:
+                                logger.error(f"Failed to get content tags for {repo_ver_href}. Assuming tag doesn't exist.")
+                                return False
+
+                            tags_data = tags_result["stdout"]
+                            if not isinstance(tags_data, dict) or "results" not in tags_data:
+                                logger.error(f"Invalid tags data for {repo_ver_href}. Assuming tag doesn't exist.")
+                                return False
+
+                            tags = tags_data["results"]
+                            tag_exists = False
+
+                            # Use the tag parameter if provided, otherwise fall back to checking package_content
+                            tag_to_check = tag if tag else package_content
+
+                            for tag_item in tags:
+                                if isinstance(tag_item, dict) and "name" in tag_item and tag_item["name"] == tag_to_check:
+                                    tag_exists = True
+                                    break
+
+                            if tag_exists:
+                                logger.info(f"Tag '{tag_to_check}' already exists in Pulp repository {repo_name}. No sync needed - image is already available.")
+                            else:
+                                logger.error(f"Sync completed but repository version did not change for {repo_name}. "
+                                        f"Version remained at {version_after}. "
+                                        f"Tag '{tag_to_check}' does not exist in Pulp repository content. "
+                                        f"This indicates the tag likely does not exist in the upstream registry.")
+                                return False
                             
                     except Exception as e:
-                        logger.error(f"Error checking repository tag existence: {e}. Assuming tag doesn't exist.")
+                        logger.error(
+                            f"Error checking repository tag existence: {e}. Assuming tag doesn't exist."
+                        )
                         return False
-                
-                logger.info(f"Sync validation successful: repository {repo_name} version changed from {version_before} to {version_after}")
-        
-        result = create_container_distribution(repo_name,package_content,logger)
+
+                logger.info(
+                    f"Sync validation successful: repository {repo_name} version changed "
+                    f"from {version_before} to {version_after}"
+                )
+        result = create_container_distribution(repo_name, package_content, logger)
         return result
     except Exception as e:
         logger.error(f"Failed to synchronize repository {repo_name} with remote {remote_name}. Error: {e}")

--- a/common/library/module_utils/local_repo/download_rpm.py
+++ b/common/library/module_utils/local_repo/download_rpm.py
@@ -20,7 +20,8 @@ import os
 import shutil
 from pathlib import Path
 from ansible.module_utils.local_repo.config import (
-    DNF_COMMANDS
+    DNF_COMMANDS,
+    DNF_INFO_COMMANDS
 )
 from multiprocessing import Lock
 from ansible.module_utils.local_repo.parse_and_download import write_status_to_file
@@ -95,11 +96,30 @@ def process_rpm(package, repo_store_path, status_file_path, cluster_os_type,
             for pkg in rpm_list:
                 # Get repo_name for this specific RPM from mapping
                 pkg_repo_name = repo_mapping.get(pkg, "")
-                if any(pkg in line and ".rpm" in line for line in stdout_lines + stderr_lines):
+                # Check if package was downloaded successfully
+                # Look for "Already downloaded" or actual .rpm file in output
+                pkg_downloaded = False
+                for line in stdout_lines + stderr_lines:
+                    if pkg in line and (".rpm" in line or "Already downloaded" in line):
+                        pkg_downloaded = True
+                        break
+
+                # Also check for "No match for argument" or "No package" errors
+                pkg_not_found = False
+                for line in stderr_lines:
+                    if pkg in line and ("No match for argument" in line or 
+                                       "No package" in line or
+                                       "not found" in line.lower()):
+                        pkg_not_found = True
+                        break
+
+                if pkg_downloaded and not pkg_not_found:
                     downloaded.append(pkg)
                     write_status_to_file(status_file_path, pkg, "rpm", "Success", logger, file_lock, pkg_repo_name)
                 else:
                     failed.append(pkg)
+                    if pkg_not_found:
+                        logger.warning(f"Package '{pkg}' not found in configured repositories")
 
             # Retry failed ones individually
             if failed:
@@ -110,6 +130,15 @@ def process_rpm(package, repo_store_path, status_file_path, cluster_os_type,
                     # Get repo_name for this specific RPM from mapping
                     pkg_repo_name = repo_mapping.get(pkg, "")
 
+                    # Check for package not found errors
+                    retry_stderr = retry_res.stderr.lower()
+                    pkg_invalid = any(err in retry_stderr for err in [
+                        "no match for argument",
+                        "no package",
+                        "not found",
+                        "unable to find a match"
+                    ])
+
                     if retry_res.returncode == 0 and ".rpm" in retry_res.stdout + retry_res.stderr:
                         downloaded.append(pkg)
                         failed.remove(pkg)
@@ -117,7 +146,10 @@ def process_rpm(package, repo_store_path, status_file_path, cluster_os_type,
                         logger.info(f"Package '{pkg}' downloaded successfully on retry.")
                     else:
                         write_status_to_file(status_file_path, pkg, "rpm", "Failed", logger, file_lock, pkg_repo_name)
-                        logger.error(f"Package '{pkg}' still failed after retry.")
+                        if pkg_invalid:
+                            logger.error(f"Package '{pkg}' does not exist in configured repositories.")
+                        else:
+                            logger.error(f"Package '{pkg}' still failed after retry.")
 
             # Determine final status
             if not failed:
@@ -128,12 +160,59 @@ def process_rpm(package, repo_store_path, status_file_path, cluster_os_type,
                 status = "Failed"
 
         else:
-            status = "Success"
             logger.info("RPM won't be downloaded when repo_config is partial or never")
+            logger.info("Validating package availability using dnf info...")
+
+            arch_key = "x86_64" if arc.lower() in ("x86_64") else "aarch64"
+            valid_packages = []
+            invalid_packages = []
+
             for pkg in package["rpm_list"]:
+                # Validate package using dnf info
+                dnf_info_command = DNF_INFO_COMMANDS[arch_key] + [
+                    "--repo=*",  # Search all enabled repositories
+                    pkg
+                ]
+                result = subprocess.run(
+                    dnf_info_command,
+                    check=False,
+                    capture_output=True,
+                    text=True
+                )
                 # Get repo_name for this specific RPM from mapping
                 pkg_repo_name = repo_mapping.get(pkg, "")
-                write_status_to_file(status_file_path, pkg, "rpm", "Success", logger, file_lock, pkg_repo_name)
+                if result.returncode == 0:
+                    # Package exists and is available
+                    valid_packages.append(pkg)
+                    write_status_to_file(
+                        status_file_path, pkg, "rpm", "Success", 
+                        logger, file_lock, pkg_repo_name
+                    )
+                    logger.info(f"Package '{pkg}' validated successfully")
+                else:
+                    # Package not found or invalid
+                    invalid_packages.append(pkg)
+                    write_status_to_file(
+                        status_file_path, pkg, "rpm", "Failed", 
+                        logger, file_lock, pkg_repo_name
+                    )
+                    logger.error(
+                        f"Package '{pkg}' validation failed. "
+                        f"Package may not exist in configured repositories."
+                    )
+
+            # Determine final status based on validation results
+            if not invalid_packages:
+                status = "Success"
+            elif valid_packages:
+                status = "Partial"
+            else:
+                status = "Failed"
+
+            logger.info(
+                f"Validation complete - Valid: {len(valid_packages)}, "
+                f"Invalid: {len(invalid_packages)}"
+            )
 
     except Exception as e:
         logger.error(f"Exception occurred: {e}")


### PR DESCRIPTION
Fix for local_repo.yml playbook passes even if the user mentions an invalid package name in the JSON files.
