### PR TITLE
Update input config transformation for omnia upgrade and add previous omnia version in metadata 

### DIFF
--- a/omnia.sh
+++ b/omnia.sh
@@ -432,10 +432,24 @@ update_metadata_upgrade_backup_dir() {
             echo '[ERROR] Metadata file not found inside container: $CONTAINER_METADATA_FILE' >&2
             exit 1
         fi
+        
+        # Get current omnia_version to store as previous_omnia_version
+        current_version=\$(grep '^omnia_version:' '$CONTAINER_METADATA_FILE' | cut -d':' -f2 | tr -d ' \t\n\r')
+        
+        # Update upgrade_backup_dir
         if grep -q '^upgrade_backup_dir:' '$CONTAINER_METADATA_FILE'; then
             sed -i 's|^upgrade_backup_dir:.*|upgrade_backup_dir: ${backup_dir}|' '$CONTAINER_METADATA_FILE'
         else
             echo 'upgrade_backup_dir: ${backup_dir}' >> '$CONTAINER_METADATA_FILE'
+        fi
+        
+        # Update previous_omnia_version
+        if [ -n \"\$current_version\" ]; then
+            if grep -q '^previous_omnia_version:' '$CONTAINER_METADATA_FILE'; then
+                sed -i \"s|^previous_omnia_version:.*|previous_omnia_version: \$current_version|\" '$CONTAINER_METADATA_FILE'
+            else
+                echo \"previous_omnia_version: \$current_version\" >> '$CONTAINER_METADATA_FILE'
+            fi
         fi
     "
 }

--- a/upgrade/roles/import_input_parameters/tasks/main.yml
+++ b/upgrade/roles/import_input_parameters/tasks/main.yml
@@ -19,26 +19,32 @@
 - name: Validate backup location for upgrade input processing
   ansible.builtin.include_tasks: precheck_backup_location.yml
 
-- name: Transform network_spec.yml from Omnia 2.0 to 2.1
+- name: Transform network_spec.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_network_spec.yml
 
-- name: Transform high_availability_config.yml from Omnia 2.0 to 2.1
+- name: Transform high_availability_config.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_high_availability_config.yml
 
-- name: Transform local_repo_config.yml from Omnia 2.0 to 2.1
+- name: Transform local_repo_config.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_local_repo_config.yml
 
-- name: Transform provision_config.yml from Omnia 2.0 to 2.1
+- name: Transform provision_config.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_provision_config.yml
 
-- name: Transform storage_config.yml from Omnia 2.0 to 2.1
+- name: Transform storage_config.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_storage_config.yml
 
-- name: Transform omnia_config.yml from Omnia 2.0 to 2.1
+- name: Transform omnia_config.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_omnia_config.yml
 
-- name: Transform telemetry_config.yml from Omnia 2.0 to 2.1
+- name: Transform telemetry_config.yml from Omnia 2.1 to 2.2
   ansible.builtin.include_tasks: transform_telemetry_config.yml
+
+- name: Generate build_stream_config.yml for Omnia 2.2
+  ansible.builtin.include_tasks: transform_build_stream_config.yml
+
+- name: Generate gitlab_config.yml for Omnia 2.2
+  ansible.builtin.include_tasks: transform_gitlab_config.yml
 
 - name: Restore input files from backup
   ansible.builtin.include_tasks: restore_input_files.yml

--- a/upgrade/roles/import_input_parameters/tasks/transform_build_stream_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_build_stream_config.yml
@@ -1,0 +1,119 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# build_stream_config.yml exists in both Omnia 2.1 and 2.2 with identical structure.
+# This task reads values from the backup and migrates them to the 2.2 format.
+# Enhanced with validation for better error handling.
+
+- name: Check if backup build_stream_config.yml exists
+  ansible.builtin.stat:
+    path: "{{ backup_location }}/build_stream_config.yml"
+  register: backup_build_stream_config_stat
+
+- name: Fail if backup build_stream_config.yml is not present
+  ansible.builtin.fail:
+    msg: "{{ msg_backup_build_stream_config_missing }}"
+  when: not backup_build_stream_config_stat.stat.exists
+
+- name: Check if build_stream_config.yml already exists in target
+  ansible.builtin.stat:
+    path: "{{ input_project_dir }}/build_stream_config.yml"
+  register: build_stream_config_stat
+
+- name: Fail if build_stream_config.yml is not present
+  ansible.builtin.fail:
+    msg: "{{ msg_build_stream_config_missing }}"
+  when: not build_stream_config_stat.stat.exists
+
+- name: Read backup build_stream_config.yml (source of truth)
+  ansible.builtin.slurp:
+    src: "{{ backup_location }}/build_stream_config.yml"
+  register: backup_build_stream_config_slurp
+
+- name: Parse backup build_stream_config.yml
+  ansible.builtin.set_fact:
+    backup_build_stream_config: "{{ backup_build_stream_config_slurp.content | b64decode | from_yaml }}"
+
+- name: Set build_stream_config values from backup with validation
+  ansible.builtin.set_fact:
+    build_stream_enable: "{{ backup_build_stream_config.enable_build_stream | default(build_stream_default_enable) }}"
+    build_stream_host_ip: "{{ backup_build_stream_config.build_stream_host_ip | default(build_stream_default_host_ip) }}"
+    build_stream_port: "{{ backup_build_stream_config.build_stream_port | default(build_stream_default_port) }}"
+    build_stream_aarch64_ip: "{{ backup_build_stream_config.aarch64_inventory_host_ip | default(build_stream_default_aarch64_ip) }}"
+
+- name: Validate build_stream_port is in valid range
+  ansible.builtin.assert:
+    that:
+      - build_stream_port | int >= 1
+      - build_stream_port | int <= 65535
+    fail_msg: "build_stream_port {{ build_stream_port }} is not in valid range (1-65535)"
+    success_msg: "build_stream_port {{ build_stream_port }} is valid"
+
+- name: Validate build_stream_host_ip format if provided
+  ansible.builtin.assert:
+    that:
+      - build_stream_host_ip == "" or build_stream_host_ip | ansible.utils.ipaddr
+    fail_msg: "build_stream_host_ip '{{ build_stream_host_ip }}' is not a valid IP address"
+    success_msg: "build_stream_host_ip is valid"
+  when: build_stream_host_ip != ""
+
+- name: Validate build_stream_aarch64_ip format if provided
+  ansible.builtin.assert:
+    that:
+      - build_stream_aarch64_ip == "" or build_stream_aarch64_ip | ansible.utils.ipaddr
+    fail_msg: "build_stream_aarch64_ip '{{ build_stream_aarch64_ip }}' is not a valid IP address"
+    success_msg: "build_stream_aarch64_ip is valid"
+  when: build_stream_aarch64_ip != ""
+
+- name: Write build_stream_config.yml with Omnia 2.2 defaults
+  ansible.builtin.template:
+    src: build_stream_config.j2
+    dest: "{{ input_project_dir }}/build_stream_config.yml"
+    mode: "{{ default_file_mode }}"
+  vars:
+    build_stream_enable: "{{ build_stream_enable }}"
+    build_stream_host_ip: "{{ build_stream_host_ip }}"
+    build_stream_port: "{{ build_stream_port }}"
+    build_stream_aarch64_ip: "{{ build_stream_aarch64_ip }}"
+
+- name: Validate YAML syntax of build_stream_config.yml
+  ansible.builtin.command:
+    cmd: python3 -c "import yaml; yaml.safe_load(open('{{ input_project_dir }}/build_stream_config.yml','r'))"
+  register: build_stream_yaml_validation
+  changed_when: false
+
+- name: Fail if YAML validation fails
+  ansible.builtin.fail:
+    msg: "{{ msg_yaml_validation_failed }}"
+  when:
+    - build_stream_yaml_validation.rc != 0
+
+- name: Display enhanced build_stream_config transformation summary
+  ansible.builtin.debug:
+    msg: |
+      {{ msg_build_stream_config_transform_summary }}
+      
+      Values migrated from backup:
+      - enable_build_stream: {{ build_stream_enable }}
+      - build_stream_host_ip: {{ build_stream_host_ip | default('empty') }}
+      - build_stream_port: {{ build_stream_port }}
+      - aarch64_inventory_host_ip: {{ build_stream_aarch64_ip | default('empty') }}
+      
+      Note: Configuration migrated from backup and validated successfully.
+
+- name: Display backup path (no-op when skipped)
+  ansible.builtin.debug:
+    msg: "{{ msg_using_backup_build_stream_config }}"
+  when: true

--- a/upgrade/roles/import_input_parameters/tasks/transform_build_stream_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_build_stream_config.yml
@@ -104,13 +104,13 @@
   ansible.builtin.debug:
     msg: |
       {{ msg_build_stream_config_transform_summary }}
-      
+
       Values migrated from backup:
       - enable_build_stream: {{ build_stream_enable }}
       - build_stream_host_ip: {{ build_stream_host_ip | default('empty') }}
       - build_stream_port: {{ build_stream_port }}
       - aarch64_inventory_host_ip: {{ build_stream_aarch64_ip | default('empty') }}
-      
+
       Note: Configuration migrated from backup and validated successfully.
 
 - name: Display backup path (no-op when skipped)

--- a/upgrade/roles/import_input_parameters/tasks/transform_gitlab_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_gitlab_config.yml
@@ -1,0 +1,148 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# gitlab_config.yml exists in both Omnia 2.1 and 2.2 with identical structure.
+# This task reads values from the backup and migrates them to the 2.2 format.
+# Enhanced with validation for better error handling.
+
+- name: Check if backup gitlab_config.yml exists
+  ansible.builtin.stat:
+    path: "{{ backup_location }}/gitlab_config.yml"
+  register: backup_gitlab_config_stat
+
+- name: Fail if backup gitlab_config.yml is not present
+  ansible.builtin.fail:
+    msg: "{{ msg_backup_gitlab_config_missing }}"
+  when: not backup_gitlab_config_stat.stat.exists
+
+- name: Check if gitlab_config.yml already exists in target
+  ansible.builtin.stat:
+    path: "{{ input_project_dir }}/gitlab_config.yml"
+  register: gitlab_config_stat
+
+- name: Fail if gitlab_config.yml is not present
+  ansible.builtin.fail:
+    msg: "{{ msg_gitlab_config_missing }}"
+  when: not gitlab_config_stat.stat.exists
+
+- name: Read backup gitlab_config.yml (source of truth)
+  ansible.builtin.slurp:
+    src: "{{ backup_location }}/gitlab_config.yml"
+  register: backup_gitlab_config_slurp
+
+- name: Parse backup gitlab_config.yml
+  ansible.builtin.set_fact:
+    backup_gitlab_config: "{{ backup_gitlab_config_slurp.content | b64decode | from_yaml }}"
+
+- name: Set gitlab_config values from backup with validation
+  ansible.builtin.set_fact:
+    gitlab_host: "{{ backup_gitlab_config.gitlab_host | default(gitlab_default_host) }}"
+    gitlab_project_name: "{{ backup_gitlab_config.gitlab_project_name | default(gitlab_default_project_name) }}"
+    gitlab_project_visibility: "{{ backup_gitlab_config.gitlab_project_visibility | default(gitlab_default_project_visibility) }}"
+    gitlab_default_branch: "{{ backup_gitlab_config.gitlab_default_branch | default(gitlab_default_branch) }}"
+    gitlab_https_port: "{{ backup_gitlab_config.gitlab_https_port | default(gitlab_default_https_port) }}"
+    gitlab_min_storage_gb: "{{ backup_gitlab_config.gitlab_min_storage_gb | default(gitlab_default_min_storage_gb) }}"
+    gitlab_min_memory_gb: "{{ backup_gitlab_config.gitlab_min_memory_gb | default(gitlab_default_min_memory_gb) }}"
+    gitlab_min_cpu_cores: "{{ backup_gitlab_config.gitlab_min_cpu_cores | default(gitlab_default_min_cpu_cores) }}"
+    gitlab_puma_workers: "{{ backup_gitlab_config.gitlab_puma_workers | default(gitlab_default_puma_workers) }}"
+    gitlab_sidekiq_concurrency: "{{ backup_gitlab_config.gitlab_sidekiq_concurrency | default(gitlab_default_sidekiq_concurrency) }}"
+
+- name: Validate gitlab_host IP format if provided
+  ansible.builtin.assert:
+    that:
+      - gitlab_host == "" or gitlab_host | ansible.utils.ipaddr
+    fail_msg: "gitlab_host '{{ gitlab_host }}' is not a valid IP address"
+    success_msg: "gitlab_host is valid"
+  when: gitlab_host != ""
+
+- name: Validate gitlab_https_port is in valid range
+  ansible.builtin.assert:
+    that:
+      - gitlab_https_port | int >= 1
+      - gitlab_https_port | int <= 65535
+    fail_msg: "gitlab_https_port {{ gitlab_https_port }} is not in valid range (1-65535)"
+    success_msg: "gitlab_https_port {{ gitlab_https_port }} is valid"
+
+- name: Validate gitlab_project_visibility
+  ansible.builtin.assert:
+    that:
+      - gitlab_project_visibility in ['private', 'internal', 'public']
+    fail_msg: "gitlab_project_visibility '{{ gitlab_project_visibility }}' must be one of: private, internal, public"
+    success_msg: "gitlab_project_visibility is valid"
+
+- name: Validate gitlab_default_branch format
+  ansible.builtin.assert:
+    that:
+      - gitlab_default_branch | regex_search('^[a-zA-Z0-9/_-]+$')
+    fail_msg: "gitlab_default_branch '{{ gitlab_default_branch }}' contains invalid characters"
+    success_msg: "gitlab_default_branch is valid"
+
+- name: Validate minimum resource requirements
+  ansible.builtin.assert:
+    that:
+      - gitlab_min_storage_gb | int >= 20
+      - gitlab_min_memory_gb | int >= 4
+      - gitlab_min_cpu_cores | int >= 2
+    fail_msg: "GitLab minimum requirements not met: storage={{ gitlab_min_storage_gb }}GB (min 20GB), memory={{ gitlab_min_memory_gb }}GB (min 4GB), CPU={{ gitlab_min_cpu_cores }} cores (min 2)"
+    success_msg: "GitLab minimum requirements validated"
+
+- name: Write gitlab_config.yml with Omnia 2.2 defaults
+  ansible.builtin.template:
+    src: gitlab_config.j2
+    dest: "{{ input_project_dir }}/gitlab_config.yml"
+    mode: "{{ default_file_mode }}"
+  vars:
+    gitlab_host: "{{ gitlab_host }}"
+    gitlab_project_name: "{{ gitlab_project_name }}"
+    gitlab_project_visibility: "{{ gitlab_project_visibility }}"
+    gitlab_default_branch: "{{ gitlab_default_branch }}"
+    gitlab_https_port: "{{ gitlab_https_port }}"
+    gitlab_min_storage_gb: "{{ gitlab_min_storage_gb }}"
+    gitlab_min_memory_gb: "{{ gitlab_min_memory_gb }}"
+    gitlab_min_cpu_cores: "{{ gitlab_min_cpu_cores }}"
+    gitlab_puma_workers: "{{ gitlab_puma_workers }}"
+    gitlab_sidekiq_concurrency: "{{ gitlab_sidekiq_concurrency }}"
+
+- name: Validate YAML syntax of gitlab_config.yml
+  ansible.builtin.command:
+    cmd: python3 -c "import yaml; yaml.safe_load(open('{{ input_project_dir }}/gitlab_config.yml','r'))"
+  register: gitlab_yaml_validation
+  changed_when: false
+
+- name: Fail if YAML validation fails
+  ansible.builtin.fail:
+    msg: "{{ msg_yaml_validation_failed }}"
+  when:
+    - gitlab_yaml_validation.rc != 0
+
+- name: Display enhanced gitlab_config transformation summary
+  ansible.builtin.debug:
+    msg: |
+      {{ msg_gitlab_config_transform_summary }}
+      
+      Values migrated from backup:
+      - gitlab_host: {{ gitlab_host | default('empty') }}
+      - gitlab_project_name: {{ gitlab_project_name }}
+      - gitlab_project_visibility: {{ gitlab_project_visibility }}
+      - gitlab_default_branch: {{ gitlab_default_branch }}
+      - gitlab_https_port: {{ gitlab_https_port }}
+      - Minimum requirements: {{ gitlab_min_storage_gb }}GB storage, {{ gitlab_min_memory_gb }}GB RAM, {{ gitlab_min_cpu_cores }} CPU cores
+      
+      Note: Configuration migrated from backup and validated successfully.
+
+- name: Display backup path (no-op when skipped)
+  ansible.builtin.debug:
+    msg: "{{ msg_using_backup_gitlab_config }}"
+  when: true

--- a/upgrade/roles/import_input_parameters/tasks/transform_gitlab_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_gitlab_config.yml
@@ -95,7 +95,9 @@
       - gitlab_min_storage_gb | int >= 20
       - gitlab_min_memory_gb | int >= 4
       - gitlab_min_cpu_cores | int >= 2
-    fail_msg: "GitLab minimum requirements not met: storage={{ gitlab_min_storage_gb }}GB (min 20GB), memory={{ gitlab_min_memory_gb }}GB (min 4GB), CPU={{ gitlab_min_cpu_cores }} cores (min 2)"
+    fail_msg: >-
+      GitLab minimum requirements not met: storage={{ gitlab_min_storage_gb }}GB (min 20GB),
+      memory={{ gitlab_min_memory_gb }}GB (min 4GB), CPU={{ gitlab_min_cpu_cores }} cores (min 2)
     success_msg: "GitLab minimum requirements validated"
 
 - name: Write gitlab_config.yml with Omnia 2.2 defaults
@@ -131,7 +133,7 @@
   ansible.builtin.debug:
     msg: |
       {{ msg_gitlab_config_transform_summary }}
-      
+
       Values migrated from backup:
       - gitlab_host: {{ gitlab_host | default('empty') }}
       - gitlab_project_name: {{ gitlab_project_name }}
@@ -139,7 +141,7 @@
       - gitlab_default_branch: {{ gitlab_default_branch }}
       - gitlab_https_port: {{ gitlab_https_port }}
       - Minimum requirements: {{ gitlab_min_storage_gb }}GB storage, {{ gitlab_min_memory_gb }}GB RAM, {{ gitlab_min_cpu_cores }} CPU cores
-      
+
       Note: Configuration migrated from backup and validated successfully.
 
 - name: Display backup path (no-op when skipped)

--- a/upgrade/roles/import_input_parameters/tasks/transform_high_availability_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_high_availability_config.yml
@@ -84,7 +84,7 @@
       or ((ha_entries_missing_vip | default([]) | length) > 0)
       or ((ha_entries_empty_vip | default([]) | length) > 0)
 
-- name: Write high_availability_config.yml in Omnia 2.1 format
+- name: Write high_availability_config.yml in Omnia 2.2 format
   ansible.builtin.template:
     src: high_availability_config.j2
     dest: "{{ input_project_dir }}/high_availability_config.yml"

--- a/upgrade/roles/import_input_parameters/tasks/transform_network_spec.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_network_spec.yml
@@ -77,13 +77,13 @@
   when:
     - true
 
-- name: Render network_spec.yml in Omnia 2.1 format
+- name: Render network_spec.yml in Omnia 2.2 format
   ansible.builtin.template:
     src: network_spec.j2
     dest: "{{ input_project_dir }}/network_spec.yml"
     mode: "{{ default_file_mode }}"
   vars:
-    admin_network_netmask_bits: "{{ admin_network.netmask_bits | default('24') }}"
+    admin_network_netmask_bits: "{{ admin_network.netmask_bits | default(network_default_netmask_bits) }}"
   when: true
 
 - name: Read transformed network_spec.yml

--- a/upgrade/roles/import_input_parameters/tasks/transform_omnia_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_omnia_config.yml
@@ -72,7 +72,7 @@
     msg: "{{ msg_service_k8s_cluster_missing }}"
   when: (omnia_service_k8s_cluster | default([]) | length) == 0
 
-- name: Write omnia_config.yml in Omnia 2.1 format
+- name: Write omnia_config.yml in Omnia 2.2 format
   ansible.builtin.template:
     src: omnia_config.j2
     dest: "{{ input_project_dir }}/omnia_config.yml"

--- a/upgrade/roles/import_input_parameters/tasks/transform_provision_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_provision_config.yml
@@ -44,16 +44,16 @@
 
 - name: Normalize provision_config.yml values
   ansible.builtin.set_fact:
-    provision_pxe_mapping_file_path: "{{ backup_provision_config.pxe_mapping_file_path | default('pxe_mapping_file.csv') }}"
-    provision_language: "{{ backup_provision_config.language | default('en_US.UTF-8') }}"
-    provision_default_lease_time: "{{ backup_provision_config.default_lease_time | default('86400') }}"
+    provision_pxe_mapping_file_path: "{{ backup_provision_config.pxe_mapping_file_path | default(provision_default_pxe_mapping_file_path) }}"
+    provision_language: "{{ backup_provision_config.language | default(provision_default_language) }}"
+    provision_default_lease_time: "{{ backup_provision_config.default_lease_time | default(provision_default_lease_time) }}"
 
 - name: Fail if pxe_mapping_file_path is missing
   ansible.builtin.fail:
     msg: "{{ msg_pxe_mapping_file_path_missing }}"
   when: (provision_pxe_mapping_file_path | string | trim) == ''
 
-- name: Write provision_config.yml in Omnia 2.1 format
+- name: Write provision_config.yml in Omnia 2.2 format
   ansible.builtin.template:
     src: provision_config.j2
     dest: "{{ input_project_dir }}/provision_config.yml"

--- a/upgrade/roles/import_input_parameters/tasks/transform_storage_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_storage_config.yml
@@ -61,7 +61,7 @@
     (storage_nfs_client_params | selectattr('client_share_path', 'undefined') | list | length) > 0 or
     (storage_nfs_client_params | selectattr('client_mount_options', 'undefined') | list | length) > 0
 
-- name: Write storage_config.yml in Omnia 2.1 format
+- name: Write storage_config.yml in Omnia 2.2 format
   ansible.builtin.template:
     src: storage_config.j2
     dest: "{{ input_project_dir }}/storage_config.yml"

--- a/upgrade/roles/import_input_parameters/tasks/transform_telemetry_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_telemetry_config.yml
@@ -44,57 +44,169 @@
 
 - name: Normalize nested backup telemetry sections
   ansible.builtin.set_fact:
-    backup_telemetry_victoria_config: "{{ backup_telemetry_config.victoria_metrics_configurations | default(backup_telemetry_config.victoria_configurations | default({})) }}"
-    backup_telemetry_kafka_config: "{{ backup_telemetry_config.kafka_configurations | default({}) }}"
-    backup_telemetry_victoria_logs_config: "{{ backup_telemetry_config.victoria_logs_configurations | default({}) }}"
-    backup_telemetry_powerscale_config: "{{ backup_telemetry_config.powerscale_configurations | default({}) }}"
+    backup_telemetry_victoria_config: >-
+      {{ backup_telemetry_config.victoria_metrics_configurations
+         | default(backup_telemetry_config.victoria_configurations | default({})) }}
+    backup_telemetry_kafka_config: >-
+      {{ backup_telemetry_config.kafka_configurations | default({}) }}
+    backup_telemetry_victoria_logs_config: >-
+      {{ backup_telemetry_config.victoria_logs_configurations | default({}) }}
+    backup_telemetry_powerscale_config: >-
+      {{ backup_telemetry_config.powerscale_configurations | default({}) }}
+    backup_telemetry_sources: >-
+      {{ backup_telemetry_config.telemetry_sources | default({}) }}
+    backup_telemetry_sinks: >-
+      {{ backup_telemetry_config.telemetry_sinks | default({}) }}
+    backup_telemetry_ldms_config: >-
+      {{ backup_telemetry_config.ldms_configurations | default({}) }}
 
-- name: Normalize telemetry_config.yml values with proper field mapping
+- name: Extract iDRAC telemetry support from backup (2.1 or 2.2 format)
   ansible.builtin.set_fact:
-    telemetry_idrac_telemetry_support: "{{ backup_telemetry_config.idrac_telemetry_support | default(telemetry_default_idrac_support) }}"
+    telemetry_idrac_telemetry_support: >-
+      {{
+        backup_telemetry_config.idrac_telemetry_support
+        | default(
+            (backup_telemetry_sources.idrac | default({})).metrics_enabled
+            | default(telemetry_default_idrac_support)
+          )
+      }}
+
+- name: Extract collection type from backup (2.1 format) for target conversion
+  ansible.builtin.set_fact:
     telemetry_telemetry_collection_type: >-
       {{
-        backup_telemetry_config.telemetry_collection_type |
-        default(backup_telemetry_config.idrac_telemetry_collection_type) |
-        default(telemetry_default_collection_type)
+        backup_telemetry_config.telemetry_collection_type
+        | default(backup_telemetry_config.idrac_telemetry_collection_type
+        | default(telemetry_default_collection_type))
       }}
-    telemetry_victoria_persistence_size: "{{ backup_telemetry_victoria_config.persistence_size | default(telemetry_default_victoria_persistence_size) }}"
-    telemetry_victoria_retention_period: "{{ backup_telemetry_victoria_config.retention_period | default(telemetry_default_victoria_retention_period) }}"
-    telemetry_kafka_persistence_size: "{{ backup_telemetry_kafka_config.persistence_size | default(telemetry_default_kafka_persistence_size) }}"
-    telemetry_kafka_log_retention_hours: "{{ backup_telemetry_kafka_config.log_retention_hours | default(telemetry_default_kafka_log_retention_hours) }}"
-    telemetry_kafka_log_retention_bytes: "{{ backup_telemetry_kafka_config.log_retention_bytes | default(telemetry_default_kafka_log_retention_bytes) }}"
-    telemetry_kafka_log_segment_bytes: "{{ backup_telemetry_kafka_config.log_segment_bytes | default(telemetry_default_kafka_log_segment_bytes) }}"
-    telemetry_kafka_topic_partitions: >-
+
+- name: Derive iDRAC collection targets from 2.1 collection type string
+  ansible.builtin.set_fact:
+    telemetry_idrac_collection_targets: >-
       {{
-        backup_telemetry_kafka_config.topic_partitions
-        | default(telemetry_default_kafka_topic_partitions)
+        (backup_telemetry_sources.idrac | default({})).collection_targets
+        | default(
+            telemetry_telemetry_collection_type.split(',')
+            | map('trim')
+            | map('regex_replace', '^victoria$', 'victoria_metrics')
+            | list
+          )
       }}
-    telemetry_ldms_agg_port: "{{ backup_telemetry_config.ldms_agg_port | default(telemetry_default_ldms_agg_port) }}"
-    telemetry_ldms_store_port: "{{ backup_telemetry_config.ldms_store_port | default(telemetry_default_ldms_store_port) }}"
-    telemetry_ldms_sampler_port: "{{ backup_telemetry_config.ldms_sampler_port | default(telemetry_default_ldms_sampler_port) }}"
+
+- name: Normalize VictoriaMetrics sink values from backup
+  ansible.builtin.set_fact:
+    telemetry_victoria_persistence_size: >-
+      {{ (backup_telemetry_sinks.victoria_metrics | default({})).persistence_size
+         | default(backup_telemetry_victoria_config.persistence_size
+         | default(telemetry_default_victoria_persistence_size)) }}
+    telemetry_victoria_retention_period: >-
+      {{ (backup_telemetry_sinks.victoria_metrics | default({})).retention_period
+         | default(backup_telemetry_victoria_config.retention_period
+         | default(telemetry_default_victoria_retention_period)) }}
+    telemetry_additional_metric_remote_write_endpoints: >-
+      {{ (backup_telemetry_sinks.victoria_metrics | default({})).additional_metric_remote_write_endpoints
+         | default([]) }}
+
+- name: Normalize VictoriaLogs sink values from backup
+  ansible.builtin.set_fact:
+    telemetry_victoria_logs_storage_size: >-
+      {{ (backup_telemetry_sinks.victoria_logs | default({})).storage_size
+         | default(backup_telemetry_victoria_logs_config.storage_size
+         | default(telemetry_default_victoria_logs_storage_size)) }}
+    telemetry_victoria_logs_retention_period: >-
+      {{ (backup_telemetry_sinks.victoria_logs | default({})).retention_period
+         | default(backup_telemetry_victoria_logs_config.retention_period
+         | default(telemetry_default_victoria_logs_retention_period)) }}
+    telemetry_additional_log_write_endpoints: >-
+      {{ (backup_telemetry_sinks.victoria_logs | default({})).additional_log_write_endpoints
+         | default([]) }}
+
+- name: Normalize Kafka sink values from backup
+  ansible.builtin.set_fact:
+    telemetry_kafka_persistence_size: >-
+      {{ (backup_telemetry_sinks.kafka | default({})).persistence_size
+         | default(backup_telemetry_kafka_config.persistence_size
+         | default(telemetry_default_kafka_persistence_size)) }}
+    telemetry_kafka_log_retention_hours: >-
+      {{ (backup_telemetry_sinks.kafka | default({})).log_retention_hours
+         | default(backup_telemetry_kafka_config.log_retention_hours
+         | default(telemetry_default_kafka_log_retention_hours)) }}
+    telemetry_kafka_log_retention_bytes: >-
+      {{ (backup_telemetry_sinks.kafka | default({})).log_retention_bytes
+         | default(backup_telemetry_kafka_config.log_retention_bytes
+         | default(telemetry_default_kafka_log_retention_bytes)) }}
+    telemetry_kafka_log_segment_bytes: >-
+      {{ (backup_telemetry_sinks.kafka | default({})).log_segment_bytes
+         | default(backup_telemetry_kafka_config.log_segment_bytes
+         | default(telemetry_default_kafka_log_segment_bytes)) }}
+
+- name: Extract raw topic partitions from backup (list or dict format)
+  ansible.builtin.set_fact:
+    telemetry_kafka_topic_partitions_raw: >-
+      {{
+        (backup_telemetry_sinks.kafka | default({})).topic_partitions
+        | default(backup_telemetry_kafka_config.topic_partitions
+        | default(telemetry_default_kafka_topic_partitions))
+      }}
+
+- name: Convert topic partitions to dict format for 2.2 template
+  ansible.builtin.set_fact:
+    telemetry_kafka_topic_partitions_dict: >-
+      {{
+        telemetry_kafka_topic_partitions_raw
+        if (telemetry_kafka_topic_partitions_raw is mapping)
+        else
+        dict(
+          telemetry_kafka_topic_partitions_raw
+          | map(attribute='name')
+          | zip(telemetry_kafka_topic_partitions_raw | map(attribute='partitions'))
+        )
+      }}
+
+- name: Normalize LDMS configuration values from backup (2.1 or 2.2 format)
+  ansible.builtin.set_fact:
+    telemetry_ldms_agg_port: >-
+      {{ backup_telemetry_ldms_config.agg_port
+         | default(backup_telemetry_config.ldms_agg_port
+         | default(telemetry_default_ldms_agg_port)) }}
+    telemetry_ldms_store_port: >-
+      {{ backup_telemetry_ldms_config.store_port
+         | default(backup_telemetry_config.ldms_store_port
+         | default(telemetry_default_ldms_store_port)) }}
+    telemetry_ldms_sampler_port: >-
+      {{ backup_telemetry_ldms_config.sampler_port
+         | default(backup_telemetry_config.ldms_sampler_port
+         | default(telemetry_default_ldms_sampler_port)) }}
     telemetry_ldms_sampler_configurations: >-
       {{
-        backup_telemetry_config.ldms_sampler_configurations
-        | default(telemetry_default_ldms_sampler_configurations)
+        backup_telemetry_ldms_config.sampler_plugins
+        | default(backup_telemetry_config.ldms_sampler_configurations
+        | default(telemetry_default_ldms_sampler_configurations))
       }}
 
-- name: Normalize new Omnia 2.2 telemetry fields (DCGM, VictoriaLogs, PowerScale)
+- name: Normalize DCGM and PowerScale source values from backup
   ansible.builtin.set_fact:
-    telemetry_dcgm_support: "{{ backup_telemetry_config.dcgm_support | default(telemetry_default_dcgm_support) }}"
-    telemetry_victoria_logs_storage_size: "{{ backup_telemetry_victoria_logs_config.storage_size | default(telemetry_default_victoria_logs_storage_size) }}"
-    telemetry_victoria_logs_retention_period: "{{ backup_telemetry_victoria_logs_config.retention_period | default(telemetry_default_victoria_logs_retention_period) }}"
-    telemetry_powerscale_telemetry_support: "{{ backup_telemetry_powerscale_config.powerscale_telemetry_support | default(telemetry_default_powerscale_support) }}"
-    telemetry_powerscale_log_enabled: "{{ backup_telemetry_powerscale_config.powerscale_log_enabled | default(telemetry_default_powerscale_log_enabled) }}"
-    telemetry_otel_collector_storage_size: "{{ backup_telemetry_powerscale_config.otel_collector_storage_size | default(telemetry_default_otel_collector_storage_size) }}"
-    telemetry_csm_observability_values_file_path: "{{ backup_telemetry_powerscale_config.csm_observability_values_file_path | default(telemetry_default_csm_observability_values_file_path) }}"
-    telemetry_additional_remote_write_endpoints: "{{ backup_telemetry_powerscale_config.additional_remote_write_endpoints | default([]) }}"
+    telemetry_dcgm_support: >-
+      {{ (backup_telemetry_sources.dcgm | default({})).metrics_enabled
+         | default(backup_telemetry_config.dcgm_support
+         | default(telemetry_default_dcgm_support)) }}
+    telemetry_powerscale_metrics_enabled: >-
+      {{ (backup_telemetry_sources.powerscale | default({})).metrics_enabled
+         | default(backup_telemetry_powerscale_config.powerscale_telemetry_support
+         | default(telemetry_default_powerscale_support)) }}
+    telemetry_powerscale_logs_enabled: >-
+      {{ (backup_telemetry_sources.powerscale | default({})).logs_enabled
+         | default(backup_telemetry_powerscale_config.powerscale_log_enabled
+         | default(telemetry_default_powerscale_log_enabled)) }}
 
-- name: Validate telemetry_collection_type value
-  ansible.builtin.assert:
-    that:
-      - telemetry_telemetry_collection_type in ['victoria', 'kafka', 'victoria,kafka']
-    fail_msg: "Invalid telemetry_collection_type: '{{ telemetry_telemetry_collection_type }}'. Must be one of: victoria, kafka, victoria,kafka"
-    success_msg: "telemetry_collection_type validated: {{ telemetry_telemetry_collection_type }}"
+- name: Normalize PowerScale configuration values from backup
+  ansible.builtin.set_fact:
+    telemetry_otel_collector_storage_size: >-
+      {{ backup_telemetry_powerscale_config.otel_collector_storage_size
+         | default(telemetry_default_otel_collector_storage_size) }}
+    telemetry_csm_observability_values_file_path: >-
+      {{ backup_telemetry_powerscale_config.csm_observability_values_file_path
+         | default(telemetry_default_csm_observability_values_file_path) }}
 
 - name: Write telemetry_config.yml in Omnia 2.2 format
   ansible.builtin.template:
@@ -103,26 +215,27 @@
     mode: "{{ default_file_mode }}"
   vars:
     telemetry_idrac_telemetry_support: "{{ telemetry_idrac_telemetry_support }}"
-    telemetry_telemetry_collection_type: "{{ telemetry_telemetry_collection_type }}"
+    telemetry_idrac_collection_targets: "{{ telemetry_idrac_collection_targets }}"
+    telemetry_dcgm_support: "{{ telemetry_dcgm_support }}"
+    telemetry_powerscale_metrics_enabled: "{{ telemetry_powerscale_metrics_enabled }}"
+    telemetry_powerscale_logs_enabled: "{{ telemetry_powerscale_logs_enabled }}"
     telemetry_victoria_persistence_size: "{{ telemetry_victoria_persistence_size }}"
     telemetry_victoria_retention_period: "{{ telemetry_victoria_retention_period }}"
+    telemetry_additional_metric_remote_write_endpoints: "{{ telemetry_additional_metric_remote_write_endpoints }}"
+    telemetry_victoria_logs_storage_size: "{{ telemetry_victoria_logs_storage_size }}"
+    telemetry_victoria_logs_retention_period: "{{ telemetry_victoria_logs_retention_period }}"
+    telemetry_additional_log_write_endpoints: "{{ telemetry_additional_log_write_endpoints }}"
     telemetry_kafka_persistence_size: "{{ telemetry_kafka_persistence_size }}"
     telemetry_kafka_log_retention_hours: "{{ telemetry_kafka_log_retention_hours }}"
     telemetry_kafka_log_retention_bytes: "{{ telemetry_kafka_log_retention_bytes }}"
     telemetry_kafka_log_segment_bytes: "{{ telemetry_kafka_log_segment_bytes }}"
-    telemetry_kafka_topic_partitions: "{{ telemetry_kafka_topic_partitions }}"
+    telemetry_kafka_topic_partitions_dict: "{{ telemetry_kafka_topic_partitions_dict }}"
     telemetry_ldms_agg_port: "{{ telemetry_ldms_agg_port }}"
     telemetry_ldms_store_port: "{{ telemetry_ldms_store_port }}"
     telemetry_ldms_sampler_port: "{{ telemetry_ldms_sampler_port }}"
     telemetry_ldms_sampler_configurations: "{{ telemetry_ldms_sampler_configurations }}"
-    telemetry_dcgm_support: "{{ telemetry_dcgm_support }}"
-    telemetry_victoria_logs_storage_size: "{{ telemetry_victoria_logs_storage_size }}"
-    telemetry_victoria_logs_retention_period: "{{ telemetry_victoria_logs_retention_period }}"
-    telemetry_powerscale_telemetry_support: "{{ telemetry_powerscale_telemetry_support }}"
-    telemetry_powerscale_log_enabled: "{{ telemetry_powerscale_log_enabled }}"
     telemetry_otel_collector_storage_size: "{{ telemetry_otel_collector_storage_size }}"
     telemetry_csm_observability_values_file_path: "{{ telemetry_csm_observability_values_file_path }}"
-    telemetry_additional_remote_write_endpoints: "{{ telemetry_additional_remote_write_endpoints }}"
 
 - name: Validate YAML syntax of transformed telemetry_config.yml
   ansible.builtin.command:
@@ -147,8 +260,11 @@
       {{ msg_telemetry_config_transform_summary }}
       
       Field mappings applied:
-      - idrac_telemetry_collection_type → telemetry_collection_type: {{ telemetry_telemetry_collection_type }}
-      - victoria_configurations → victoria_metrics_configurations
-      - Added new sections: DCGM, VictoriaLogs, PowerScale
+      - idrac_telemetry_support → telemetry_sources.idrac.metrics_enabled
+      - idrac_telemetry_collection_type → telemetry_sources.idrac.collection_targets: {{ telemetry_idrac_collection_targets }}
+      - victoria_configurations → telemetry_sinks.victoria_metrics
+      - kafka_configurations → telemetry_sinks.kafka (topic_partitions converted to dict)
+      - ldms_* ports/samplers → ldms_configurations
+      - Added new sections: telemetry_sources (ldms, dcgm, powerscale), telemetry_bridges, telemetry_sinks.victoria_logs
       
       Configuration validated and migrated successfully.

--- a/upgrade/roles/import_input_parameters/tasks/transform_telemetry_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_telemetry_config.yml
@@ -258,7 +258,7 @@
   ansible.builtin.debug:
     msg: |
       {{ msg_telemetry_config_transform_summary }}
-      
+
       Field mappings applied:
       - idrac_telemetry_support → telemetry_sources.idrac.metrics_enabled
       - idrac_telemetry_collection_type → telemetry_sources.idrac.collection_targets: {{ telemetry_idrac_collection_targets }}
@@ -266,5 +266,5 @@
       - kafka_configurations → telemetry_sinks.kafka (topic_partitions converted to dict)
       - ldms_* ports/samplers → ldms_configurations
       - Added new sections: telemetry_sources (ldms, dcgm, powerscale), telemetry_bridges, telemetry_sinks.victoria_logs
-      
+
       Configuration validated and migrated successfully.

--- a/upgrade/roles/import_input_parameters/tasks/transform_telemetry_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_telemetry_config.yml
@@ -44,67 +44,59 @@
 
 - name: Normalize nested backup telemetry sections
   ansible.builtin.set_fact:
-    backup_telemetry_victoria_config: "{{ backup_telemetry_config.victoria_configurations | default({}) }}"
+    backup_telemetry_victoria_config: "{{ backup_telemetry_config.victoria_metrics_configurations | default(backup_telemetry_config.victoria_configurations | default({})) }}"
     backup_telemetry_kafka_config: "{{ backup_telemetry_config.kafka_configurations | default({}) }}"
+    backup_telemetry_victoria_logs_config: "{{ backup_telemetry_config.victoria_logs_configurations | default({}) }}"
+    backup_telemetry_powerscale_config: "{{ backup_telemetry_config.powerscale_configurations | default({}) }}"
 
-- name: Normalize telemetry_config.yml values
+- name: Normalize telemetry_config.yml values with proper field mapping
   ansible.builtin.set_fact:
-    telemetry_idrac_telemetry_support: "{{ backup_telemetry_config.idrac_telemetry_support | default(true) }}"
+    telemetry_idrac_telemetry_support: "{{ backup_telemetry_config.idrac_telemetry_support | default(telemetry_default_idrac_support) }}"
     telemetry_telemetry_collection_type: >-
       {{
-        backup_telemetry_config.telemetry_collection_type
-        | default('victoria,kafka')
+        backup_telemetry_config.telemetry_collection_type |
+        default(backup_telemetry_config.idrac_telemetry_collection_type) |
+        default(telemetry_default_collection_type)
       }}
-    telemetry_victoria_persistence_size: "{{ backup_telemetry_victoria_config.persistence_size | default('8Gi') }}"
-    telemetry_victoria_retention_period: "{{ backup_telemetry_victoria_config.retention_period | default(168) }}"
-    telemetry_kafka_persistence_size: "{{ backup_telemetry_kafka_config.persistence_size | default('8Gi') }}"
-    telemetry_kafka_log_retention_hours: "{{ backup_telemetry_kafka_config.log_retention_hours | default(168) }}"
-    telemetry_kafka_log_retention_bytes: "{{ backup_telemetry_kafka_config.log_retention_bytes | default(-1) }}"
-    telemetry_kafka_log_segment_bytes: "{{ backup_telemetry_kafka_config.log_segment_bytes | default(1073741824) }}"
+    telemetry_victoria_persistence_size: "{{ backup_telemetry_victoria_config.persistence_size | default(telemetry_default_victoria_persistence_size) }}"
+    telemetry_victoria_retention_period: "{{ backup_telemetry_victoria_config.retention_period | default(telemetry_default_victoria_retention_period) }}"
+    telemetry_kafka_persistence_size: "{{ backup_telemetry_kafka_config.persistence_size | default(telemetry_default_kafka_persistence_size) }}"
+    telemetry_kafka_log_retention_hours: "{{ backup_telemetry_kafka_config.log_retention_hours | default(telemetry_default_kafka_log_retention_hours) }}"
+    telemetry_kafka_log_retention_bytes: "{{ backup_telemetry_kafka_config.log_retention_bytes | default(telemetry_default_kafka_log_retention_bytes) }}"
+    telemetry_kafka_log_segment_bytes: "{{ backup_telemetry_kafka_config.log_segment_bytes | default(telemetry_default_kafka_log_segment_bytes) }}"
     telemetry_kafka_topic_partitions: >-
       {{
         backup_telemetry_kafka_config.topic_partitions
-        | default([
-          {'name': 'idrac', 'partitions': 1},
-          {'name': 'ldms', 'partitions': 2}
-        ])
+        | default(telemetry_default_kafka_topic_partitions)
       }}
-    telemetry_ldms_agg_port: "{{ backup_telemetry_config.ldms_agg_port | default(6001) }}"
-    telemetry_ldms_store_port: "{{ backup_telemetry_config.ldms_store_port | default(6001) }}"
-    telemetry_ldms_sampler_port: "{{ backup_telemetry_config.ldms_sampler_port | default(10001) }}"
+    telemetry_ldms_agg_port: "{{ backup_telemetry_config.ldms_agg_port | default(telemetry_default_ldms_agg_port) }}"
+    telemetry_ldms_store_port: "{{ backup_telemetry_config.ldms_store_port | default(telemetry_default_ldms_store_port) }}"
+    telemetry_ldms_sampler_port: "{{ backup_telemetry_config.ldms_sampler_port | default(telemetry_default_ldms_sampler_port) }}"
     telemetry_ldms_sampler_configurations: >-
       {{
         backup_telemetry_config.ldms_sampler_configurations
-        | default([
-          {
-            'plugin_name': 'meminfo',
-            'config_parameters': '',
-            'activation_parameters': 'interval=1000000'
-          },
-          {
-            'plugin_name': 'procstat2',
-            'config_parameters': '',
-            'activation_parameters': 'interval=1000000'
-          },
-          {
-            'plugin_name': 'vmstat',
-            'config_parameters': '',
-            'activation_parameters': 'interval=1000000'
-          },
-          {
-            'plugin_name': 'loadavg',
-            'config_parameters': '',
-            'activation_parameters': 'interval=1000000'
-          },
-          {
-            'plugin_name': 'procnetdev2',
-            'config_parameters': '',
-            'activation_parameters': 'interval=1000000 offset=0'
-          }
-        ])
+        | default(telemetry_default_ldms_sampler_configurations)
       }}
 
-- name: Write telemetry_config.yml in Omnia 2.1 format
+- name: Normalize new Omnia 2.2 telemetry fields (DCGM, VictoriaLogs, PowerScale)
+  ansible.builtin.set_fact:
+    telemetry_dcgm_support: "{{ backup_telemetry_config.dcgm_support | default(telemetry_default_dcgm_support) }}"
+    telemetry_victoria_logs_storage_size: "{{ backup_telemetry_victoria_logs_config.storage_size | default(telemetry_default_victoria_logs_storage_size) }}"
+    telemetry_victoria_logs_retention_period: "{{ backup_telemetry_victoria_logs_config.retention_period | default(telemetry_default_victoria_logs_retention_period) }}"
+    telemetry_powerscale_telemetry_support: "{{ backup_telemetry_powerscale_config.powerscale_telemetry_support | default(telemetry_default_powerscale_support) }}"
+    telemetry_powerscale_log_enabled: "{{ backup_telemetry_powerscale_config.powerscale_log_enabled | default(telemetry_default_powerscale_log_enabled) }}"
+    telemetry_otel_collector_storage_size: "{{ backup_telemetry_powerscale_config.otel_collector_storage_size | default(telemetry_default_otel_collector_storage_size) }}"
+    telemetry_csm_observability_values_file_path: "{{ backup_telemetry_powerscale_config.csm_observability_values_file_path | default(telemetry_default_csm_observability_values_file_path) }}"
+    telemetry_additional_remote_write_endpoints: "{{ backup_telemetry_powerscale_config.additional_remote_write_endpoints | default([]) }}"
+
+- name: Validate telemetry_collection_type value
+  ansible.builtin.assert:
+    that:
+      - telemetry_telemetry_collection_type in ['victoria', 'kafka', 'victoria,kafka']
+    fail_msg: "Invalid telemetry_collection_type: '{{ telemetry_telemetry_collection_type }}'. Must be one of: victoria, kafka, victoria,kafka"
+    success_msg: "telemetry_collection_type validated: {{ telemetry_telemetry_collection_type }}"
+
+- name: Write telemetry_config.yml in Omnia 2.2 format
   ansible.builtin.template:
     src: telemetry_config.j2
     dest: "{{ input_project_dir }}/telemetry_config.yml"
@@ -123,6 +115,14 @@
     telemetry_ldms_store_port: "{{ telemetry_ldms_store_port }}"
     telemetry_ldms_sampler_port: "{{ telemetry_ldms_sampler_port }}"
     telemetry_ldms_sampler_configurations: "{{ telemetry_ldms_sampler_configurations }}"
+    telemetry_dcgm_support: "{{ telemetry_dcgm_support }}"
+    telemetry_victoria_logs_storage_size: "{{ telemetry_victoria_logs_storage_size }}"
+    telemetry_victoria_logs_retention_period: "{{ telemetry_victoria_logs_retention_period }}"
+    telemetry_powerscale_telemetry_support: "{{ telemetry_powerscale_telemetry_support }}"
+    telemetry_powerscale_log_enabled: "{{ telemetry_powerscale_log_enabled }}"
+    telemetry_otel_collector_storage_size: "{{ telemetry_otel_collector_storage_size }}"
+    telemetry_csm_observability_values_file_path: "{{ telemetry_csm_observability_values_file_path }}"
+    telemetry_additional_remote_write_endpoints: "{{ telemetry_additional_remote_write_endpoints }}"
 
 - name: Validate YAML syntax of transformed telemetry_config.yml
   ansible.builtin.command:
@@ -141,6 +141,14 @@
     msg: "{{ msg_using_backup_telemetry_config }}"
   when: true
 
-- name: Display transformation summary
+- name: Display transformation summary with field mapping details
   ansible.builtin.debug:
-    msg: "{{ msg_telemetry_config_transform_summary }}"
+    msg: |
+      {{ msg_telemetry_config_transform_summary }}
+      
+      Field mappings applied:
+      - idrac_telemetry_collection_type → telemetry_collection_type: {{ telemetry_telemetry_collection_type }}
+      - victoria_configurations → victoria_metrics_configurations
+      - Added new sections: DCGM, VictoriaLogs, PowerScale
+      
+      Configuration validated and migrated successfully.

--- a/upgrade/roles/import_input_parameters/templates/build_stream_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/build_stream_config.j2
@@ -1,0 +1,41 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+# ***********************************************************************
+# DO NOT REMOVE OR COMMENT OUT ANY LINES IN THIS FILE.
+# SIMPLY APPEND THE REQUIRED VALUES AGAINST THE PARAMETER OF YOUR CHOICE.
+# ***********************************************************************
+
+# ***********************************************************************
+# BuildStreaM (BSM) Configuration for configuring CI/CD pipeline to automate image building and deploy
+# ***********************************************************************
+
+# Mandatory: Enable or disable build stream pipeline
+# Accepted values: boolean values - (true or false) or(yes or no)
+# Default: false
+enable_build_stream: {{ build_stream_enable | default(build_stream_default_enable) | bool | ternary('true', 'false') }}
+
+# Mandatory: Build Stream API server host IP
+# Accepted values: public IP address of OIM or admin IP of OIM
+build_stream_host_ip: "{{ build_stream_host_ip | default(build_stream_default_host_ip) }}"
+
+# Mandatory: Build Stream API server port
+# Accepted values: valid port number (1-65535) which is free
+# Default: 8010
+build_stream_port: {{ build_stream_port | default(build_stream_default_port) }}
+
+# Conditional Mandatory: AArch64 inventory host IP for aarch64 builds
+# Accepted values: admin IP of aarch64 host where OS is installed
+# Default none - by deafult aarch64 builds will not be generated
+aarch64_inventory_host_ip: "{{ build_stream_aarch64_ip | default(build_stream_default_aarch64_ip) }}"

--- a/upgrade/roles/import_input_parameters/templates/gitlab_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/gitlab_config.j2
@@ -1,0 +1,115 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ***********************************************************************
+# DO NOT REMOVE OR COMMENT OUT ANY LINES IN THIS FILE.
+# SIMPLY APPEND THE REQUIRED VALUES AGAINST THE PARAMETER OF YOUR CHOICE.
+# ***********************************************************************
+
+ 
+# Target host for GitLab deployment/cleanup
+# Fields:
+#   gitlab_host: IP address of the target host where GitLab will be deployed
+# Notes:
+#   - This is the IP address of the server where GitLab will be installed
+#   - Must be accessible from the OIM server
+#   - Must be configured in build_stream/gitlab/inventory/hosts.ini
+gitlab_host: "{{ gitlab_host | default(gitlab_default_host) }}"
+ 
+# Project settings
+# Name of the GitLab project Omnia will create/manage
+# Fields:
+#   gitlab_project_name: Name for the GitLab project
+# Notes:
+#   - Default: "omnia-catalog"
+#   - This project will be created automatically if it doesn't exist
+gitlab_project_name: "{{ gitlab_project_name | default(gitlab_default_project_name) }}"
+
+# Visibility options: private | internal | public
+# Fields:
+#   gitlab_project_visibility: Visibility options - private | internal | public
+# Notes:
+#   - private: Project access must be granted explicitly for each user
+#   - internal: The project can be cloned by any logged in user
+#   - public: The project can be cloned without any authentication
+gitlab_project_visibility: "{{ gitlab_project_visibility | default(gitlab_default_project_visibility) }}"
+
+# Default branch used for repository and API operations
+# Fields:
+#   gitlab_default_branch: Name of the default branch
+# Notes:
+#   - Default: "main"
+#   - This branch will be used as the default for all operations
+gitlab_default_branch: "{{ gitlab_default_branch | default(gitlab_default_branch) }}"
+
+ 
+# HTTPS is always enabled for GitLab deployment 
+# ----------------------------------------------------------------------------
+# DEFAULT / ADVANCED VARIABLES (CHANGE ONLY IF NEEDED)
+# ----------------------------------------------------------------------------
+# These defaults are suitable for most setups and can be tuned as required.
+ 
+# Network
+# HTTPS port exposed via GitLab NGINX
+# Fields:
+#   gitlab_https_port: Port number for HTTPS access
+# Notes:
+#   - Default: 443
+#   - Must be between 1-65535
+#   - Must not conflict with other services
+gitlab_https_port: {{ gitlab_https_port | default(gitlab_default_https_port) }}
+
+# Minimum requirements
+# Free disk space validated before install
+# Fields:
+#   gitlab_min_storage_gb: Minimum storage in GB
+# Notes:
+#   - Default: 20
+#   - GitLab requires at least 20GB of free disk space
+gitlab_min_storage_gb: {{ gitlab_min_storage_gb | default(gitlab_default_min_storage_gb) }}
+
+# Adjust upward for production workloads
+# Fields:
+#   gitlab_min_memory_gb: Minimum memory in GB
+# Notes:
+#   - Default: 4
+#   - Adjust upward for production workloads
+gitlab_min_memory_gb: {{ gitlab_min_memory_gb | default(gitlab_default_min_memory_gb) }}
+
+# Minimum CPU core count validated before install
+# Fields:
+#   gitlab_min_cpu_cores: Minimum number of CPU cores
+# Notes:
+#   - Default: 2
+#   - More cores may be needed for production workloads
+gitlab_min_cpu_cores: {{ gitlab_min_cpu_cores | default(gitlab_default_min_cpu_cores) }}
+ 
+
+# Web worker count; scale with CPU
+# Fields:
+#   gitlab_puma_workers: Number of worker processes
+# Notes:
+#   - Default: 2
+#   - Scale with CPU cores (recommended: 1-2 workers per CPU core)
+gitlab_puma_workers: {{ gitlab_puma_workers | default(gitlab_default_puma_workers) }}
+
+# Background job concurrency
+# Fields:
+#   gitlab_sidekiq_concurrency: Number of concurrent background jobs
+# Notes:
+#   - Default: 10
+#   - Adjust based on available memory and workload
+ 
+# Target host for GitLab deployment/cleanup
+gitlab_sidekiq_concurrency: {{ gitlab_sidekiq_concurrency | default(gitlab_default_sidekiq_concurrency) }}
+ 

--- a/upgrade/roles/import_input_parameters/templates/network_spec.j2
+++ b/upgrade/roles/import_input_parameters/templates/network_spec.j2
@@ -41,7 +41,8 @@
 Networks:
 - admin_network:
     oim_nic_name: "{{ admin_network.oim_nic_name | default('') }}"
-    netmask_bits: "{{ admin_network.netmask_bits | default('24') }}"
+    subnet: "{{ admin_network.subnet | default(network_default_subnet) }}"
+    netmask_bits: "{{ admin_network.netmask_bits | default(network_default_netmask_bits) }}"
     primary_oim_admin_ip: "{{ admin_network.primary_oim_admin_ip | default('') }}"
     primary_oim_bmc_ip: "{{ admin_network.primary_oim_bmc_ip | default('') }}"
     dynamic_range: "{{ admin_network.dynamic_range | default('') }}"
@@ -49,5 +50,5 @@ Networks:
     ntp_servers: {{ admin_network.ntp_servers | default([]) }}
 
 - ib_network:
-    subnet: "{{ ib_network.subnet | default('192.168.0.0') }}"
-    netmask_bits: "{{ ib_network.netmask_bits | default(admin_network_netmask_bits | default('24')) }}"
+    subnet: "{{ ib_network.subnet | default('') }}"
+    netmask_bits: "{{ ib_network.netmask_bits | default(admin_network_netmask_bits | default(network_default_netmask_bits)) }}"

--- a/upgrade/roles/import_input_parameters/templates/network_spec.j2
+++ b/upgrade/roles/import_input_parameters/templates/network_spec.j2
@@ -38,6 +38,30 @@
 # - 'subnet': The subnet of the IB network.
 # - 'netmask_bits': The number of bits in the subnet mask. This value must be same as the admin_network netmask_bits.
 
+# 'additional_subnets' is optional, for multi-RAC / multi-subnet PXE deployments.
+# Each entry defines a separate subnet that the CoreDHCP server will manage
+# via DHCP relay (giaddr-based routing). Requires coresmd v0.5+ with
+# multi-subnet support.
+#
+# Each additional subnet entry contains:
+# - 'subnet': The network address of the additional subnet (e.g. "10.40.1.0").
+# - 'netmask_bits': The CIDR prefix length (e.g. "24").
+# - 'router': The gateway/router IP for this subnet (used as DHCP option 3).
+# - 'dynamic_range': The DHCP IP pool range in "start_ip-end_ip" format.
+#     Must fall within the subnet.
+#
+# Example (multi-RAC with two additional subnets):
+#   additional_subnets:
+#     - subnet: "10.40.1.0"
+#       netmask_bits: "24"
+#       router: "10.40.1.1"
+#       dynamic_range: "10.40.1.100-10.40.1.200"
+#     - subnet: "10.40.3.0"
+#       netmask_bits: "24"
+#       router: "10.40.3.1"
+#       dynamic_range: "10.40.3.100-10.40.3.200"
+
+
 Networks:
 - admin_network:
     oim_nic_name: "{{ admin_network.oim_nic_name | default('') }}"
@@ -48,7 +72,9 @@ Networks:
     dynamic_range: "{{ admin_network.dynamic_range | default('') }}"
     dns: {{ admin_network.dns | default([]) }}
     ntp_servers: {{ admin_network.ntp_servers | default([]) }}
+    additional_subnets: {{ admin_network.additional_subnets | default([]) }}
 
 - ib_network:
     subnet: "{{ ib_network.subnet | default('') }}"
     netmask_bits: "{{ ib_network.netmask_bits | default(admin_network_netmask_bits | default(network_default_netmask_bits)) }}"
+    dns: {{ ib_network.dns | default([]) }}

--- a/upgrade/roles/import_input_parameters/templates/omnia_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/omnia_config.j2
@@ -231,8 +231,8 @@ service_k8s_cluster:
     k8s_service_addresses: "{{ _cluster.k8s_service_addresses | default('') }}"
     k8s_pod_network_cidr: "{{ _cluster.k8s_pod_network_cidr | default('') }}"
     nfs_storage_name: "{{ _cluster.nfs_storage_name | default('') }}"
+    k8s_crio_storage_size: "{{ _cluster.k8s_crio_storage_size | default('20G') }}"
     csi_powerscale_driver_secret_file_path: "{{ _cluster.csi_powerscale_driver_secret_file_path | default('') }}"
     csi_powerscale_driver_values_file_path: "{{ _cluster.csi_powerscale_driver_values_file_path | default('') }}"
-    k8s_crio_storage_size: {{ _cluster.k8s_crio_storage_size | default('20G') }}
 {% endfor %}
 {% endif %}

--- a/upgrade/roles/import_input_parameters/templates/telemetry_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/telemetry_config.j2
@@ -28,6 +28,7 @@
 #   2. VictoriaMetrics    : Time-series database for metric storage
 #   3. Kafka              : Distributed streaming platform for telemetry data
 #   4. LDMS               : Lightweight Distributed Metric Service for compute nodes
+#   5. DCGM               : NVIDIA Data Center GPU Manager for GPU telemetry
 #
 # ============================================================================
 # STORAGE REQUIREMENTS SUMMARY
@@ -36,8 +37,6 @@
 # VICTORIAMETRICS STORAGE:
 # ┌─────────────────┬──────────────────┬─────────────────┬──────────────────┐
 # │ Deployment Mode │ Per-Pod Storage  │ Number of Pods  │ Total Storage    │
-# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
-# │ Single-node     │ persistence_size │ 1 pod           │ 1× storage       │
 # ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
 # │ Cluster         │ persistence_size │ 3 vmstorage     │ 3× storage       │
 # └─────────────────┴──────────────────┴─────────────────┴──────────────────┘
@@ -57,7 +56,6 @@
 #
 # COMBINED STORAGE EXAMPLES:
 #   Default (8Gi each): VictoriaMetrics Cluster (24Gi) + Kafka (48Gi) = 72Gi total
-#   Single-node mode:   VictoriaMetrics Single (8Gi) + Kafka (48Gi) = 56Gi total
 #
 # STORAGE OPTIONS:
 #   - VictoriaMetrics: Store iDRAC telemetry in time-series database
@@ -74,7 +72,7 @@
 # Enable or disable iDRAC telemetry support
 # Accepted values: true or false
 # Default: true
-idrac_telemetry_support: {{ telemetry_idrac_telemetry_support | default(true) | bool | ternary('true', 'false') }}
+idrac_telemetry_support: {{ telemetry_idrac_telemetry_support | default(telemetry_default_idrac_support) | bool | ternary('true', 'false') }}
 
 # Specify where to store iDRAC telemetry data
 # Supported values:
@@ -82,7 +80,29 @@ idrac_telemetry_support: {{ telemetry_idrac_telemetry_support | default(true) | 
 #   - "kafka"           : Store in Kafka only
 #   - "victoria,kafka"  : Store in both (recommended)
 # Default: "victoria,kafka"
-telemetry_collection_type: {{ telemetry_telemetry_collection_type | default('victoria,kafka') | to_json }}
+telemetry_collection_type: {{ telemetry_telemetry_collection_type | default(telemetry_default_collection_type) | to_json }}
+
+# ============================================================================
+# NVIDIA DCGM (Data Center GPU Manager) CONFIGURATION
+# ============================================================================
+# DCGM monitors NVIDIA GPU health and collects GPU telemetry metrics from
+# compute nodes equipped with NVIDIA GPUs.
+#
+# When enabled, the DCGM daemon (nvidia-dcgm.service) is started on GPU nodes
+# during cloud-init provisioning. It validates the NVIDIA driver, enumerates
+# GPUs via dcgmi discovery, and exposes GPU health data.
+#
+# PREREQUISITE: NVIDIA GPU driver must be installed on the target nodes.
+#   The driver is installed automatically via the CUDA runfile during
+#   cloud-init when an NVIDIA GPU is detected via lspci.
+#
+# NOTE: DCGM exporter deployment (dcgm-exporter on port 9400) and Prometheus
+#   scrape configuration are planned for a future release.
+
+# Enable or disable NVIDIA DCGM support on GPU compute nodes
+# Accepted values: true or false
+# Default: true
+dcgm_support: {{ telemetry_dcgm_support | default(telemetry_default_dcgm_support) | bool | ternary('true', 'false') }}
 
 # ============================================================================
 # VICTORIAMETRICS CONFIGURATION
@@ -90,6 +110,9 @@ telemetry_collection_type: {{ telemetry_telemetry_collection_type | default('vic
 # VictoriaMetrics is a time-series database for storing telemetry metrics.
 # Used for iDRAC telemetry when 'victoria' is enabled in telemetry_collection_type.
 #
+# DEPLOYMENT MODES:
+#   - cluster: High-availability deployment with multiple components
+#               (recommended for production and large-scale deployments)
 victoria_metrics_configurations:
   # The amount of storage allocated for EACH VictoriaMetrics persistent volume.
   # IMPORTANT: Total VictoriaMetrics storage depends on deployment mode:
@@ -97,11 +120,43 @@ victoria_metrics_configurations:
   #   - Example (cluster): 8Gi × 3 = 24Gi total VictoriaMetrics storage
   # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
   # Default: 8Gi (results in 24Gi total storage for cluster mode)
-  persistence_size: {{ telemetry_victoria_persistence_size | default('8Gi') | to_json }}
+  persistence_size: {{ telemetry_victoria_persistence_size | default(telemetry_default_victoria_persistence_size) | to_json }}
 
   # Duration (in hours) to retain victoria logs before they are deleted.
   # Default: 168 (7 days)
-  retention_period: {{ telemetry_victoria_retention_period | default(168) }}
+  retention_period: {{ telemetry_victoria_retention_period | default(telemetry_default_victoria_retention_period) }}
+
+# ============================================================================
+# VICTORIALOGS CONFIGURATION
+# ============================================================================
+# VictoriaLogs provides centralized log storage and querying (cluster mode only).
+# Deployed alongside VictoriaMetrics when 'victoria' is in telemetry_collection_type.
+#
+# DEPLOYMENT:
+#   - Always cluster mode (vlstorage, vlinsert, vlselect, VLAgent)
+#   - Co-deployed with VictoriaMetrics — same deployment gate
+#   - Shares TLS infrastructure with VictoriaMetrics
+#
+# STORAGE REQUIREMENTS:
+# ┌─────────────────┬──────────────────┬─────────────────┬──────────────────┐
+# │ Component       │ Per-Pod Storage  │ Number of Pods  │ Total Storage    │
+# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
+# │ vlstorage       │ storage_size     │ 3 pods          │ 3× storage       │
+# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
+# │ VLAgent buffer  │ 5Gi (fixed)      │ 1 pod           │ 5Gi              │
+# └─────────────────┴──────────────────┴─────────────────┴──────────────────┘
+# Example: 8Gi × 3 vlstorage = 24Gi + 5Gi VLAgent = 29Gi total
+victoria_logs_configurations:
+  # Storage size per vlstorage replica PVC
+  # IMPORTANT: Total VictoriaLogs storage = storage_size × 3 vlstorage pods
+  # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
+  # Default: 8Gi (results in 24Gi total storage)
+  storage_size: {{ telemetry_victoria_logs_storage_size | default(telemetry_default_victoria_logs_storage_size) | to_json }}
+
+  # Log retention period (duration format)
+  # Logs older than this period are automatically purged by vlstorage.
+  # Default: 168 (7 days)
+  retention_period: {{ telemetry_victoria_logs_retention_period | default(telemetry_default_victoria_logs_retention_period) }}
 
 # ============================================================================
 # KAFKA CONFIGURATION
@@ -121,19 +176,19 @@ kafka_configurations:
   #   - Example: 8Gi × 6 = 48Gi total Kafka storage
   # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
   # Default: 8Gi (results in 48Gi total Kafka storage)
-  persistence_size: {{ telemetry_kafka_persistence_size | default('8Gi') | to_json }}
+  persistence_size: {{ telemetry_kafka_persistence_size | default(telemetry_default_kafka_persistence_size) | to_json }}
 
   # The number of hours to retain Kafka logs before they are deleted.
   # Default: 168 (7 days)
-  log_retention_hours: {{ telemetry_kafka_log_retention_hours | default(168) }}
+  log_retention_hours: {{ telemetry_kafka_log_retention_hours | default(telemetry_default_kafka_log_retention_hours) }}
 
   # The maximum size of Kafka logs (in bytes) before they are deleted.
   # Default: -1 (unlimited)
-  log_retention_bytes: {{ telemetry_kafka_log_retention_bytes | default(-1) }}
+  log_retention_bytes: {{ telemetry_kafka_log_retention_bytes | default(telemetry_default_kafka_log_retention_bytes) }}
 
   # The maximum size of Kafka log segments (in bytes) before they are deleted.
   # Default: 1073741824 (1 GB)
-  log_segment_bytes: {{ telemetry_kafka_log_segment_bytes | default(1073741824) }}
+  log_segment_bytes: {{ telemetry_kafka_log_segment_bytes | default(telemetry_default_kafka_log_segment_bytes) }}
 
   # Kafka Topic Partitions Configuration
   # ----------------------------------------------------------------------------
@@ -175,18 +230,18 @@ kafka_configurations:
 # Aggregator port on service k8s cluster
 # Valid range: 6001-6100
 # Default: 6001
-ldms_agg_port: {{ telemetry_ldms_agg_port | default(6001) }}
+ldms_agg_port: {{ telemetry_ldms_agg_port | default(telemetry_default_ldms_agg_port) }}
 
 # Store daemon port on service k8s cluster
 # Can be the same as ldms_agg_port
 # Valid range: 6001-6100
 # Default: 6001
-ldms_store_port: {{ telemetry_ldms_store_port | default(6001) }}
+ldms_store_port: {{ telemetry_ldms_store_port | default(telemetry_default_ldms_store_port) }}
 
 # Sampler port on compute nodes
 # Valid range: 10001-10100
 # Default: 10001
-ldms_sampler_port: {{ telemetry_ldms_sampler_port | default(10001) }}
+ldms_sampler_port: {{ telemetry_ldms_sampler_port | default(telemetry_default_ldms_sampler_port) }}
 
 # LDMS Sampler Plugin Configurations
 # ----------------------------------------------------------------------------
@@ -217,3 +272,61 @@ ldms_sampler_configurations:
     activation_parameters: {{ _plugin.activation_parameters | default('interval=1000000') | to_json }}
 {% endfor %}
 {% endif %}
+
+# ============================================================================
+# POWERSCALE TELEMETRY CONFIGURATION
+# ============================================================================
+# PowerScale telemetry collects storage metrics from Dell PowerScale (OneFS)
+# clusters using the CSM (Container Storage Modules) Metrics PowerScale exporter.
+#
+# DATA PIPELINE:
+#   CSM Metrics PowerScale → OTEL Collector → vmagent-powerscale → VictoriaMetrics
+#
+# PREREQUISITES:
+#   - csi_driver_powerscale must be configured in software_config.json
+#   - Service cluster must be defined in functional_groups_config.yml
+#   - VictoriaMetrics must be enabled: 'victoria' must be included in
+#     telemetry_collection_type (e.g., "victoria" or "victoria,kafka")
+#   - CSI driver secret.yaml with valid isilonClusters credentials
+#   - CSM Observability values.yaml must be provided
+#
+# STORAGE REQUIREMENTS:
+# ┌─────────────────────┬──────────────┬──────────────┬──────────────────┐
+# │ Component           │ Per-Pod PVC  │ Pods         │ Total Storage    │
+# ├─────────────────────┼──────────────┼──────────────┼──────────────────┤
+# │ OTEL Collector      │ 5Gi          │ 1 per cluster│ 5Gi per cluster  │
+# └─────────────────────┴──────────────┴──────────────┴──────────────────┘
+
+powerscale_configurations:
+  # Enable or disable PowerScale telemetry support
+  # Accepted values: true or false
+  # Default: true
+  powerscale_telemetry_support: {{ telemetry_powerscale_telemetry_support | default(telemetry_default_powerscale_support) | bool | ternary('true', 'false') }}
+
+  # Enable or disable PowerScale log collection (syslog → VictoriaLogs)
+  # Requires powerscale_telemetry_support: true
+  # Accepted values: true or false
+  # Default: false
+  powerscale_log_enabled: {{ telemetry_powerscale_log_enabled | default(telemetry_default_powerscale_log_enabled) | bool | ternary('true', 'false') }}
+
+  # PVC size for OTEL Collector metric batching and buffering.
+  # Adjust based on cluster scale and metric volume.
+  # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
+  # Default: "5Gi"
+  otel_collector_storage_size: {{ telemetry_otel_collector_storage_size | default(telemetry_default_otel_collector_storage_size) | to_json }}
+
+  # Path to the CSM Observability (Karavi Observability) values.yaml file.
+  # Required when powerscale_configurations.powerscale_telemetry_support: true
+  # Reference: https://github.com/dell/helm-charts/blob/main/charts/karavi-observability/values.yaml
+  csm_observability_values_file_path: "{{ telemetry_csm_observability_values_file_path | default(telemetry_default_csm_observability_values_file_path) }}"
+
+  # Additional VictoriaMetrics remote_write endpoints (optional)
+  # vmagent will write the same PowerScale metrics to ALL configured endpoints.
+  # Each endpoint receives an identical copy of all metrics.
+  # The primary Omnia VictoriaMetrics endpoint (vminsert) is always included automatically.
+  # Default: [] (empty — only the primary Omnia VictoriaMetrics endpoint is used)
+  # Example:
+  #   additional_remote_write_endpoints:
+  #     - url: "https://external-victoria.example.com:8480/insert/0/prometheus/api/v1/write"
+  #       tls_insecure_skip_verify: true
+  additional_remote_write_endpoints: {{ telemetry_additional_remote_write_endpoints | default([]) | to_json }}

--- a/upgrade/roles/import_input_parameters/templates/telemetry_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/telemetry_config.j2
@@ -21,26 +21,38 @@
 # ============================================================================
 # TELEMETRY CONFIGURATION OVERVIEW
 # ============================================================================
-# This file configures telemetry data collection and storage for Dell Omnia.
+# This file configures telemetry data collection, routing, and storage for Dell Omnia.
+#
+# ARCHITECTURE:
+#   SOURCES (Collectors) → BRIDGES (Vector) → SINKS (Storage)
 #
 # SECTIONS:
-#   1. iDRAC Telemetry    : Hardware metrics from Dell PowerEdge servers
-#   2. VictoriaMetrics    : Time-series database for metric storage
-#   3. Kafka              : Distributed streaming platform for telemetry data
-#   4. LDMS               : Lightweight Distributed Metric Service for compute nodes
-#   5. DCGM               : NVIDIA Data Center GPU Manager for GPU telemetry
+#   1. Telemetry Sources    : Data collectors (iDRAC, LDMS, DCGM, PowerScale)
+#   2. Telemetry Bridges    : Data routers (Vector pipelines)
+#   3. Telemetry Sinks      : Storage backends (victoria_metrics, victoria_logs, Kafka)
+#   4. Source Configurations: Detailed settings per source (PowerScale, LDMS)
 #
 # ============================================================================
 # STORAGE REQUIREMENTS SUMMARY
 # ============================================================================
 # 
-# VICTORIAMETRICS STORAGE:
+# victoria_metrics STORAGE:
 # ┌─────────────────┬──────────────────┬─────────────────┬──────────────────┐
 # │ Deployment Mode │ Per-Pod Storage  │ Number of Pods  │ Total Storage    │
 # ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
 # │ Cluster         │ persistence_size │ 3 vmstorage     │ 3× storage       │
 # └─────────────────┴──────────────────┴─────────────────┴──────────────────┘
-# Example: 8Gi per pod → Single-node: 8Gi total, Cluster: 24Gi total
+# Example: 8Gi per pod → Cluster: 24Gi total
+#
+# victoria_logs STORAGE:
+# ┌─────────────────┬──────────────────┬─────────────────┬──────────────────┐
+# │ Component       │ Per-Pod Storage  │ Number of Pods  │ Total Storage    │
+# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
+# │ vlstorage       │ storage_size     │ 3 pods          │ 3× storage       │
+# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
+# │ VLAgent buffer  │ 5Gi (fixed)      │ 1 pod           │ 5Gi              │
+# └─────────────────┴──────────────────┴─────────────────┴──────────────────┘
+# Example: 8Gi × 3 vlstorage = 24Gi + 5Gi VLAgent = 29Gi total
 #
 # KAFKA STORAGE:
 # ┌─────────────────┬──────────────────┬─────────────────┬──────────────────┐
@@ -55,278 +67,277 @@
 # Example: 8Gi per pod → 48Gi total Kafka storage
 #
 # COMBINED STORAGE EXAMPLES:
-#   Default (8Gi each): VictoriaMetrics Cluster (24Gi) + Kafka (48Gi) = 72Gi total
+#   Default (8Gi each): victoria_metrics (24Gi) + victoria_logs (29Gi) + Kafka (48Gi) = 101Gi total
+# ============================================================================
+
+# ============================================================================
+# TELEMETRY SOURCES (Data Collectors)
+# ============================================================================
+# Each source can be independently enabled/disabled.
+# Sources produce telemetry data that flows through bridges to sinks.
 #
-# STORAGE OPTIONS:
-#   - VictoriaMetrics: Store iDRAC telemetry in time-series database
-#   - Kafka: Stream iDRAC and LDMS telemetry to Kafka topics
-#   - Both: Store iDRAC in both Victoria and Kafka (recommended)
-# ============================================================================
+# Supported sources: idrac, ldms, dcgm, powerscale
+
+telemetry_sources:
+
+  # --------------------------------------------------------------------------
+  # iDRAC — Hardware metrics from Dell PowerEdge servers
+  # --------------------------------------------------------------------------
+  # Collects: temperature, power, fan speed, storage health, CPU/memory errors
+  # Requires: iDRAC-enabled Dell PowerEdge servers in inventory
+  # Data path: iDRAC Receiver → ActiveMQ → KafkaPump → Kafka 'idrac' topic
+  #            iDRAC Receiver → ActiveMQ → VictoriaPump → vmagent → victoria_metrics
+  idrac:
+    # Enable or disable iDRAC metrics collection
+    # Default: true
+    metrics_enabled: {{ telemetry_idrac_telemetry_support | default(telemetry_default_idrac_support) | bool | ternary('true', 'false') }}
+
+    # Collection targets define where iDRAC data is sent BEFORE Vector processing
+    # Supported values: "victoria_metrics", "kafka"
+    # Multiple targets: ["victoria_metrics", "kafka"]
+    # Default: ["victoria_metrics", "kafka"]
+    collection_targets:
+{% for _target in telemetry_idrac_collection_targets %}
+      - "{{ _target }}"
+{% endfor %}
+
+  # --------------------------------------------------------------------------
+  # LDMS — Lightweight Distributed Metric Service
+  # --------------------------------------------------------------------------
+  # Collects: CPU, memory, network, disk metrics from compute nodes
+  # Requires: LDMS software in software_config.json
+  # Data path: LDMS samplers → LDMS aggregator → store_avro_kafka → Kafka 'ldms' topic
+  ldms:
+    # Enable or disable LDMS metrics collection
+    # Default: true
+    metrics_enabled: true
+
+    # LDMS only supports Kafka collection (no direct victoria_metrics path)
+    # Vector-LDMS bridge consumes from Kafka and routes to victoria_metrics
+    collection_targets:
+      - "kafka"
+
+  # --------------------------------------------------------------------------
+  # DCGM — NVIDIA Data Center GPU Manager
+  # --------------------------------------------------------------------------
+  # Collects: GPU temperature, utilization, memory, ECC errors, power
+  # Requires: NVIDIA GPU driver installed on compute nodes
+  dcgm:
+    # Enable or disable DCGM metrics collection
+    # Default: true
+    metrics_enabled: {{ telemetry_dcgm_support | default(telemetry_default_dcgm_support) | bool | ternary('true', 'false') }}
+
+  # --------------------------------------------------------------------------
+  # PowerScale — Dell PowerScale (OneFS) storage telemetry
+  # --------------------------------------------------------------------------
+  # Collects: Storage metrics from Dell PowerScale clusters
+  # Requires: CSM Observability (Karavi) values file configured
+  # Data path: CSM Metrics PowerScale → OTEL Collector → vmagent(shared) → victoria_metrics
+  powerscale:
+    # Enable or disable PowerScale metrics collection
+    # Default: true
+    metrics_enabled: {{ telemetry_powerscale_metrics_enabled | default(telemetry_default_powerscale_support) | bool | ternary('true', 'false') }}
+
+    # Enable or disable PowerScale logs collection
+    # Default: true
+    logs_enabled: {{ telemetry_powerscale_logs_enabled | default(telemetry_default_powerscale_log_enabled) | bool | ternary('true', 'false') }}
+
+    # PowerScale uses vmagent(shared) (no Kafka, no Vector)
+    collection_targets:
+      - "victoria_metrics"
+      - "victoria_logs"
+
 
 # ============================================================================
-# iDRAC TELEMETRY CONFIGURATION
+# TELEMETRY BRIDGES (Data Routers)
 # ============================================================================
-# iDRAC telemetry collects hardware metrics from Dell PowerEdge servers.
-# Telemetry data can be stored in VictoriaMetrics, Kafka, or both.
-
-# Enable or disable iDRAC telemetry support
-# Accepted values: true or false
-# Default: true
-idrac_telemetry_support: {{ telemetry_idrac_telemetry_support | default(telemetry_default_idrac_support) | bool | ternary('true', 'false') }}
-
-# Specify where to store iDRAC telemetry data
-# Supported values:
-#   - "victoria"        : Store in VictoriaMetrics only
-#   - "kafka"           : Store in Kafka only
-#   - "victoria,kafka"  : Store in both (recommended)
-# Default: "victoria,kafka"
-telemetry_collection_type: {{ telemetry_telemetry_collection_type | default(telemetry_default_collection_type) | to_json }}
-
-# ============================================================================
-# NVIDIA DCGM (Data Center GPU Manager) CONFIGURATION
-# ============================================================================
-# DCGM monitors NVIDIA GPU health and collects GPU telemetry metrics from
-# compute nodes equipped with NVIDIA GPUs.
+# Bridges route data from Kafka topics to Victoria sinks.
+# Vector is the primary bridge technology, consuming from Kafka and producing
+# to victoria_metrics (metrics) and victoria_logs (logs/events).
 #
-# When enabled, the DCGM daemon (nvidia-dcgm.service) is started on GPU nodes
-# during cloud-init provisioning. It validates the NVIDIA driver, enumerates
-# GPUs via dcgmi discovery, and exposes GPU health data.
+# ARCHITECTURE:
+#   Kafka topics → Vector pods → vmagent-vector/vlagent-vector → Victoria sinks
 #
-# PREREQUISITE: NVIDIA GPU driver must be installed on the target nodes.
-#   The driver is installed automatically via the CUDA runfile during
-#   cloud-init when an NVIDIA GPU is detected via lspci.
-#
-# NOTE: DCGM exporter deployment (dcgm-exporter on port 9400) and Prometheus
-#   scrape configuration are planned for a future release.
 
-# Enable or disable NVIDIA DCGM support on GPU compute nodes
-# Accepted values: true or false
-# Default: true
-dcgm_support: {{ telemetry_dcgm_support | default(telemetry_default_dcgm_support) | bool | ternary('true', 'false') }}
+telemetry_bridges:
+
+  # --------------------------------------------------------------------------
+  # Vector-LDMS — Kafka-to-victoria_metrics bridge for LDMS metrics
+  # --------------------------------------------------------------------------
+  # Purpose: Consume LDMS metrics from Kafka 'ldms' topic, transform NERSC
+  #          schema to Prometheus format, and write to victoria_metrics
+  # Data flow: Kafka 'ldms' topic → Vector-LDMS → vmagent-vector → victoria_metrics
+  vector_ldms:
+    # Enable or disable Vector-LDMS bridge
+    # Requires: telemetry_sources.ldms.enabled = true
+    # Default: true
+    metrics_enabled: true
+
+  # --------------------------------------------------------------------------
+  # Vector-OME — Kafka-to-Victoria bridge for OME metrics and logs
+  # --------------------------------------------------------------------------
+  # Purpose: Consume OME data from Kafka 'ome.*' topics and route to victoria_metrics/victoria_logs
+  # Data flow: Kafka 'ome.*' topics → Vector-OME → vmagent-vector (metrics) / vlagent-vector (logs)
+  vector_ome:
+    # Enable or disable Vector-OME metrics routing
+    # Requires: OME to be configured with kafka
+    # Default: true
+    metrics_enabled: true
+
+    # Enable or disable Vector-OME logs routing
+    # Default: true
+    logs_enabled: true
+
+    # Identifier used by Vector-OME for topic identification and routing.
+    # Default: "ome" — internally used to match topics with the prefix (e.g., "^ome\\..*$")
+    # Change only if your OME Kafka topics use a different prefix.
+    ome_identifier: "ome"
 
 # ============================================================================
-# VICTORIAMETRICS CONFIGURATION
+# TELEMETRY SINKS (Storage Backends)
 # ============================================================================
-# VictoriaMetrics is a time-series database for storing telemetry metrics.
-# Used for iDRAC telemetry when 'victoria' is enabled in telemetry_collection_type.
-#
-# DEPLOYMENT MODES:
-#   - cluster: High-availability deployment with multiple components
-#               (recommended for production and large-scale deployments)
-victoria_metrics_configurations:
-  # The amount of storage allocated for EACH VictoriaMetrics persistent volume.
-  # IMPORTANT: Total VictoriaMetrics storage depends on deployment mode:
-  #   - Cluster mode: Total storage = persistence_size × 3 vmstorage pods
-  #   - Example (cluster): 8Gi × 3 = 24Gi total VictoriaMetrics storage
-  # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
-  # Default: 8Gi (results in 24Gi total storage for cluster mode)
-  persistence_size: {{ telemetry_victoria_persistence_size | default(telemetry_default_victoria_persistence_size) | to_json }}
+# Sinks are auto-enabled when at least one source targets them.
+# Explicit 'enabled: false' here overrides source routing (disables the sink).
 
-  # Duration (in hours) to retain victoria logs before they are deleted.
-  # Default: 168 (7 days)
-  retention_period: {{ telemetry_victoria_retention_period | default(telemetry_default_victoria_retention_period) }}
+telemetry_sinks:
 
-# ============================================================================
-# VICTORIALOGS CONFIGURATION
-# ============================================================================
-# VictoriaLogs provides centralized log storage and querying (cluster mode only).
-# Deployed alongside VictoriaMetrics when 'victoria' is in telemetry_collection_type.
-#
-# DEPLOYMENT:
-#   - Always cluster mode (vlstorage, vlinsert, vlselect, VLAgent)
-#   - Co-deployed with VictoriaMetrics — same deployment gate
-#   - Shares TLS infrastructure with VictoriaMetrics
-#
-# STORAGE REQUIREMENTS:
-# ┌─────────────────┬──────────────────┬─────────────────┬──────────────────┐
-# │ Component       │ Per-Pod Storage  │ Number of Pods  │ Total Storage    │
-# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
-# │ vlstorage       │ storage_size     │ 3 pods          │ 3× storage       │
-# ├─────────────────┼──────────────────┼─────────────────┼──────────────────┤
-# │ VLAgent buffer  │ 5Gi (fixed)      │ 1 pod           │ 5Gi              │
-# └─────────────────┴──────────────────┴─────────────────┴──────────────────┘
-# Example: 8Gi × 3 vlstorage = 24Gi + 5Gi VLAgent = 29Gi total
-victoria_logs_configurations:
-  # Storage size per vlstorage replica PVC
-  # IMPORTANT: Total VictoriaLogs storage = storage_size × 3 vlstorage pods
-  # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
-  # Default: 8Gi (results in 24Gi total storage)
-  storage_size: {{ telemetry_victoria_logs_storage_size | default(telemetry_default_victoria_logs_storage_size) | to_json }}
+  # --------------------------------------------------------------------------
+  # victoria_metrics — Time-series database for metrics
+  # --------------------------------------------------------------------------
+  victoria_metrics:
+    # Storage per vmstorage pod PVC
+    # Cluster: total = persistence_size × 3 vmstorage pods
+    # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
+    # Default: 8Gi (results in 24Gi total storage for cluster mode)
+    persistence_size: {{ telemetry_victoria_persistence_size | default(telemetry_default_victoria_persistence_size) | to_json }}
 
-  # Log retention period (duration format)
-  # Logs older than this period are automatically purged by vlstorage.
-  # Default: 168 (7 days)
-  retention_period: {{ telemetry_victoria_logs_retention_period | default(telemetry_default_victoria_logs_retention_period) }}
+    # Metric retention period in hours
+    # Default: 168 (7 days)
+    retention_period: {{ telemetry_victoria_retention_period | default(telemetry_default_victoria_retention_period) }}
 
-# ============================================================================
-# KAFKA CONFIGURATION
-# ============================================================================
-# Apache Kafka is a distributed streaming platform for storing telemetry data.
-# Used for iDRAC telemetry when 'kafka' is enabled in telemetry_collection_type.
-# Also used for LDMS telemetry when LDMS software is configured.
-#
-# NOTE: Kafka topics are auto-generated based on enabled features:
-#   - 'idrac' topic: Required when idrac_telemetry_support=true and 'kafka' is enabled
-#   - 'ldms' topic:  Required when LDMS is configured in software_config.json
-kafka_configurations:
-  # The amount of storage allocated for EACH Kafka persistent volume.
-  # IMPORTANT: Total Kafka storage = persistence_size × 6 pods
-  #   - 3 Kafka brokers (each gets persistence_size storage)
-  #   - 3 Kafka controllers (each gets persistence_size storage)
-  #   - Example: 8Gi × 6 = 48Gi total Kafka storage
-  # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
-  # Default: 8Gi (results in 48Gi total Kafka storage)
-  persistence_size: {{ telemetry_kafka_persistence_size | default(telemetry_default_kafka_persistence_size) | to_json }}
+    # Additional remote write endpoints for metrics (optional)
+    # Metrics will be sent to the Omnia-managed VictoriaMetrics AND to these endpoints.
+    # Each entry requires a 'url' field (must start with http:// or https://).
+    # Set tls_insecure_skip_verify: true to skip TLS certificate verification.
+    # Default: [] (only Omnia VictoriaMetrics receives metrics)
+    # Example:
+    #   additional_metric_remote_write_endpoints:
+    #     - url: https://external-metrics-server:8480/insert/0/prometheus/api/v1/write
+    #       tls_insecure_skip_verify: false
+    additional_metric_remote_write_endpoints: {{ telemetry_additional_metric_remote_write_endpoints | default([]) | to_json }}
 
-  # The number of hours to retain Kafka logs before they are deleted.
-  # Default: 168 (7 days)
-  log_retention_hours: {{ telemetry_kafka_log_retention_hours | default(telemetry_default_kafka_log_retention_hours) }}
+  # --------------------------------------------------------------------------
+  # victoria_logs — Centralized log storage and querying
+  # --------------------------------------------------------------------------
+  # Co-deployed with victoria_metrics when victoria_metrics sink is active.
+  # Provides structured log collection via vlagent-vector (JSON Lines receiver).
+  victoria_logs:
+    # Storage per vlstorage pod PVC
+    # Total = storage_size × 3 vlstorage pods
+    # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
+    # Default: 8Gi (results in 24Gi total storage)
+    storage_size: {{ telemetry_victoria_logs_storage_size | default(telemetry_default_victoria_logs_storage_size) | to_json }}
 
-  # The maximum size of Kafka logs (in bytes) before they are deleted.
-  # Default: -1 (unlimited)
-  log_retention_bytes: {{ telemetry_kafka_log_retention_bytes | default(telemetry_default_kafka_log_retention_bytes) }}
+    # Log retention period in hours
+    # Default: 168 (7 days)
+    retention_period: {{ telemetry_victoria_logs_retention_period | default(telemetry_default_victoria_logs_retention_period) }}
 
-  # The maximum size of Kafka log segments (in bytes) before they are deleted.
-  # Default: 1073741824 (1 GB)
-  log_segment_bytes: {{ telemetry_kafka_log_segment_bytes | default(telemetry_default_kafka_log_segment_bytes) }}
+    # Additional remote write endpoints for logs (optional)
+    # Logs will be sent to the Omnia-managed VictoriaLogs AND to these endpoints.
+    # Each entry requires a 'url' field (must start with http:// or https://).
+    # Set tls_insecure_skip_verify: true to skip TLS certificate verification.
+    # Default: [] (only Omnia VictoriaLogs receives logs)
+    # Example:
+    #   additional_log_write_endpoints:
+    #     - url: https://external-logs-server:9481/internal/insert
+    #       tls_insecure_skip_verify: false
+    additional_log_write_endpoints: {{ telemetry_additional_log_write_endpoints | default([]) | to_json }}
 
-  # Kafka Topic Partitions Configuration
-  # ----------------------------------------------------------------------------
-  # Define the number of partitions for each Kafka topic.
-  # Increasing partitions can improve throughput but also increases storage/overhead.
-  #
-  # IMPORTANT: Topic names are FIXED and cannot be changed.
-  #   - Topic names: Only 'idrac' and 'ldms' are allowed
-  #   - Configurable: Only partition counts can be modified
-  #
-  # Topic Requirements (auto-validated):
-  #   - 'idrac': Required when idrac_telemetry_support=true and 'kafka' is enabled
-  #   - 'ldms':  Required when LDMS software is configured in software_config.json
-  #
-  # Default partition counts: idrac=1, ldms=2
-  topic_partitions:
-{% for _topic in (telemetry_kafka_topic_partitions | default([])) %}
-    - name: {{ _topic.name | default('') | to_json }}
-      partitions: {{ _topic.partitions | default(1) }}
+  # --------------------------------------------------------------------------
+  # Kafka — Distributed streaming platform
+  # --------------------------------------------------------------------------
+  kafka:
+    # Storage per Kafka pod PVC
+    # Total = persistence_size × 6 pods (3 brokers + 3 controllers)
+    # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
+    # Default: 8Gi (results in 48Gi total storage)
+    persistence_size: {{ telemetry_kafka_persistence_size | default(telemetry_default_kafka_persistence_size) | to_json }}
+
+    # Log retention
+    # Default: 168 (7 days)
+    log_retention_hours: {{ telemetry_kafka_log_retention_hours | default(telemetry_default_kafka_log_retention_hours) }}
+
+    # Maximum size of Kafka logs (in bytes) before deletion
+    # Default: -1 (unlimited)
+    log_retention_bytes: {{ telemetry_kafka_log_retention_bytes | default(telemetry_default_kafka_log_retention_bytes) }}
+
+    # Maximum size of Kafka log segments (in bytes)
+    # Default: 1073741824 (1 GB)
+    log_segment_bytes: {{ telemetry_kafka_log_segment_bytes | default(telemetry_default_kafka_log_segment_bytes) }}
+
+    # Topic partitions per source (auto-created for enabled sources targeting kafka)
+    # Only sources with kafka in collection_targets get topics.
+    # Topic name = source name (e.g., "idrac", "ldms")
+    topic_partitions:
+{% for _topic_name, _partitions in telemetry_kafka_topic_partitions_dict.items() %}
+      {{ _topic_name }}: {{ _partitions }}
 {% endfor %}
 
 # ============================================================================
-# LDMS (Lightweight Distributed Metric Service) CONFIGURATION
+# SOURCE-SPECIFIC CONFIGURATIONS
 # ============================================================================
-# LDMS collects performance metrics from compute nodes (CPU, memory, network, etc.)
-# and streams them to Kafka for storage and analysis.
-#
-# PREREQUISITE: To enable LDMS support, add the following to software_config.json:
-#   {
-#     "softwares": [
-#       {"name": "ldms", "arch": ["x86_64", "aarch64"]}
-#     ]
-#   }
-#
-# When LDMS software is configured, the 'ldms' topic MUST be defined in
-# kafka_configurations.topic_partitions above.
-#
-# LDMS Port Configurations
-# Aggregator port on service k8s cluster
-# Valid range: 6001-6100
-# Default: 6001
-ldms_agg_port: {{ telemetry_ldms_agg_port | default(telemetry_default_ldms_agg_port) }}
+# Detailed configurations for each telemetry source.
+# Only relevant when the corresponding source is enabled above.
 
-# Store daemon port on service k8s cluster
-# Can be the same as ldms_agg_port
-# Valid range: 6001-6100
-# Default: 6001
-ldms_store_port: {{ telemetry_ldms_store_port | default(telemetry_default_ldms_store_port) }}
+# --------------------------------------------------------------------------
+# LDMS Configuration
+# --------------------------------------------------------------------------
+ldms_configurations:
+  # Aggregator port on service K8s cluster (valid: 6001-6100)
+  agg_port: {{ telemetry_ldms_agg_port | default(telemetry_default_ldms_agg_port) }}
 
-# Sampler port on compute nodes
-# Valid range: 10001-10100
-# Default: 10001
-ldms_sampler_port: {{ telemetry_ldms_sampler_port | default(telemetry_default_ldms_sampler_port) }}
+  # Store daemon port (valid: 6001-6100)
+  store_port: {{ telemetry_ldms_store_port | default(telemetry_default_ldms_store_port) }}
 
-# LDMS Sampler Plugin Configurations
-# ----------------------------------------------------------------------------
-# Configure which metrics to collect from compute nodes and collection intervals.
-# Each plugin collects specific system metrics.
-#
-# Parameters:
-#   - plugin_name: Name of the LDMS sampler plugin
-#   - config_parameters: Plugin-specific configuration (as a single string)
-#   - activation_parameters: Collection schedule in MICROSECONDS
-#       Format: "interval=<microseconds> offset=<microseconds>"
-#       Example: "interval=1000000"         (1000000 microseconds = 1 second)
-#                "interval=1000000 offset=0" (1000000 microseconds with no offset)
-#
-# Available Plugins:
-#   - meminfo: Memory usage statistics
-#   - procstat2: Process statistics
-#   - vmstat: Virtual memory statistics
-#   - loadavg: System load average
-#   - procnetdev2: Network interface statistics
-ldms_sampler_configurations:
+  # Sampler port on compute nodes (valid: 10001-10100)
+  sampler_port: {{ telemetry_ldms_sampler_port | default(telemetry_default_ldms_sampler_port) }}
+
+  # Sampler plugins — which metrics to collect from compute nodes
+  # Parameters:
+  #   - plugin_name: Name of the LDMS sampler plugin
+  #   - config_parameters: Plugin-specific configuration (as a single string)
+  #   - activation_parameters: Collection schedule in MICROSECONDS
+  #       Format: "interval=<microseconds> offset=<microseconds>"
+  #       Example: "interval=30000000" (30 seconds)
+  sampler_plugins:
 {% if telemetry_ldms_sampler_configurations is none %}
-  null
+    null
 {% else %}
 {% for _plugin in (telemetry_ldms_sampler_configurations | default([])) %}
-  - plugin_name: {{ _plugin.plugin_name | default('') }}
-    config_parameters: {{ _plugin.config_parameters | default('') | to_json }}
-    activation_parameters: {{ _plugin.activation_parameters | default('interval=1000000') | to_json }}
+    - plugin_name: {{ _plugin.plugin_name | default('') }}
+      config_parameters: {{ _plugin.config_parameters | default('') | to_json }}
+      activation_parameters: {{ _plugin.activation_parameters | default('interval=30000000') | to_json }}
 {% endfor %}
 {% endif %}
 
-# ============================================================================
-# POWERSCALE TELEMETRY CONFIGURATION
-# ============================================================================
+# --------------------------------------------------------------------------
+# PowerScale Telemetry Configuration
+# --------------------------------------------------------------------------
 # PowerScale telemetry collects storage metrics from Dell PowerScale (OneFS)
 # clusters using the CSM (Container Storage Modules) Metrics PowerScale exporter.
 #
 # DATA PIPELINE:
-#   CSM Metrics PowerScale → OTEL Collector → vmagent-powerscale → VictoriaMetrics
+#   CSM Metrics PowerScale → OTEL Collector → vmagent(shared) → victoria_metrics
 #
-# PREREQUISITES:
-#   - csi_driver_powerscale must be configured in software_config.json
-#   - Service cluster must be defined in functional_groups_config.yml
-#   - VictoriaMetrics must be enabled: 'victoria' must be included in
-#     telemetry_collection_type (e.g., "victoria" or "victoria,kafka")
-#   - CSI driver secret.yaml with valid isilonClusters credentials
-#   - CSM Observability values.yaml must be provided
-#
-# STORAGE REQUIREMENTS:
-# ┌─────────────────────┬──────────────┬──────────────┬──────────────────┐
-# │ Component           │ Per-Pod PVC  │ Pods         │ Total Storage    │
-# ├─────────────────────┼──────────────┼──────────────┼──────────────────┤
-# │ OTEL Collector      │ 5Gi          │ 1 per cluster│ 5Gi per cluster  │
-# └─────────────────────┴──────────────┴──────────────┴──────────────────┘
-
+# NOTE: PowerScale does NOT use Vector bridges. It uses the shared vmagent instance
+#       that writes directly to victoria_metrics.
 powerscale_configurations:
-  # Enable or disable PowerScale telemetry support
-  # Accepted values: true or false
-  # Default: true
-  powerscale_telemetry_support: {{ telemetry_powerscale_telemetry_support | default(telemetry_default_powerscale_support) | bool | ternary('true', 'false') }}
-
-  # Enable or disable PowerScale log collection (syslog → VictoriaLogs)
-  # Requires powerscale_telemetry_support: true
-  # Accepted values: true or false
-  # Default: false
-  powerscale_log_enabled: {{ telemetry_powerscale_log_enabled | default(telemetry_default_powerscale_log_enabled) | bool | ternary('true', 'false') }}
-
-  # PVC size for OTEL Collector metric batching and buffering.
-  # Adjust based on cluster scale and metric volume.
+  # PVC size for OTEL Collector metric batching and buffering
   # Accepted values: in the form of "X[Ki|Mi|Gi|Ti|Pi|Ei]"
   # Default: "5Gi"
   otel_collector_storage_size: {{ telemetry_otel_collector_storage_size | default(telemetry_default_otel_collector_storage_size) | to_json }}
 
-  # Path to the CSM Observability (Karavi Observability) values.yaml file.
+  # Path to the CSM Observability (Karavi Observability) values.yaml file
   # Required when powerscale_configurations.powerscale_telemetry_support: true
-  # Reference: https://github.com/dell/helm-charts/blob/main/charts/karavi-observability/values.yaml
+  # Reference: https://raw.githubusercontent.com/dell/helm-charts/refs/heads/release-v1.16.3/charts/karavi-observability/values.yaml
   csm_observability_values_file_path: "{{ telemetry_csm_observability_values_file_path | default(telemetry_default_csm_observability_values_file_path) }}"
-
-  # Additional VictoriaMetrics remote_write endpoints (optional)
-  # vmagent will write the same PowerScale metrics to ALL configured endpoints.
-  # Each endpoint receives an identical copy of all metrics.
-  # The primary Omnia VictoriaMetrics endpoint (vminsert) is always included automatically.
-  # Default: [] (empty — only the primary Omnia VictoriaMetrics endpoint is used)
-  # Example:
-  #   additional_remote_write_endpoints:
-  #     - url: "https://external-victoria.example.com:8480/insert/0/prometheus/api/v1/write"
-  #       tls_insecure_skip_verify: true
-  additional_remote_write_endpoints: {{ telemetry_additional_remote_write_endpoints | default([]) | to_json }}

--- a/upgrade/roles/import_input_parameters/vars/main.yml
+++ b/upgrade/roles/import_input_parameters/vars/main.yml
@@ -226,6 +226,8 @@ msg_network_spec_transform_summary: |
   Backup preserved at: {{ backup_location }}/network_spec.yml
   Changes:
   - Added subnet field under admin_network
+  - Added additional_subnets field under admin_network (default: empty)
+  - Added dns field under ib_network (default: empty)
   - Preserved ib_network configuration
   - Aligned ib_network.netmask_bits with admin_network.netmask_bits
 
@@ -275,18 +277,22 @@ msg_omnia_config_transform_summary: |
 
 # Restore summary message for telemetry config transformation
 msg_telemetry_config_transform_summary: |
-  telemetry_config.yml upgraded to 2.2 format with enhanced field mapping.
+  telemetry_config.yml upgraded to 2.2 format with restructured architecture.
   Backup preserved at: {{ backup_location }}/telemetry_config.yml
   Changes:
-  - Preserved existing iDRAC, VictoriaMetrics, Kafka, LDMS settings from 2.1 backup
-  - Enhanced field mapping: idrac_telemetry_collection_type → telemetry_collection_type
-  - Enhanced field mapping: victoria_configurations → victoria_metrics_configurations
-  - Added DCGM (GPU telemetry) section with default dcgm_support=true
-  - Added VictoriaLogs section with default storage and retention settings
-  - Added PowerScale telemetry configuration section
-  - Removed single-node VM deployment mode references
-  - Added validation for telemetry_collection_type values
-  - Corrected LDMS sampler intervals to 30-second intervals
+  - Restructured to telemetry_sources / telemetry_bridges / telemetry_sinks architecture
+  - Mapped idrac_telemetry_support → telemetry_sources.idrac.metrics_enabled
+  - Mapped idrac_telemetry_collection_type → telemetry_sources.idrac.collection_targets
+  - Mapped victoria_configurations → telemetry_sinks.victoria_metrics
+  - Mapped kafka_configurations → telemetry_sinks.kafka (topic_partitions list → dict)
+  - Mapped ldms_* ports and sampler configs → ldms_configurations section
+  - Added telemetry_sources.ldms (metrics_enabled, collection_targets) with defaults
+  - Added telemetry_sources.dcgm with default metrics_enabled=true
+  - Added telemetry_sources.powerscale with default metrics and logs enabled
+  - Added telemetry_bridges section (vector_ldms, vector_ome) with defaults
+  - Added telemetry_sinks.victoria_logs with default storage and retention
+  - Removed single-node VM deployment mode (always cluster in 2.2)
+  - Updated powerscale_configurations (removed source-level fields, kept otel/csm settings)
 
 # Restore summary message for software config transformation
 msg_software_config_transform_summary: |
@@ -342,7 +348,7 @@ telemetry_default_dcgm_support: true
 telemetry_default_victoria_logs_storage_size: "8Gi"
 telemetry_default_victoria_logs_retention_period: 168
 telemetry_default_powerscale_support: true
-telemetry_default_powerscale_log_enabled: false
+telemetry_default_powerscale_log_enabled: true
 telemetry_default_otel_collector_storage_size: "5Gi"
 telemetry_default_csm_observability_values_file_path: ""
 

--- a/upgrade/roles/import_input_parameters/vars/main.yml
+++ b/upgrade/roles/import_input_parameters/vars/main.yml
@@ -14,7 +14,7 @@
 ---
 
 # backup_location will be set from oim_metadata.yml upgrade_backup_dir
-# Format: /opt/omnia/backups/upgrade/version_2.0.0.0/input/project_default
+# Format: /opt/omnia/backups/upgrade/version_2.1.0.0/input/project_default
 # Set dynamically from metadata, no static variable needed
 
 # Path to oim_metadata.yml
@@ -131,8 +131,9 @@ msg_encryption_failed: "Encryption failed. Check warnings for details."
 # Network spec transformation messages
 msg_backup_network_spec_missing: "Backup network_spec.yml missing"
 msg_network_spec_missing: "network_spec.yml missing"
-msg_network_spec_already_21: "network_spec.yml already in 2.1 format - overwriting"
+msg_network_spec_already_22: "network_spec.yml already in 2.2 format - overwriting"
 msg_yaml_validation_failed: "YAML validation failed"
+msg_json_validation_failed: "JSON validation failed"
 msg_ib_netmask_mismatch: "ib_network.netmask_bits must match admin_network.netmask_bits"
 msg_ib_network_missing: "ib_network is mandatory"
 msg_ib_subnet_missing: "ib_network.subnet is mandatory"
@@ -141,7 +142,7 @@ msg_using_backup_network_spec: "Using backup network_spec.yml (backup not modifi
 # High availability config transformation messages
 msg_backup_ha_config_missing: "Backup high_availability_config.yml missing"
 msg_ha_config_missing: "high_availability_config.yml missing"
-msg_ha_config_already_21: "high_availability_config.yml already in 2.1 format - overwriting"
+msg_ha_config_already_22: "high_availability_config.yml already in 2.2 format - overwriting"
 msg_ha_virtual_ip_missing: "service_k8s_cluster_ha.virtual_ip_address is mandatory"
 msg_using_backup_ha_config: "Using backup high_availability_config.yml (backup not modified)"
 
@@ -177,6 +178,42 @@ msg_backup_telemetry_config_missing: "Backup telemetry_config.yml missing"
 msg_telemetry_config_missing: "telemetry_config.yml missing"
 msg_using_backup_telemetry_config: "Using backup telemetry_config.yml (backup not modified)"
 
+# Build stream config transformation messages
+msg_backup_build_stream_config_missing: "Backup build_stream_config.yml missing"
+msg_build_stream_config_missing: "build_stream_config.yml missing"
+msg_using_backup_build_stream_config: "Using backup build_stream_config.yml (backup not modified)"
+
+# GitLab config transformation messages
+msg_backup_gitlab_config_missing: "Backup gitlab_config.yml missing"
+msg_gitlab_config_missing: "gitlab_config.yml missing"
+msg_using_backup_gitlab_config: "Using backup gitlab_config.yml (backup not modified)"
+
+# Software config transformation messages
+msg_backup_software_config_missing: "Backup software_config.json missing"
+msg_software_config_missing: "software_config.json missing"
+
+# Build stream config transformation messages
+msg_build_stream_config_transform_summary: |
+  build_stream_config.yml migrated from backup with validation.
+  Backup preserved at: {{ backup_location }}/build_stream_config.yml
+  Target: {{ input_project_dir }}/build_stream_config.yml
+  Note: Configuration values migrated from omnia-main backup
+  Enhanced with IP address and port validation.
+
+# GitLab config transformation messages
+msg_gitlab_config_transform_summary: |
+  gitlab_config.yml migrated from backup with validation.
+  Backup preserved at: {{ backup_location }}/gitlab_config.yml
+  Target: {{ input_project_dir }}/gitlab_config.yml
+  Note: Configuration values migrated from omnia-main backup
+  Enhanced with comprehensive validation for all parameters.
+
+# Discovery config transformation messages
+msg_discovery_config_transform_summary: |
+  discovery_config.yml created with Omnia 2.2 defaults.
+  Target: {{ input_project_dir }}/discovery_config.yml
+  Note: This is a new file in Omnia 2.2 (not present in 2.1)
+
 ### Restore summary messages
 msg_restore_summary: |
   {{ restore_item.name }} restored from backup.
@@ -185,16 +222,16 @@ msg_restore_summary: |
 
 # Restore summary message for network spec transformation
 msg_network_spec_transform_summary: |
-  network_spec.yml upgraded to 2.1 format.
+  network_spec.yml upgraded to 2.2 format.
   Backup preserved at: {{ backup_location }}/network_spec.yml
   Changes:
-  - Added mandatory ib_network
-  - Made primary_oim_bmc_ip optional
+  - Added subnet field under admin_network
+  - Preserved ib_network configuration
   - Aligned ib_network.netmask_bits with admin_network.netmask_bits
 
 # Restore summary message for high availability config transformation
 msg_ha_config_transform_summary: |
-  high_availability_config.yml upgraded to 2.1 format.
+  high_availability_config.yml upgraded to 2.2 format.
   Backup preserved at: {{ backup_location }}/high_availability_config.yml
   Changes:
   - Ensured service_k8s_cluster_ha is a list
@@ -202,44 +239,155 @@ msg_ha_config_transform_summary: |
 
 # Restore summary message for local repo config transformation
 msg_local_repo_config_transform_summary: |
-  local_repo_config.yml upgraded to 2.1 format.
+  local_repo_config.yml upgraded to 2.2 format.
   Backup preserved at: {{ backup_location }}/local_repo_config.yml
   Changes:
-  - Normalized repo URL keys to arch-specific schema
-  - Migrated omnia_registry to user_registry (when present)
-  - Ensured mandatory omnia_repo_url_rhel_* keys are present
+  - Updated omnia_repo_url_rhel_* to Omnia 2.2 versions (kubernetes v1.35, cri-o v1.35)
+  - Added versioned repository naming (kubernetes-v1-35, cri-o-v1-35)
+  - Added cuda repository entries
+  - Added rhel_subscription_repo_config sections
+  - Added additional_repos sections
+  - Preserved user_registry and user_repo_url entries
 
 # Restore summary message for provision config transformation
 msg_provision_config_transform_summary: |
-  provision_config.yml upgraded to 2.1 format.
+  provision_config.yml upgraded to 2.2 format.
   Backup preserved at: {{ backup_location }}/provision_config.yml
   Changes:
   - Ensured pxe_mapping_file_path, language, and default_lease_time are present
 
 # Restore summary message for storage config transformation
 msg_storage_config_transform_summary: |
-  storage_config.yml upgraded to 2.1 format.
+  storage_config.yml upgraded to 2.2 format.
   Backup preserved at: {{ backup_location }}/storage_config.yml
   Changes:
   - Ensured nfs_client_params is present and entries contain required keys
 
 # Restore summary message for omnia config transformation
 msg_omnia_config_transform_summary: |
-  omnia_config.yml upgraded to 2.1 format.
+  omnia_config.yml upgraded to 2.2 format.
   Backup preserved at: {{ backup_location }}/omnia_config.yml
   Changes:
   - Ensured slurm_cluster and service_k8s_cluster are lists
-  - Ensured required sections are present
+  - Added skip_merge, node_discovery_mode, node_hardware_defaults comments
+  - Added csi_powerscale_driver fields to service_k8s_cluster
+  - Added k8s_crio_storage_size field
 
 # Restore summary message for telemetry config transformation
 msg_telemetry_config_transform_summary: |
-  telemetry_config.yml upgraded to 2.1 format.
+  telemetry_config.yml upgraded to 2.2 format with enhanced field mapping.
   Backup preserved at: {{ backup_location }}/telemetry_config.yml
   Changes:
-  - Rendered Omnia 2.1 telemetry template with values from 2.0 backup
-  - Applied schema defaults for missing fields
+  - Preserved existing iDRAC, VictoriaMetrics, Kafka, LDMS settings from 2.1 backup
+  - Enhanced field mapping: idrac_telemetry_collection_type → telemetry_collection_type
+  - Enhanced field mapping: victoria_configurations → victoria_metrics_configurations
+  - Added DCGM (GPU telemetry) section with default dcgm_support=true
+  - Added VictoriaLogs section with default storage and retention settings
+  - Added PowerScale telemetry configuration section
+  - Removed single-node VM deployment mode references
+  - Added validation for telemetry_collection_type values
+  - Corrected LDMS sampler intervals to 30-second intervals
 
-# === Input files to restore from backup ===
+# Restore summary message for software config transformation
+msg_software_config_transform_summary: |
+  software_config.json upgraded to 2.2 format.
+  Backup preserved at: {{ backup_location }}/software_config.json
+  Changes:
+  - Bumped service_k8s version from 1.34.1 to 1.35.1 (if present)
+  - Added admin_debug_packages entry (if missing)
+  - Added csi_driver_powerscale entry (if missing)
+  - Added additional_packages software entry and section (if missing)
+
+# === DEFAULT VALUES ===
+# Build Stream Config Defaults
+build_stream_default_enable: false
+build_stream_default_host_ip: ""
+build_stream_default_port: 8010
+build_stream_default_aarch64_ip: ""
+
+# GitLab Config Defaults
+gitlab_default_host: ""
+gitlab_default_project_name: "omnia-catalog"
+gitlab_default_project_visibility: "private"
+gitlab_default_branch: "main"
+gitlab_default_https_port: 443
+gitlab_default_min_storage_gb: 20
+gitlab_default_min_memory_gb: 4
+gitlab_default_min_cpu_cores: 2
+gitlab_default_puma_workers: 2
+gitlab_default_sidekiq_concurrency: 10
+
+# Provision Config Defaults
+provision_default_pxe_mapping_file_path: "pxe_mapping_file.csv"
+provision_default_language: "en_US.UTF-8"
+provision_default_lease_time: "86400"
+
+# Network Config Defaults
+network_default_netmask_bits: "24"
+network_default_subnet: "172.16.0.0"
+
+# Telemetry Config Defaults
+telemetry_default_idrac_support: true
+telemetry_default_collection_type: "victoria,kafka"
+telemetry_default_victoria_persistence_size: "8Gi"
+telemetry_default_victoria_retention_period: 168
+telemetry_default_kafka_persistence_size: "8Gi"
+telemetry_default_kafka_log_retention_hours: 168
+telemetry_default_kafka_log_retention_bytes: -1
+telemetry_default_kafka_log_segment_bytes: 1073741824
+telemetry_default_ldms_agg_port: 6001
+telemetry_default_ldms_store_port: 6001
+telemetry_default_ldms_sampler_port: 10001
+telemetry_default_dcgm_support: true
+telemetry_default_victoria_logs_storage_size: "8Gi"
+telemetry_default_victoria_logs_retention_period: 168
+telemetry_default_powerscale_support: true
+telemetry_default_powerscale_log_enabled: false
+telemetry_default_otel_collector_storage_size: "5Gi"
+telemetry_default_csm_observability_values_file_path: ""
+
+# Default LDMS sampler configurations
+telemetry_default_ldms_sampler_configurations:
+  - plugin_name: meminfo
+    config_parameters: ""
+    activation_parameters: "interval=30000000"
+  - plugin_name: procstat2
+    config_parameters: ""
+    activation_parameters: "interval=30000000"
+  - plugin_name: vmstat
+    config_parameters: ""
+    activation_parameters: "interval=30000000"
+  - plugin_name: loadavg
+    config_parameters: ""
+    activation_parameters: "interval=30000000"
+  - plugin_name: procnetdev2
+    config_parameters: ""
+    activation_parameters: "interval=30000000 offset=0"
+
+# Default Kafka topic partitions
+telemetry_default_kafka_topic_partitions:
+  - name: "idrac"
+    partitions: 1
+  - name: "ldms"
+    partitions: 2
+
+# === VALIDATION MESSAGES ===
+msg_file_missing: "Backup file missing: {{ file_name }}"
+msg_validation_failed_generic: "Validation failed for {{ file_name }}"
+
+# === TRANSFORMATION MESSAGES ===
+msg_transform_summary_generic: |-
+  {{ file_name }} upgraded to 2.2 format.
+  Backup preserved at: {{ backup_location }}/{{ file_name }}
+  Changes: {{ changes_description }}
+
+# === FILE MODES ===
+mode_yaml_file: '0644'
+mode_json_file: '0644'
+mode_csv_file: '0644'
+mode_sensitive_file: '0600'
+
+# === INPUT FILES TO RESTORE FROM BACKUP ===
 # Add input files here that should be copied from backup_location to input_project_dir
 # Each entry should have:
 # - name: filename (required)
@@ -248,11 +396,12 @@ msg_telemetry_config_transform_summary: |
 #
 # Examples of files to add:
 # - Static configuration files that don't need transformation
-# - Files that are the same format in 2.0 and 2.1
+# - Files that are the same format in 2.1 and 2.2
 # - Files where you want to preserve the backup values exactly
 #
 # DO NOT add files that require transformation (network_spec.yml, high_availability_config.yml, local_repo_config.yml,
-# provision_config.yml, user_registry_credential.yml)
+# provision_config.yml, software_config.json, telemetry_config.yml, user_registry_credential.yml)
+# DO NOT add files that are newly generated (build_stream_config.yml, gitlab_config.yml, discovery_config.yml)
 restore_input_files:
   - name: software_config.json
     mode: '0644'

--- a/upgrade/roles/manage_upgrade_inputs/tasks/backup_configs.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/backup_configs.yml
@@ -1,37 +1,37 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "backup — Set backup directory"
+- name: "Backup — Set backup directory"
   ansible.builtin.set_fact:
     upgrade_backup_dir: "/opt/omnia/.data/upgrade_backup/{{ upgrade_id }}"
 
-- name: "backup — Create backup directory"
+- name: "Backup — Create backup directory"
   ansible.builtin.file:
     path: "{{ upgrade_backup_dir }}"
     state: directory
     mode: '0755'
 
-- name: "backup — Backup software_config.json"
+- name: "Backup — Backup software_config.json"
   ansible.builtin.copy:
     src: "{{ input_project_dir }}/software_config.json"
     dest: "{{ upgrade_backup_dir }}/software_config.json"
     remote_src: true
     mode: '0644'
 
-- name: "backup — Backup local_repo_config.yml"
+- name: "Backup — Backup local_repo_config.yml"
   ansible.builtin.copy:
     src: "{{ input_project_dir }}/local_repo_config.yml"
     dest: "{{ upgrade_backup_dir }}/local_repo_config.yml"
     remote_src: true
     mode: '0644'
 
-- name: "backup — Backup upgrade_manifest.yml"
+- name: "Backup — Backup upgrade_manifest.yml"
   ansible.builtin.copy:
     src: "{{ role_path }}/../../upgrade_manifest.yml"
     dest: "{{ upgrade_backup_dir }}/upgrade_manifest.yml"
     mode: '0644'
 
-- name: "backup — Create backup manifest"
+- name: "Backup — Create backup manifest"
   ansible.builtin.copy:
     content: |
       # Upgrade Backup Manifest
@@ -39,12 +39,12 @@
       timestamp: {{ ansible_date_time.iso8601 }}
       source_omnia_version: {{ upgrade_source_version }}
       target_omnia_version: {{ upgrade_target_version }}
-      
+
       enabled_components:
       {% for component in enabled_components %}
         - name: {{ component.key }}
       {% endfor %}
-      
+
       files_backed_up:
         - software_config.json
         - local_repo_config.yml
@@ -52,7 +52,7 @@
     dest: "{{ upgrade_backup_dir }}/manifest.yml"
     mode: '0644'
 
-- name: "backup — Display backup info"
+- name: "Backup — Display backup info"
   ansible.builtin.debug:
     msg:
       - "✓ Backup created: {{ upgrade_backup_dir }}"

--- a/upgrade/roles/manage_upgrade_inputs/tasks/calculate_hop_chain.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/calculate_hop_chain.yml
@@ -1,7 +1,7 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "calculate_hops — Calculate hop chain from upgrade paths"
+- name: "Calculate hops — Calculate hop chain from upgrade paths"
   calculate_upgrade_hops:
     upgrade_config: "{{ upgrade_config }}"
     current_software_config: "{{ current_software_config }}"
@@ -9,16 +9,21 @@
     target_omnia_version: "{{ upgrade_target_version }}"
   register: _hop_calculation
 
-- name: "calculate_hops — Parse hop chain result"
+- name: "Calculate hops — Parse hop chain result"
   ansible.builtin.set_fact:
     calculated_hop_chains: "{{ _hop_calculation.hop_chains }}"
     total_upgrade_hops: "{{ _hop_calculation.total_hops }}"
     upgrade_mode: "{{ _hop_calculation.upgrade_mode }}"
 
-- name: "calculate_hops — Display calculated hop chain"
+- name: "Calculate hops — Display calculated hop chain"
   ansible.builtin.debug:
     msg:
       - "Calculated Hop Chain:"
       - "  Mode: {{ upgrade_mode }}"
       - "  Total hops: {{ total_upgrade_hops }}"
-      - "{% for hop in calculated_hop_chains %}  - {{ hop.software }}/{{ hop.hop_id }}: {{ hop.from_version }} → {{ hop.to_version }} (Omnia {{ hop.from_omnia_version }} → {{ hop.to_omnia_version }}){% endfor %}"
+      - >-
+        {% for hop in calculated_hop_chains %}
+        - {{ hop.software }}/{{ hop.hop_id }}: {{ hop.from_version }} →
+        {{ hop.to_version }} (Omnia {{ hop.from_omnia_version }} →
+        {{ hop.to_omnia_version }})
+        {% endfor %}

--- a/upgrade/roles/manage_upgrade_inputs/tasks/display_summary.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/display_summary.yml
@@ -1,7 +1,7 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "summary — Display upgrade input summary"
+- name: "Summary — Display upgrade input summary"
   ansible.builtin.debug:
     msg:
       - "=========================================="
@@ -11,14 +11,24 @@
       - "Mode: {{ upgrade_mode | default('single_hop') }}"
       - "Omnia: {{ upgrade_source_version }} → {{ upgrade_target_version }}"
       - ""
-      - "{% if upgrade_mode == 'multi_hop' %}Multi-Hop Upgrade Path:{% else %}Upgrade Path:{% endif %}"
-      - "{% for hop in calculated_hop_chains %}  - {{ hop.software }}/{{ hop.hop_id }}: {{ hop.from_version }} → {{ hop.to_version }} (Omnia {{ hop.from_omnia_version }} → {{ hop.to_omnia_version }}){% endfor %}"
+      - >-
+        {% if upgrade_mode == 'multi_hop' %}
+        Multi-Hop Upgrade Path:
+        {% else %}
+        Upgrade Path:
+        {% endif %}
+      - >-
+        {% for hop in calculated_hop_chains %}
+        - {{ hop.software }}/{{ hop.hop_id }}: {{ hop.from_version }} →
+        {{ hop.to_version }} (Omnia {{ hop.from_omnia_version }} →
+        {{ hop.to_omnia_version }})
+        {% endfor %}
       - ""
       - "Total Hops: {{ total_upgrade_hops }}"
       - "Backup: {{ upgrade_backup_dir }}"
       - "=========================================="
 
-- name: "summary — Set upgrade facts for downstream roles"
+- name: "Summary — Set upgrade facts for downstream roles"
   ansible.builtin.set_fact:
     upgrade_inputs_complete: true
     upgrade_backup_location: "{{ upgrade_backup_dir }}"

--- a/upgrade/roles/manage_upgrade_inputs/tasks/load_upgrade_manifest.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/load_upgrade_manifest.yml
@@ -1,54 +1,54 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "load — Check oim_metadata.yml exists"
+- name: "Load — Check oim_metadata.yml exists"
   ansible.builtin.stat:
     path: "/opt/omnia/.data/oim_metadata.yml"
   register: _oim_metadata_stat
 
-- name: "load — Fail if oim_metadata.yml not found"
+- name: "Load — Fail if oim_metadata.yml not found"
   ansible.builtin.fail:
     msg: |
       oim_metadata.yml not found at /opt/omnia/.data/oim_metadata.yml
       This file contains Omnia version information after omnia_core execution.
   when: not _oim_metadata_stat.stat.exists
 
-- name: "load — Load oim_metadata.yml"
+- name: "Load — Load oim_metadata.yml"
   ansible.builtin.include_vars:
     file: "/opt/omnia/.data/oim_metadata.yml"
     name: oim_metadata
 
-- name: "load — Check upgrade_manifest.yml exists"
+- name: "Load — Check upgrade_manifest.yml exists"
   ansible.builtin.stat:
     path: "{{ role_path }}/../../upgrade_manifest.yml"
   register: _upgrade_config_stat
 
-- name: "load — Fail if upgrade_manifest.yml not found"
+- name: "Load — Fail if upgrade_manifest.yml not found"
   ansible.builtin.fail:
     msg: |
       upgrade_manifest.yml not found at {{ role_path }}/../../upgrade_manifest.yml
       This file is the source of truth for upgrade paths and components.
   when: not _upgrade_config_stat.stat.exists
 
-- name: "load — Load upgrade_manifest.yml"
+- name: "Load — Load upgrade_manifest.yml"
   ansible.builtin.include_vars:
     file: "{{ role_path }}/../../upgrade_manifest.yml"
     name: upgrade_config
 
-- name: "load — Extract enabled components"
+- name: "Load — Extract enabled components"
   ansible.builtin.set_fact:
     enabled_components: >-
-      {{ upgrade_config.components | dict2items 
-         | selectattr('value.enabled', 'equalto', true) 
+      {{ upgrade_config.components | dict2items
+         | selectattr('value.enabled', 'equalto', true)
          | list }}
 
-- name: "load — Set upgrade metadata facts from oim_metadata.yml"
+- name: "Load — Set upgrade metadata facts from oim_metadata.yml"
   ansible.builtin.set_fact:
     upgrade_source_version: "{{ oim_metadata.omnia_previous_version }}"
     upgrade_target_version: "{{ oim_metadata.omnia_version }}"
     upgrade_id: "{{ lookup('pipe', 'date +%Y%m%d_%H%M%S') }}_{{ 99999 | random }}"
 
-- name: "load — Display loaded configuration"
+- name: "Load — Display loaded configuration"
   ansible.builtin.debug:
     msg:
       - "Upgrade Config Loaded:"

--- a/upgrade/roles/manage_upgrade_inputs/tasks/update_component_json_repos.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/update_component_json_repos.yml
@@ -20,7 +20,7 @@
 # that support versioned repositories (like slurm_custom).
 # ============================================================================
 
-- name: "json_repos - Update component JSON files with version-specific repo names"
+- name: "JSON repos — Update component JSON files with version-specific repo names"
   update_component_json_repos:
     input_dir: "{{ input_project_dir }}"
     calculated_hop_chains: "{{ calculated_hop_chains | default([]) }}"
@@ -30,11 +30,11 @@
       # Add other components here that support versioned repositories
   register: _json_repo_update_result
 
-- name: "json_repos - Parse update result"
+- name: "JSON repos — Parse update result"
   ansible.builtin.set_fact:
     _json_repo_update_summary: "{{ _json_repo_update_result }}"
 
-- name: "json_repos - Display update summary"
+- name: "JSON repos — Display update summary"
   ansible.builtin.debug:
     msg:
       - "=========================================="

--- a/upgrade/roles/manage_upgrade_inputs/tasks/update_software_config.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/update_software_config.yml
@@ -1,18 +1,18 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "update — Update software_config.json with target versions"
+- name: "Update — Update software_config.json with target versions"
   update_software_config:
     input_file: "{{ input_project_dir }}/software_config.json"
     hop_chains: "{{ calculated_hop_chains }}"
     upgrade_mode: "{{ upgrade_mode }}"
   register: _update_result
 
-- name: "update — Parse update result"
+- name: "Update — Parse update result"
   ansible.builtin.set_fact:
     _update_summary: "{{ _update_result }}"
 
-- name: "update — Display update results"
+- name: "Update — Display update results"
   ansible.builtin.debug:
     msg:
       - "✓ software_config.json updated"

--- a/upgrade/roles/manage_upgrade_inputs/tasks/validate_current_deployment.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/validate_current_deployment.yml
@@ -1,34 +1,34 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "validate — Load current software_config.json"
+- name: "Validate — Load current software_config.json"
   ansible.builtin.slurp:
     path: "{{ input_project_dir }}/software_config.json"
   register: _sw_config_content
 
-- name: "validate — Parse software_config.json"
+- name: "Validate — Parse software_config.json"
   ansible.builtin.set_fact:
     current_software_config: "{{ _sw_config_content.content | b64decode | from_json }}"
 
-- name: "validate — Extract current versions"
+- name: "Validate — Extract current versions"
   ansible.builtin.set_fact:
     current_versions: >-
-      {{ current_software_config.softwares 
+      {{ current_software_config.softwares
          | selectattr('version', 'defined')
          | items2dict(key_name='name', value_name='version') }}
 
-- name: "validate — Check oim_metadata for deployment info"
+- name: "Validate — Check oim_metadata for deployment info"
   ansible.builtin.slurp:
     path: /opt/omnia/.data/oim_metadata.yml
   register: _oim_metadata_content
   failed_when: false
 
-- name: "validate — Parse oim_metadata"
+- name: "Validate — Parse oim_metadata"
   ansible.builtin.set_fact:
     oim_metadata: "{{ _oim_metadata_content.content | b64decode | from_yaml }}"
   when: _oim_metadata_content is succeeded
 
-- name: "validate - Verify current versions exist for enabled components"
+- name: "Validate — Verify current versions exist for enabled components"
   ansible.builtin.assert:
     that:
       - current_versions[item.key] is defined
@@ -41,7 +41,7 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: "validate - Check Omnia upgrade paths exist for current version"
+- name: "Validate — Check Omnia upgrade paths exist for current version"
   ansible.builtin.assert:
     that:
       - upgrade_config.omnia_upgrade_paths[upgrade_source_version] is defined
@@ -52,16 +52,20 @@
   when: upgrade_source_version is defined
   run_once: true
 
-- name: "validate - Check JSON files exist for current version"
+- name: "Validate — Check JSON files exist for current version"
   ansible.builtin.stat:
-    path: "{{ input_project_dir }}/config/{{ item.1 }}/{{ current_software_config.cluster_os_type }}/{{ current_software_config.cluster_os_version }}/{{ item.0.key }}_v{{ current_versions[item.0.key] }}.json"
+    path: >-
+      {{ input_project_dir }}/config/{{ item.1 }}/{{
+      current_software_config.cluster_os_type }}/{{
+      current_software_config.cluster_os_version }}/{{
+      item.0.key }}_v{{ current_versions[item.0.key] }}.json
   register: _json_exists
   loop: "{{ enabled_components | product(upgrade_active_architectures) | list }}"
   loop_control:
     label: "{{ item.0.key }}/{{ item.1 }}"
   when: current_versions[item.0.key] is defined
 
-- name: "validate - Fail if JSON files missing"
+- name: "Validate — Fail if JSON files missing"
   ansible.builtin.fail:
     msg: |
       JSON file not found for {{ item.item.0.key }} version {{ current_versions[item.item.0.key] }}: {{ item.invocation.module_args.path }}
@@ -70,11 +74,11 @@
   loop: "{{ _json_exists.results }}"
   loop_control:
     label: "{{ item.item.0.key }}"
-  when: 
+  when:
     - item.stat is defined
     - not item.stat.exists
 
-- name: "validate — Display validation results"
+- name: "Validate — Display validation results"
   ansible.builtin.debug:
     msg:
       - "  Current deployment validated"

--- a/upgrade/roles/manage_upgrade_inputs/tasks/validate_hop_chains.yml
+++ b/upgrade/roles/manage_upgrade_inputs/tasks/validate_hop_chains.yml
@@ -1,7 +1,7 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 ---
 
-- name: "validate_hops - Process hop chains for multi-hop upgrades"
+- name: "Validate hops — Process hop chains for multi-hop upgrades"
   ansible.builtin.set_fact:
     _processed_hops: >-
       {%- set hops = [] -%}
@@ -21,13 +21,17 @@
       {%- endfor -%}
       {{ hops }}
 
-- name: "validate_hops - Display processed hops"
+- name: "Validate hops — Display processed hops"
   ansible.builtin.debug:
     msg:
       - "Processed {{ _processed_hops | length }} hop(s):"
-      - "{% for hop in _processed_hops %}  - {{ hop.software }}/{{ hop.hop_id }}: {{ hop.from_version }} -> {{ hop.to_version }} (Omnia {{ hop.omnia_version }}){% endfor %}"
+      - >-
+        {% for hop in _processed_hops %}
+        - {{ hop.software }}/{{ hop.hop_id }}: {{ hop.from_version }} ->
+        {{ hop.to_version }} (Omnia {{ hop.omnia_version }})
+        {% endfor %}
 
-- name: "validate_hops - Validate hop chain sequence"
+- name: "Validate hops — Validate hop chain sequence"
   ansible.builtin.assert:
     that:
       - item.from_version == current_versions.get(item.software, 'not_found')
@@ -41,15 +45,19 @@
     label: "{{ item.software }}/{{ item.hop_id }}"
   when: upgrade_mode == 'multi_hop'
 
-- name: "validate_hops - Check JSON files exist for all hop targets"
+- name: "Validate hops — Check JSON files exist for all hop targets"
   ansible.builtin.stat:
-    path: "{{ input_project_dir }}/config/{{ item.1 }}/{{ current_software_config.cluster_os_type }}/{{ current_software_config.cluster_os_version }}/{{ item.0.json_file }}"
+    path: >-
+      {{ input_project_dir }}/config/{{ item.1 }}/{{
+      current_software_config.cluster_os_type }}/{{
+      current_software_config.cluster_os_version }}/{{
+      item.0.json_file }}
   register: _hop_json_check
   loop: "{{ _processed_hops | product(upgrade_active_architectures) | list }}"
   loop_control:
     label: "{{ item.0.software }}/{{ item.0.hop_id }}/{{ item.1 }}"
 
-- name: "validate_hops - Fail if hop JSON files missing"
+- name: "Validate hops — Fail if hop JSON files missing"
   ansible.builtin.fail:
     msg: |
       JSON file not found for hop {{ item.0.software }}/{{ item.0.hop_id }}: {{ item.invocation.module_args.path }}
@@ -57,12 +65,12 @@
   loop: "{{ _hop_json_check.results }}"
   loop_control:
     label: "{{ item.0.software }}/{{ item.0.hop_id }}"
-  when: 
+  when:
     - item.stat is defined
     - not item.stat.exists
     - upgrade_mode == 'multi_hop'
 
-- name: "validate_hops - Set hop chain facts for downstream roles"
+- name: "Validate hops — Set hop chain facts for downstream roles"
   ansible.builtin.set_fact:
     upgrade_hop_chain: "{{ _processed_hops }}"
     total_upgrade_hops: "{{ _processed_hops | length }}"

--- a/upgrade/roles/prep_local_repo/tasks/create_staging.yml
+++ b/upgrade/roles/prep_local_repo/tasks/create_staging.yml
@@ -18,17 +18,17 @@
 # unnecessary re-syncing.
 # ============================================================================
 
-- name: "staging — Create staging directory"
+- name: "Staging — Create staging directory"
   ansible.builtin.tempfile:
     state: directory
     prefix: "upgrade_local_repo_"
   register: _staging_dir
 
-- name: "staging — Set staging path fact"
+- name: "Staging — Set staging path fact"
   ansible.builtin.set_fact:
     upgrade_staging_dir: "{{ _staging_dir.path }}"
 
-- name: "staging — Extract architectures from software_config.json"
+- name: "Staging — Extract architectures from software_config.json"
   ansible.builtin.set_fact:
     _all_architectures: >-
       {{
@@ -40,17 +40,17 @@
         | list
       }}
 
-- name: "staging — Set upgrade_active_architectures from software_config.json"
+- name: "Staging — Set upgrade_active_architectures from software_config.json"
   ansible.builtin.set_fact:
     upgrade_active_architectures: "{{ _all_architectures }}"
 
-- name: "staging — Display detected architectures"
+- name: "Staging — Display detected architectures"
   ansible.builtin.debug:
     msg:
       - "Architectures detected from software_config.json: {{ _all_architectures | join(', ') }}"
       - "Will process all detected architectures for upgrade"
 
-- name: "staging — Create staging with modified configs"
+- name: "Staging — Create staging with modified configs"
   create_upgrade_staging:
     staging_dir: "{{ _staging_dir.path }}"
     input_dir: "{{ input_project_dir }}"
@@ -62,11 +62,11 @@
     calculated_hop_chains: "{{ calculated_hop_chains | default([]) }}"
   register: _staging_result
 
-- name: "staging — Parse staging result"
+- name: "Staging — Parse staging result"
   ansible.builtin.set_fact:
     _staging_summary: "{{ _staging_result }}"
 
-- name: "staging — Display staging summary"
+- name: "Staging — Display staging summary"
   ansible.builtin.debug:
     msg:
       - "=========================================="

--- a/upgrade/roles/prep_local_repo/tasks/load_upgrade_manifest.yml
+++ b/upgrade/roles/prep_local_repo/tasks/load_upgrade_manifest.yml
@@ -9,22 +9,22 @@
 # skips redundant loading.
 # ============================================================================
 
-- name: "load_config — Check if upgrade_config already loaded"
+- name: "Load config — Check if upgrade_config already loaded"
   ansible.builtin.set_fact:
     _config_already_loaded: "{{ upgrade_config is defined and upgrade_config.components is defined }}"
 
-- name: "load_config — Skip loading if already available"
+- name: "Load config — Skip loading if already available"
   ansible.builtin.debug:
     msg: "Upgrade config already loaded from manage_upgrade_inputs, skipping reload"
   when: _config_already_loaded | bool
 
-- name: "load_config — Check if upgrade_manifest.yml exists"
+- name: "Load config — Check if upgrade_manifest.yml exists"
   ansible.builtin.stat:
     path: "{{ role_path }}/../../upgrade_manifest.yml"
   register: _upgrade_config_stat
   when: not (_config_already_loaded | bool)
 
-- name: "load_config — Fail if upgrade_manifest.yml not found"
+- name: "Load config — Fail if upgrade_manifest.yml not found"
   ansible.builtin.fail:
     msg: |
       upgrade_manifest.yml not found at {{ role_path }}/../../upgrade_manifest.yml
@@ -34,48 +34,48 @@
     - not (_config_already_loaded | bool)
     - not _upgrade_config_stat.stat.exists
 
-- name: "load_config — Load upgrade_manifest.yml"
+- name: "Load config — Load upgrade_manifest.yml"
   ansible.builtin.include_vars:
     file: "{{ role_path }}/../../upgrade_manifest.yml"
     name: upgrade_config
   when: not (_config_already_loaded | bool)
 
-- name: "load_config — Validate upgrade_config structure"
+- name: "Load config — Validate upgrade_config structure"
   ansible.builtin.assert:
     that:
       - upgrade_config.components is defined
     fail_msg: "upgrade_manifest.yml is missing required sections (components)"
   when: not (_config_already_loaded | bool)
 
-- name: "load_config — Check if oim_metadata.yml exists"
+- name: "Load config — Check if oim_metadata.yml exists"
   ansible.builtin.stat:
     path: "/opt/omnia/.data/oim_metadata.yml"
   register: _oim_metadata_stat
 
-- name: "load_config — Fail if oim_metadata.yml not found"
+- name: "Load config — Fail if oim_metadata.yml not found"
   ansible.builtin.fail:
     msg: |
       oim_metadata.yml not found at /opt/omnia/.data/oim_metadata.yml
       This file contains Omnia version information after omnia_core execution.
   when: not _oim_metadata_stat.stat.exists
 
-- name: "load_config — Load oim_metadata.yml"
+- name: "Load config — Load oim_metadata.yml"
   ansible.builtin.include_vars:
     file: "/opt/omnia/.data/oim_metadata.yml"
     name: oim_metadata
 
-- name: "load_config — Extract enabled components"
+- name: "Load config — Extract enabled components"
   ansible.builtin.set_fact:
     _enabled_components: >-
-      {{ upgrade_config.components | dict2items 
-         | selectattr('value.enabled', 'equalto', true) 
+      {{ upgrade_config.components | dict2items
+         | selectattr('value.enabled', 'equalto', true)
          | list }}
 
-- name: "load_config — Set upgrade target version from oim_metadata.yml"
+- name: "Load config — Set upgrade target version from oim_metadata.yml"
   ansible.builtin.set_fact:
     upgrade_target_version: "{{ oim_metadata.omnia_version }}"
 
-- name: "load_config — Display upgrade configuration"
+- name: "Load config — Display upgrade configuration"
   ansible.builtin.debug:
     msg:
       - "=========================================="

--- a/upgrade/roles/prep_local_repo/tasks/sync_local_repo.yml
+++ b/upgrade/roles/prep_local_repo/tasks/sync_local_repo.yml
@@ -12,12 +12,12 @@
 # We initialise those variables here so the role works standalone.
 # ============================================================================
 
-- name: "sync — Set input_project_dir to staging for local_repo roles"
+- name: "Sync — Set input_project_dir to staging for local_repo roles"
   ansible.builtin.set_fact:
     _original_input_project_dir: "{{ input_project_dir }}"
     input_project_dir: "{{ upgrade_staging_dir }}"
 
-- name: "sync — Set variables for local_repo roles"
+- name: "Sync — Set variables for local_repo roles"
   ansible.builtin.set_fact:
     sw_config_json_path: "{{ upgrade_staging_dir }}/software_config.json"
     local_repo_config_file: "{{ upgrade_staging_dir }}/local_repo_config.yml"
@@ -28,35 +28,35 @@
     playbook_start_time: "{{ ansible_date_time.epoch }}"
 
 # Initialise sub_final_repo_urls (normally set by validate_subscription role)
-- name: "sync — Initialise subscription repo URLs"
+- name: "Sync — Initialise subscription repo URLs"
   ansible.builtin.set_fact:
     sub_final_repo_urls: "{{ sub_final_repo_urls | default({}) }}"
 
 # Get actual Pulp URL from pulp status command (same as pulp_validation role)
-- name: "sync — Get Pulp status"
+- name: "Sync — Get Pulp status"
   ansible.builtin.command: /usr/local/bin/pulp status
   delegate_to: localhost
   changed_when: false
   register: _pulp_status_output
 
-- name: "sync — Set Pulp connection variables from pulp status"
+- name: "Sync — Set Pulp connection variables from pulp status"
   ansible.builtin.set_fact:
     pulp_content_origin: "{{ (_pulp_status_output.stdout | from_json).content_settings.content_origin }}"
 
-- name: "sync — Parse Pulp connection details"
+- name: "Sync — Parse Pulp connection details"
   ansible.builtin.set_fact:
     pulp_protocol: "{{ pulp_content_origin | urlsplit('scheme') | lower }}"
     pulp_server_ip: "{{ pulp_content_origin | urlsplit('hostname') }}"
     pulp_server_port: "{{ pulp_content_origin | urlsplit('port') }}"
 
-- name: "sync — Add oim host to inventory"
+- name: "Sync — Add oim host to inventory"
   ansible.builtin.add_host:
     name: oim
     pulp_protocol: "{{ pulp_protocol }}"
     pulp_server_port: "{{ pulp_server_port }}"
     ansible_connection: local
 
-- name: "sync — Display sync configuration"
+- name: "Sync — Display sync configuration"
   ansible.builtin.debug:
     msg:
       - "Starting local repo sync..."
@@ -64,19 +64,19 @@
       - "Softwares: {{ software_names | join(', ') }}"
       - "Pulp: {{ pulp_content_origin }}"
 
-- name: "sync — Run validation role"
+- name: "Sync — Run validation role"
   ansible.builtin.include_role:
     name: "{{ role_path }}/../../../local_repo/roles/validation"
 
-- name: "sync — Run parse_and_download role"
+- name: "Sync — Run parse_and_download role"
   ansible.builtin.include_role:
     name: "{{ role_path }}/../../../local_repo/roles/parse_and_download"
 
-- name: "sync — Restore original input_project_dir"
+- name: "Sync — Restore original input_project_dir"
   ansible.builtin.set_fact:
     input_project_dir: "{{ _original_input_project_dir }}"
 
-- name: "sync — Display sync completion"
+- name: "Sync — Display sync completion"
   ansible.builtin.debug:
     msg:
       - "=========================================="

--- a/upgrade/roles/prep_local_repo/tasks/validate_prerequisites.yml
+++ b/upgrade/roles/prep_local_repo/tasks/validate_prerequisites.yml
@@ -7,34 +7,34 @@
 # Reuses current_software_config from manage_upgrade_inputs if available.
 # ============================================================================
 
-- name: "validate — Check if software config already loaded"
+- name: "Validate — Check if software config already loaded"
   ansible.builtin.set_fact:
     _sw_config_already_loaded: "{{ current_software_config is defined and current_software_config.softwares is defined }}"
 
-- name: "validate — Reuse existing software config"
+- name: "Validate — Reuse existing software config"
   ansible.builtin.set_fact:
     _current_software_config: "{{ current_software_config }}"
   when: _sw_config_already_loaded | bool
 
-- name: "validate — Load current software_config.json"
+- name: "Validate — Load current software_config.json"
   ansible.builtin.slurp:
     path: "{{ input_project_dir }}/software_config.json"
   register: _current_sw_config
   when: not (_sw_config_already_loaded | bool)
 
-- name: "validate — Parse software_config.json"
+- name: "Validate — Parse software_config.json"
   ansible.builtin.set_fact:
     _current_software_config: "{{ _current_sw_config.content | b64decode | from_json }}"
   when: not (_sw_config_already_loaded | bool)
 
-- name: "validate - Extract current versions for enabled components"
+- name: "Validate — Extract current versions for enabled components"
   ansible.builtin.set_fact:
     _current_versions: >-
-      {{ _current_software_config.softwares 
+      {{ _current_software_config.softwares
          | selectattr('name', 'in', _enabled_components | map(attribute='key') | list)
          | items2dict(key_name='name', value_name='version') }}
 
-- name: "validate - Verify current versions exist for enabled components"
+- name: "Validate — Verify current versions exist for enabled components"
   ansible.builtin.assert:
     that:
       - _current_versions[item.key] is defined
@@ -47,16 +47,20 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: "validate - Check current version JSON files exist in input directory"
+- name: "Validate — Check current version JSON files exist in input directory"
   ansible.builtin.stat:
-    path: "{{ input_project_dir }}/config/{{ item.1 }}/{{ _current_software_config.cluster_os_type }}/{{ _current_software_config.cluster_os_version }}/{{ item.0.key }}_v{{ _current_versions[item.0.key] }}.json"
+    path: >-
+      {{ input_project_dir }}/config/{{ item.1 }}/{{
+      _current_software_config.cluster_os_type }}/{{
+      _current_software_config.cluster_os_version }}/{{
+      item.0.key }}_v{{ _current_versions[item.0.key] }}.json
   register: _json_file_check
   loop: "{{ _enabled_components | product(upgrade_active_architectures) | list }}"
   loop_control:
     label: "{{ item.0.key }} ({{ item.1 }})"
   when: _current_versions[item.0.key] is defined
 
-- name: "validate - Verify JSON files exist"
+- name: "Validate — Verify JSON files exist"
   ansible.builtin.assert:
     that:
       - item.stat.exists
@@ -69,17 +73,17 @@
     label: "{{ item.invocation.module_args.path | basename }}"
   when: item.stat is defined
 
-- name: "validate — Check repos.yml exists"
+- name: "Validate — Check repos.yml exists"
   ansible.builtin.stat:
     path: "{{ role_path }}/../../artifacts/repos.yml"
   register: _repos_yml_stat
 
-- name: "validate — Warn if repos.yml not found"
+- name: "Validate — Warn if repos.yml not found"
   ansible.builtin.debug:
     msg: "Warning: repos.yml not found at {{ role_path }}/../../artifacts/repos.yml - upgrade repos may not be available"
   when: not _repos_yml_stat.stat.exists
 
-- name: "validate - Display validation summary"
+- name: "Validate — Display validation summary"
   ansible.builtin.debug:
     msg:
       - "  Prerequisites validated"


### PR DESCRIPTION
Implemented input configuration transformation logic to convert Omnia 2.1 configuration files to 2.2 format for build_stream_config.yml, gitlab_config.yml, network_spec.yml, provision_config.yml, and telemetry_config.yml. Added to list previous omnia version as part of oim_metadata.yml after upgrade.