### PR TITLE
feat(discovery): robust OME pagination, GPU collection, and timestamped PXE mapping

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/logical_validation.py
+++ b/common/library/module_utils/input_validation/common_utils/logical_validation.py
@@ -25,6 +25,7 @@ from ansible.module_utils.input_validation.validation_flows import high_availabi
 from ansible.module_utils.input_validation.validation_flows import local_repo_validation
 from ansible.module_utils.input_validation.validation_flows import build_stream_validation
 from ansible.module_utils.input_validation.validation_flows import gitlab_validation
+from ansible.module_utils.input_validation.validation_flows import telemetry_validation
 
 
 # L2 Validation Code - validate anything that could not have been validated with JSON schema
@@ -61,7 +62,7 @@ def validate_input_logic(
         "network_spec.yml": provision_validation.validate_network_spec,
         "omnia_config.yml": common_validation.validate_omnia_config,
         "local_repo_config.yml": local_repo_validation.validate_local_repo_config,
-        "telemetry_config.yml": common_validation.validate_telemetry_config,
+        "telemetry_config.yml": telemetry_validation.validate_telemetry_config,
         "security_config.yml": common_validation.validate_security_config,
         "storage_config.yml": common_validation.validate_storage_config,
         "high_availability_config.yml":

--- a/common/library/modules/generate_pxe_mapping.py
+++ b/common/library/modules/generate_pxe_mapping.py
@@ -225,7 +225,9 @@ def main():
         "BMC_MAC",
         "BMC_IP",
         "IB_MAC",
-        "IB_IP"
+        "IB_IP",
+        "GPU_VENDOR",
+        "GPU_TYPE"
     ]
 
     if module.check_mode:
@@ -281,7 +283,9 @@ def main():
                 "BMC_MAC": server.get('idrac_mac', ''),
                 "BMC_IP": bmc_ip,
                 "IB_MAC": ib_mac,
-                "IB_IP": ib_ip
+                "IB_IP": ib_ip,
+                "GPU_VENDOR": server.get('gpu_vendor', ''),
+                "GPU_TYPE": server.get('gpu_type', '')
             }
             rows.append(row)
 

--- a/common/library/modules/ome_server_inventory.py
+++ b/common/library/modules/ome_server_inventory.py
@@ -16,8 +16,13 @@
 """Ansible module to collect server inventory from Dell OpenManage Enterprise (OME)."""
 
 import json
+import logging
+import math
+import time
 import urllib3
 from ansible.module_utils.basic import AnsibleModule
+
+logger = logging.getLogger("ome_server_inventory")
 
 try:
     import requests
@@ -59,6 +64,13 @@ options:
         required: false
         type: bool
         default: false
+    page_size:
+        description:
+            - Number of devices to request per page from OME OData API.
+            - Must be between 1 and 1000. Values above 1000 risk overloading OME.
+        required: false
+        type: int
+        default: 200
 author:
     - Dell Inc.
 '''
@@ -69,6 +81,14 @@ EXAMPLES = r'''
     ome_ip: "192.168.1.100"
     ome_username: "admin"
     ome_password: "password"
+  register: inventory_result
+
+- name: Collect with custom page size for large environments
+  ome_server_inventory:
+    ome_ip: "192.168.1.100"
+    ome_username: "admin"
+    ome_password: "password"
+    page_size: 500
   register: inventory_result
 '''
 
@@ -88,17 +108,26 @@ devices:
           model: "PowerEdge R640"
           ib_nic_name: "NIC.Mezzanine.1-1-1"
           ib_nic_mac: "AA:BB:CC:DD:EE:20"
+          gpu_vendor: "NVIDIA"
+          gpu_type: "NVIDIA A100"
 '''
 
 
 class OMEClient:
     """Client for interacting with Dell OpenManage Enterprise REST API."""
 
-    def __init__(self, ip, username, password, verify_ssl=False):
+    # Maximum retries for transient HTTP failures (5xx / timeouts)
+    MAX_RETRIES = 3
+    # Initial backoff delay in seconds; doubles on each retry
+    BACKOFF_BASE = 2
+
+    def __init__(self, ip, username, password, verify_ssl=False, page_size=200):
         self.base_url = f"https://{ip}"
         self.username = username
         self.password = password
         self.verify_ssl = verify_ssl
