### PR TITLE
Add cloud-init reload post openchami upgrade

### DIFF
--- a/upgrade/roles/upgrade_openchami/tasks/main.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/main.yml
@@ -41,6 +41,9 @@
         - name: Post-upgrade database migration and integrity check
           ansible.builtin.include_tasks: migrate_database.yml
 
+        - name: Reload cloud-init data into cloud-init-server
+          ansible.builtin.include_tasks: reload_cloud_init_data.yml
+
         - name: Post-upgrade health check
           ansible.builtin.include_tasks: post_upgrade_health_check.yml
 

--- a/upgrade/roles/upgrade_openchami/tasks/post_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/post_upgrade_health_check.yml
@@ -219,6 +219,7 @@
         set -o pipefail
         ochami smd --cacert {{ ca_cert_path | default('/root_ca/root_ca.crt') }} \
           component get 2>&1 | head -20 || echo "ochami_unavailable"
+      environment: "{{ ci_reload_ochami_env | default({}) }}"
       register: ochami_smd_check
       changed_when: false
       failed_when: false
@@ -256,6 +257,121 @@
       delegate_facts: true
       connection: ssh
 
+    # ── BSS cloud-init datasource validation (non-fatal) ─────────────
+    # Verify BSS boot params contain cloud-init datasource URL.
+    # Without 'ds=nocloud;s=http://...:8081/cloud-init/' in boot params,
+    # nodes will boot but cloud-init will have no datasource and hang
+    # in 'running' state — Slurm/Munge services will never start.
+    - name: Check BSS boot params include cloud-init datasource
+      ansible.builtin.shell: |
+        set -o pipefail
+        /usr/bin/ochami bss boot params get -F yaml 2>&1 | grep -c 'cloud-init' || echo "0"
+      environment: "{{ ci_reload_ochami_env | default({}) }}"
+      register: bss_ci_ds_check
+      changed_when: false
+      failed_when: false
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Warn if BSS boot params missing cloud-init datasource
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: BSS boot parameters do not include the cloud-init
+          datasource URL (ds=nocloud;s=http://...:8081/cloud-init/).
+          Nodes will boot but cloud-init will hang in 'running' state
+          and services (Slurm, Munge) will not start. Re-provision
+          nodes or manually update BSS boot params.
+      when: bss_ci_ds_check.stdout | default('0') | trim == '0'
+
+    # ── Cloud-init HTTP endpoint validation (non-fatal) ──────────────
+    # Verify the cloud-init-server HTTP endpoint (port 8081) that
+    # nodes query is actually responding. If down, cloud-init hangs.
+    - name: Check cloud-init-server container is running
+      ansible.builtin.shell: |
+        set -o pipefail
+        podman ps --filter name=cloud-init-server --format '{{ '{{' }}.Status{{ '}}' }}' 2>&1
+      register: ci_container_health
+      changed_when: false
+      failed_when: false
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Check cloud-init-server API is reachable
+      ansible.builtin.shell: |
+        set -o pipefail
+        /usr/bin/ochami cloud-init service status 2>&1
+      environment: "{{ ci_reload_ochami_env | default({}) }}"
+      register: ci_http_health
+      changed_when: false
+      failed_when: false
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Warn if cloud-init-server not reachable
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Cloud-init-server is not reachable.
+          Container status: {{ ci_container_health.stdout | default('unknown') }}.
+          Nodes will not receive cloud-init data, causing cloud-init to
+          hang in 'running' state and services (Slurm, Munge) will not
+          start. Check: podman ps --filter name=cloud-init
+      when: ci_http_health.rc | default(1) != 0
+
+    # ── Cloud-init data serving validation (non-fatal) ───────────────
+    # Verify the cloud-init-server is serving group configs after reload.
+    # Without this data, nodes will boot but SSH/services won't start.
+    - name: Check cloud-init-server is serving group data
+      ansible.builtin.shell: |
+        set -o pipefail
+        /usr/bin/ochami cloud-init group get 2>&1 || echo "ci_unavailable"
+      environment: "{{ ci_reload_ochami_env | default({}) }}"
+      register: ci_group_list
+      changed_when: false
+      failed_when: false
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Warn if cloud-init-server has no group data
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Cloud-init-server has no group configurations loaded.
+          Provisioned nodes will NOT receive cloud-init data on reboot
+          (SSH, network, Slurm will not start). Re-run the upgrade or
+          manually reload: ochami cloud-init group set -f yaml -d @<file>
+      when:
+        - ci_group_list.stdout is defined
+        - "'ci_unavailable' in ci_group_list.stdout or ci_group_list.stdout | trim | length < 3"
+
+    # ── Per-node hostname data validation (non-fatal) ─────────────────
+    # Verify per-node hostname mappings are loaded. Without this data,
+    # nodes will boot with nid-based hostnames instead of PXE mapping names.
+    - name: Check cloud-init-server has per-node hostname data
+      ansible.builtin.shell: |
+        set -o pipefail
+        /usr/bin/ochami cloud-init node get 2>&1 || echo "ci_node_unavailable"
+      environment: "{{ ci_reload_ochami_env | default({}) }}"
+      register: ci_node_list
+      changed_when: false
+      failed_when: false
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Warn if cloud-init-server has no per-node hostname data
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Cloud-init-server has no per-node hostname mappings.
+          Nodes will boot with default nid-based hostnames (e.g. nid001)
+          instead of PXE mapping file hostnames. To fix, run:
+          ochami cloud-init node set -f yaml -d @<nodes_dir>/hostname.yaml
+      when:
+        - ci_node_list.stdout is defined
+        - "'ci_node_unavailable' in ci_node_list.stdout or ci_node_list.stdout | trim | length < 3"
+
     # ── Comprehensive health summary ───────────────────────────────────
     - name: Display post-upgrade health check summary
       ansible.builtin.debug:
@@ -281,6 +397,20 @@
             BSS boot params: {{ 'configured' if ('bss_unavailable' not in
             bss_bootparams.stdout | default('bss_unavailable') and bss_bootparams.stdout
             | default('') | trim | length > 2) else 'empty (non-fatal — may need initialization)' }}
+          - >-
+            BSS cloud-init datasource: {{ 'present' if (bss_ci_ds_check.stdout | default('0')
+            | trim) != '0' else 'MISSING (WARNING — cloud-init will hang on nodes)' }}
+          - >-
+            Cloud-init-server: {{ 'running and reachable' if ci_http_health.rc | default(1) == 0
+            else 'NOT REACHABLE (WARNING — cloud-init will hang on nodes) — container: ' ~ (ci_container_health.stdout | default('unknown')) }}
+          - >-
+            Cloud-init groups: {{ 'loaded' if (ci_group_list.stdout | default('')
+            | trim | length > 2 and 'ci_unavailable' not in ci_group_list.stdout
+            | default('ci_unavailable')) else 'empty (WARNING — nodes may not boot correctly)' }}
+          - >-
+            Cloud-init hostnames: {{ 'loaded' if (ci_node_list.stdout | default('')
+            | trim | length > 2 and 'ci_node_unavailable' not in ci_node_list.stdout
+            | default('ci_node_unavailable')) else 'empty (WARNING — nodes will use nid-based hostnames)' }}
           - "════════════════════════════════════════════"
 
     - name: Display post-upgrade health check success

--- a/upgrade/roles/upgrade_openchami/tasks/reload_cloud_init_data.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/reload_cloud_init_data.yml
@@ -78,7 +78,10 @@
     # <CLUSTER_NAME>_ACCESS_TOKEN env var. gen_access_token is a shell
     # function available on the OIM host via login shell.
     - name: Generate ochami access token on OIM host
-      ansible.builtin.shell: sudo bash -lc 'gen_access_token'
+      ansible.builtin.command:
+        cmd: gen_access_token
+        executable: /bin/bash -l
+      become: true
       register: reload_access_token_result
       changed_when: false
       failed_when: reload_access_token_result.rc != 0 or reload_access_token_result.stdout in ["", "null"]
@@ -308,8 +311,10 @@
 
         - name: Warn if cloud-init-server is not reachable
           ansible.builtin.debug:
-            msg: "{{ upgrade_messages.cloud_init_reload.server_not_reachable }}"
-          when: ci_http_endpoint_check.rc | default(1) != 0
+            msg: >-
+              Cloud-init-server: {{ 'running and reachable' if ci_http_endpoint_check.rc
+              | default(1) == 0 else 'NOT REACHABLE (nodes may hang) — container: '
+              ~ (ci_container_status.stdout | default('unknown')) }}
 
         # ── 8. Verify BSS boot params include cloud-init datasource ───
         # BSS boot params must contain 'ds=nocloud;s=http://...:8081/

--- a/upgrade/roles/upgrade_openchami/tasks/reload_cloud_init_data.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/reload_cloud_init_data.yml
@@ -1,0 +1,344 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# reload_cloud_init_data.yml — Reload Cloud-Init Data After Container Upgrade
+# ============================================================================
+# The cloud-init-server stores its configuration data (ci-defaults, ci-group-
+# common, ci-group-<group>) in-memory, NOT in PostgreSQL. When the container
+# is stopped, removed, and restarted during the upgrade, all cloud-init
+# configuration data is LOST.
+#
+# Without this reload step, provisioned nodes that reboot after the upgrade
+# will receive EMPTY cloud-init responses, causing:
+#   - SSH not configured (Connection refused)
+#   - Network routes not set
+#   - Slurm/Munge services not started
+#   - Firewall rules not applied
+#
+# This task file re-loads all cloud-init YAML files from the workdir into
+# the cloud-init-server using the ochami CLI after the container upgrade.
+#
+# Data re-loaded:
+#   1. ci-defaults.yaml       → ochami cloud-init defaults set
+#   2. ci-group-common.yaml   → ochami cloud-init group set
+#   3. ci-group-<group>.yaml  → ochami cloud-init group set (per group)
+#   4. hostname.yaml           → ochami cloud-init node set (per-node hostnames)
+#
+# Execution context:
+#   Runs INSIDE omnia_core container. ochami CLI commands are DELEGATED
+#   to the OIM host via SSH (where ochami CLI and containers run).
+#   File paths are resolved to OIM host-side paths via oim_shared_path.
+# ============================================================================
+
+- name: Reload cloud-init data into cloud-init-server after upgrade
+  block:
+    # ── Resolve OIM host-side paths for workdir files ──────────────────
+    # omnia_core bind mount: ${oim_shared_path}/omnia → /opt/omnia
+    # ochami CLI runs on OIM host, so file paths must be OIM host paths.
+    - name: Read oim_metadata.yml for shared path
+      ansible.builtin.slurp:
+        src: "{{ oim_metadata_path }}"
+      register: reload_oim_metadata_raw
+
+    - name: Parse oim_shared_path and cluster_name from metadata
+      ansible.builtin.set_fact:
+        reload_oim_shared_path: "{{ (reload_oim_metadata_raw.content | b64decode | from_yaml).oim_shared_path | regex_replace('/$', '') }}"
+        reload_cluster_name: "{{ (reload_oim_metadata_raw.content | b64decode | from_yaml).oim_node_name | default(cluster_name | default(ansible_hostname)) }}"
+
+    - name: Compute OIM host-side cloud-init paths
+      ansible.builtin.set_fact:
+        oim_host_ci_dir: "{{ openchami_cloud_init_dir | regex_replace('^/opt/omnia', reload_oim_shared_path ~ '/omnia') }}"
+        oim_host_ci_defaults: "{{ openchami_ci_defaults_path | regex_replace('^/opt/omnia', reload_oim_shared_path ~ '/omnia') }}"
+        oim_host_ci_common: "{{ openchami_ci_common_path | regex_replace('^/opt/omnia', reload_oim_shared_path ~ '/omnia') }}"
+        oim_host_hostname: "{{ openchami_hostname_path | regex_replace('^/opt/omnia', reload_oim_shared_path ~ '/omnia') }}"
+
+    - name: Display resolved cloud-init paths
+      ansible.builtin.debug:
+        msg:
+          - "OIM host cloud-init dir: {{ oim_host_ci_dir }}"
+          - "OIM host hostname file: {{ oim_host_hostname }}"
+          - "OIM shared path: {{ reload_oim_shared_path }}"
+          - "Cluster name: {{ reload_cluster_name }}"
+
+    # ── Generate ochami access token on OIM host ─────────────────────
+    # ochami CLI requires an OAuth access token set as
+    # <CLUSTER_NAME>_ACCESS_TOKEN env var. gen_access_token is a shell
+    # function available on the OIM host via login shell.
+    - name: Generate ochami access token on OIM host
+      ansible.builtin.shell: sudo bash -lc 'gen_access_token'
+      register: reload_access_token_result
+      changed_when: false
+      failed_when: reload_access_token_result.rc != 0 or reload_access_token_result.stdout in ["", "null"]
+      retries: 5
+      delay: 5
+      until: reload_access_token_result.rc == 0 and reload_access_token_result.stdout not in ["", "null"]
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Set ochami environment for cloud-init reload
+      ansible.builtin.set_fact:
+        ci_reload_ochami_env: "{{ {(reload_cluster_name | upper) ~ '_ACCESS_TOKEN': reload_access_token_result.stdout} }}"
+
+    # ── Verify cloud-init directory exists on OIM host ─────────────────
+    - name: Check cloud-init workdir exists on OIM host
+      ansible.builtin.stat:
+        path: "{{ oim_host_ci_dir }}"
+      register: ci_dir_stat
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Skip reload if no cloud-init workdir (prepare_oim-only scenario)
+      ansible.builtin.debug:
+        msg: "{{ upgrade_messages.cloud_init_reload.workdir_not_found }}"
+      when: not (ci_dir_stat.stat.exists | default(false))
+
+    # ── Main reload block (only if workdir exists) ─────────────────────
+    - name: Reload cloud-init data from workdir
+      when: ci_dir_stat.stat.exists | default(false)
+      block:
+        # ── Wait for cloud-init-server API readiness ───────────────────
+        - name: Wait for cloud-init-server to accept requests
+          ansible.builtin.shell: |
+            set -o pipefail
+            /usr/bin/ochami cloud-init service status 2>&1
+          environment: "{{ ci_reload_ochami_env }}"
+          register: ci_service_ready
+          changed_when: false
+          retries: "{{ api_readiness_retries }}"
+          delay: "{{ api_readiness_delay }}"
+          until: ci_service_ready.rc == 0
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        # ── Discover cloud-init YAML files ─────────────────────────────
+        - name: Check ci-defaults.yaml exists
+          ansible.builtin.stat:
+            path: "{{ oim_host_ci_defaults }}"
+          register: ci_defaults_file_stat
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Check ci-group-common.yaml exists
+          ansible.builtin.stat:
+            path: "{{ oim_host_ci_common }}"
+          register: ci_common_file_stat
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Find all ci-group-*.yaml files (excluding common)
+          ansible.builtin.find:
+            paths: "{{ oim_host_ci_dir }}"
+            patterns: "ci-group-*.yaml"
+            excludes: "ci-group-common.yaml"
+          register: ci_group_files_found
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Display discovered cloud-init files
+          ansible.builtin.debug:
+            msg:
+              - "ci-defaults.yaml: {{ 'found' if ci_defaults_file_stat.stat.exists | default(false) else 'MISSING' }}"
+              - "ci-group-common.yaml: {{ 'found' if ci_common_file_stat.stat.exists | default(false) else 'MISSING' }}"
+              - "ci-group files: {{ ci_group_files_found.files | default([]) | map(attribute='path') | map('basename') | list }}"
+
+        # ── 1. Reload ci-defaults ──────────────────────────────────────
+        - name: Reload ci-defaults configuration into cloud-init-server
+          ansible.builtin.command: >
+            /usr/bin/ochami cloud-init defaults set -f yaml -d @{{ oim_host_ci_defaults }}
+          environment: "{{ ci_reload_ochami_env }}"
+          changed_when: true
+          when: ci_defaults_file_stat.stat.exists | default(false)
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        # ── 2. Reload ci-group-common ──────────────────────────────────
+        - name: Reload ci-group-common configuration into cloud-init-server
+          ansible.builtin.command: >
+            /usr/bin/ochami cloud-init group set -f yaml -d @{{ oim_host_ci_common }}
+          environment: "{{ ci_reload_ochami_env }}"
+          changed_when: true
+          when: ci_common_file_stat.stat.exists | default(false)
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        # ── 3. Reload each ci-group-<functional_group>.yaml ───────────
+        - name: Reload cloud-init group configurations into cloud-init-server
+          ansible.builtin.command: >
+            /usr/bin/ochami cloud-init group set -f yaml -d @{{ item.path }}
+          environment: "{{ ci_reload_ochami_env }}"
+          loop: "{{ ci_group_files_found.files | default([]) }}"
+          loop_control:
+            label: "{{ item.path | basename }}"
+          changed_when: true
+          register: ci_group_reload_results
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        # ── 4. Reload per-node hostname data ─────────────────────────
+        # hostname.yaml maps xname → local-hostname for each node.
+        # Without this, nodes get the default nid-based hostname instead
+        # of the PXE mapping file hostname (e.g. nid001 vs slurm-h-2).
+        - name: Check hostname.yaml exists on OIM host
+          ansible.builtin.stat:
+            path: "{{ oim_host_hostname }}"
+          register: ci_hostname_file_stat
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Reload per-node hostname data into cloud-init-server
+          ansible.builtin.command: >
+            /usr/bin/ochami cloud-init node set -f yaml -d @{{ oim_host_hostname }}
+          environment: "{{ ci_reload_ochami_env }}"
+          changed_when: true
+          when: ci_hostname_file_stat.stat.exists | default(false)
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Warn if hostname.yaml not found
+          ansible.builtin.debug:
+            msg: "{{ upgrade_messages.cloud_init_reload.hostname_not_found }}"
+          when: not (ci_hostname_file_stat.stat.exists | default(false))
+
+        # ── 5. Restore SELinux context on openchami workdir ───────────
+        # During provisioning, SELinux context is set on the openchami
+        # workdir so containers can read cloud-init YAML files via
+        # bind mounts. After upgrade, container UIDs may change and
+        # SELinux labels need refreshing to prevent permission denied.
+        - name: Restore SELinux context on openchami workdir
+          ansible.builtin.command: >
+            chcon -R system_u:object_r:container_file_t:s0
+            {{ reload_oim_shared_path }}/omnia/openchami
+          changed_when: true
+          failed_when: false
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        # ── 6. Verify data was loaded ──────────────────────────────────
+        - name: Verify cloud-init defaults loaded
+          ansible.builtin.command: /usr/bin/ochami cloud-init defaults get -F json-pretty
+          environment: "{{ ci_reload_ochami_env }}"
+          changed_when: false
+          register: ci_defaults_verify
+          failed_when: false
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+          when: ci_defaults_file_stat.stat.exists | default(false)
+
+        - name: Extract reloaded group names from filenames
+          ansible.builtin.set_fact:
+            reloaded_ci_group_names: >-
+              {{ ci_group_files_found.files | default([]) |
+                 map(attribute='path') |
+                 map('basename') |
+                 map('regex_replace', '^ci-group-(.+)\.yaml$', '\1') |
+                 list }}
+
+        - name: Verify each cloud-init group config was loaded
+          ansible.builtin.shell: |
+            set -o pipefail
+            /usr/bin/ochami cloud-init group get config {{ item }} 2>&1 | head -3
+          environment: "{{ ci_reload_ochami_env }}"
+          loop: "{{ reloaded_ci_group_names }}"
+          changed_when: false
+          register: ci_group_verify_results
+          failed_when: ci_group_verify_results.rc != 0
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+          when: reloaded_ci_group_names | length > 0
+
+        # ── 7. Verify cloud-init-server is running and reachable ────────
+        # Nodes contact the cloud-init-server via HTTP on port 8081.
+        # If the container is down after reload, cloud-init on nodes will
+        # hang in 'running' state and services (Slurm, Munge) never start.
+        # Note: The /cloud-init/ base path does not serve a directory
+        # listing, so we verify via ochami CLI service status and
+        # container running state instead of curl.
+        - name: Verify cloud-init-server container is running
+          ansible.builtin.shell: |
+            set -o pipefail
+            podman ps --filter name=cloud-init-server --format '{{ '{{' }}.Status{{ '}}' }}' 2>&1
+          register: ci_container_status
+          changed_when: false
+          failed_when: false
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Verify cloud-init-server API is reachable
+          ansible.builtin.shell: |
+            set -o pipefail
+            /usr/bin/ochami cloud-init service status 2>&1
+          environment: "{{ ci_reload_ochami_env }}"
+          register: ci_http_endpoint_check
+          changed_when: false
+          failed_when: false
+          retries: 3
+          delay: 5
+          until: ci_http_endpoint_check.rc == 0
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Warn if cloud-init-server is not reachable
+          ansible.builtin.debug:
+            msg: "{{ upgrade_messages.cloud_init_reload.server_not_reachable }}"
+          when: ci_http_endpoint_check.rc | default(1) != 0
+
+        # ── 8. Verify BSS boot params include cloud-init datasource ───
+        # BSS boot params must contain 'ds=nocloud;s=http://...:8081/
+        # cloud-init/' for nodes to know where to fetch cloud-init config.
+        # Without this, cloud-init uses fallback datasource and gets no data,
+        # causing it to hang in 'running' state indefinitely.
+        - name: Check BSS boot params include cloud-init datasource
+          ansible.builtin.shell: |
+            set -o pipefail
+            /usr/bin/ochami bss boot params get -F yaml 2>&1 | grep -c 'cloud-init' || echo "0"
+          environment: "{{ ci_reload_ochami_env }}"
+          register: bss_ci_datasource_check
+          changed_when: false
+          failed_when: false
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Warn if BSS boot params missing cloud-init datasource
+          ansible.builtin.debug:
+            msg: "{{ upgrade_messages.cloud_init_reload.bss_datasource_missing }}"
+          when: bss_ci_datasource_check.stdout | default('0') | trim == '0'
+
+        # ── Summary ───────────────────────────────────────────────────
+        - name: Display cloud-init data reload summary
+          ansible.builtin.debug:
+            msg: "{{ upgrade_messages.cloud_init_reload.summary }}"
+
+  rescue:
+    - name: Cloud-init data reload failed
+      ansible.builtin.fail:
+        msg: "{{ upgrade_messages.cloud_init_reload.failure }}"

--- a/upgrade/roles/upgrade_openchami/vars/main.yml
+++ b/upgrade/roles/upgrade_openchami/vars/main.yml
@@ -328,7 +328,10 @@ upgrade_messages:
       - "ci-group configs reloaded: {{ reloaded_ci_group_names | default([]) | join(', ') or 'none found' }}"
       - "hostname data: {{ 'reloaded' if ci_hostname_file_stat.stat.exists | default(false) else 'MISSING (nodes will use nid-based hostnames)' }}"
       - "SELinux context: restored"
-      - "Cloud-init-server: {{ 'running and reachable' if ci_http_endpoint_check.rc | default(1) == 0 else 'NOT REACHABLE (nodes may hang) — container: ' ~ (ci_container_status.stdout | default('unknown')) }}"
+      - >-
+        Cloud-init-server: {{ 'running and reachable' if ci_http_endpoint_check.rc
+        | default(1) == 0 else 'NOT REACHABLE (nodes may hang) — container: '
+        ~ (ci_container_status.stdout | default('unknown')) }}
       - "BSS cloud-init datasource: {{ 'present' if (bss_ci_datasource_check.stdout | default('0') | trim) != '0' else 'MISSING (nodes may hang)' }}"
       - "Verification: passed"
       - "════════════════════════════════════════════"

--- a/upgrade/roles/upgrade_openchami/vars/main.yml
+++ b/upgrade/roles/upgrade_openchami/vars/main.yml
@@ -189,6 +189,18 @@ openchami_config_vars_path: "/opt/omnia/openchami/configs_vars.yaml"
 openchami_work_dir: "/opt/omnia/openchami/workdir"
 ochami_dir: "/etc/ochami"
 
+# Cloud-init workdir paths (for reloading data after container upgrade)
+# The cloud-init-server stores group configs in-memory, NOT in PostgreSQL.
+# When the container is restarted during upgrade, all cloud-init data is lost.
+# These paths point to the pre-rendered YAML files that must be re-loaded.
+openchami_cloud_init_dir: "{{ openchami_work_dir }}/cloud-init"
+openchami_ci_defaults_path: "{{ openchami_cloud_init_dir }}/ci-defaults.yaml"
+openchami_ci_common_path: "{{ openchami_cloud_init_dir }}/ci-group-common.yaml"
+# Per-node hostname data is also in-memory in cloud-init-server.
+# The hostname.yaml maps xname → local-hostname for each provisioned node.
+openchami_nodes_dir: "{{ openchami_work_dir }}/nodes"
+openchami_hostname_path: "{{ openchami_nodes_dir }}/hostname.yaml"
+
 # Source-of-truth paths for regenerating configs_vars.yaml when missing
 oim_metadata_path: "/opt/omnia/.data/oim_metadata.yml"
 network_spec_path: "{{ input_project_dir | default('/opt/omnia/input/project_default') }}/network_spec.yml"
@@ -284,3 +296,58 @@ upgrade_messages:
       - SMD API: curl -s http://<smd_ip>:<smd_port>/hsm/v2/State/Components
       - BSS boot params: curl -s http://<bss_ip>:<bss_port>/boot/v1/bootparameters
       - Get container IPs: podman inspect -f '{{ "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" }}' <container>
+  cloud_init_reload:
+    workdir_not_found: >-
+      Cloud-init workdir not found at {{ oim_host_ci_dir }}.
+      This is expected for prepare_oim-only setups where no nodes
+      have been provisioned yet. Skipping cloud-init data reload.
+    hostname_not_found: >-
+      WARNING: hostname.yaml not found at {{ oim_host_hostname }}.
+      Nodes will boot with default nid-based hostnames instead of
+      PXE mapping file hostnames. To fix, re-run provision.yml or
+      manually: ochami cloud-init node set -f yaml -d @<hostname.yaml>
+    server_not_reachable: >-
+      WARNING: Cloud-init-server is not reachable.
+      Container status: {{ ci_container_status.stdout | default('unknown') }}.
+      Nodes will not receive cloud-init data on boot, causing cloud-init
+      to hang in 'running' state and Slurm/Munge services will not start.
+      Verify the cloud-init-server container is running:
+      podman ps --filter name=cloud-init
+    bss_datasource_missing: >-
+      WARNING: BSS boot parameters do not include the cloud-init
+      datasource URL (ds=nocloud;s=http://...:8081/cloud-init/).
+      Without this, nodes will boot but cloud-init will have no
+      datasource, causing it to hang. Re-provision nodes or manually
+      update BSS boot params to include the cloud-init datasource.
+    summary:
+      - "════════════════════════════════════════════"
+      - "  CLOUD-INIT DATA RELOAD COMPLETED"
+      - "════════════════════════════════════════════"
+      - "ci-defaults: {{ 'reloaded' if ci_defaults_file_stat.stat.exists | default(false) else 'skipped (not found)' }}"
+      - "ci-group-common: {{ 'reloaded' if ci_common_file_stat.stat.exists | default(false) else 'skipped (not found)' }}"
+      - "ci-group configs reloaded: {{ reloaded_ci_group_names | default([]) | join(', ') or 'none found' }}"
+      - "hostname data: {{ 'reloaded' if ci_hostname_file_stat.stat.exists | default(false) else 'MISSING (nodes will use nid-based hostnames)' }}"
+      - "SELinux context: restored"
+      - "Cloud-init-server: {{ 'running and reachable' if ci_http_endpoint_check.rc | default(1) == 0 else 'NOT REACHABLE (nodes may hang) — container: ' ~ (ci_container_status.stdout | default('unknown')) }}"
+      - "BSS cloud-init datasource: {{ 'present' if (bss_ci_datasource_check.stdout | default('0') | trim) != '0' else 'MISSING (nodes may hang)' }}"
+      - "Verification: passed"
+      - "════════════════════════════════════════════"
+      - ""
+      - "Provisioned nodes will now receive correct cloud-init"
+      - "configuration on reboot (SSH, network, Slurm, etc.)."
+    failure: |
+      CRITICAL: Failed to reload cloud-init data after container upgrade.
+      Without this data, provisioned nodes will NOT receive cloud-init
+      configuration on reboot (SSH, network, Slurm will not start).
+
+      Cloud-init files at: {{ oim_host_ci_dir | default(openchami_cloud_init_dir) }}
+
+      Manual fix — run on the OIM host:
+        ochami cloud-init defaults set -f yaml -d @<ci_dir>/ci-defaults.yaml
+        ochami cloud-init group set -f yaml -d @<ci_dir>/ci-group-common.yaml
+        ochami cloud-init group set -f yaml -d @<ci_dir>/ci-group-<group>.yaml
+      for each ci-group-*.yaml file in the cloud-init directory.
+
+      For per-node hostnames (from PXE mapping file):
+        ochami cloud-init node set -f yaml -d @<nodes_dir>/hostname.yaml
+      Hostname file at: {{ oim_host_hostname | default(openchami_hostname_path) }}


### PR DESCRIPTION
Added cloud-init reload task to ensure nodes boot with existing 2.1 images post openchami upgrade before running build image after upgrade.