### PR TITLE
Additional_Packages defect fix

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/config.py
+++ b/common/library/module_utils/input_validation/common_utils/config.py
@@ -36,12 +36,10 @@ OMNIA_REDHAT_REPO = '/opt/omnia/rhel_repo_certs/redhat.repo'
 # Supported functional groups for additional_packages per architecture
 ADDITIONAL_PACKAGES_SUPPORTED_SUBGROUPS = {
     "x86_64": [
-        "additional_packages",
         "slurm_control_node", "slurm_node", "login_node", "login_compiler_node",
         "service_kube_control_plane", "service_kube_control_plane_first", "service_kube_node"
     ],
     "aarch64": [
-        "additional_packages",
         "slurm_control_node", "slurm_node", "login_node", "login_compiler_node"
     ]
 }

--- a/common/library/module_utils/input_validation/common_utils/config.py
+++ b/common/library/module_utils/input_validation/common_utils/config.py
@@ -33,6 +33,19 @@ SYSTEM_REDHAT_REPO = '/etc/yum.repos.d/redhat.repo'
 OMNIA_ENTITLEMENT_PATH = '/opt/omnia/rhel_repo_certs/*.pem'
 OMNIA_REDHAT_REPO = '/opt/omnia/rhel_repo_certs/redhat.repo'
 