+        # Clamp page_size to [1, 1000] to prevent OME overload
+        self.page_size = max(1, min(int(page_size), 1000))
         self.session = requests.Session()
         self.session.verify = verify_ssl
         self.auth_token = None
@@ -129,34 +158,131 @@ class OMEClient:
             except Exception:
                 pass
 
+    def _request_with_retry(self, method, url, **kwargs):
+        """Execute an HTTP request with retry on transient failures (5xx / timeout)."""
+        last_exc = None
+        for attempt in range(1, self.MAX_RETRIES + 1):
+            try:
+                response = self.session.request(method, url, **kwargs)
+                if response.status_code < 500:
+                    return response
+                logger.warning("OME returned %s for %s (attempt %d/%d)",
+                               response.status_code, url, attempt, self.MAX_RETRIES)
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as exc:
+                logger.warning("Transient error fetching %s (attempt %d/%d): %s",
+                               url, attempt, self.MAX_RETRIES, exc)
+                last_exc = exc
+            if attempt < self.MAX_RETRIES:
+                time.sleep(self.BACKOFF_BASE ** attempt)
+        # After all retries exhausted, return last response or raise
+        if last_exc:
+            raise last_exc
+        return response  # 5xx response from final attempt
+
     def get_paginated(self, url):
-        """Handle paginated API responses."""
-        results = []
-        while url:
-            response = self.session.get(url)
-            if response.status_code == 200:
-                data = response.json()
-                results.extend(data.get("value", []))
-                next_link = data.get("@odata.nextLink")
-                url = f"{self.base_url}{next_link}" if next_link and not next_link.startswith("http") else next_link
-            else:
+        """Fetch all pages from an OData endpoint using explicit $top/$skip.
+
+        OME does NOT return all records in a single response for large
+        inventories.  This method uses OData $top (page size) and $skip
+        (offset) parameters to iterate deterministically through all
+        pages, rather than relying solely on @odata.nextLink.
+
+        Returns:
+            tuple: (all_results, pagination_stats) where pagination_stats
+                   is a dict with total_devices, page_size, total_pages,
+                   and pages_fetched.
+        """
+        page_size = self.page_size
+        skip = 0
+        total = None
+        total_pages = 1
+        pages_fetched = 0
+        all_results = []
+
+        while True:
+            # Build the paginated URL with OData query parameters
+            separator = "&" if "?" in url else "?"
+            paginated_url = f"{url}{separator}$top={page_size}&$skip={skip}"
+
+            response = self._request_with_retry("GET", paginated_url)
+            if response.status_code != 200:
+                logger.error("OME API returned HTTP %s for %s", response.status_code, paginated_url)
                 break
