### PR TITLE
fix: allow zero-padded SU group names in PXE mapping validation

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/provision_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/provision_validation.py
@@ -404,7 +404,7 @@ def validate_mapping_file_entries(mapping_file_path):
     # Pre-compile regexes
     mac_re = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
     hostname_re = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$")
-    group_re = re.compile(r"^(?:grp(?:[0-9]|[1-9][0-9]|100)|[Ss][Uu](?:[1-9]|[1-9][0-9]|100))$")
+    group_re = re.compile(r"^(?:grp(?:[0-9]|[1-9][0-9]|100)|[Ss][Uu][A-Za-z]?(?:0*[1-9][0-9]?|100))$")
     fg_re = re.compile(r"^[A-Za-z0-9_]+$")
 
     row_seen = False
@@ -455,7 +455,7 @@ def validate_mapping_file_entries(mapping_file_path):
 
         # GROUP_NAME format
         if not group_re.match(group_name):
-            raise ValueError(f"Invalid GROUP_NAME: '{group_name}' at CSV row {row_idx} in mapping file. Must be in format grp0 to grp100 or SU1 to SU100.")
+            raise ValueError(f"Invalid GROUP_NAME: '{group_name}' at CSV row {row_idx} in mapping file. Must be grp0-grp100 or SU[A-Z]1-100 (e.g. SU1, SU01, SUA99).")
 
         # FUNCTIONAL_GROUP_NAME format
         if not fg_re.match(fg_name):


### PR DESCRIPTION
## Summary

Fix GROUP_NAME validation to accept zero-padded SU names (e.g. `SU01`, `SU03`, `SUA01`) in the PXE mapping file.

## Problem

`extract_su_from_hostname()` in `generate_pxe_mapping.py` produces zero-padded SU names from iDRAC hostnames:
- `idrac-SU03R1OU03C8` → `SU03`

But the validation regex in `provision_validation.py` only accepted non-padded forms (`SU1`–`SU100`), rejecting `SU01`, `SU03`, etc.

## Fix

Updated `group_re` regex to accept:
- `SU01`, `SU001`, `SU03` (zero-padded)
- `SUA01`, `SUA99` (optional letter + zero-padded)
- Existing `SU1`–`SU100` and `grp0`–`grp100` still accepted

## Files Changed

- `common/library/module_utils/input_validation/validation_flows/provision_validation.py` — GROUP_NAME regex and error message

## Testing

Verified regex matches all expected patterns:
- ✅ `SU1`, `SU01`, `SU001`, `SU03`, `SU10`, `SU99`, `SU100`
- ✅ `SUA1`, `SUA01`, `SUA99`, `SUA100`
- ✅ `grp0`–`grp100`
- ❌ `SU0`, `SU00`, `SU101`, `grp101` (correctly rejected)