### PR TITLE
Resolve undefined variable check_gitlab_port_script in gitlab_passwordless_ssh role

### DIFF
--- a/gitlab/roles/gitlab_passwordless_ssh/vars/main.yml
+++ b/gitlab/roles/gitlab_passwordless_ssh/vars/main.yml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Script path
+check_gitlab_port_script: "/tmp/check_gitlab_port.sh"
+
 # Port validation error message
 gitlab_https_port_in_use_msg: >
   GitLab HTTPS port {{ gitlab_https_port }} is already in use by another service.

--- a/gitlab/roles/hosted_gitlab/vars/main.yml
+++ b/gitlab/roles/hosted_gitlab/vars/main.yml
@@ -224,9 +224,6 @@ podman_login_fail_msg: >
   Podman login failed. Please ensure the podman login credentials in the input/omnia_config_credentials.yml are valid.
   If they are, this error can occur due to a pull limit issue or multiple requests. Please try running the playbook again after waiting for a while.
 
-# Script paths
-check_gitlab_port_script: "/tmp/check_gitlab_port.sh"
-
 # Image pull configuration
 gitlab_image_pull_retries: 5
 gitlab_image_pull_delay: 10


### PR DESCRIPTION
The GitLab deployment playbook was failing during the gitlab_passwordless_ssh role execution due to an undefined variable check_gitlab_port_script.

The variable was defined in the hosted_gitlab role but referenced inside the gitlab_passwordless_ssh role. Due to Ansible role variable scoping, variables defined in one role are not accessible in another role unless explicitly passed.

**Fix**

- Removed check_gitlab_port_script from hosted_gitlab/vars/main.yml.

- Added check_gitlab_port_script to gitlab_passwordless_ssh/vars/main.yml where it is actually used.

 @abhishek-sa1 Please review 