-        return results
+
+            data = response.json()
+
+            # On the first page, read @odata.count to know the total
+            if total is None:
+                if "@odata.count" not in data:
+                    raise ValueError(
+                        f"OME response for {url} is missing '@odata.count'. "
+                        "Cannot determine total number of records for safe pagination."
+                    )
+                total = data["@odata.count"]
+                total_pages = math.ceil(total / page_size) if total > 0 else 1
+                logger.info("OME pagination: total=%d, page_size=%d, total_pages=%d",
+                            total, page_size, total_pages)
+
+            page_items = data.get("value", [])
+            all_results.extend(page_items)
+            pages_fetched += 1
+
+            current_page = (skip // page_size) + 1
+            logger.info("OME page %d/%d fetched: %d items (skip=%d, accumulated=%d/%d)",
+                        current_page, total_pages, len(page_items), skip,
+                        len(all_results), total)
+
+            # Stop when the page is smaller than requested (last page)
+            if len(page_items) < page_size:
+                break
+
+            # Stop when we have accumulated all expected records
+            if len(all_results) >= total:
+                break
+
+            skip += page_size
+
+        pagination_stats = {
+            "total_devices_in_ome": total if total is not None else 0,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "pages_fetched": pages_fetched,
+            "devices_retrieved": len(all_results)
+        }
+        return all_results, pagination_stats
 
     def get_all_devices(self, device_type=None):
-        """Get all devices managed by OME, optionally filtered by type."""
+        """Get all devices managed by OME, optionally filtered by type.
+
+        Uses explicit $top/$skip pagination to handle inventories of any
+        size (8k–20k+ nodes) without relying on OME default page sizes.
+
+        Returns:
+            tuple: (devices, pagination_stats)
+        """
         url = f"{self.base_url}/api/DeviceService/Devices"
-        devices = self.get_paginated(url)
+        devices, pagination_stats = self.get_paginated(url)
         if device_type:
-            devices = [d for d in devices if d.get("Type") == device_type]
-        return devices
+            filtered = [d for d in devices if d.get("Type") == device_type]
+            pagination_stats["devices_after_type_filter"] = len(filtered)
+            pagination_stats["device_type_filter"] = device_type
+            devices = filtered
+        return devices, pagination_stats
 
     def get_device_inventory(self, device_id, inventory_type):
         """Get specific inventory type for a device."""
         url = f"{self.base_url}/api/DeviceService/Devices({device_id})/InventoryDetails('{inventory_type}')"
-        response = self.session.get(url)
-        if response.status_code == 200:
-            return response.json()
+        try:
+            response = self.session.get(url)
+            if response.status_code == 200:
+                data = response.json()
+                # OME may return a list instead of a dict for some inventory types
+                if isinstance(data, list):
+                    return {"InventoryInfo": data}
+                return data
+        except Exception as exc:
+            logger.warning("Failed to fetch inventory type '%s' for device %s: %s",
+                           inventory_type, device_id, exc)
         return {}
 
     def get_device_management_info(self, device_id):
@@ -185,7 +311,7 @@ class OMEClient:
         device_all_groups = {}
 
         all_groups_url = f"{self.base_url}/api/GroupService/Groups"
-        all_groups = self.get_paginated(all_groups_url)
+        all_groups, _ = self.get_paginated(all_groups_url)
 
         # Names of OME built-in container/system groups to always skip
         _SYSTEM_NAMES = {
@@ -225,7 +351,7 @@ class OMEClient:
             else:
                 devices_url = f"{self.base_url}/api/GroupService/Groups({group_id})/Devices"
 
-            group_devices = self.get_paginated(devices_url)
+            group_devices, _ = self.get_paginated(devices_url)
             for gd in group_devices:
                 dev_id = gd.get("Id")
                 if not dev_id:
@@ -270,7 +396,9 @@ def extract_server_info(client, device, device_group_map=None):
         "first_nic_mac": "",
         "group_name": "",
         "ib_nic_name": "",
-        "ib_nic_mac": ""
+        "ib_nic_mac": "",
+        "gpu_vendor": "",
+        "gpu_type": ""
     }
 
     # Get management IP from device info
@@ -343,6 +471,16 @@ def extract_server_info(client, device, device_group_map=None):
                     info["ib_nic_mac"] = partitions[0].get("CurrentMacAddress", "")
                     break
 
+    # Get GPU information from devicePciDevice inventory
+    pci_inventory = client.get_device_inventory(device_id, "devicePciDevice")
+    for pci in pci_inventory.get("InventoryInfo", []):
+        desc = (pci.get("Description", "") or "").lower()
+        data_bus = (pci.get("DataBusWidth", "") or "").lower()
+        if "gpu" in desc or "vga" in desc or "3d controller" in desc or "display" in desc:
+            info["gpu_vendor"] = pci.get("Manufacturer", "") or pci.get("VendorName", "")
+            info["gpu_type"] = pci.get("Description", "")
+            break
+
     # Get group name from pre-built device→group map
     if device_group_map:
         info["group_name"] = device_group_map.get(device_id, "")
@@ -357,7 +495,8 @@ def main():
         "ome_username": {"type": "str", "required": True},
         "ome_password": {"type": "str", "required": True, "no_log": True},
         "device_type": {"type": "int", "required": False, "default": 1000},
-        "verify_ssl": {"type": "bool", "required": False, "default": False}
+        "verify_ssl": {"type": "bool", "required": False, "default": False},
+        "page_size": {"type": "int", "required": False, "default": 200}
     }
 
     module = AnsibleModule(
@@ -373,8 +512,9 @@ def main():
     ome_password = module.params['ome_password']
     device_type = module.params['device_type']
     verify_ssl = module.params['verify_ssl']
+    page_size = module.params['page_size']
 
-    client = OMEClient(ome_ip, ome_username, ome_password, verify_ssl)
+    client = OMEClient(ome_ip, ome_username, ome_password, verify_ssl, page_size)
 
     try:
         if not client.authenticate():
@@ -384,7 +524,7 @@ def main():
                 "omnia_config_credentials.yml (managed via prepare_oim.yml) and rerun the playbook."
             ))
 
