### PR TITLE
Fix/adapter policy arch x86 64

### DIFF
--- a/build_stream/core/catalog/resources/adapter_policy_default.json
+++ b/build_stream/core/catalog/resources/adapter_policy_default.json
@@ -96,6 +96,9 @@
       ]
     },
     "service_k8s.json": {
+      "conditions": {
+        "architectures": ["x86_64"]
+      },
       "transform": {
         "exclude_fields": ["architecture"],
         "rename_fields": {"uri": "url"}
@@ -177,6 +180,9 @@
       ]
     },
     "csi_driver_powerscale.json": {
+      "conditions": {
+        "architectures": ["x86_64"]
+      },
       "transform": {
         "exclude_fields": ["architecture"],
         "rename_fields": {"uri": "url"}


### PR DESCRIPTION

Making sure the k8 and csi jsons are created only for 64bit