### PR TITLE
Implement validate stage molecule execution, request generation & result polling with database update.

### DIFF
--- a/build_stream/api/local_repo/routes.py
+++ b/build_stream/api/local_repo/routes.py
@@ -29,6 +29,7 @@ from api.logging_utils import log_secure_info
 from core.jobs.exceptions import (
     InvalidStateTransitionError,
     JobNotFoundError,
+    StageAlreadyCompletedError,
     TerminalStateViolationError,
     UpstreamStageNotCompletedError,
 )
@@ -176,6 +177,22 @@ def create_local_repository(
             status_code=status.HTTP_409_CONFLICT,
             detail=_build_error_response(
                 "INVALID_STATE_TRANSITION",
+                exc.message,
+                correlation_id.value,
+            ).model_dump(),
+        ) from exc
+
+    except StageAlreadyCompletedError as exc:
+        log_secure_info(
+            "warning",
+            f"Local repo failed: job_id={job_id}, reason=stage_already_completed, status=409",
+            job_id=job_id,
+            end_section=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_build_error_response(
+                "STAGE_ALREADY_COMPLETED",
                 exc.message,
                 correlation_id.value,
             ).model_dump(),

--- a/build_stream/core/jobs/entities/stage.py
+++ b/build_stream/core/jobs/entities/stage.py
@@ -14,9 +14,9 @@
 
 """Stage entity within Job aggregate."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from ..exceptions import InvalidStateTransitionError, TerminalStateViolationError
 from ..value_objects import JobId, StageName, StageState
@@ -51,6 +51,7 @@ class Stage:
     error_code: Optional[str] = None
     error_summary: Optional[str] = None
     log_file_path: Optional[str] = None
+    result_detail: Optional[Dict[str, Any]] = None
     version: int = 1
 
     def _initialize_timestamps(self) -> None:

--- a/build_stream/core/localrepo/entities.py
+++ b/build_stream/core/localrepo/entities.py
@@ -111,6 +111,9 @@ class PlaybookResult:
     timestamp: str = ""
     log_file_path: Optional[str] = None
     node_results_file_path: Optional[str] = None
+    correlation_id: Optional[str] = None
+    test_summary: Optional[Dict[str, Any]] = None
+    artifact_dir: Optional[str] = None
 
     @property
     def is_success(self) -> bool:
@@ -152,6 +155,9 @@ class PlaybookResult:
             timestamp=data.get("timestamp", ""),
             log_file_path=data.get("log_file_path"),
             node_results_file_path=data.get("node_results_file_path"),
+            correlation_id=data.get("correlation_id"),
+            test_summary=data.get("test_summary"),
+            artifact_dir=data.get("artifact_dir"),
         )
 
 

--- a/build_stream/infra/db/mappers.py
+++ b/build_stream/infra/db/mappers.py
@@ -117,6 +117,7 @@ class StageMapper:
             error_code=stage.error_code,
             error_summary=stage.error_summary,
             log_file_path=stage.log_file_path,
+            result_detail=stage.result_detail,
             version=stage.version,
         )
 
@@ -140,6 +141,7 @@ class StageMapper:
             error_code=model.error_code,
             error_summary=model.error_summary,
             log_file_path=model.log_file_path,
+            result_detail=model.result_detail,
             version=model.version,
         )
 

--- a/build_stream/infra/db/repositories.py
+++ b/build_stream/infra/db/repositories.py
@@ -186,6 +186,7 @@ class SqlStageRepository:
             existing.error_code = stage.error_code
             existing.error_summary = stage.error_summary
             existing.log_file_path = stage.log_file_path
+            existing.result_detail = stage.result_detail
             existing.version = stage.version
         else:
             stage_model = StageMapper.to_orm(stage)

--- a/build_stream/orchestrator/common/result_poller.py
+++ b/build_stream/orchestrator/common/result_poller.py
@@ -301,6 +301,12 @@ class ResultPoller:
                 return
 
             if result.status == "success":
+                # For validate stage, populate result_detail BEFORE complete() to avoid version conflict
+                if result.stage_name == "validate":
+                    stage.result_detail = self._build_validate_result_detail(
+                        result, outcome="PASSED"
+                    )
+
                 stage.complete()
                 log_secure_info(
                     "info",
@@ -312,7 +318,7 @@ class ResultPoller:
                 if self._is_build_image_stage(result.stage_name):
                     self._on_build_image_success(result)
 
-                # On validate success, mark job as PASSED
+                # On validate success, mark ImageGroup PASSED
                 if result.stage_name == "validate":
                     self._on_validate_success(result)
                     JobStateHelper.handle_job_completion(
@@ -321,9 +327,9 @@ class ResultPoller:
                         uuid_generator=self._uuid_generator,
                         job_id=JobId(result.job_id),
                         correlation_id=(
-                            result.request_id.value
-                            if hasattr(result.request_id, 'value')
-                            else str(result.request_id)
+                            str(result.correlation_id)
+                            if getattr(result, "correlation_id", None)
+                            else str(self._uuid_generator.generate())
                         ),
                         client_id=str(result.job_id),
                     )
@@ -338,6 +344,13 @@ class ResultPoller:
             else:
                 error_code = result.error_code or "PLAYBOOK_FAILED"
                 error_summary = result.error_summary or "Playbook execution failed"
+
+                # For validate stage, populate result_detail BEFORE fail() to avoid version conflict
+                if result.stage_name == "validate":
+                    stage.result_detail = self._build_validate_result_detail(
+                        result, outcome="FAILED"
+                    )
+
                 stage.fail(error_code=error_code, error_summary=error_summary)
                 log_secure_info(
                     "warning",
@@ -350,6 +363,10 @@ class ResultPoller:
                 if result.stage_name == "restart":
                     self._on_restart_completed(result)
 
+                # On validate failure, mark ImageGroup FAILED
+                if result.stage_name == "validate":
+                    self._on_validate_failure(result)
+
                 # Update job state to FAILED when stage fails
                 JobStateHelper.handle_stage_failure(
                     job_repo=self._job_repo,
@@ -360,9 +377,9 @@ class ResultPoller:
                     error_code=error_code,
                     error_summary=error_summary,
                     correlation_id=(
-                        result.request_id.value
-                        if hasattr(result.request_id, 'value')
-                        else str(result.request_id)
+                        str(result.correlation_id)
+                        if getattr(result, "correlation_id", None)
+                        else str(self._uuid_generator.generate())
                     ),
                     client_id=str(result.job_id),
                 )
@@ -376,15 +393,21 @@ class ResultPoller:
                     job_id=str(result.job_id),
                 )
 
-            # Save updated stage
+            # Save updated stage and commit immediately to avoid stale API responses
             self._stage_repo.save(stage)
+            if hasattr(self._stage_repo, 'session'):
+                self._stage_repo.session.commit()
 
             # Emit audit event
             event = AuditEvent(
                 event_id=str(self._uuid_generator.generate()),
                 job_id=result.job_id,
                 event_type="STAGE_COMPLETED" if result.status == "success" else "STAGE_FAILED",
-                correlation_id=result.request_id,
+                correlation_id=(
+                    str(result.correlation_id)
+                    if getattr(result, "correlation_id", None)
+                    else str(self._uuid_generator.generate())
+                ),
                 client_id=result.job_id,  # Using job_id as client_id placeholder
                 timestamp=datetime.now(timezone.utc),
                 details={
@@ -396,10 +419,7 @@ class ResultPoller:
             )
             self._audit_repo.save(event)
 
-            # Commit both repositories if using SQL
-            # Note: Each repository may have its own session, so commit both
-            if hasattr(self._stage_repo, 'session'):
-                self._stage_repo.session.commit()
+            # Commit audit event if using SQL
             if hasattr(self._audit_repo, 'session'):
                 self._audit_repo.session.commit()
 
@@ -813,41 +833,111 @@ class ResultPoller:
                 exc_info=True,
             )
 
-    def _on_validate_success(self, result: PlaybookResult) -> None:
-        """Copy test report artifacts to artifact store on validate success.
+    def _build_validate_result_detail(self, result: PlaybookResult, outcome: str) -> dict:
+        """Build result_detail JSONB for validate stage per spec §9.3."""
+        artifact_dir = result.artifact_dir or ""
+        detail = {
+            "outcome": outcome,
+            "exit_code": result.exit_code,
+            "test_summary": result.test_summary or {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "errors": 0},
+            "duration_seconds": result.duration_seconds,
+            "artifact_dir": artifact_dir,
+            "report_path": str(Path(artifact_dir) / "test_report.html") if artifact_dir else "",
+            "correlation_id": str(result.request_id),
+        }
+        if outcome == "FAILED":
+            detail["error_message"] = (
+                result.error_summary
+                or f"Molecule exited with code {result.exit_code}"
+            )
+        return detail
 
-        Copies test_report.json, test_report.html, molecule_output.log,
-        and junit.xml to {artifacts_base}/{job_id}/validate/attempt_{N}/.
-        """
+    def _on_validate_success(self, result: PlaybookResult) -> None:
+        """Transition ImageGroup to PASSED on validate success."""
+        if self._image_group_repo is None:
+            log_secure_info(
+                "warning",
+                f"ImageGroup repo not available; skipping validate status "
+                f"update for job={result.job_id}",
+                job_id=str(result.job_id),
+            )
+            return
+
         try:
+            image_group = self._image_group_repo.find_by_job_id(
+                JobId(str(result.job_id))
+            )
+            if image_group is None:
+                log_secure_info(
+                    "warning",
+                    f"Validate success: No ImageGroup found for job={result.job_id}",
+                    job_id=str(result.job_id),
+                )
+                return
+
+            self._image_group_repo.update_status(
+                image_group_id=image_group.id,
+                new_status=ImageGroupStatus.PASSED,
+            )
+            if hasattr(self._image_group_repo, 'session'):
+                self._image_group_repo.session.commit()
+
             log_secure_info(
                 "info",
                 f"Validate SUCCESS for job={result.job_id}. "
-                f"Processing test artifacts.",
+                f"ImageGroup '{image_group.id}' -> PASSED. "
+                f"test_summary={result.test_summary}",
                 job_id=str(result.job_id),
             )
         except Exception as exc:  # pylint: disable=broad-except
             log_secure_info(
                 "error",
-                f"Failed to process validate artifacts for job={result.job_id}: {exc}",
+                f"Failed to update ImageGroup to PASSED for job={result.job_id}: {exc}",
                 job_id=str(result.job_id),
                 exc_info=True,
             )
 
     def _on_validate_failure(self, result: PlaybookResult) -> None:
-        """Copy partial test report artifacts on validate failure."""
+        """Transition ImageGroup to FAILED on validate failure."""
+        if self._image_group_repo is None:
+            log_secure_info(
+                "warning",
+                f"ImageGroup repo not available; skipping validate failure "
+                f"update for job={result.job_id}",
+                job_id=str(result.job_id),
+            )
+            return
+
         try:
+            image_group = self._image_group_repo.find_by_job_id(
+                JobId(str(result.job_id))
+            )
+            if image_group is None:
+                log_secure_info(
+                    "warning",
+                    f"Validate failure: No ImageGroup found for job={result.job_id}",
+                    job_id=str(result.job_id),
+                )
+                return
+
+            self._image_group_repo.update_status(
+                image_group_id=image_group.id,
+                new_status=ImageGroupStatus.FAILED,
+            )
+            if hasattr(self._image_group_repo, 'session'):
+                self._image_group_repo.session.commit()
+
             log_secure_info(
                 "warning",
                 f"Validate FAILED for job={result.job_id}. "
-                f"exit_code={result.exit_code}, error={result.error_summary}. "
-                f"Processing partial artifacts.",
+                f"ImageGroup '{image_group.id}' -> FAILED. "
+                f"exit_code={result.exit_code}, error={result.error_summary}",
                 job_id=str(result.job_id),
             )
         except Exception as exc:  # pylint: disable=broad-except
             log_secure_info(
                 "error",
-                f"Failed to process validate failure artifacts for job={result.job_id}: {exc}",
+                f"Failed to update ImageGroup to FAILED for job={result.job_id}: {exc}",
                 job_id=str(result.job_id),
                 exc_info=True,
             )

--- a/build_stream/orchestrator/validate/use_cases/validate.py
+++ b/build_stream/orchestrator/validate/use_cases/validate.py
@@ -169,20 +169,18 @@ class ValidateUseCase:
                 correlation_id=str(command.correlation_id),
             )
 
-        # Check no active validate stage (QUEUED or IN_PROGRESS)
+        # Check no active validate stage (IN_PROGRESS only)
+        # PENDING is allowed since it means nothing is running
         validate_stage_name = StageName(StageType.VALIDATE.value)
         validate_stage = self._stage_repo.find_by_job_and_name(
             command.job_id, validate_stage_name
         )
-        if validate_stage is not None and validate_stage.stage_state in (
-            StageState.PENDING,
-            StageState.IN_PROGRESS,
-        ):
+        if validate_stage is not None and validate_stage.stage_state == StageState.IN_PROGRESS:
             raise InvalidStateTransitionError(
                 entity_type="Stage",
                 entity_id=f"{command.job_id}/validate",
                 from_state=validate_stage.stage_state.value,
-                to_state="QUEUED",
+                to_state=StageState.IN_PROGRESS.value,
                 correlation_id=str(command.correlation_id),
             )
 
@@ -363,7 +361,7 @@ class ValidateUseCase:
         return ValidateResponse(
             job_id=str(command.job_id),
             stage_name=StageType.VALIDATE.value,
-            status="QUEUED",
+            status="accepted",
             submitted_at=request.submitted_at,
             correlation_id=str(command.correlation_id),
             attempt=attempt,

--- a/build_stream/orchestrator/validate/use_cases/validate.py
+++ b/build_stream/orchestrator/validate/use_cases/validate.py
@@ -209,7 +209,13 @@ class ValidateUseCase:
             existing_stage.stage_state = StageState.PENDING
             existing_stage.attempt = attempt
             existing_stage.version = existing_stage.version + 1  # Increment version for optimistic locking
+            existing_stage.error_code = None  # Clear error fields from previous attempt
+            existing_stage.error_summary = None
+            existing_stage.ended_at = None  # Clear ended_at from previous attempt
+            existing_stage.result_detail = None  # Clear result_detail from previous attempt
             self._stage_repo.save(existing_stage)
+            if hasattr(self._stage_repo, 'session'):
+                self._stage_repo.session.commit()
             return existing_stage
         else:
             # Create new stage if none exists
@@ -220,6 +226,8 @@ class ValidateUseCase:
                 attempt=attempt,
             )
             self._stage_repo.save(stage)
+            if hasattr(self._stage_repo, 'session'):
+                self._stage_repo.session.commit()
             return stage
 
     def _transition_job_to_validating(self, command: ValidateCommand) -> None:
@@ -274,6 +282,8 @@ class ValidateUseCase:
         try:
             stage.start()
             self._stage_repo.save(stage)
+            if hasattr(self._stage_repo, 'session'):
+                self._stage_repo.session.commit()
         except Exception as save_exc:
             log_secure_info(
                 "warning",

--- a/build_stream/orchestrator/validate/use_cases/validate.py
+++ b/build_stream/orchestrator/validate/use_cases/validate.py
@@ -200,15 +200,29 @@ class ValidateUseCase:
         return 1
 
     def _create_stage(self, command: ValidateCommand, attempt: int) -> Stage:
-        """Create a new job_stages record with status QUEUED."""
-        stage = Stage(
-            job_id=command.job_id,
-            stage_name=StageName(StageType.VALIDATE.value),
-            stage_state=StageState.PENDING,
-            attempt=attempt,
+        """Create or update a job_stages record with status QUEUED."""
+        validate_stage_name = StageName(StageType.VALIDATE.value)
+        existing_stage = self._stage_repo.find_by_job_and_name(
+            command.job_id, validate_stage_name
         )
-        self._stage_repo.save(stage)
-        return stage
+        
+        if existing_stage is not None:
+            # Update existing stage instead of creating duplicate
+            existing_stage.stage_state = StageState.PENDING
+            existing_stage.attempt = attempt
+            existing_stage.version = existing_stage.version + 1  # Increment version for optimistic locking
+            self._stage_repo.save(existing_stage)
+            return existing_stage
+        else:
+            # Create new stage if none exists
+            stage = Stage(
+                job_id=command.job_id,
+                stage_name=validate_stage_name,
+                stage_state=StageState.PENDING,
+                attempt=attempt,
+            )
+            self._stage_repo.save(stage)
+            return stage
 
     def _transition_job_to_validating(self, command: ValidateCommand) -> None:
         """Update job status to VALIDATING (IN_PROGRESS)."""

--- a/build_stream/playbook-watcher/playbook_watcher_service.py
+++ b/build_stream/playbook-watcher/playbook_watcher_service.py
@@ -458,8 +458,14 @@ def parse_request_file(request_path: Path) -> Optional[Dict[str, Any]]:
             )
             return None
 
-        # Validate required fields
-        required_fields = ["job_id", "stage_name", "playbook_path"]
+        # Validate required fields - different for molecule vs ansible-playbook
+        command_type = request_data.get("command_type", "ansible-playbook")
+        
+        if command_type == "test_automation":
+            required_fields = ["job_id", "stage_type", "command_type", "scenario_names", "artifact_dir", "config_path"]
+        else:
+            required_fields = ["job_id", "stage_name", "playbook_path"]
+            
         missing_fields = [field for field in required_fields if field not in request_data]
 
         if missing_fields:
@@ -468,23 +474,59 @@ def parse_request_file(request_path: Path) -> Optional[Dict[str, Any]]:
 
         # Validate inputs to prevent injection
         job_id = str(request_data["job_id"])
-        stage_name = str(request_data["stage_name"])
-        playbook_name = str(request_data["playbook_path"])  # This is actually the playbook name
-
+        
         if not validate_job_id(job_id):
             log_secure_info("error", "Invalid job_id format in request", job_id[:8])
             return None
 
-        if not validate_stage_name(stage_name):
-            log_secure_info("error", "Invalid stage_name format in request", stage_name[:8])
-            return None
+        if command_type == "test_automation":
+            # Validate molecule-specific fields
+            stage_type = str(request_data["stage_type"])
+            scenario_names = request_data["scenario_names"]
+            artifact_dir = str(request_data["artifact_dir"])
+            config_path = str(request_data["config_path"])
+            
+            if not validate_stage_name(stage_type):
+                log_secure_info("error", "Invalid stage_type format in request", stage_type[:8])
+                return None
+                
+            # Validate scenario names
+            if not isinstance(scenario_names, list) or not scenario_names:
+                log_secure_info("error", "scenario_names must be a non-empty list", job_id[:8])
+                return None
+                
+            for scenario in scenario_names:
+                if not isinstance(scenario, str) or not validate_stage_name(scenario):
+                    log_secure_info("error", "Invalid scenario name format", str(scenario)[:8])
+                    return None
+                    
+            # Validate paths are within /opt/omnia/
+            if not artifact_dir.startswith("/opt/omnia/") or ".." in artifact_dir:
+                log_secure_info("error", "Invalid artifact_dir path", artifact_dir[:8])
+                return None
+                
+            if not config_path.startswith("/opt/omnia/") or ".." in config_path:
+                log_secure_info("error", "Invalid config_path", config_path[:8])
+                return None
+        else:
+            # Original ansible-playbook validation
+            stage_name = str(request_data["stage_name"])
+            playbook_name = str(request_data["playbook_path"])  # This is actually the playbook name
 
-        # Map the playbook name to its full path
-        # This returns the full path or None if validation fails
-        full_playbook_path = map_playbook_name_to_path(playbook_name)
-        if full_playbook_path is None:
-            log_secure_info("error", "Invalid or unknown playbook name in request", playbook_name[:8])
-            return None
+            if not validate_stage_name(stage_name):
+                log_secure_info("error", "Invalid stage_name format in request", stage_name[:8])
+                return None
+
+            # Map the playbook name to its full path
+            # This returns the full path or None if validation fails
+            full_playbook_path = map_playbook_name_to_path(playbook_name)
+            if full_playbook_path is None:
+                log_secure_info("error", "Invalid or unknown playbook name in request", playbook_name[:8])
+                return None
+                
+            # Store both the original playbook name and the mapped full path
+            request_data["playbook_name"] = playbook_name
+            request_data["full_playbook_path"] = full_playbook_path
 
         # Set defaults
         request_data.setdefault("correlation_id", job_id)
@@ -529,20 +571,10 @@ def parse_request_file(request_path: Path) -> Optional[Dict[str, Any]]:
             # Remove extra_args from request_data
             del request_data["extra_args"]
 
-        # Store both the original playbook name and the mapped full path
-        # The full path will be used for command execution
-        request_data["playbook_name"] = playbook_name
-        request_data["full_playbook_path"] = full_playbook_path
-
         log_secure_info(
             "info",
             "Parsed request for job",
             job_id
-        )
-        log_secure_info(
-            "debug",
-            "Stage name",
-            stage_name
         )
 
         return request_data
@@ -925,6 +957,183 @@ def execute_playbook(request_data: Dict[str, Any]) -> Dict[str, Any]:
             "timestamp": completed_at.isoformat(),
         }
 
+
+def execute_molecule(request_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute Molecule test automation and capture results.
+    
+    Args:
+        request_data: Parsed request dictionary with molecule-specific fields
+        
+    Returns:
+        Result dictionary with execution details
+    """
+    job_id = request_data["job_id"]
+    stage_type = request_data["stage_type"]
+    scenario_names = request_data["scenario_names"]
+    artifact_dir = request_data["artifact_dir"]
+    config_path = request_data["config_path"]
+    test_suite = request_data.get("test_suite", "")
+    timeout_minutes = request_data.get("timeout_minutes", 120)
+    correlation_id = request_data.get("correlation_id", job_id)
+    
+    log_secure_info("info", "Executing molecule for job", job_id)
+    log_secure_info("debug", "Stage type", stage_type)
+    log_secure_info("debug", "Scenarios", str(scenario_names))
+    
+    started_at = datetime.now(timezone.utc)
+    
+    # Ensure artifact directory exists
+    try:
+        os.makedirs(artifact_dir, exist_ok=True)
+    except OSError as e:
+        log_secure_info("error", "Failed to create artifact directory", job_id)
+        return {
+            "job_id": job_id,
+            "stage_type": stage_type,
+            "request_id": request_data.get("request_id", job_id),
+            "correlation_id": correlation_id,
+            "status": "FAILED",
+            "exit_code": 2,
+            "error_message": f"Failed to create artifact directory: {e}",
+            "started_at": started_at.isoformat(),
+            "completed_at": started_at.isoformat(),
+            "duration_seconds": 0,
+            "timestamp": started_at.isoformat(),
+        }
+    
+    # Build molecule command - execute directly on OIM host, not via podman exec
+    # run_molecule.sh format: run_molecule.sh <scenario> <command> [--suite <suite>] [--marker <marker>]
+    cmd = [
+        "bash", "/opt/omnia/automation/run_molecule.sh",
+        scenario_names[0],  # First scenario
+        "verify"  # Use verify command for validation stage
+    ]
+    
+    # Add test suite if specified
+    if test_suite:
+        cmd.extend(["--suite", test_suite])
+    
+    # Set environment variables
+    env = os.environ.copy()
+    env["ANSIBLE_HOST_KEY_CHECKING"] = "False"
+    env["MOLECULE_REPORT_DIR"] = artifact_dir
+    
+    log_secure_info("info", "Executing molecule command for job", job_id)
+    
+    try:
+        timeout_seconds = timeout_minutes * 60
+        
+        # Execute molecule directly on OIM host
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+            shell=False,
+            text=True,
+            env=env,
+            start_new_session=True
+        )
+        
+        completed_at = datetime.now(timezone.utc)
+        duration_seconds = (completed_at - started_at).total_seconds()
+        
+        # Write molecule output to log file
+        log_file_path = os.path.join(artifact_dir, "molecule_output.log")
+        try:
+            with open(log_file_path, 'w') as f:
+                f.write(f"STDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}\n")
+        except OSError:
+            log_secure_info("warning", "Failed to write molecule output log", job_id)
+        
+        # Determine status based on exit code
+        if result.returncode == 0:
+            status = "COMPLETED"
+        elif result.returncode == 124:  # Timeout
+            status = "FAILED"
+        else:
+            status = "FAILED"
+        
+        # Parse test_report.json if available for test summary
+        test_summary = {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "errors": 0}
+        test_report_path = os.path.join(artifact_dir, "test_report.json")
+        if os.path.exists(test_report_path):
+            try:
+                with open(test_report_path, 'r') as f:
+                    test_report = json.load(f)
+                    # Extract test counts from report
+                    if "summary" in test_report:
+                        test_summary.update(test_report["summary"])
+            except (json.JSONDecodeError, OSError):
+                log_secure_info("warning", "Failed to parse test_report.json", job_id)
+        
+        log_secure_info("info", "Molecule execution completed for job", job_id)
+        log_secure_info("debug", "Execution status", status)
+        
+        result_data = {
+            "job_id": job_id,
+            "stage_type": stage_type,
+            "request_id": request_data.get("request_id", job_id),
+            "correlation_id": correlation_id,
+            "status": status,
+            "exit_code": result.returncode,
+            "duration_seconds": int(duration_seconds),
+            "test_summary": test_summary,
+            "started_at": started_at.isoformat(),
+            "completed_at": completed_at.isoformat(),
+            "timestamp": completed_at.isoformat(),
+        }
+        
+        # Add error details if failed
+        if status == "FAILED":
+            if result.returncode == 124:
+                result_data["error_message"] = f"Molecule execution timed out after {timeout_minutes} minutes"
+            else:
+                result_data["error_message"] = f"Molecule exited with code {result.returncode}"
+        
+        return result_data
+        
+    except subprocess.TimeoutExpired:
+        completed_at = datetime.now(timezone.utc)
+        duration_seconds = (completed_at - started_at).total_seconds()
+        
+        log_secure_info("error", "Molecule execution timed out for job", job_id)
+        
+        return {
+            "job_id": job_id,
+            "stage_type": stage_type,
+            "request_id": request_data.get("request_id", job_id),
+            "correlation_id": correlation_id,
+            "status": "FAILED",
+            "exit_code": 124,
+            "error_message": f"Molecule execution timed out after {timeout_minutes} minutes",
+            "started_at": started_at.isoformat(),
+            "completed_at": completed_at.isoformat(),
+            "duration_seconds": int(duration_seconds),
+            "timestamp": completed_at.isoformat(),
+        }
+        
+    except (OSError, subprocess.SubprocessError) as e:
+        completed_at = datetime.now(timezone.utc)
+        duration_seconds = (completed_at - started_at).total_seconds()
+        
+        log_secure_info("error", "Unexpected error executing molecule for job", job_id, exc_info=True)
+        
+        return {
+            "job_id": job_id,
+            "stage_type": stage_type,
+            "request_id": request_data.get("request_id", job_id),
+            "correlation_id": correlation_id,
+            "status": "FAILED",
+            "exit_code": -1,
+            "error_message": f"System error during molecule execution: {str(e)}",
+            "started_at": started_at.isoformat(),
+            "completed_at": completed_at.isoformat(),
+            "duration_seconds": int(duration_seconds),
+            "timestamp": completed_at.isoformat(),
+        }
+
+
 def write_result_file(result_data: Dict[str, Any], original_filename: str) -> bool:
     """Write result file to results directory.
 
@@ -1039,8 +1248,12 @@ def process_request(request_path: Path) -> None:
                 archive_request_file(processing_path)
                 return
 
-            # Execute playbook
-            result_data = execute_playbook(request_data)
+            # Execute based on command type
+            command_type = request_data.get("command_type", "ansible-playbook")
+            if command_type == "test_automation":
+                result_data = execute_molecule(request_data)
+            else:
+                result_data = execute_playbook(request_data)
 
             # Write result
             write_result_file(result_data, request_filename)

--- a/build_stream/playbook-watcher/playbook_watcher_service.py
+++ b/build_stream/playbook-watcher/playbook_watcher_service.py
@@ -989,12 +989,12 @@ def execute_molecule(request_data: Dict[str, Any]) -> Dict[str, Any]:
         log_secure_info("error", "Failed to create artifact directory", job_id)
         return {
             "job_id": job_id,
-            "stage_type": stage_type,
+            "stage_name": stage_type,
             "request_id": request_data.get("request_id", job_id),
             "correlation_id": correlation_id,
-            "status": "FAILED",
+            "status": "failed",
             "exit_code": 2,
-            "error_message": f"Failed to create artifact directory: {e}",
+            "error_summary": f"Failed to create artifact directory: {e}",
             "started_at": started_at.isoformat(),
             "completed_at": started_at.isoformat(),
             "duration_seconds": 0,
@@ -1046,50 +1046,84 @@ def execute_molecule(request_data: Dict[str, Any]) -> Dict[str, Any]:
         except OSError:
             log_secure_info("warning", "Failed to write molecule output log", job_id)
         
-        # Determine status based on exit code
-        if result.returncode == 0:
-            status = "COMPLETED"
-        elif result.returncode == 124:  # Timeout
-            status = "FAILED"
-        else:
-            status = "FAILED"
-        
-        # Parse test_report.json if available for test summary
+        # Parse test summary from molecule_output.log (avoids stale reports from shared directory)
         test_summary = {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "errors": 0}
-        test_report_path = os.path.join(artifact_dir, "test_report.json")
-        if os.path.exists(test_report_path):
+        
+        if os.path.exists(log_file_path):
             try:
-                with open(test_report_path, 'r') as f:
-                    test_report = json.load(f)
-                    # Extract test counts from report
-                    if "summary" in test_report:
-                        test_summary.update(test_report["summary"])
-            except (json.JSONDecodeError, OSError):
-                log_secure_info("warning", "Failed to parse test_report.json", job_id)
+                import re
+                with open(log_file_path, 'r') as f:
+                    log_content = f.read()
+                    # Parse summary line: "Results:       10 passed, 1 failed, 11 skipped"
+                    results_match = re.search(r'Results:\s+(\d+)\s+passed,\s+(\d+)\s+failed,\s+(\d+)\s+skipped', log_content)
+                    if results_match:
+                        passed = int(results_match.group(1))
+                        failed = int(results_match.group(2))
+                        skipped = int(results_match.group(3))
+                        test_summary = {
+                            "total": passed + failed + skipped,
+                            "passed": passed,
+                            "failed": failed,
+                            "skipped": skipped,
+                            "errors": 0,
+                        }
+                    else:
+                        # Fallback: try parsing pytest summary line: "1 failed, 10 passed, 11 skipped"
+                        pytest_match = re.search(r'(\d+)\s+failed,\s+(\d+)\s+passed,\s+(\d+)\s+skipped', log_content)
+                        if pytest_match:
+                            failed = int(pytest_match.group(1))
+                            passed = int(pytest_match.group(2))
+                            skipped = int(pytest_match.group(3))
+                            test_summary = {
+                                "total": passed + failed + skipped,
+                                "passed": passed,
+                                "failed": failed,
+                                "skipped": skipped,
+                                "errors": 0,
+                            }
+            except (OSError, IOError, ValueError) as e:
+                log_secure_info("warning", f"Failed to parse molecule_output.log: {e}", job_id)
+        
+        # Determine status: if any test failed, mark as failed regardless of exit code
+        if test_summary["failed"] > 0 or test_summary["errors"] > 0:
+            status = "failed"
+            exit_code = 1  # Override exit code
+        elif result.returncode == 0:
+            status = "success"
+            exit_code = 0
+        elif result.returncode == 124:  # Timeout
+            status = "failed"
+            exit_code = 124
+        else:
+            status = "failed"
+            exit_code = result.returncode
         
         log_secure_info("info", "Molecule execution completed for job", job_id)
         log_secure_info("debug", "Execution status", status)
         
         result_data = {
             "job_id": job_id,
-            "stage_type": stage_type,
+            "stage_name": stage_type,  # Use stage_name not stage_type
             "request_id": request_data.get("request_id", job_id),
             "correlation_id": correlation_id,
-            "status": status,
-            "exit_code": result.returncode,
+            "status": status,  # success or failed
+            "exit_code": exit_code,
             "duration_seconds": int(duration_seconds),
             "test_summary": test_summary,
+            "artifact_dir": artifact_dir,
             "started_at": started_at.isoformat(),
             "completed_at": completed_at.isoformat(),
             "timestamp": completed_at.isoformat(),
         }
         
         # Add error details if failed
-        if status == "FAILED":
-            if result.returncode == 124:
-                result_data["error_message"] = f"Molecule execution timed out after {timeout_minutes} minutes"
+        if status == "failed":
+            if exit_code == 124:
+                result_data["error_summary"] = f"Molecule execution timed out after {timeout_minutes} minutes"
+            elif test_summary["failed"] > 0:
+                result_data["error_summary"] = f"Test failures: {test_summary['failed']} failed, {test_summary['errors']} errors"
             else:
-                result_data["error_message"] = f"Molecule exited with code {result.returncode}"
+                result_data["error_summary"] = f"Molecule exited with code {exit_code}"
         
         return result_data
         
@@ -1101,12 +1135,13 @@ def execute_molecule(request_data: Dict[str, Any]) -> Dict[str, Any]:
         
         return {
             "job_id": job_id,
-            "stage_type": stage_type,
+            "stage_name": stage_type,
             "request_id": request_data.get("request_id", job_id),
             "correlation_id": correlation_id,
-            "status": "FAILED",
+            "status": "failed",
             "exit_code": 124,
-            "error_message": f"Molecule execution timed out after {timeout_minutes} minutes",
+            "error_summary": f"Molecule execution timed out after {timeout_minutes} minutes",
+            "artifact_dir": artifact_dir,
             "started_at": started_at.isoformat(),
             "completed_at": completed_at.isoformat(),
             "duration_seconds": int(duration_seconds),
@@ -1121,12 +1156,13 @@ def execute_molecule(request_data: Dict[str, Any]) -> Dict[str, Any]:
         
         return {
             "job_id": job_id,
-            "stage_type": stage_type,
+            "stage_name": stage_type,
             "request_id": request_data.get("request_id", job_id),
             "correlation_id": correlation_id,
-            "status": "FAILED",
+            "status": "failed",
             "exit_code": -1,
-            "error_message": f"System error during molecule execution: {str(e)}",
+            "error_summary": f"System error during molecule execution: {str(e)}",
+            "artifact_dir": artifact_dir,
             "started_at": started_at.isoformat(),
             "completed_at": completed_at.isoformat(),
             "duration_seconds": int(duration_seconds),

--- a/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
@@ -21,6 +21,9 @@ build_stream_container_name: "omnia_build_stream"
 # Build Stream source code location (in omnia_core container)
 build_stream_source_path: "/omnia/build_stream"
 
+# Build Stream root directory for artifacts and shared data
+build_stream_root_dir: "/opt/omnia/build_stream_root"
+
 # Rsync configuration for source code deployment
 bs_rsync_options: "-av --checksum"
 bs_rsync_source: "{{ role_path }}/../../../../build_stream/"


### PR DESCRIPTION
Extended Playbook Watcher to execute run_molecule.sh directly on OIM host for validate stage
Result handling in Result poller
Result JSON with status, exit_code, test_summary, artifact_dir, error_summary
Implemented validate success/failure callbacks in Result Poller
Added result_detail JSONB field to Stage entity with test summary, artifact paths, error summary