-        devices = client.get_all_devices(device_type)
+        devices, pagination_stats = client.get_all_devices(device_type)
         device_group_map, conflicts, group_debug = client.build_device_group_map()
 
         if not group_debug["static_container_found"]:
@@ -425,7 +565,8 @@ def main():
             changed=False,
             devices=server_info_list,
             device_count=len(server_info_list),
-            group_debug=group_debug
+            group_debug=group_debug,
+            pagination=pagination_stats
         )
 
     except Exception as e:

--- a/common/library/modules/tests/__init__.py
+++ b/common/library/modules/tests/__init__.py
@@ -11,25 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
-
-# Default functional group name for discovered nodes (used when OME group name is absent)
-default_functional_group: "slurm_node_aarch64"
-
-# Default group name prefix
-default_group_name: "grp0"
-
-# Hostname prefix for discovered nodes
-hostname_prefix: "nid"
-
-# Starting hostname number
-hostname_start_number: 1
-
-# Hostname padding (e.g., 5 digits = nid00001)
-hostname_padding: 5
-
-# OME device type for servers
-ome_server_device_type: 1000
-
-# Number of devices per OData page when querying OME (1–1000)
-ome_page_size: 200

--- a/common/library/modules/tests/test_ome_pagination.py
+++ b/common/library/modules/tests/test_ome_pagination.py
@@ -1,0 +1,356 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for OME OData pagination in ome_server_inventory.OMEClient.
+
+Tests cover:
+  - Small inventories that fit in a single page
+  - Large inventories (8 000 devices) requiring many pages
+  - @odata.count missing → ValueError
+  - Retry on transient 5xx errors
+  - Page size clamping (>1000, <1)
+  - Empty inventory (0 devices)
+  - device_type filtering via get_all_devices
+"""
+
+import json
+import math
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out ansible.module_utils so we can import ome_server_inventory
+# without an Ansible installation.
+# ---------------------------------------------------------------------------
+_ansible_stub = types.ModuleType("ansible")
+_ansible_mu = types.ModuleType("ansible.module_utils")
+_ansible_basic = types.ModuleType("ansible.module_utils.basic")
+_ansible_basic.AnsibleModule = MagicMock  # type: ignore[attr-defined]
+_ansible_stub.module_utils = _ansible_mu  # type: ignore[attr-defined]
+_ansible_mu.basic = _ansible_basic  # type: ignore[attr-defined]
+sys.modules.setdefault("ansible", _ansible_stub)
+sys.modules.setdefault("ansible.module_utils", _ansible_mu)
+sys.modules.setdefault("ansible.module_utils.basic", _ansible_basic)
+
+# Now we can safely import the module under test
+from ome_server_inventory import OMEClient  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_device(device_id, device_type=1000):
+    """Return a minimal device dict as OME would."""
+    return {"Id": device_id, "Type": device_type, "Identifier": f"SVC{device_id}"}
+
+
+def _make_page_response(devices, total_count, status_code=200):
+    """Build a mock ``requests.Response`` for one OData page."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {
+        "@odata.count": total_count,
+        "value": devices,
+    }
+    return resp
+
+
+def _build_paginated_side_effect(all_devices, page_size, total_count=None):
+    """Return a side_effect callable that serves pages from *all_devices*.
+
+    Each call to the side_effect pops one page of *page_size* items.
+    """
+    if total_count is None:
+        total_count = len(all_devices)
+    remaining = list(all_devices)
+
+    def _side_effect(_method, _url, **_kwargs):
+        page = remaining[:page_size]
+        del remaining[:page_size]
+        return _make_page_response(page, total_count)
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPageSizeClamping:
+    """page_size should be clamped to [1, 1000]."""
+
+    def test_page_size_default(self):
+        client = OMEClient("10.0.0.1", "u", "p")
+        assert client.page_size == 200
+
+    def test_page_size_custom(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=500)
+        assert client.page_size == 500
+
+    def test_page_size_clamped_high(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=5000)
+        assert client.page_size == 1000
+
+    def test_page_size_clamped_low(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=0)
+        assert client.page_size == 1
+
+    def test_page_size_negative(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=-10)
+        assert client.page_size == 1
+
+
+class TestGetPaginatedSmallInventory:
+    """Inventory fits in a single page (<= page_size)."""
+
+    def test_single_page(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=200)
+        devices = [_make_device(i) for i in range(5)]
+        client._request_with_retry = MagicMock(
+            side_effect=_build_paginated_side_effect(devices, 200)
+        )
+
+        result, stats = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+        assert len(result) == 5
+        assert result == devices
+        # Only one HTTP call expected
+        assert client._request_with_retry.call_count == 1
+        assert stats["total_devices_in_ome"] == 5
+        assert stats["page_size"] == 200
+        assert stats["total_pages"] == 1
+        assert stats["pages_fetched"] == 1
+        assert stats["devices_retrieved"] == 5
+
+    def test_exact_one_page(self):
+        """Exactly page_size items → one full page then an empty second page check."""
+        page_size = 3
+        client = OMEClient("10.0.0.1", "u", "p", page_size=page_size)
+        devices = [_make_device(i) for i in range(page_size)]
+
+        # First call returns full page, count == page_size → accumulated == total → stop
+        client._request_with_retry = MagicMock(
+            side_effect=_build_paginated_side_effect(devices, page_size)
+        )
+
+        result, stats = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+        assert len(result) == page_size
+        assert stats["pages_fetched"] == 1
+
+
+class TestGetPaginatedLargeInventory:
+    """Simulate a large-scale environment (8 000 devices)."""
+
+    def test_8k_devices(self):
+        total = 8000
+        page_size = 200
+        client = OMEClient("10.0.0.1", "u", "p", page_size=page_size)
+        all_devices = [_make_device(i) for i in range(total)]
+
+        client._request_with_retry = MagicMock(
+            side_effect=_build_paginated_side_effect(all_devices, page_size)
+        )
+
+        result, stats = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+        assert len(result) == total
+        expected_calls = math.ceil(total / page_size)
+        assert client._request_with_retry.call_count == expected_calls
+        assert stats["total_devices_in_ome"] == total
+        assert stats["page_size"] == page_size
+        assert stats["total_pages"] == expected_calls
+        assert stats["pages_fetched"] == expected_calls
+        assert stats["devices_retrieved"] == total
+
+    def test_20k_devices(self):
+        total = 20000
+        page_size = 500
+        client = OMEClient("10.0.0.1", "u", "p", page_size=page_size)
+        all_devices = [_make_device(i) for i in range(total)]
+
+        client._request_with_retry = MagicMock(
+            side_effect=_build_paginated_side_effect(all_devices, page_size)
+        )
+
+        result, stats = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+        assert len(result) == total
+        expected_calls = math.ceil(total / page_size)
+        assert client._request_with_retry.call_count == expected_calls
+        assert stats["total_devices_in_ome"] == total
+        assert stats["pages_fetched"] == expected_calls
+
+
+class TestGetPaginatedEmptyInventory:
+    """Zero devices in OME."""
+
+    def test_empty(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=200)
+        client._request_with_retry = MagicMock(
+            return_value=_make_page_response([], 0)
+        )
+
+        result, stats = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+        assert result == []
+        assert client._request_with_retry.call_count == 1
+        assert stats["total_devices_in_ome"] == 0
+        assert stats["devices_retrieved"] == 0
+        assert stats["pages_fetched"] == 1
+
+
+class TestGetPaginatedMissingOdataCount:
+    """@odata.count missing from first response → must fail fast."""
+
+    def test_missing_count_raises(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=200)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"value": [_make_device(1)]}  # no @odata.count
+        client._request_with_retry = MagicMock(return_value=resp)
+
+        with pytest.raises(ValueError, match="@odata.count"):
+            client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+
+class TestGetPaginatedNon200:
+    """Non-200 response on first page → return empty list."""
+
+    def test_404_returns_empty(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=200)
+        resp = MagicMock()
+        resp.status_code = 404
+        client._request_with_retry = MagicMock(return_value=resp)
+
+        result, stats = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+        assert result == []
+        assert stats["total_devices_in_ome"] == 0
+        assert stats["pages_fetched"] == 0
+
+
+class TestGetPaginatedURLConstruction:
+    """Verify $top and $skip are appended correctly."""
+
+    def test_url_params_first_page(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=100)
+        client._request_with_retry = MagicMock(
+            return_value=_make_page_response([], 0)
+        )
+
+        _, _ = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices")
+
+        called_url = client._request_with_retry.call_args[0][1]
+        assert "$top=100" in called_url
+        assert "$skip=0" in called_url
+
+    def test_url_with_existing_query_params(self):
+        """When the base URL already has ?filter=..., use & instead of ?."""
+        client = OMEClient("10.0.0.1", "u", "p", page_size=50)
+        client._request_with_retry = MagicMock(
+            return_value=_make_page_response([], 0)
+        )
+
+        _, _ = client.get_paginated("https://10.0.0.1/api/DeviceService/Devices?$filter=Type eq 1000")
+
+        called_url = client._request_with_retry.call_args[0][1]
+        assert "?$filter=Type eq 1000&$top=50&$skip=0" in called_url
+
+
+class TestRequestWithRetry:
+    """_request_with_retry retries on 5xx and transient errors."""
+
+    @patch("time.sleep", return_value=None)  # skip real delays
+    def test_retry_on_500(self, _mock_sleep):
+        client = OMEClient("10.0.0.1", "u", "p")
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+
+        client.session.request = MagicMock(side_effect=[fail_resp, ok_resp])
+        result = client._request_with_retry("GET", "https://10.0.0.1/test")
+
+        assert result.status_code == 200
+        assert client.session.request.call_count == 2
+
+    @patch("time.sleep", return_value=None)
+    def test_retry_exhausted_returns_last_5xx(self, _mock_sleep):
+        client = OMEClient("10.0.0.1", "u", "p")
+        fail_resp = MagicMock()
+        fail_resp.status_code = 500
+
+        client.session.request = MagicMock(return_value=fail_resp)
+        result = client._request_with_retry("GET", "https://10.0.0.1/test")
+
+        assert result.status_code == 500
+        assert client.session.request.call_count == client.MAX_RETRIES
+
+    @patch("time.sleep", return_value=None)
+    def test_retry_on_connection_error(self, _mock_sleep):
+        import requests as req
+
+        client = OMEClient("10.0.0.1", "u", "p")
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+
+        client.session.request = MagicMock(
+            side_effect=[req.exceptions.ConnectionError("conn refused"), ok_resp]
+        )
+        result = client._request_with_retry("GET", "https://10.0.0.1/test")
+        assert result.status_code == 200
+
+    @patch("time.sleep", return_value=None)
+    def test_retry_exhausted_raises_on_timeout(self, _mock_sleep):
+        import requests as req
+
+        client = OMEClient("10.0.0.1", "u", "p")
+        client.session.request = MagicMock(
+            side_effect=req.exceptions.Timeout("timed out")
+        )
+        with pytest.raises(req.exceptions.Timeout):
+            client._request_with_retry("GET", "https://10.0.0.1/test")
+
+
+class TestGetAllDevices:
+    """get_all_devices delegates to get_paginated and applies type filter."""
+
+    def test_type_filter(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=100)
+        mixed = [_make_device(1, 1000), _make_device(2, 2000), _make_device(3, 1000)]
+        client._request_with_retry = MagicMock(
+            side_effect=_build_paginated_side_effect(mixed, 100)
+        )
+
+        result, stats = client.get_all_devices(device_type=1000)
+        assert len(result) == 2
+        assert all(d["Type"] == 1000 for d in result)
+        assert stats["devices_after_type_filter"] == 2
+        assert stats["device_type_filter"] == 1000
+        assert stats["devices_retrieved"] == 3
+
+    def test_no_type_filter(self):
+        client = OMEClient("10.0.0.1", "u", "p", page_size=100)
+        mixed = [_make_device(1, 1000), _make_device(2, 2000)]
+        client._request_with_retry = MagicMock(
+            side_effect=_build_paginated_side_effect(mixed, 100)
+        )
+
+        result, stats = client.get_all_devices(device_type=None)
+        assert len(result) == 2
+        assert "devices_after_type_filter" not in stats

