### PR TITLE
Update to hide build_stream and postgress passwords in prepare_oim execution

### DIFF
--- a/prepare_oim/roles/deploy_containers/auth/tasks/deploy_auth_service.yml
+++ b/prepare_oim/roles/deploy_containers/auth/tasks/deploy_auth_service.yml
@@ -158,11 +158,14 @@
         name: "{{ auth_service_container_name }}.service"
         enabled: true
         state: started
+      no_log: true
+      changed_when: false
 
     - name: Check if auth service container is running after deployment
       containers.podman.podman_container_info:
         name: "{{ auth_service_container_name }}"
       register: auth_service_container_status
+      no_log: true
 
     - name: Notify user of auth service container deployment status
       ansible.builtin.debug:

--- a/prepare_oim/roles/deploy_containers/auth/tasks/generate_ldap_password_hashes.yml
+++ b/prepare_oim/roles/deploy_containers/auth/tasks/generate_ldap_password_hashes.yml
@@ -17,8 +17,9 @@
   generate_ssha_password:
     password: "{{ hostvars['127.0.0.1']['openldap_db_password'] }}"
   register: password_hash
+  no_log: true
 
 - name: Set variables for OpenLDAP database password
   ansible.builtin.set_fact:
     openldap_db_password_hash: "{{ password_hash.pswd_ssha }}"
-  no_log: false
+  no_log: true

--- a/prepare_oim/roles/deploy_containers/build_stream/handlers/main.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/handlers/main.yml
@@ -25,3 +25,4 @@
     name: "{{ build_stream_service }}"
     state: restarted
     enabled: true
+  no_log: true

--- a/prepare_oim/roles/deploy_containers/build_stream/tasks/deploy_build_stream.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/tasks/deploy_build_stream.yml
@@ -22,6 +22,7 @@
   register: build_stream_service_status
   failed_when: false
   changed_when: false
+  no_log: true
 
 - name: Stop and disable omnia_build_stream service if present
   ansible.builtin.systemd_service:
@@ -30,6 +31,8 @@
     enabled: false
   when: build_stream_service_status.status is defined
   failed_when: false
+  no_log: true
+  changed_when: false
 
 - name: Check if omnia_build_stream container exists
   containers.podman.podman_container_info:
@@ -157,6 +160,7 @@
     -subj "/C=US/ST=State/L=City/O=Omnia/CN={{ ansible_hostname }}"
     -addext "subjectAltName=DNS:{{ ansible_hostname }},DNS:localhost,IP:{{ ansible_default_ipv4.address }},IP:127.0.0.1,IP:{{ admin_ip }}"
   changed_when: true
+  no_log: true
 
 - name: Set permissions on SSL certificates
   ansible.builtin.file:
@@ -193,8 +197,10 @@
 
 - name: Generate JWT keys
   ansible.builtin.command: "{{ build_stream_jwt_keys_script }}"
+  register: jwt_keys
+  changed_when: true
   delegate_to: localhost
-  changed_when: false
+  no_log: true
 
 # - name: Update project name in default.yml
 #  ansible.builtin.replace:
@@ -221,6 +227,7 @@
         mode: "{{ build_stream_quadlet_file_mode }}"
       notify:
         - Reload systemd
+      no_log: true
 
     # Ensure systemd reload happens even if Quadlet content was already up-to-date
     - name: Force systemd to re-read Quadlet units
@@ -236,6 +243,8 @@
         name: "{{ build_stream_service }}"
         enabled: true
         state: started
+      no_log: true
+      changed_when: false
 
     - name: Wait until omnia_build_stream container exists and is running
       containers.podman.podman_container_info:
@@ -248,6 +257,7 @@
         - bs_info.containers | length > 0
         - bs_info.containers[0].State is defined
         - bs_info.containers[0].State.Running | bool
+      no_log: true
 
     - name: Run Alembic database migrations inside build_stream container
       containers.podman.podman_container_exec:
