### PR TITLE
Delete local_repo_metadata.yml when all rpms are cleaned up

### DIFF
--- a/common/library/modules/pulp_cleanup.py
+++ b/common/library/modules/pulp_cleanup.py
@@ -1147,17 +1147,22 @@ def write_cleanup_status(results: List[Dict], base_path: str):
     return status_file
 
 
-def update_metadata_after_cleanup(cleaned_repos: List[str], metadata_file: str, logger):
+def update_metadata_after_cleanup(cleaned_repos: List[str], metadata_file: str, logger,
+                                  cleanup_all: bool = False):
     """Remove cleaned-up repository entries from localrepo_metadata.yml.
 
     For each successfully cleaned repo, find and remove its policy entry
     from the metadata file. Repo names in metadata are normalized
     (hyphens replaced with underscores, suffixed with _policy).
 
+    When cleanup_all is True (i.e. cleanup_repos=all), the entire metadata
+    file is deleted.
+
     Args:
         cleaned_repos: List of repo names that were successfully deleted
         metadata_file: Path to localrepo_metadata.yml
         logger: Logger instance
+        cleanup_all: If True, delete the entire metadata file
     """
     if not cleaned_repos or not metadata_file:
         return
@@ -1167,6 +1172,12 @@ def update_metadata_after_cleanup(cleaned_repos: List[str], metadata_file: str, 
         return
 
     try:
+        # When cleanup_repos=all, delete the metadata file entirely.
+        if cleanup_all:
+            os.remove(metadata_file)
+            logger.info(f"Deleted metadata file: {metadata_file}")
+            return
+
         with open(metadata_file, 'r', encoding='utf-8') as f:
             metadata = yaml.safe_load(f) or {}
 
@@ -1441,7 +1452,8 @@ def run_module():
     # Update metadata file to remove entries for successfully cleaned repos
     successfully_cleaned = [r['name'] for r in all_results if r['status'] == 'Success']
     if successfully_cleaned and metadata_file:
-        update_metadata_after_cleanup(successfully_cleaned, metadata_file, logger)
+        update_metadata_after_cleanup(successfully_cleaned, metadata_file, logger,
+                                          cleanup_all=cleanup_all_repos)
 
     # Update yum repo file (pulp.repo) to remove stanzas for successfully cleaned repositories
     cleaned_repo_names = [r['name'] for r in all_results if r['status'] == 'Success' and r.get('type') == 'repository']

--- a/local_repo/pulp_cleanup.yml
+++ b/local_repo/pulp_cleanup.yml
@@ -66,19 +66,6 @@
         container_list: "{{ cleanup_containers.split(',') | map('trim') | list if cleanup_containers is string else (cleanup_containers | default([])) }}"
         file_list: "{{ cleanup_files.split(',') | map('trim') | list if cleanup_files is string else (cleanup_files | default([])) }}"
 
-    - name: Load local_repo_config.yml
-      ansible.builtin.include_vars:
-        file: "/opt/omnia/input/project_default/local_repo_config.yml"
-        name: local_repo_config
-
-    - name: Extract omnia repo names from local_repo_config
-      ansible.builtin.set_fact:
-        omnia_repo_names: >-
-          {{
-            (((local_repo_config.omnia_repo_url_rhel_x86_64 | default([])) | map(attribute='name') | list) +
-            ((local_repo_config.omnia_repo_url_rhel_aarch64 | default([])) | map(attribute='name') | list)) | unique
-          }}
-
     - name: Display cleanup summary
       ansible.builtin.debug:
         msg:
@@ -94,11 +81,6 @@
 
           WARNING: This will permanently delete the specified artifacts.
           This action cannot be undone.
-
-          NOTE: If you are deleting any of the following Omnia repos: {{ omnia_repo_names | join(', ') }}
-          You MUST rerun local_repo.yml after cleanup to reconfigure the repo(s).
-          Failure to do so will result in failures in execution of further playbooks.
-
           Type 'yes' to continue or press Ctrl+C to abort
       register: user_input
       when: not (force | default(false)) | bool
@@ -132,7 +114,9 @@
     - name: Display summary
       ansible.builtin.debug:
         msg:
-          - "========== CLEANUP COMPLETED =========="
+          - "================================================CLEANUP COMPLETED==========================================================="
           - "Total: {{ cleanup_result.total }}, Success: {{ cleanup_result.success_count }}, Failed: {{ cleanup_result.failed_count }}"
           - "Status file: {{ cleanup_result.status_file }}"
-          - "========================================"
+          - "NOTE: If the deleted artifact is required by any software, you must rerun local_repo.yml to sync the artifact(s) again."
+          - "If the artifact(s) is not synced in local repo, subsequent playbooks having dependency may fail"
+          - "============================================================================================================================"

--- a/local_repo/pulp_cleanup.yml
+++ b/local_repo/pulp_cleanup.yml
@@ -66,6 +66,19 @@
         container_list: "{{ cleanup_containers.split(',') | map('trim') | list if cleanup_containers is string else (cleanup_containers | default([])) }}"
         file_list: "{{ cleanup_files.split(',') | map('trim') | list if cleanup_files is string else (cleanup_files | default([])) }}"
 
+    - name: Load local_repo_config.yml
+      ansible.builtin.include_vars:
+        file: "/opt/omnia/input/project_default/local_repo_config.yml"
+        name: local_repo_config
+
+    - name: Extract omnia repo names from local_repo_config
+      ansible.builtin.set_fact:
+        omnia_repo_names: >-
+          {{
+            (((local_repo_config.omnia_repo_url_rhel_x86_64 | default([])) | map(attribute='name') | list) +
+            ((local_repo_config.omnia_repo_url_rhel_aarch64 | default([])) | map(attribute='name') | list)) | unique
+          }}
+
     - name: Display cleanup summary
       ansible.builtin.debug:
         msg:
@@ -74,12 +87,17 @@
           - "Containers   : {{ (container_list | default([]) | join(', ')) if cleanup_containers | default([]) | length > 0 else 'None' }}"
           - "Files        : {{ (file_list | default([]) | join(', ')) if cleanup_files | default([]) | length > 0 else 'None' }}"
           - "====================================="
+
     - name: Get user confirmation
       ansible.builtin.pause:
         prompt: |
 
           WARNING: This will permanently delete the specified artifacts.
           This action cannot be undone.
+
+          NOTE: If you are deleting any of the following Omnia repos: {{ omnia_repo_names | join(', ') }}
+          You MUST rerun local_repo.yml after cleanup to reconfigure the repo(s).
+          Failure to do so will result in failures in execution of further playbooks.
 
           Type 'yes' to continue or press Ctrl+C to abort
       register: user_input


### PR DESCRIPTION
- Delete local_repo_metadata.yml when all rpm repositories,remotes,distributions are cleanup up using pulp_cleanup.yml
