### PR TITLE
delete cloud-init cache

### DIFF
--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -479,6 +479,7 @@
             {{ lookup('template', 'templates/hpc_tools/export_nvhpc_env.sh.j2') | indent(12) }}
 
       runcmd:
+        - rm -rf /var/lib/cloud/instance
         - /usr/local/bin/set-ssh.sh
         - /usr/local/bin/install_nvidia_driver.sh
 

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -483,6 +483,7 @@
             {{ lookup('template', 'templates/hpc_tools/export_nvhpc_env.sh.j2') | indent(12) }}
 
       runcmd:
+        - rm -rf /var/lib/cloud/instance
         - /usr/local/bin/set-ssh.sh
         - /usr/local/bin/install_nvidia_driver.sh
         # slurm user and group created in the users module


### PR DESCRIPTION
if we swap the slurm nodes hostnames in pxe it was not taking the correct slurm node hostname because of cache of cloud-init.
so deleting cloud-init cache in slurm-nodes.