--- a/discovery/roles/ome_discovery/tasks/collect_inventory.yml
+++ b/discovery/roles/ome_discovery/tasks/collect_inventory.yml
@@ -47,7 +47,10 @@
       - "  Total pages:             {{ ome_inventory_result.pagination.total_pages }}"
       - "  Pages fetched:           {{ ome_inventory_result.pagination.pages_fetched }}"
       - "  Devices retrieved:       {{ ome_inventory_result.pagination.devices_retrieved }}"
-      - "  Devices after filtering: {{ ome_inventory_result.pagination.devices_after_type_filter | default(ome_inventory_result.pagination.devices_retrieved) }}"
+      - >-
+        Devices after filtering:
+        {{ ome_inventory_result.pagination.devices_after_type_filter
+        | default(ome_inventory_result.pagination.devices_retrieved) }}
 
 - name: Display connection status
   ansible.builtin.debug:

--- a/discovery/roles/ome_discovery/tasks/collect_inventory.yml
+++ b/discovery/roles/ome_discovery/tasks/collect_inventory.yml
@@ -35,7 +35,19 @@
     ome_username: "{{ ome_username }}"
     ome_password: "{{ ome_password }}"
     device_type: "{{ ome_server_device_type }}"
+    page_size: "{{ ome_page_size }}"
   register: ome_inventory_result