+# Supported functional groups for additional_packages per architecture
+ADDITIONAL_PACKAGES_SUPPORTED_SUBGROUPS = {
+    "x86_64": [
+        "additional_packages",
+        "slurm_control_node", "slurm_node", "login_node", "login_compiler_node",
+        "service_kube_control_plane", "service_kube_control_plane_first", "service_kube_node"
+    ],
+    "aarch64": [
+        "additional_packages",
+        "slurm_control_node", "slurm_node", "login_node", "login_compiler_node"
+    ]
+}
+
 # dict to hold the file names. If any file's name changes just change it here.
 files = {
     "local_repo_config": "local_repo_config.yml",

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -266,16 +266,27 @@ def validate_software_config(
                 try:
                     subgroup_softwares = subgroup_dict.get(software, None)
                     json_data = load_json(json_path)
-                    # For additional_packages, check for unsupported subgroups in the JSON
+                    # For additional_packages, validate subgroup keys in the JSON
                     if software == "additional_packages":
                         arch_supported = supported_subgroups.get(arch, [])
+                        user_subgroups = [p.get('name') for p in data.get(software, [])]
                         for json_key in json_data:
+                            if json_key == "additional_packages":
+                                continue
                             if json_key not in arch_supported:
                                 errors.append(
                                     create_error_msg(
                                         software + '/' + arch,
                                         json_path,
                                         f"Subgroup '{json_key}' is not supported for architecture {arch}."
+                                    )
+                                )
+                            elif json_key not in user_subgroups:
+                                errors.append(
+                                    create_error_msg(
+                                        software + '/' + arch,
+                                        json_path,
+                                        f"Subgroup '{json_key}' is present in JSON but not listed under additional_packages in software_config.json."
                                     )
                                 )
                     for subgroup_software in subgroup_softwares:

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -246,14 +246,14 @@ def validate_software_config(
                     )
                 )
 
+    supported_subgroups = config.ADDITIONAL_PACKAGES_SUPPORTED_SUBGROUPS
+
     for software_pkg in data['softwares']:
         software = software_pkg['name']
         arch_list = software_pkg.get('arch')
-        json_paths = []
         for arch in arch_list:
-            json_paths.append(get_json_file_path(
-                software, cluster_os_type, cluster_os_version, input_file_path, arch))
-        for json_path in json_paths:
+            json_path = get_json_file_path(
+                software, cluster_os_type, cluster_os_version, input_file_path, arch)
             # Check if json_path is None or if the JSON syntax is invalid
             if not json_path:
                 errors.append(
@@ -266,7 +266,24 @@ def validate_software_config(
                 try:
                     subgroup_softwares = subgroup_dict.get(software, None)
                     json_data = load_json(json_path)
+                    # For additional_packages, check for unsupported subgroups in the JSON
+                    if software == "additional_packages":
+                        arch_supported = supported_subgroups.get(arch, [])
+                        for json_key in json_data:
+                            if json_key not in arch_supported:
+                                errors.append(
+                                    create_error_msg(
+                                        software + '/' + arch,
+                                        json_path,
+                                        f"Subgroup '{json_key}' is not supported for architecture {arch}."
+                                    )
+                                )
                     for subgroup_software in subgroup_softwares:
+                        # For additional_packages, skip subgroups that are
+                        # not supported for this arch
+                        if software == "additional_packages":
+                            if subgroup_software not in supported_subgroups.get(arch, []):
+                                continue
                         _, fail_data = validation_utils.validate_softwaresubgroup_entries(
                             subgroup_software, json_path, json_data, validation_results, failures
                         )

--- a/common/library/module_utils/input_validation/validation_flows/common_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/common_validation.py
@@ -268,6 +268,14 @@ def validate_software_config(
                     json_data = load_json(json_path)
                     # For additional_packages, validate subgroup keys in the JSON
                     if software == "additional_packages":
+                        if "additional_packages" not in json_data:
+                            errors.append(
+                                create_error_msg(
+                                    software + '/' + arch,
+                                    json_path,
+                                    f"Required key 'additional_packages' is missing from the JSON file."
+                                )
+                            )
                         arch_supported = supported_subgroups.get(arch, [])
                         user_subgroups = [p.get('name') for p in data.get(software, [])]
                         for json_key in json_data:

--- a/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
@@ -223,15 +223,23 @@ def validate_local_repo_config(input_file_path, data,
             else:
                 curr_json = load_json(json_path)
                 pkg_list = curr_json[sw]['cluster']
-                # For additional_packages, check for unsupported subgroups in the JSON
+                # For additional_packages, validate subgroup keys in the JSON
                 if sw == "additional_packages":
                     arch_supported = supported_subgroups.get(arch, [])
+                    user_subgroups = [p.get('name') for p in software_config_json.get(sw, [])]
                     for json_key in curr_json:
+                        if json_key == "additional_packages":
+                            continue
                         if json_key not in arch_supported:
                             errors.append(
                                 create_error_msg(sw + '/' + arch,
                                                 json_path,
                                                 f"Subgroup '{json_key}' is not supported for architecture {arch}."))
+                        elif json_key not in user_subgroups:
+                            errors.append(
+                                create_error_msg(sw + '/' + arch,
+                                                json_path,
+                                                f"Subgroup '{json_key}' is present in JSON but not listed under additional_packages in software_config.json."))
                 if sw in software_config_json:
                     for sub_pkg in software_config_json[sw]:
                         sub_sw = sub_pkg.get('name')

--- a/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
@@ -208,6 +208,8 @@ def validate_local_repo_config(input_file_path, data,
                     )
 
     os_ver_path = f"/{software_config_json['cluster_os_type']}/{software_config_json['cluster_os_version']}/"
+    supported_subgroups = config.ADDITIONAL_PACKAGES_SUPPORTED_SUBGROUPS
+
     for software in software_config_json["softwares"]:
         sw = software["name"]
         arch_list = software.get("arch")
@@ -221,10 +223,24 @@ def validate_local_repo_config(input_file_path, data,
             else:
                 curr_json = load_json(json_path)
                 pkg_list = curr_json[sw]['cluster']
+                # For additional_packages, check for unsupported subgroups in the JSON
+                if sw == "additional_packages":
+                    arch_supported = supported_subgroups.get(arch, [])
+                    for json_key in curr_json:
+                        if json_key not in arch_supported:
+                            errors.append(
+                                create_error_msg(sw + '/' + arch,
+                                                json_path,
+                                                f"Subgroup '{json_key}' is not supported for architecture {arch}."))
                 if sw in software_config_json:
                     for sub_pkg in software_config_json[sw]:
                         sub_sw = sub_pkg.get('name')
                         if sub_sw not in curr_json:
+                            # For additional_packages, skip subgroups that
+                            # are not supported for this arch
+                            if sw == "additional_packages":
+                                if sub_sw not in supported_subgroups.get(arch, []):
+                                    continue
                             errors.append(
                                 create_error_msg(sw + '/' + arch,
                                                 json_path,

--- a/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/local_repo_validation.py
@@ -225,6 +225,11 @@ def validate_local_repo_config(input_file_path, data,
                 pkg_list = curr_json[sw]['cluster']
                 # For additional_packages, validate subgroup keys in the JSON
                 if sw == "additional_packages":
+                    if "additional_packages" not in curr_json:
+                        errors.append(
+                            create_error_msg(sw + '/' + arch,
+                                            json_path,
+                                            f"Required key 'additional_packages' is missing from the JSON file."))
                     arch_supported = supported_subgroups.get(arch, [])
                     user_subgroups = [p.get('name') for p in software_config_json.get(sw, [])]
                     for json_key in curr_json:

--- a/input/config/aarch64/rhel/10.0/additional_packages.json
+++ b/input/config/aarch64/rhel/10.0/additional_packages.json
@@ -4,21 +4,6 @@
 
         ]
     },
-    "service_kube_control_plane_first": {
-        "cluster": [
-
-        ]
-    },
-    "service_kube_control_plane": {
-        "cluster": [
-
-        ]
-    },
-    "service_kube_node": {
-        "cluster": [
-
-        ]
-    },
     "slurm_control_node": {
         "cluster": [
 


### PR DESCRIPTION
PR: Fix arch-specific validation for additional_packages
Added ADDITIONAL_PACKAGES_SUPPORTED_SUBGROUPS dict in config.py (x86_64 supports slurm + k8s groups, aarch64 supports slurm only)
Error if additional_packages parent key missing from arch JSON
Error if arch JSON has unsupported subgroups for that architecture
Error if arch JSON has subgroups not declared in software_config.json
Skip validation for subgroups not supported on the current arch instead of failing
Files changed: config.py, common_validation.py, local_repo_validation.py