### PR TITLE
To configure per-repository sync and caching policies in localrepo

### DIFF
--- a/common/library/module_utils/input_validation/schema/local_repo_config.json
+++ b/common/library/module_utils/input_validation/schema/local_repo_config.json
@@ -1136,6 +1136,284 @@
         ]
       },
       "description": "Optional list of additional repository URLs for aarch64 architecture. These repos are aggregated into a single Pulp repository."
+    },
+     "rhel_subscription_repo_config_x86_64": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(https?:\\/\\/).+"
+          },
+          "gpgkey": {
+            "type": "string",
+            "pattern": "^(|[a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/\\S+)$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!\\s*$).+"
+          },
+          "policy": {
+            "type": "string",
+            "enum": [
+              "always",
+              "partial"
+            ]
+          },
+          "caching": {
+            "type": "boolean"
+          },
+          "sslcacert": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sslclientkey": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sslclientcert": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "url",
+          "gpgkey",
+          "name"
+        ],
+        "allOf": [
+          {
+            "if": {
+              "required": [
+                "sslcacert"
+              ],
+              "properties": {
+                "sslcacert": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "sslclientkey",
+                "sslclientcert"
+              ],
+              "properties": {
+                "sslclientkey": {
+                  "minLength": 1
+                },
+                "sslclientcert": {
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "required": [
+                "sslclientkey"
+              ],
+              "properties": {
+                "sslclientkey": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "sslcacert",
+                "sslclientcert"
+              ],
+              "properties": {
+                "sslcacert": {
+                  "minLength": 1
+                },
+                "sslclientcert": {
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "required": [
+                "sslclientcert"
+              ],
+              "properties": {
+                "sslclientcert": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "sslcacert",
+                "sslclientkey"
+              ],
+              "properties": {
+                "sslcacert": {
+                  "minLength": 1
+                },
+                "sslclientkey": {
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        ]
+      },
+      "description": "Optional configuration for overriding policy and caching settings for RHEL subscription-based repositories on x86_64 architecture."
+    },
+    "rhel_subscription_repo_config_aarch64": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(https?:\\/\\/).+"
+          },
+          "gpgkey": {
+            "type": "string",
+            "pattern": "^(|[a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/\\S+)$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!\\s*$).+"
+          },
+          "policy": {
+            "type": "string",
+            "enum": [
+              "always",
+              "partial"
+            ]
+          },
+          "caching": {
+            "type": "boolean"
+          },
+          "sslcacert": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sslclientkey": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sslclientcert": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "url",
+          "gpgkey",
+          "name"
+        ],
+        "allOf": [
+          {
+            "if": {
+              "required": [
+                "sslcacert"
+              ],
+              "properties": {
+                "sslcacert": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "sslclientkey",
+                "sslclientcert"
+              ],
+              "properties": {
+                "sslclientkey": {
+                  "minLength": 1
+                },
+                "sslclientcert": {
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "required": [
+                "sslclientkey"
+              ],
+              "properties": {
+                "sslclientkey": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "sslcacert",
+                "sslclientcert"
+              ],
+              "properties": {
+                "sslcacert": {
+                  "minLength": 1
+                },
+                "sslclientcert": {
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "required": [
+                "sslclientcert"
+              ],
+              "properties": {
+                "sslclientcert": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "sslcacert",
+                "sslclientkey"
+              ],
+              "properties": {
+                "sslcacert": {
+                  "minLength": 1
+                },
+                "sslclientkey": {
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        ]
+      },
+      "description": "Optional configuration for overriding policy and caching settings for RHEL subscription-based repositories on aarch64 architecture."
     }
   },
   "required": [

--- a/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
@@ -137,19 +137,41 @@ def validate_local_repo_config(input_file_path, data,
         arch_repo_names = []
         arch_list = url_list + [url+'_'+arch for url in url_list]
          # define base repos dynamically for this arch if subscription registered 
-        if sub_result:       
-            base_repo_names = [f"{arch}_baseos",f"{arch}_appstream",f"{arch}_codeready-builder"]
-            logger.info(f"Adding base repos for {arch}: {base_repo_names}")
+        if sub_result:
+            base_subscription_repos = [f"{arch}_baseos", f"{arch}_appstream", f"{arch}_codeready-builder"]
+            logger.info(f"Base subscription repos for {arch}: {base_subscription_repos}")
+        
+        # Collect repo names from standard repo lists
         for repurl in arch_list:
             repos = data.get(repurl)
             if repos:
                 arch_repo_names = arch_repo_names + [x.get('name') for x in repos]
+
+        # Handle rhel_subscription_repo_config separately
+        # Only add non-base repos to the name list (base repos are overrides, not duplicates)
+        subscription_config_key = f"rhel_subscription_repo_config_{arch}"
+        subscription_config = data.get(subscription_config_key, [])
+        if subscription_config:
+            for repo in subscription_config:
+                repo_name = repo.get('name')
+                if repo_name and repo_name not in base_subscription_repos:
+                    # This is a new repo, not an override of base repos
+                    arch_repo_names.append(repo_name)
+                    logger.info(f"Adding new subscription config repo: {repo_name}")
+                else:
+                    logger.info(f"Skipping base repo override from duplicate check: {repo_name}")
+
         # Add additional_repos names for this arch
         additional_repos_key = f"additional_repos_{arch}"
         additional_repos = data.get(additional_repos_key)
         if additional_repos:
             arch_repo_names = arch_repo_names + [x.get('name') for x in additional_repos]
-        repo_names[arch] = repo_names.get(arch, []) + arch_repo_names + base_repo_names
+        
+        # Add base subscription repos to the final list (they will be dynamically generated)
+        if sub_result:
+            arch_repo_names = arch_repo_names + base_subscription_repos
+        
+        repo_names[arch] = arch_repo_names
         logger.info(f"Total repos for {arch}: {repo_names[arch]}")
 
     for k,v in repo_names.items():

--- a/common/library/module_utils/local_repo/config.py
+++ b/common/library/module_utils/local_repo/config.py
@@ -58,8 +58,17 @@ RPM_LABEL_TEMPLATE = "RPMs for {key}"
 RHEL_OS_URL = "rhel_os_url"
 SOFTWARES_KEY = "softwares"
 USER_REPO_URL = "user_repo_url"
-REPO_CONFIG = { "always": "on_demand", "partial": "on_demand", "never": "streamed" }
 ARCH_SUFFIXES = {"x86_64", "aarch64"}
+DEFAULT_POLICY = "on_demand"
+DEFAULT_CACHING = True
+POLICY_CACHING_MAP = {
+    ("always", False): "immediate",
+    ("always", True): "on_demand",
+    ("partial", False): "streamed",
+    ("partial", True): "on_demand",
+    ("never", False): "streamed",
+    ("never", True): "streamed"
+}
 DNF_COMMANDS = {
     "x86_64": ["dnf", "download", "--resolve", "--alldeps", "--arch=x86_64,noarch"],
     "aarch64": ["dnf", "download", "--forcearch", "aarch64", "--resolve", "--alldeps", "--exclude=*.x86_64"]

--- a/common/library/module_utils/local_repo/software_utils.py
+++ b/common/library/module_utils/local_repo/software_utils.py
@@ -36,7 +36,9 @@ from ansible.module_utils.local_repo.config import (
     RPM_LABEL_TEMPLATE,
     RHEL_OS_URL,
     SOFTWARES_KEY,
-    REPO_CONFIG,
+    POLICY_CACHING_MAP,
+    DEFAULT_POLICY,
+    DEFAULT_CACHING,
     ARCH_SUFFIXES,
     ADDITIONAL_REPOS_KEY,
     pulp_container_commands
@@ -210,6 +212,32 @@ def transform_package_dict(data, arch_val,logger):
     logger.info("Transformation complete for arch '%s'. Final result keys: %s", arch_val, list(final_result.keys()))
     return final_result
 
+def resolve_pulp_policy(policy_str, caching_val, logger=None):
+    """
+    Resolve user-facing policy and caching into Pulp download policy.
+    Args:
+        policy_str (str): User policy ('always', 'on_demand', 'partial').
+        caching_val: Caching flag (bool, str 'true'/'false', or None).
+        logger: Optional logger instance.
+    Returns:
+        str: Pulp download policy ('immediate', 'on_demand', 'streamed').
+    """
+    policy = str(policy_str).lower() if policy_str else DEFAULT_POLICY
+    if isinstance(caching_val, str):
+        caching = caching_val.lower() in ('true', '1', 'yes')
+    elif isinstance(caching_val, bool):
+        caching = caching_val
+    else:
+        caching = DEFAULT_CACHING
+    pulp_policy = POLICY_CACHING_MAP.get(
+        (policy, caching), "on_demand"
+    )
+    if logger:
+        logger.info(
+            f"Resolved policy='{policy}', caching={caching}"
+            f" -> pulp_policy='{pulp_policy}'"
+        )
+    return pulp_policy
 
 def parse_repo_urls(repo_config, local_repo_config_path,
                     version_variables, vault_key_path, sub_urls,logger,sw_archs=None):
@@ -271,7 +299,10 @@ def parse_repo_urls(repo_config, local_repo_config_path,
             client_key = url_.get("sslclientkey", "")
             client_cert = url_.get("sslclientcert", "")
             policy_given = url_.get("policy", repo_config)
-            policy = REPO_CONFIG.get(policy_given)
+            caching_given = url_.get("caching", True)
+            policy = resolve_pulp_policy(
+                policy_given, caching_given, logger
+            )
 
             logger.info(f"Processing user repo '{name}' for arch '{arch}' - URL: {url}")
 
@@ -302,7 +333,7 @@ def parse_repo_urls(repo_config, local_repo_config_path,
 
             logger.info(f"Added user repo entry: {name}")
 
-    # Handle RHEL repositories
+    # Handle RHEL repositories (includes subscription-based repos)
     for arch, repo_list in rhel_repo_entry.items():
         for url_ in repo_list:
             name = url_.get("name", "unknown")
@@ -312,7 +343,10 @@ def parse_repo_urls(repo_config, local_repo_config_path,
             client_key = url_.get("sslclientkey", "")
             client_cert = url_.get("sslclientcert", "")
             policy_given = url_.get("policy", repo_config)
-            policy = REPO_CONFIG.get(policy_given)
+            caching_given = url_.get("caching", True)
+            policy = resolve_pulp_policy(
+                policy_given, caching_given, logger
+            )
 
             logger.info(f"Processing RHEL repo '{name}' for arch '{arch}' - URL: {url}")
 
@@ -357,7 +391,10 @@ def parse_repo_urls(repo_config, local_repo_config_path,
             url = repo.get("url", "")
             gpgkey = repo.get("gpgkey", "")
             policy_given = repo.get("policy", repo_config)
-            policy = REPO_CONFIG.get(policy_given)
+            caching_given = repo.get("caching", True)
+            policy = resolve_pulp_policy(
+                policy_given, caching_given, logger
+            )
             logger.info(f"Processing OMNIA repo '{name}' for arch '{arch}' - Template URL: {url}")
 
             # Find unresolved template vars in URL
@@ -476,17 +513,11 @@ def get_subgroup_dict(user_data,logger):
 def get_csv_software(file_name):
 
     """
-
     Retrieves a list of software names from a CSV file.
- 
     Parameters:
-
         file_name (str): The name of the CSV file.
- 
     Returns:
-
         list: A list of software names.
-
     """
 
     csv_software = []
@@ -892,7 +923,9 @@ def parse_additional_repos(local_repo_config_path, repo_config, vault_key_path, 
     local_yaml = load_yaml(local_repo_config_path)
 
     additional_repos_config = {}
-    policy = REPO_CONFIG.get(repo_config, "on_demand")
+    global_policy = resolve_pulp_policy(
+        repo_config, True, logger
+    )
 
     vault_key_full_path = os.path.join(vault_key_path, ".local_repo_credentials_key")
 
@@ -949,7 +982,7 @@ def parse_additional_repos(local_repo_config_path, repo_config, vault_key_path, 
                 "ca_cert": ca_cert,
                 "client_key": client_key,
                 "client_cert": client_cert,
-                "policy": policy,
+                "policy": global_policy,
                 "arch": arch
             })
             logger.info(f"Added additional repo entry: {name}")

--- a/input/local_repo_config.yml
+++ b/input/local_repo_config.yml
@@ -43,7 +43,10 @@
 #   sslcacert   : Path to SSL CA certificate (if using SSL)
 #   sslclientkey: Path to SSL client key (if using SSL)
 #   sslclientcert: Path to SSL client certificate (if using SSL)
-#   policy      : Repository policy (always, partial)
+#   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
 # Notes:
 #   - Do not use Jinja variables in this configuration.
 #   - Omit SSL fields entirely if SSL is not in use.
@@ -63,7 +66,10 @@
 #   sslcacert   : Path to SSL CA certificate (if using SSL)
 #   sslclientkey: Path to SSL client key (if using SSL)
 #   sslclientcert: Path to SSL client certificate (if using SSL)
-#   policy      : Repository policy if mentioned allowed values (always, partial). IF not mentioned will consider from software_config.json
+#   policy      : Repository policy if mentioned allowed values (always, partial). 
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
 #   name        : Name of the repository [ Allowed repo names <arch>_codeready-builder, <arch>_appstream, <arch>_baseos
 # Notes:
 #   - Do not use Jinja variables in this configuration.
@@ -75,8 +81,35 @@
 #----------------------------
 #    Same as above but for aarch64 architecture.
 #
+# 6. rhel_subscription_repo_config_x86_64
+#-------------------------------------------
+#    Optional configuration for overriding policy and caching settings for RHEL 
+#    subscription-based repositories on x86_64 architecture.
+#    When subscription is enabled, this config takes precedence over dynamically 
+#    generated URLs for matching repositories and adds any additional repositories.
+# Fields:
+#   url         : Base URL of the repository (REQUIRED)
+#   gpgkey      : GPG key URL (REQUIRED, can be empty to disable gpgcheck)
+#   name        : Repository name for matching (REQUIRED)
+#   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
+#   sslcacert   : Path to SSL CA certificate (optional)
+#   sslclientkey: Path to SSL client key (optional)
+#   sslclientcert: Path to SSL client certificate (optional)
+# Notes:
+#   - Do not use Jinja variables in this configuration.
+#   - Omit SSL fields entirely if SSL is not in use.
+#   - Matching is done by repository name (e.g., x86_64_appstream)
+#   - Non-matching repositories are added as additional repos
+#
+# 7. rhel_subscription_repo_config_aarch64
+#--------------------------------------------
+#    Same as above but for aarch64 architecture.
+#
 #### ADVANCE CONFIGURATIONS FOR LOCAL REPO ###
-# 6. omnia_repo_url_rhel_x86_64
+# 8. omnia_repo_url_rhel_x86_64
 #-------------------------------
 #    Mandatory repository URLs for downloading RPMS for Omnia features on RHEL x86_64.
 #    Each entry includes url, gpgkey, and name.
@@ -88,12 +121,15 @@
 #  gpgkey     : URL of the GPG key for the repository.
 #                   If left empty, gpgcheck=0 for that repository.
 #  name       : A unique identifier for the repository or registry.
-#
-# 7. omnia_repo_url_rhel_aarch64
+#  policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#  caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
+# 9. omnia_repo_url_rhel_aarch64
 #--------------------------------
 #    Same as above but for RHEL aarch64.
 #
-# 8. additional_repos_x86_64
+# 10. additional_repos_x86_64
 #----------------------------
 #    Optional list of additional repository URLs for x86_64 architecture.
 #    These repos are aggregated into a single Pulp repository, allowing dynamic
@@ -105,6 +141,10 @@
 #   sslcacert     : Path to SSL CA certificate (optional)
 #   sslclientkey  : Path to SSL client key (optional)
 #   sslclientcert : Path to SSL client certificate (optional)
+#   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
 # Notes:
 #   - All repos are synced into a single aggregated Pulp repository
 #   - Compute nodes are configured once with a fixed URL that never changes
@@ -112,7 +152,7 @@
 #   - Name must be unique within this list and must not conflict with names in other repo keys
 #   - Packages from these repos can only be used via additional_packages.json
 #
-# 9. additional_repos_aarch64
+# 11. additional_repos_aarch64
 #-----------------------------
 #    Same as above but for aarch64 architecture.
 
@@ -133,6 +173,12 @@ user_repo_url_aarch64:
 #  - { url: "http://AppStream.com/AppStream/x86_64/os/", gpgkey: "http://AppStream.com/AppStream/x86_64/os/RPM-GPG-KEY", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "x86_64_appstream" }
 rhel_os_url_x86_64:
 rhel_os_url_aarch64:
+# Example:
+# rhel_subscription_repo_config_x86_64:
+#  - { url: "https://example.com/appstream", gpgkey: "", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "x86_64_appstream", policy: "always", caching: true }
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "x86_64_supplementary", policy: "always", caching: false }
+rhel_subscription_repo_config_x86_64:
+rhel_subscription_repo_config_aarch64:
 # Making incorrect changes to this variable can cause omnia failure. Please edit cautiously.
 omnia_repo_url_rhel_x86_64:
   - { url: "https://download.docker.com/linux/centos/10/x86_64/stable/", gpgkey: "https://download.docker.com/linux/centos/gpg", name: "docker-ce"}

--- a/local_repo/roles/validation/tasks/configure_rhel_os_urls.yml
+++ b/local_repo/roles/validation/tasks/configure_rhel_os_urls.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,11 @@
         sslclientkey: "{{ lookup('pipe', 'ls {{ omnia_rhel_cert_dir }}/*-key.pem | head -n1') }}"
         sslclientcert: "{{ lookup('pipe', 'ls {{ omnia_rhel_cert_dir }}/*.pem | grep -v -- -key.pem | head -n1') }}"
         sub_rhel_x86_64_urls: []
+        sub_rhel_aarch64_urls: []
+        sub_policy_default: "{{ sw_config.repo_config | default('on_demand') }}"
+        sub_caching_default: true
+        sub_x86_64_override_config: "{{ local_config.rhel_subscription_repo_config_x86_64 | default([]) }}"
+        sub_aarch64_override_config: "{{ local_config.rhel_subscription_repo_config_aarch64 | default([]) }}"
 
     - name: Append repo entries to x86_64 list
       ansible.builtin.set_fact:
@@ -64,7 +69,8 @@
               'sslcacert' : sslcacert,
               'sslclientkey' : sslclientkey,
               'sslclientcert': sslclientcert,
-              'policy': 'partial',
+              'policy': sub_policy_default,
+              'caching': sub_caching_default,
               'name': (
                 arch ~ '_appstream' if 'appstream' in repo_url else
                 arch ~ '_baseos' if 'baseos' in repo_url else
@@ -83,12 +89,106 @@
           'name': item.name | replace('x86_64', 'aarch64'),
           'gpgkey': item.gpgkey,
           'policy': item.policy,
+          'caching': item.caching,
           'sslcacert': item.sslcacert,
           'sslclientcert': item.sslclientcert,
           'sslclientkey': item.sslclientkey}] }}"
       loop: "{{ sub_rhel_x86_64_urls }}"
       loop_control:
         loop_var: item
+
+    # 3️ Apply override configurations and merge additional repositories
+    - name: Create name mapping for x86_64 dynamic repos
+      ansible.builtin.set_fact:
+        x86_64_dynamic_names: "{{ sub_rhel_x86_64_urls | map(attribute='name') | list }}"
+
+    - name: Apply x86_64 overrides to matching repos
+      ansible.builtin.set_fact:
+        sub_rhel_x86_64_urls: >-
+          {%- set result = [] -%}
+          {%- for repo in sub_rhel_x86_64_urls -%}
+            {%- set override = (sub_x86_64_override_config | selectattr('name', 'equalto', repo.name) | first | default({})) -%}
+            {%- set updated_repo = repo | combine({
+              'policy': override.policy | default(repo.policy),
+              'caching': override.caching | default(repo.caching),
+              'url': override.url | default(repo.url),
+              'gpgkey': override.gpgkey | default(repo.gpgkey)
+            }) -%}
+            {%- set _ = result.append(updated_repo) -%}
+          {%- endfor -%}
+          {{ result }}
+
+    - name: Identify non-matching x86_64 override repos
+      ansible.builtin.set_fact:
+        additional_x86_64_repos: >-
+          {{
+            sub_x86_64_override_config | rejectattr('name', 'in', x86_64_dynamic_names) | list
+          }}
+
+    - name: Add non-matching x86_64 override repos as additional
+      ansible.builtin.set_fact:
+        sub_rhel_x86_64_urls: >-
+          {%- set result = sub_rhel_x86_64_urls -%}
+          {%- for repo in additional_x86_64_repos -%}
+            {%- set new_repo = {
+              'url': repo.url,
+              'gpgkey': repo.gpgkey | default(''),
+              'name': repo.name,
+              'policy': repo.policy | default(sub_policy_default),
+              'caching': repo.caching | default(sub_caching_default),
+              'sslcacert': sslcacert,
+              'sslclientcert': sslclientcert,
+              'sslclientkey': sslclientkey
+            } -%}
+            {%- set _ = result.append(new_repo) -%}
+          {%- endfor -%}
+          {{ result }}
+
+    - name: Apply aarch64 overrides to matching repos
+      ansible.builtin.set_fact:
+        sub_rhel_aarch64_urls: >-
+          {%- set result = [] -%}
+          {%- for repo in sub_rhel_aarch64_urls -%}
+            {%- set override = (sub_aarch64_override_config | selectattr('name', 'equalto', repo.name) | first | default({})) -%}
+            {%- set updated_repo = repo | combine({
+              'policy': override.policy | default(repo.policy),
+              'caching': override.caching | default(repo.caching),
+              'url': override.url | default(repo.url),
+              'gpgkey': override.gpgkey | default(repo.gpgkey)
+            }) -%}
+            {%- set _ = result.append(updated_repo) -%}
+          {%- endfor -%}
+          {{ result }}
+
+    - name: Identify non-matching aarch64 override repos
+      ansible.builtin.set_fact:
+        aarch64_dynamic_names: "{{ sub_rhel_aarch64_urls | map(attribute='name') | list }}"
+        additional_aarch64_repos: >-
+          {{
+            sub_aarch64_override_config | rejectattr('name', 'in', aarch64_dynamic_names) | list
+          }}
+      when: "'aarch64' in archs"
+
+    - name: Add non-matching aarch64 override repos as additional
+      ansible.builtin.set_fact:
+        sub_rhel_aarch64_urls: >-
+          {%- set result = sub_rhel_aarch64_urls -%}
+          {%- for repo in additional_aarch64_repos -%}
+            {%- set new_repo = {
+              'url': repo.url,
+              'gpgkey': repo.gpgkey | default(''),
+              'name': repo.name,
+              'policy': repo.policy | default(sub_policy_default),
+              'caching': repo.caching | default(sub_caching_default),
+              'sslcacert': sslcacert,
+              'sslclientcert': sslclientcert,
+              'sslclientkey': sslclientkey
+            } -%}
+            {%- set _ = result.append(new_repo) -%}
+          {%- endfor -%}
+          {{ result }}
+      when: "'aarch64' in archs"
+
 - name: Build final repo dict
   ansible.builtin.set_fact:
     sub_final_repo_urls:

--- a/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
@@ -42,9 +42,9 @@ pulp_deployed_msg: "The {{ pulp_container_name }} container has been successfull
 pulp_deployed_fail_msg:
   "The {{ pulp_container_name }} container deployment failed. Common causes:
   • Missing or inaccessible pulp container image
-  • Pulp service not starting successfully  
+  • Pulp service not starting successfully
   • NFS storage not reachable or not mounted
-  Run utility/oim_cleanup.yml to cleanup, then re-run the playbook to deploy the {{ pulp_container_name }} 
+  Run utility/oim_cleanup.yml to cleanup, then re-run the playbook to deploy the {{ pulp_container_name }}
   container successfully."
 retries_var: 8
 delay_var: 30

--- a/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
@@ -40,9 +40,12 @@ arg_list:
   - "-e PULP_API_WORKERS_MAX_REQUESTS_JITTER=50"
 pulp_deployed_msg: "The {{ pulp_container_name }} container has been successfully deployed."
 pulp_deployed_fail_msg:
-  The deployment of the {{ pulp_container_name }} container has failed. To resolve this issue,
-  please run the utility/oim_cleanup.yml playbook to clean up any existing OIM resources.
-  After the cleanup, you can re-run the original playbook to deploy the {{ pulp_container_name }} container successfully.
+  "The {{ pulp_container_name }} container deployment failed. Common causes:
+  • Missing or inaccessible pulp container image
+  • Pulp service not starting successfully  
+  • NFS storage not reachable or not mounted
+  Run utility/oim_cleanup.yml to cleanup, then re-run the playbook to deploy the {{ pulp_container_name }} 
+  container successfully."
 retries_var: 8
 delay_var: 30
 delay_var_sixty: 30


### PR DESCRIPTION
Added support in local-repo-config.yaml to allow users to define per-repository sync policies and caching behavior. By default, caching is enabled and repositories operate in sync-on-demand mode unless specified otherwise.

If policy: always and caching: false → All packages are immediately downloaded and synced.
If policy: partial and caching: true (default) → Packages are downloaded only when required