+
+- name: Display OME pagination summary
+  ansible.builtin.debug:
+    msg:
+      - "OME Pagination Summary:"
+      - "  Total devices in OME:    {{ ome_inventory_result.pagination.total_devices_in_ome }}"
+      - "  Page size:               {{ ome_inventory_result.pagination.page_size }}"
+      - "  Total pages:             {{ ome_inventory_result.pagination.total_pages }}"
+      - "  Pages fetched:           {{ ome_inventory_result.pagination.pages_fetched }}"
+      - "  Devices retrieved:       {{ ome_inventory_result.pagination.devices_retrieved }}"
+      - "  Devices after filtering: {{ ome_inventory_result.pagination.devices_after_type_filter | default(ome_inventory_result.pagination.devices_retrieved) }}"
 
 - name: Display connection status
   ansible.builtin.debug:

--- a/discovery/roles/ome_discovery/tasks/generate_pxe_mapping.yml
+++ b/discovery/roles/ome_discovery/tasks/generate_pxe_mapping.yml
@@ -26,6 +26,14 @@
   ansible.builtin.set_fact:
     ib_subnet: "{{ (network_spec_data.Networks | selectattr('ib_network', 'defined') | first).ib_network.subnet | default('') }}"
 
+- name: Set timestamp for PXE mapping file
+  ansible.builtin.set_fact:
+    pxe_mapping_timestamp: "{{ ansible_date_time.iso8601_basic_short | default(lookup('pipe', 'date +%Y%m%dT%H%M%S')) }}"
+
+- name: Set timestamped PXE mapping output file path
+  ansible.builtin.set_fact:
+    pxe_mapping_output_file: "{{ input_project_dir | default(playbook_dir + '/../input') }}/bmc_pxe_mapping_file_{{ pxe_mapping_timestamp }}.csv"
+
 - name: Ensure input directory exists
   ansible.builtin.file:
     path: "{{ pxe_mapping_output_file | dirname }}"
