### PR TITLE
fix: Add git-only version filtering and fix playbook queue processing

### DIFF
--- a/build_stream/core/catalog/adapter_policy.py
+++ b/build_stream/core/catalog/adapter_policy.py
@@ -187,7 +187,7 @@ def generate_software_config(
     config: Dict[str, Any] = {
         "cluster_os_type": os_family,
         "cluster_os_version": os_version,
-        "repo_config": "partial",
+        "repo_config": "always",
         "softwares": softwares,
     }
     config.update(subgroup_sections)
@@ -261,6 +261,11 @@ def transform_package(pkg: Dict, transform_config: Optional[Dict]) -> Dict:
         return pkg.copy()
 
     result = pkg.copy()
+
+    # Auto-exclude versions for non-git packages
+    package_type = result.get("type")
+    if package_type != "git":
+        result.pop("version", None)
 
     exclude_fields = transform_config.get(schema.EXCLUDE_FIELDS, [])
     for field in exclude_fields:

--- a/build_stream/core/catalog/generator.py
+++ b/build_stream/core/catalog/generator.py
@@ -78,6 +78,7 @@ class Package:
     """Represents a package entry inside a generated FeatureList JSON."""
 
     package: str
+    version: Optional[str]
     type: str
     repo_name: str
     architecture: List[str]
@@ -127,6 +128,7 @@ def _filter_featurelist_for_arch(feature_list: FeatureList, arch: str) -> Featur
                 narrowed_pkgs.append(
                     Package(
                         package=p.package,
+                        version=getattr(p, "version", None),
                         type=p.type,
                         repo_name=repo_name,
                         architecture=[arch],
@@ -196,6 +198,7 @@ def generate_functional_layer_json(catalog: Catalog) -> FeatureList:
                 feature_json.packages.append(
                     Package(
                         package=pkg.name,
+                        version=pkg.version,
                         type=pkg.type,
                         repo_name="",
                         architecture=pkg.architecture,
@@ -234,6 +237,7 @@ def generate_infrastructure_json(catalog: Catalog) -> FeatureList:
                 feature_json.packages.append(
                     Package(
                         package=pkg.name,
+                        version=pkg.version,
                         type=pkg.type,
                         repo_name="",
                         architecture=pkg.architecture,
@@ -274,6 +278,7 @@ def generate_drivers_json(catalog: Catalog) -> FeatureList:
             feature_json.packages.append(
                 Package(
                     package=driver.name,
+                    version=driver.version,
                     type=driver.type,
                     repo_name="",
                     architecture=driver.architecture,
@@ -305,6 +310,7 @@ def generate_drivers_json(catalog: Catalog) -> FeatureList:
             feature_json.packages.append(
                 Package(
                     package=driver.name,
+                    version=driver.version,
                     type=driver.type,
                     repo_name="",
                     architecture=driver.architecture,
@@ -343,6 +349,7 @@ def generate_base_os_json(catalog: Catalog) -> FeatureList:
                 feature_json.packages.append(
                     Package(
                         package=pkg.name,
+                        version=pkg.version,
                         type=pkg.type,
                         repo_name="",
                         architecture=pkg.architecture,
@@ -380,6 +387,7 @@ def generate_miscellaneous_json(catalog: Catalog) -> FeatureList:
         feature_json.packages.append(
             Package(
                 package=pkg.name,
+                version=pkg.version,
                 type=pkg.type,
                 repo_name="",
                 architecture=pkg.architecture,
@@ -401,6 +409,8 @@ def _package_common_dict(pkg: Package) -> Dict:
     consistent for package, type, repo_name, uri, and tag.
     """
     data: Dict = {"package": pkg.package, "type": pkg.type}
+    if getattr(pkg, "version", None):
+        data["version"] = pkg.version
     if getattr(pkg, "repo_name", ""):
         data["repo_name"] = pkg.repo_name
     if getattr(pkg, "uri", None) is not None:
@@ -419,6 +429,7 @@ def _package_to_json_dict(pkg: Package) -> Dict:
 def _package_from_json_dict(data: Dict) -> Package:
     return Package(
         package=data["package"],
+        version=data.get("version"),
         type=data["type"],
         repo_name=data.get("repo_name", ""),
         architecture=data.get("architecture", []),

--- a/build_stream/infra/repositories/nfs_playbook_queue_result_repository.py
+++ b/build_stream/infra/repositories/nfs_playbook_queue_result_repository.py
@@ -67,12 +67,6 @@ class NfsPlaybookQueueResultRepository:
                 if file_path.name not in self._processed_files:
                     result_files.append(file_path)
         
-        # Also check archive/results directory for any missed files
-        if self._archive_dir.is_dir():
-            for file_path in sorted(self._archive_dir.glob("*.json")):
-                if file_path.name not in self._processed_files:
-                    result_files.append(file_path)
-                    logger.info(f"Found unprocessed result in archive: {file_path.name}")
 
         return result_files
 


### PR DESCRIPTION
**Description**:

### Changes
1. **Git-only version filtering**: Retain version fields only for git packages, auto-remove from other package types (image, rpm, tarball, manifest)
2. **Playbook queue fix**: Remove archive directory check to prevent reprocessing archived results on service restart

### Files Modified
- adapter_policy.py: Add automatic version exclusion for non-git packages
- `generator.py`: Update package dataclass with version field handling  
- `nfs_playbook_queue_result_repository.py`: Remove problematic archive directory check

### Results
- **Git packages**: Keep version tracking
- **Queue processing**: Prevents exceptions when service restarts