@@ -261,6 +271,7 @@
           DB_NAME: "{{ postgres_db_name }}"
       register: alembic_result
       changed_when: "'Running upgrade' in alembic_result.stdout"
+      no_log: true
 
     - name: Display migration result
       ansible.builtin.debug:

--- a/prepare_oim/roles/deploy_containers/openchami/tasks/deploy_openchami.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/deploy_openchami.yml
@@ -51,18 +51,23 @@
     mode: "{{ file_permissions_644 }}"
 
 - name: Deploy openchami containers
-  ansible.builtin.shell: |
-    set -o pipefail
-    ansible-playbook {{ openchami_clone_path }}/dell/podman-quadlets/configs.yaml \
-    -i {{ openchami_clone_path }}/dell/podman-quadlets/inventory -v \
-    -e "minio_s3_username={{ minio_s3_username }}" \
-    -e "minio_s3_password={{ minio_s3_password }}" \
-    --extra-vars "@{{ openchami_config_vars_path }}" -v | \
-    /usr/bin/tee {{ openchami_configs_log_path }}
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      ansible-playbook {{ openchami_clone_path }}/dell/podman-quadlets/configs.yaml \
+      -i {{ openchami_clone_path }}/dell/podman-quadlets/inventory -v \
+      -e "minio_s3_username=$MINIO_USERNAME" \
+      -e "minio_s3_password=$MINIO_PASSWORD" \
+      --extra-vars "@{{ openchami_config_vars_path }}" -v | \
+      /usr/bin/tee {{ openchami_configs_log_path }}
+  environment:
+    MINIO_USERNAME: "{{ minio_s3_username }}"
+    MINIO_PASSWORD: "{{ minio_s3_password }}"
   async: 3600  # Set async timeout (e.g., 1 hour)
   poll: 0  # Non-blocking (continue the playbook without waiting for completion)
   register: openchami_deploy  # Register the result to capture job ID
   changed_when: true
+  no_log: true
 
 - name: Wait for openchami installation
   block:
@@ -73,6 +78,7 @@
       until: job_result.finished
       retries: "{{ job_retry }}"  # Retry the task {{ job_retry }} times
       delay: "{{ job_delay }}"   # Wait {{ job_delay }} seconds between retries
+      no_log: true
   rescue:
     - name: Openchami installation failed
       ansible.builtin.fail:

--- a/prepare_oim/roles/deploy_containers/postgres/tasks/deploy_postgres.yml
+++ b/prepare_oim/roles/deploy_containers/postgres/tasks/deploy_postgres.yml
@@ -20,6 +20,8 @@
     name: "{{ postgres_container_name }}.service"
   register: postgres_service_status
   failed_when: false
+  no_log: true
+  changed_when: false
 
 - name: Stop omnia_postgres service if running
   ansible.builtin.systemd:
@@ -28,6 +30,8 @@
     enabled: false
   when: postgres_service_status.status is defined
   failed_when: false
+  no_log: true
+  changed_when: false
 
 - name: Check if omnia_postgres container exists
   containers.podman.podman_container_info:
@@ -91,6 +95,7 @@
         dest: "{{ postgres_quadlet_path }}"
         mode: "{{ postgres_quadlet_file_mode }}"
       register: quadlet_out
+      no_log: true
 
     - name: Reload systemd if Quadlet changed
       ansible.builtin.systemd_service:
@@ -103,6 +108,7 @@
         enabled: true
         state: started
       no_log: true
+      changed_when: false
 
     - name: Restart postgres container if Quadlet changed
       ansible.builtin.systemd_service:
@@ -110,6 +116,7 @@
         name: "{{ postgres_container_name }}.service"
       when: quadlet_out.changed # noqa: no-handler
       no_log: true
+      changed_when: false
 
     - name: Wait for PostgreSQL to be ready
       ansible.builtin.pause:
@@ -119,6 +126,7 @@
       containers.podman.podman_container_info:
         name: "{{ postgres_container_name }}"
       register: postgres_container_status
