### PR TITLE
Fix CoreDHCP template deployment by delegating copy task to localhost

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/tasks/deploy_openchami.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/deploy_openchami.yml
@@ -77,6 +77,8 @@
     src: "{{ openchami_coredhcp_template }}"
     dest: "{{ openchami_coredhcp_target }}"
     mode: "{{ file_permissions_644 }}"
+  delegate_to: localhost
+  connection: local
 
 - name: Load the openchami configs vars
   ansible.builtin.template:


### PR DESCRIPTION
This PR fixes the CoreDHCP template deployment task for multi-subnet support by ensuring the copy operation executes on the omnia_core container.

Previously, the task was executed on the OIM, which caused the template source file lookup to fail with a file not found error because the template only exists on the omnia_core container.

Changes

- Added delegate_to: localhost
- Added connection: local to the CoreDHCP template copy task