### PR TITLE
Increase Pulp Internal HTTP Timeout

### DIFF
--- a/prepare_oim/roles/deploy_containers/pulp/templates/settings_template.j2
+++ b/prepare_oim/roles/deploy_containers/pulp/templates/settings_template.j2
@@ -11,4 +11,5 @@ TOKEN_AUTH_DISABLED=True
 {% endfor -%}
 {% set random_key = ''.join(random_key) -%}
 SECRET_KEY='{{ random_key }}'
-REMOTE_CONTENT_DOWNLOAD_TIMEOUT=2700
+import aiohttp
+aiohttp.client.DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=7200, sock_connect=600, sock_read=600)


### PR DESCRIPTION
When local repo attempts to download large tarball packages (e.g NVIDIA HPC SDK ~4GB), there is a timeout after approximately 20 minutes. The code change overrides the default pulp internal http timeout from 300s to 7200s.