@@ -47,8 +55,22 @@
 
 - name: Display discovery completion message
   ansible.builtin.debug:
-    msg: "{{ discovery_complete_msg }}"
-
-- name: Display generated BMC PXE mapping file path
-  ansible.builtin.debug:
-    msg: "BMC PXE mapping file saved to: {{ pxe_mapping_output_file }}"
+    msg:
+      - "============================================================"
+      - "OME Discovery Complete"
+      - "============================================================"
+      - "BMC PXE mapping file generated: {{ pxe_mapping_output_file }}"
+      - "Total servers discovered: {{ discovered_servers | length }}"
+      - ""
+      - "Next Steps:"
+      - "1. Review and edit the generated PXE mapping file:"
+      - "     {{ pxe_mapping_output_file }}"
+      - ""
+      - "2. Update HOSTNAME, FUNCTIONAL_GROUP_NAME, GROUP_NAME as needed."
+      - ""
+      - "3. Update the following parameter in provision_config.yml:"
+      - "     pxe_mapping_file_path: {{ pxe_mapping_output_file }}"
+      - ""
+      - "4. Run:"
+      - "     ansible-playbook provision/provision.yml"
+      - "============================================================"

--- a/discovery/roles/ome_discovery/vars/main.yml
+++ b/discovery/roles/ome_discovery/vars/main.yml
@@ -24,7 +24,8 @@ omnia_config_credentials_vault_key: "{{ input_project_dir | default(playbook_dir
 
 # Output file configuration
 pxe_mapping_output_file: "{{ input_project_dir | default(playbook_dir + '/../input') }}/bmc_pxe_mapping_file.csv"