+      no_log: true
 
     - name: Wait for PostgreSQL to accept connections
       containers.podman.podman_container_exec:
@@ -129,18 +137,21 @@
       delay: "{{ postgres_ready_delay }}"
       until: pg_ready.rc == 0
       changed_when: false
+      no_log: true
 
     - name: Create temporary directory for initialization script
       ansible.builtin.tempfile:
         state: directory
         suffix: _postgres_init
       register: temp_init_dir
+      no_log: true
 
     - name: Generate database initialization script
       ansible.builtin.template:
         src: init_build_stream_db.sql.j2
         dest: "{{ temp_init_dir.path }}/init_build_stream_db.sql"
         mode: "0644"
+      no_log: true
 
     - name: Check if build_stream_db exists
       containers.podman.podman_container_exec:
@@ -149,6 +160,7 @@
       register: db_exists_check
       changed_when: false
       failed_when: false
+      no_log: true
 
     - name: Create build_stream_db database if it doesn't exist
       containers.podman.podman_container_exec:
@@ -158,11 +170,13 @@
       register: db_create_result
       changed_when: db_create_result.rc == 0
       failed_when: db_create_result.rc != 0 and 'already exists' not in db_create_result.stderr
+      no_log: true
 
     - name: Copy initialization script to postgres container
       ansible.builtin.command:
         cmd: podman cp "{{ temp_init_dir.path }}/init_build_stream_db.sql" "{{ postgres_container_name }}:/tmp/init_build_stream_db.sql"
       changed_when: true
+      no_log: true
 
     - name: Set up database schema permissions
       containers.podman.podman_container_exec:
@@ -170,6 +184,7 @@
         command: psql -U {{ postgres_user }} -d {{ postgres_db_name }} -f /tmp/init_build_stream_db.sql
       register: db_init_result
       changed_when: false
+      no_log: true
 
     - name: Display database initialization result
       ansible.builtin.debug:
@@ -187,6 +202,7 @@
       ansible.builtin.file:
         path: "{{ temp_init_dir.path }}"
         state: absent
+      no_log: true
 
     - name: Notify user of postgres container deployment status
       ansible.builtin.debug:

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/deploy_pulp_container_http.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/deploy_pulp_container_http.yml
@@ -46,6 +46,7 @@
         name: "{{ pulp_container_name }}"
         enabled: true
       no_log: true
+      changed_when: false
 
     - name: Restart pulp container
       ansible.builtin.systemd_service:
@@ -53,11 +54,13 @@
         name: "{{ pulp_container_name }}"
       when: quad_out.changed # noqa: no-handler
       no_log: true
+      changed_when: false
 
     - name: Check if Pulp container is running after deployment
       containers.podman.podman_container_info:
         name: "{{ pulp_container_name }}"
       register: pulp_container_status
+      no_log: true
 
     - name: Notify user of Pulp container deployment status
       ansible.builtin.debug:

--- a/prepare_oim/roles/deploy_containers/pulp/tasks/deploy_pulp_container_https.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/tasks/deploy_pulp_container_https.yml
@@ -52,6 +52,7 @@
         name: "{{ pulp_container_name }}"
         enabled: true
       no_log: true
+      changed_when: false
 
     - name: Restart pulp container
       ansible.builtin.systemd_service:
@@ -59,11 +60,13 @@
         name: "{{ pulp_container_name }}"
       when: quad_out.changed # noqa: no-handler
       no_log: true
+      changed_when: false
 
     - name: Check if Pulp container is running after deployment
       containers.podman.podman_container_info:
         name: "{{ pulp_container_name }}"
       register: pulp_container_status
+      no_log: true
 
     - name: Notify user of Pulp container deployment status
       ansible.builtin.debug:


### PR DESCRIPTION
the postgres, build_stream and minio elated password were being exposed in the log messages in prepare_oim, so they have been hidden so that they are not visible in the verbose mode too