### PR TITLE
Fix admin dynamic_range subnet validation and remove flawed netmask check

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/validation_utils.py
+++ b/common/library/module_utils/input_validation/common_utils/validation_utils.py
@@ -527,6 +527,30 @@ def validate_netmask_bits(bits):
     except (ValueError, TypeError):
         return False
 
+def is_range_within_subnet(ip_range, reference_ip, netmask_bits):
+    """
+    Validates that the given IP range falls within the subnet
+    derived from reference_ip and netmask_bits.
+
+    Args:
+        ip_range (str): IP range in "start_ip-end_ip" format.
+        reference_ip (str): A reference IP in the subnet (e.g., primary_oim_admin_ip).
+        netmask_bits (str or int): The CIDR prefix length (e.g., "24").
+
+    Returns:
+        bool: True if both start and end IPs are within the subnet, False otherwise.
+    """
+    try:
+        network = ipaddress.IPv4Network(f"{reference_ip}/{netmask_bits}", strict=False)
+        parts = ip_range.split("-")
+        if len(parts) != 2:
+            return False
+        start_ip = ipaddress.IPv4Address(parts[0].strip())
+        end_ip = ipaddress.IPv4Address(parts[1].strip())
+        return start_ip in network and end_ip in network
+    except (ValueError, TypeError):
+        return False
+
 def check_bmc_static_range_overlap(static_range, static_range_group_mapping) -> list:
     """
     Checks if the given static BMC range overlaps with any of the ranges in other groups.
@@ -624,41 +648,6 @@ def check_port_ranges(port_ranges) -> bool:
                 return False
 
     return True
-
-def is_range_within_netmask(ip_range, netmask_bits):
-    """
-    Check if a given IP range falls within the valid IP address range for a given netmask.
-
-    Args:
-        ip_range (str): The IP range in format "start_ip-end_ip"
-            (e.g., "192.168.1.10-192.168.1.50").
-        netmask_bits (int or str): The netmask bits (e.g., 20 for /20).
-
-    Returns:
-        bool: True if the IP range is valid for the given netmask, False otherwise.
-    """
-    try:
-        # Parse the IP range
-        start_ip, end_ip = ip_range.split('-')
-        start_ip_obj = ipaddress.ip_address(start_ip)
-        end_ip_obj = ipaddress.ip_address(end_ip)
-
-        # Ensure start_ip <= end_ip
-        if start_ip_obj > end_ip_obj:
-            return False
-
-        # Create network from start_ip with the given netmask
-        network = ipaddress.ip_network(f"{start_ip}/{netmask_bits}", strict=False)
-
-        # Get first and last usable addresses (excluding network and broadcast)
-        first_usable = network.network_address + 1
-        last_usable = network.broadcast_address - 1
-
-        # Check if both start and end IPs are within the usable range
-        return (first_usable <= start_ip_obj <= last_usable and
-                first_usable <= end_ip_obj <= last_usable)
-    except (ValueError, TypeError):
-        return False
 
 def is_ip_within_range(ip_range, ip):
     """

--- a/common/library/module_utils/input_validation/validation_flows/provision_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/provision_validation.py
@@ -905,6 +905,16 @@ def _validate_admin_network(network):
             )
         )
 
+        # Ensure dynamic_range is inside the admin subnet (primary_oim_admin_ip/netmask_bits)
+        if not validation_utils.is_range_within_subnet(admin_net["dynamic_range"], primary_oim_admin_ip, netmask):
+            errors.append(
+                create_error_msg(
+                    "admin_network.dynamic_range",
+                    admin_net["dynamic_range"],
+                    en_us_validation_msg.RANGE_NETMASK_BOUNDARY_FAIL_MSG,
+                )
+            )
+
     #  Admin and BMC IP should not be the same
     errors.extend(validate_admin_bmc_ip_not_same(primary_oim_admin_ip, primary_oim_bmc_ip))
 
@@ -1033,21 +1043,6 @@ def _validate_ip_ranges(dynamic_range, network_type, netmask_bits):
                 en_us_validation_msg.RANGE_IP_CHECK_FAIL_MSG,
             )
         )
-
-    # Validate that IP ranges are within the netmask boundaries
-    if netmask_bits:
-        # Check dynamic range
-        if (validation_utils.validate_ipv4_range(dynamic_range) and
-                not validation_utils.is_range_within_netmask(
-                    dynamic_range, netmask_bits
-                )):
-            errors.append(
-                create_error_msg(
-                    f"{network_type}.dynamic_range",
-                    dynamic_range,
-                    en_us_validation_msg.RANGE_NETMASK_BOUNDARY_FAIL_MSG,
-                )
-            )
 
     return errors
 


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

- Added is_range_within_subnet helper to validate dynamic ranges against the admin subnet derived from primary_oim_admin_ip/netmask_bits.
- Removed the flawed is_range_within_netmask logic from _validate_ip_ranges and its unused helper, keeping _validate_ip_ranges for format checks only.

### Suggested Reviewers
@abhishek-sa1 Please Review
