### PR TITLE
multi-node mpi jobs firewall permission

### DIFF
--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -315,6 +315,38 @@
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
         - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+        
+        # Add PXE network to trusted zone for ORTE communication
+        - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
+        - |
+          bash -c '
+          ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
+          NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
+          
+          # Convert IP to integer and calculate network address
+          ip_to_int() {
+            local IFS=.
+            read -r a b c d <<< "$1"
+            echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+          }
+          
+          int_to_ip() {
+            local ip=$1
+            echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"  
+          }
+          
+          ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
+          HOST_BITS=$(( 32 - NETMASK_BITS ))
+          HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
+          NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
+          NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
+          NETWORK_IP=$(int_to_ip "$NETWORK_INT")
+          
+          PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
+          echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
+          firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
+          '
+        
         - firewall-cmd --reload
         - systemctl enable sshd
         - systemctl start sshd

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -317,6 +317,38 @@
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
         - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+        
+        # Add PXE network to trusted zone for ORTE communication
+        - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
+        - |
+          bash -c '
+          ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
+          NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
+          
+          # Convert IP to integer and calculate network address
+          ip_to_int() {
+            local IFS=.
+            read -r a b c d <<< "$1"
+            echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+          }
+          
+          int_to_ip() {
+            local ip=$1
+            echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"  
+          }
+          
+          ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
+          HOST_BITS=$(( 32 - NETMASK_BITS ))
+          HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
+          NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
+          NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
+          NETWORK_IP=$(int_to_ip "$NETWORK_INT")
+          
+          PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
+          echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
+          firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
+          '
+        
         - firewall-cmd --reload
         - systemctl enable sshd
         - systemctl start sshd

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -171,6 +171,38 @@
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
         - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+        
+        # Add PXE network to trusted zone for ORTE communication
+        - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
+        - |
+          bash -c '
+          ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
+          NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
+          
+          # Convert IP to integer and calculate network address
+          ip_to_int() {
+            local IFS=.
+            read -r a b c d <<< "$1"
+            echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+          }
+          
+          int_to_ip() {
+            local ip=$1
+            echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"  
+          }
+          
+          ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
+          HOST_BITS=$(( 32 - NETMASK_BITS ))
+          HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
+          NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
+          NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
+          NETWORK_IP=$(int_to_ip "$NETWORK_INT")
+          
+          PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
+          echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
+          firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
+          '
+        
         - firewall-cmd --reload
         - systemctl enable sshd
         - systemctl start sshd

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -174,6 +174,38 @@
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
         - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+        
+        # Add PXE network to trusted zone for ORTE communication
+        - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
+        - |
+          bash -c '
+          ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
+          NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
+          
+          # Convert IP to integer and calculate network address
+          ip_to_int() {
+            local IFS=.
+            read -r a b c d <<< "$1"
+            echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+          }
+          
+          int_to_ip() {
+            local ip=$1
+            echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"  
+          }
+          
+          ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
+          HOST_BITS=$(( 32 - NETMASK_BITS ))
+          HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
+          NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
+          NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
+          NETWORK_IP=$(int_to_ip "$NETWORK_INT")
+          
+          PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
+          echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
+          firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
+          '
+        
         - firewall-cmd --reload
         - systemctl enable sshd
         - systemctl start sshd

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -386,6 +386,36 @@
             firewall-cmd --permanent --add-service=ssh
             firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
             firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
+            
+            # Add PXE network to trusted zone for ORTE communication
+            echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
+            # Calculate PXE subnet using admin IP and netmask bits
+            ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
+            NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
+            
+            # Convert IP to integer and calculate network address
+            ip_to_int() {
+              local IFS=.
+              read -r a b c d <<< "$1"
+              echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+            }
+            
+            int_to_ip() {
+              local ip=$1
+              echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"
+            }
+            
+            ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
+            HOST_BITS=$(( 32 - NETMASK_BITS ))
+            HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
+            NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
+            NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
+            NETWORK_IP=$(int_to_ip "$NETWORK_INT")
+            
+            PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
+            echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
+            firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
+            
             firewall-cmd --reload
 
             echo "[INFO] Unmounting controller slurm.conf directory from $CTLD_SLURM_DIR_MNT"

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -403,6 +403,36 @@
             firewall-cmd --permanent --add-service=ssh
             firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
             firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
+            
+            # Add PXE network to trusted zone for ORTE communication
+            echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
+            # Calculate PXE subnet using admin IP and netmask bits
+            ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
+            NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
+            
+            # Convert IP to integer and calculate network address
+            ip_to_int() {
+              local IFS=.
+              read -r a b c d <<< "$1"
+              echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
+            }
+            
+            int_to_ip() {
+              local ip=$1
+              echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"
+            }
+            
+            ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
+            HOST_BITS=$(( 32 - NETMASK_BITS ))
+            HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
+            NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
+            NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
+            NETWORK_IP=$(int_to_ip "$NETWORK_INT")
+            
+            PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
+            echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
+            firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
+            
             firewall-cmd --reload
 
             echo "[INFO] Unmounting controller slurm.conf directory from $CTLD_SLURM_DIR_MNT"

--- a/discovery/roles/slurm_config/defaults/main.yml
+++ b/discovery/roles/slurm_config/defaults/main.yml
@@ -19,7 +19,7 @@ slurmctld_service_default_path: '/usr/lib/systemd/system/slurmctld.service'
 slurmd_service_default_path: '/usr/lib/systemd/system/slurmd.service'
 slurmdbd_service_default_path: '/usr/lib/systemd/system/slurmdbd.service'
 sys_env_path: '/etc/environment'
-default_real_memory: 884736
+default_real_memory: 864
 default_threadspercore: 1
 default_corespersocket: 72
 default_sockets: 2


### PR DESCRIPTION
while running the mpi jobs in multiple nodes when ORTE deamon service trying to contact with nodes its getting blocked due to  firewall service port is closed.
so fixed that in this code.