### PR TITLE
Error update for openLDAP container not running in discovery.yml

### DIFF
--- a/discovery/discovery.yml
+++ b/discovery/discovery.yml
@@ -94,6 +94,12 @@
   hosts: oim
   connection: ssh
   tasks:
+    - name: Validate OpenLDAP container is running
+      ansible.builtin.include_role:
+        name: discovery_validations
+        tasks_from: validate_openldap_container.yml
+      when: hostvars['localhost']['openldap_support']
+    
     - name: Image validation
       ansible.builtin.include_role:
         name: discovery_validations

--- a/discovery/discovery.yml
+++ b/discovery/discovery.yml
@@ -99,7 +99,7 @@
         name: discovery_validations
         tasks_from: validate_openldap_container.yml
       when: hostvars['localhost']['openldap_support']
-    
+
     - name: Image validation
       ansible.builtin.include_role:
         name: discovery_validations

--- a/discovery/roles/discovery_validations/tasks/validate_openldap_container.yml
+++ b/discovery/roles/discovery_validations/tasks/validate_openldap_container.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Validate OpenLDAP container is running
+  block:
+    - name: Check if OpenLDAP container exists and is running
+      containers.podman.podman_container_info:
+        name: omnia_auth
+      register: openldap_container_check
+      failed_when: false
+    - name: Set OpenLDAP container status
+      ansible.builtin.set_fact:
+        openldap_container_missing: >-
+          {{ (openldap_container_check.containers | default([]) | length == 0) or
+             (openldap_container_check.containers | default([]) | length > 0 and
+              openldap_container_check.containers[0].State.Status != 'running') }}
+
+    - name: Display OpenLDAP container error
+      ansible.builtin.pause:
+        prompt: "{{ openldap_container_missing_msg }}"
+        seconds: 1
+      when: openldap_container_missing | bool
+
+    - name: Fail if OpenLDAP container is not running
+      ansible.builtin.fail:
+        msg: "OpenLDAP container is not running. See error details above."
+      when: openldap_container_missing | bool

--- a/discovery/roles/discovery_validations/vars/main.yml
+++ b/discovery/roles/discovery_validations/vars/main.yml
@@ -93,8 +93,8 @@ openldap_container_missing_msg: "{{ '\x1b[31m' }}\
   \n\
   To resolve this issue:\n\
   1. Ensure the 'openldap' package is added to software_config.json\n\
-  2. Run local_repo.yml to download OpenLDAP packages\n\
-  3. Re-run prepare_oim.yml to start the OpenLDAP container and generate certificates\n\
+  2. Re-run prepare_oim.yml to start the OpenLDAP container and generate certificates\n\
+  3. Run local_repo.yml to download OpenLDAP packages\n\
   4. Then re-run discovery.yml\n\
   \n\
   For more information, refer to the Omnia documentation on OpenLDAP configuration.\n\

--- a/discovery/roles/discovery_validations/vars/main.yml
+++ b/discovery/roles/discovery_validations/vars/main.yml
@@ -80,3 +80,23 @@ oim_timezone_changed_warning_msg: |
   inconsistent behavior.
 
 oim_metadata_file_path: "/opt/omnia/.data/oim_metadata.yml"
+
+# Usage: validate_openldap_container.yml
+openldap_container_missing_msg: "{{ '\x1b[31m' }}\
+  ==================================================================================\n\
+  ERROR: OpenLDAP container is not running.\n\
+  ==================================================================================\n\
+  \n\
+  OpenLDAP support is enabled but the OpenLDAP container was not found.\n\
+  This typically happens when prepare_oim.yml was run without the OpenLDAP\n\
+  package in software_config.json.\n\
+  \n\
+  To resolve this issue:\n\
+  1. Ensure the 'openldap' package is added to software_config.json\n\
+  2. Run local_repo.yml to download OpenLDAP packages\n\
+  3. Re-run prepare_oim.yml to start the OpenLDAP container and generate certificates\n\
+  4. Then re-run discovery.yml\n\
+  \n\
+  For more information, refer to the Omnia documentation on OpenLDAP configuration.\n\
+  ==================================================================================\
+  {{ '\x1b[0m' }}"

--- a/upgrade/roles/upgrade_cluster/vars/main.yml
+++ b/upgrade/roles/upgrade_cluster/vars/main.yml
@@ -14,5 +14,5 @@
 ---
 storage_config_path: "/opt/omnia/input/project_default/storage_config.yml"
 storage_content: "{{ lookup('file', storage_config_path, errors='ignore') | default('') }}"
-storage_yaml: "{{ storage_content | length > 0 | ternary(storage_content | from_yaml, {}) }}"
+storage_yaml: "{{ storage_content | from_yaml | default({}) }}"
 nfs_params: "{{ storage_yaml.nfs_client_params | default([]) }}"


### PR DESCRIPTION
Validation to check if openLDAP container (omnia_auth) is running or not is added as part of discovery validations in discovery.yml. Also rectified a templating error to not occur while running upgrade_omnia.yml