### PR TITLE
Fix/postgres password

### DIFF
--- a/common/library/module_utils/input_validation/schema/credential_rules.json
+++ b/common/library/module_utils/input_validation/schema/credential_rules.json
@@ -44,8 +44,8 @@
       "postgres_password": {
         "minLength": 8,
         "maxLength": 128,
-        "pattern": "^[a-zA-Z0-9!@#$%^&*()_+=,.?<>;:{}\\[\\]|-]{6,128}$",
-        "description": "Password for Postgres DB. Length must be between 8 and 128 characters and can contain letters, numbers, and special characters."
+        "pattern": "^[a-zA-Z0-9!#$%^&*()_+=,.?<>;{}\\[\\]|]{6,128}$",
+        "description": "Password for Postgres DB. Length must be between 8 and 128 characters and can contain letters, numbers, and special characters. Must not contain special characters like at symbols @ , hyphens (-), single quotes ('), double quotes (\") or backslashes (\\)"
       },
       "slurm_db_password": {
         "minLength": 8,

--- a/common/library/module_utils/input_validation/schema/credential_rules.json
+++ b/common/library/module_utils/input_validation/schema/credential_rules.json
@@ -44,8 +44,8 @@
       "postgres_password": {
         "minLength": 8,
         "maxLength": 128,
-        "pattern": "^[a-zA-Z0-9!#$%^&*()_+=,.?<>;{}\\[\\]|]{6,128}$",
-        "description": "Password for Postgres DB. Length must be between 8 and 128 characters and can contain letters, numbers, and special characters. Must not contain special characters like at symbols @ , hyphens (-), single quotes ('), double quotes (\") or backslashes (\\)"
+        "pattern": "^[a-zA-Z0-9!#$^&*()_+=,.?<>;{}\\[\\]|]{6,128}$",
+        "description": "Password for Postgres DB. Length must be between 8 and 128 characters and can contain letters, numbers, and special characters from !  #  $  %  ^  &  *  (  )  _  +  =  ,  .  ?  <  >  ;  {  }  [  ]  |"
       },
       "slurm_db_password": {
         "minLength": 8,

--- a/prepare_oim/roles/deploy_containers/postgres/templates/postgres.j2
+++ b/prepare_oim/roles/deploy_containers/postgres/templates/postgres.j2
@@ -29,7 +29,7 @@ Network=host
 
 # Environment variables
 Environment=POSTGRES_USER={{ postgres_user }}
-Environment=POSTGRES_PASSWORD={{ postgres_password }}
+Environment=POSTGRES_PASSWORD="{{ postgres_password }}"
 Environment=POSTGRES_DB={{ postgres_db_name }}
 
 # Volume mounts


### PR DESCRIPTION
### **Issue**
PostgreSQL passwords with special characters cause deployment failures due to systemd parsing errors and configparser interpolation issues.

### **Root Cause**
- Unquoted environment variables in systemd Quadlet templates
- Password validation allows problematic characters (`%`, `@`, `-`, `'`, `"`, `\`)
- ConfigParser treats `%` as interpolation syntax

### **Changes Made**
1. **Updated validation pattern** to exclude problematic characters
2. **Added quotes** around `POSTGRES_PASSWORD` in Quadlet template

Tested with "Aa1!#$^&*()_+=,.?<>;{}[]|venu"