-pxe_mapping_headers: "FUNCTIONAL_GROUP_NAME,GROUP_NAME,SERVICE_TAG,PARENT_SERVICE_TAG,HOSTNAME,ADMIN_MAC,ADMIN_IP,BMC_MAC,BMC_IP,BMC_HOSTNAME,IB_MAC,IB_IP,GPU_VENDOR,GPU_TYPE"
+pxe_mapping_headers:  # yamllint disable-line rule:line-length
+  "FUNCTIONAL_GROUP_NAME,GROUP_NAME,SERVICE_TAG,PARENT_SERVICE_TAG,HOSTNAME,ADMIN_MAC,ADMIN_IP,BMC_MAC,BMC_IP,BMC_HOSTNAME,IB_MAC,IB_IP,GPU_VENDOR,GPU_TYPE"
 
 # Messages
 ome_credentials_prompt_msg: |

--- a/discovery/roles/ome_discovery/vars/main.yml
+++ b/discovery/roles/ome_discovery/vars/main.yml
@@ -24,7 +24,7 @@ omnia_config_credentials_vault_key: "{{ input_project_dir | default(playbook_dir
 
 # Output file configuration
 pxe_mapping_output_file: "{{ input_project_dir | default(playbook_dir + '/../input') }}/bmc_pxe_mapping_file.csv"
-pxe_mapping_headers: "FUNCTIONAL_GROUP_NAME,GROUP_NAME,SERVICE_TAG,PARENT_SERVICE_TAG,HOSTNAME,ADMIN_MAC,ADMIN_IP,BMC_MAC,BMC_IP,BMC_HOSTNAME,IB_MAC,IB_IP"
+pxe_mapping_headers: "FUNCTIONAL_GROUP_NAME,GROUP_NAME,SERVICE_TAG,PARENT_SERVICE_TAG,HOSTNAME,ADMIN_MAC,ADMIN_IP,BMC_MAC,BMC_IP,BMC_HOSTNAME,IB_MAC,IB_IP,GPU_VENDOR,GPU_TYPE"
 
 # Messages
 ome_credentials_prompt_msg: |


### PR DESCRIPTION
## Summary

### OME Pagination
- Replace `@odata.nextLink`-based pagination with explicit `$top`/`$skip` OData parameters for deterministic, scalable device retrieval (8k–20k+ nodes)
- Add configurable `page_size` parameter (default 200, max 1000) to `ome_server_inventory` module and wire through Ansible role defaults
- Add retry with exponential backoff for transient HTTP 5xx/timeout failures
- Return pagination stats in module output; display summary in playbook

### GPU Collection
- Collect GPU vendor and type from OME `devicePciDevice` inventory
- Append `GPU_VENDOR` and `GPU_TYPE` columns to PXE mapping CSV

### Timestamped PXE Mapping
- Generate timestamped PXE mapping files (`bmc_pxe_mapping_file_<timestamp>.csv`) so each run produces a unique file
- Update completion message to show actual generated filename

### Bug Fixes
- Handle OME returning list instead of dict from inventory endpoints
- Fix `telemetry_config.yml` validation: point to `telemetry_validation` module instead of removed `common_validation.validate_telemetry_config`

### Tests
- Add 20 unit tests covering pagination, retry, clamping, edge cases, and type filtering

## Files Changed
- `common/library/modules/ome_server_inventory.py`
- `common/library/modules/generate_pxe_mapping.py`
- `common/library/modules/tests/test_ome_pagination.py` (new)
- `common/library/modules/tests/__init__.py` (new)
- `common/library/module_utils/input_validation/common_utils/logical_validation.py`
- `discovery/roles/ome_discovery/defaults/main.yml`
- `discovery/roles/ome_discovery/tasks/collect_inventory.yml`
- `discovery/roles/ome_discovery/tasks/generate_pxe_mapping.yml`
- `discovery/roles/ome_discovery/vars/main.yml`