### PR TITLE
Perform gitlab config and pipeline upgrade as part of upgrade_build_stream.yml playbook.

### DIFF
--- a/upgrade/playbooks/tasks/upgrade_gitlab_ci_file.yml
+++ b/upgrade/playbooks/tasks/upgrade_gitlab_ci_file.yml
@@ -26,14 +26,16 @@
 # ────────────────────────────────────────────────────────────────────────
 ---
 
-- name: "Read 2.2 version of {{ _ci_file_name }}"
+- name: Read 2.2 version of CI file
   ansible.builtin.slurp:
     src: "{{ gitlab_role_path }}/files/{{ _ci_file_name }}"
   register: _ci_file_content
 
-- name: "Check if {{ _ci_file_name }} exists in repository"
+- name: Check if CI file exists in repository
   ansible.builtin.uri:
-    url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _ci_file_name | urlencode }}?ref={{ gitlab_default_branch }}"
+    url: >-
+      {{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/
+      repository/files/{{ _ci_file_name | urlencode }}?ref={{ gitlab_default_branch }}
     method: GET
     headers:
       PRIVATE-TOKEN: "{{ gitlab_root_token }}"
@@ -42,7 +44,7 @@
   register: _ci_file_check
   no_log: true
 
-- name: "Create or update {{ _ci_file_name }} in repository"
+- name: Create or update CI file in repository
   ansible.builtin.uri:
     url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _ci_file_name | urlencode }}"
     method: "{{ 'PUT' if _ci_file_check.status == 200 else 'POST' }}"

--- a/upgrade/playbooks/tasks/upgrade_gitlab_ci_file.yml
+++ b/upgrade/playbooks/tasks/upgrade_gitlab_ci_file.yml
@@ -1,0 +1,59 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ────────────────────────────────────────────────────────────────────────
+# Upgrade a single CI/CD pipeline file in the GitLab repository.
+# Called in a loop from upgrade_build_stream.yml with loop_var: _ci_file_name
+#
+# Required variables (set by caller):
+#   _ci_file_name              — filename (e.g. .gitlab-ci-build.yml)
+#   gitlab_role_path           — path to hosted_gitlab role
+#   gitlab_external_url_computed — GitLab base URL
+#   gitlab_project_id          — numeric project ID
+#   gitlab_root_token          — API personal access token
+#   gitlab_default_branch      — target branch (e.g. main)
+# ────────────────────────────────────────────────────────────────────────
+---
+
+- name: "Read 2.2 version of {{ _ci_file_name }}"
+  ansible.builtin.slurp:
+    src: "{{ gitlab_role_path }}/files/{{ _ci_file_name }}"
+  register: _ci_file_content
+
+- name: "Check if {{ _ci_file_name }} exists in repository"
+  ansible.builtin.uri:
+    url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _ci_file_name | urlencode }}?ref={{ gitlab_default_branch }}"
+    method: GET
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+    validate_certs: false
+    status_code: [200, 404]
+  register: _ci_file_check
+  no_log: true
+
+- name: "Create or update {{ _ci_file_name }} in repository"
+  ansible.builtin.uri:
+    url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _ci_file_name | urlencode }}"
+    method: "{{ 'PUT' if _ci_file_check.status == 200 else 'POST' }}"
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+    body_format: json
+    body:
+      branch: "{{ gitlab_default_branch }}"
+      encoding: base64
+      content: "{{ _ci_file_content.content }}"
+      commit_message: "Upgrade {{ _ci_file_name }} to Omnia 2.2"
+    validate_certs: false
+    status_code: [200, 201]
+  no_log: true

--- a/upgrade/playbooks/tasks/upgrade_gitlab_input_file.yml
+++ b/upgrade/playbooks/tasks/upgrade_gitlab_input_file.yml
@@ -27,17 +27,17 @@
 # ────────────────────────────────────────────────────────────────────────
 ---
 
-- name: "Set encoded repo path for {{ _input_file.name }}"
+- name: Set encoded repo path for input file
   ansible.builtin.set_fact:
     _encoded_input_path: "{{ (gitlab_input_repo_dir ~ '/' ~ _input_file.name) | urlencode | replace('/', '%2F') }}"
 
-- name: "Read {{ _input_file.name }} from NFS input directory"
+- name: Read input file from NFS input directory
   ansible.builtin.slurp:
     src: "{{ _input_file.src }}"
   register: _input_content
   failed_when: false
 
-- name: "Check if {{ gitlab_input_repo_dir }}/{{ _input_file.name }} exists in repository"
+- name: Check if input file exists in repository
   ansible.builtin.uri:
     url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _encoded_input_path }}?ref={{ gitlab_default_branch }}"
     method: GET
@@ -49,7 +49,7 @@
   no_log: true
   when: _input_content is succeeded
 
-- name: "Create or update {{ gitlab_input_repo_dir }}/{{ _input_file.name }}"
+- name: Create or update input file in repository
   ansible.builtin.uri:
     url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _encoded_input_path }}"
     method: "{{ 'PUT' if _input_repo_check.status == 200 else 'POST' }}"

--- a/upgrade/playbooks/tasks/upgrade_gitlab_input_file.yml
+++ b/upgrade/playbooks/tasks/upgrade_gitlab_input_file.yml
@@ -1,0 +1,67 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ────────────────────────────────────────────────────────────────────────
+# Sync a single Omnia input file to the GitLab repository (create or update).
+# Called in a loop from upgrade_build_stream.yml with loop_var: _input_file
+#
+# Required variables (set by caller):
+#   _input_file.name           — filename (e.g. build_stream_config.yml)
+#   _input_file.src            — local path to the input file
+#   gitlab_input_repo_dir      — repository subdirectory (e.g. "input")
+#   gitlab_external_url_computed
+#   gitlab_project_id
+#   gitlab_root_token
+#   gitlab_default_branch
+# ────────────────────────────────────────────────────────────────────────
+---
+
+- name: "Set encoded repo path for {{ _input_file.name }}"
+  ansible.builtin.set_fact:
+    _encoded_input_path: "{{ (gitlab_input_repo_dir ~ '/' ~ _input_file.name) | urlencode | replace('/', '%2F') }}"
+
+- name: "Read {{ _input_file.name }} from NFS input directory"
+  ansible.builtin.slurp:
+    src: "{{ _input_file.src }}"
+  register: _input_content
+  failed_when: false
+
+- name: "Check if {{ gitlab_input_repo_dir }}/{{ _input_file.name }} exists in repository"
+  ansible.builtin.uri:
+    url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _encoded_input_path }}?ref={{ gitlab_default_branch }}"
+    method: GET
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+    validate_certs: false
+    status_code: [200, 404]
+  register: _input_repo_check
+  no_log: true
+  when: _input_content is succeeded
+
+- name: "Create or update {{ gitlab_input_repo_dir }}/{{ _input_file.name }}"
+  ansible.builtin.uri:
+    url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/repository/files/{{ _encoded_input_path }}"
+    method: "{{ 'PUT' if _input_repo_check.status == 200 else 'POST' }}"
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+    body_format: json
+    body:
+      branch: "{{ gitlab_default_branch }}"
+      encoding: base64
+      content: "{{ _input_content.content }}"
+      commit_message: "Upgrade {{ gitlab_input_repo_dir }}/{{ _input_file.name }} to Omnia 2.2"
+    validate_certs: false
+    status_code: [200, 201]
+  no_log: true
+  when: _input_content is succeeded

--- a/upgrade/playbooks/upgrade_build_stream.yml
+++ b/upgrade/playbooks/upgrade_build_stream.yml
@@ -103,9 +103,81 @@
 
     - name: Compute GitLab external URL
       ansible.builtin.set_fact:
-        gitlab_external_url_computed: "https://{{ gitlab_host }}{% if gitlab_https_port | default(443) | int != 443 %}:{{ gitlab_https_port }}{% endif %}"
+        gitlab_external_url_computed: "https://{{ gitlab_host }}"
+
+    # Note: Credentials are loaded via credential utility in upgrade.yml
+    # provision_password is available from hostvars['localhost']['provision_password']
 
     # ── BS-03: Detect 2.1 state — was GitLab already installed? ──
+    # Read enable_build_stream from backup directory (source of truth)
+    - name: Check if backup build_stream_config.yml exists
+      ansible.builtin.stat:
+        path: "{{ manifest.backup_dir }}/input/project_default/build_stream_config.yml"
+      register: _backup_bs_config_stat
+
+    - name: Read enable_build_stream from backup config (pre-upgrade state)
+      ansible.builtin.include_vars:
+        file: "{{ manifest.backup_dir }}/input/project_default/build_stream_config.yml"
+        name: _backup_bs_config
+      when: _backup_bs_config_stat.stat.exists
+      failed_when: false
+
+    - name: Set backup enable_build_stream flag
+      ansible.builtin.set_fact:
+        _backup_enable_build_stream: "{{ _backup_bs_config.enable_build_stream | default(false) | bool }}"
+      when: _backup_bs_config_stat.stat.exists
+
+    - name: Check if GitLab is installed on target host (using sshpass)
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "which gitlab-ctl"
+      register: _gitlab_ctl_check
+      failed_when: false
+      changed_when: false
+      no_log: true
+
+    - name: Debug GitLab detection result
+      ansible.builtin.debug:
+        msg:
+          - "GitLab detection on host {{ gitlab_host }}:"
+          - "  Return code: {{ _gitlab_ctl_check.rc }}"
+          - "  Output: {{ _gitlab_ctl_check.stdout | default('N/A') }}"
+          - "  Error: {{ _gitlab_ctl_check.stderr | default('N/A') }}"
+          - "  Backup enable_build_stream: {{ _backup_enable_build_stream | default('N/A') }}"
+
+    - name: Determine upgrade path based on gitlab-ctl detection
+      ansible.builtin.set_fact:
+        _detected_path_from_gitlab: "{{ 'path_a' if _gitlab_ctl_check.rc == 0 else 'path_b' }}"
+
+    - name: Determine upgrade path based on backup config (source of truth)
+      ansible.builtin.set_fact:
+        _detected_path_from_config: "{{ 'path_a' if (_backup_enable_build_stream | default(false) | bool) else 'path_b' }}"
+
+    - name: Check for conflict between config and GitLab detection
+      ansible.builtin.set_fact:
+        _path_conflict: "{{ _detected_path_from_config != _detected_path_from_gitlab }}"
+
+    - name: Display conflict warning if detected
+      ansible.builtin.debug:
+        msg:
+          - "WARNING: Conflict detected in upgrade path determination!"
+          - "  Config-based detection (enable_build_stream): {{ _detected_path_from_config | upper }}"
+          - "  GitLab-based detection (gitlab-ctl): {{ _detected_path_from_gitlab | upper }}"
+          - "  RESOLUTION: Using config-based detection as source of truth"
+      when: _path_conflict | bool
+
+    - name: Set final upgrade path (config takes priority)
+      ansible.builtin.set_fact:
+        upgrade_path: "{{ _detected_path_from_config }}"
+        cacheable: true
+
+    - name: Display detected upgrade path
+      ansible.builtin.debug:
+        msg: >-
+          [UPGRADE] GitLab upgrade path: {{ upgrade_path | upper }}
+          ({{ 'upgrade existing GitLab' if upgrade_path == 'path_a' else 'fresh GitLab install' }})
+          [Source: {{ 'backup config (enable_build_stream=' + (_backup_enable_build_stream | default(false) | string) + ')' if _backup_bs_config_stat.stat.exists else 'gitlab-ctl detection' }}]
+
+    # ── Register GitLab host for Ansible operations (PATH A only) ──
     - name: Register GitLab host for SSH access
       ansible.builtin.add_host:
         name: "{{ gitlab_host }}"
@@ -115,41 +187,25 @@
         ansible_password: "{{ hostvars['localhost']['provision_password'] }}"
         ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
       no_log: true
-      when: gitlab_host is defined and gitlab_host | length > 0
-
-    - name: Check if GitLab is installed on target host
-      ansible.builtin.command: which gitlab-ctl
-      delegate_to: "{{ gitlab_host }}"
-      become: true
-      register: _gitlab_ctl_check
-      failed_when: false
-      changed_when: false
-
-    - name: Set upgrade path (path_a=upgrade existing, path_b=fresh install)
-      ansible.builtin.set_fact:
-        upgrade_path: "{{ 'path_a' if _gitlab_ctl_check.rc == 0 else 'path_b' }}"
-        cacheable: true
-
-    - name: Display detected upgrade path
-      ansible.builtin.debug:
-        msg: >-
-          [UPGRADE] GitLab upgrade path: {{ upgrade_path | upper }}
-          ({{ 'upgrade existing GitLab' if upgrade_path == 'path_a' else 'fresh GitLab install' }})
+      when: 
+        - upgrade_path == 'path_a'
+        - gitlab_host is defined and gitlab_host | length > 0
 
     # ── GL-01: Pipeline gate — abort if active pipelines exist (PATH A only) ──
-    - name: Read existing root API token from GitLab host
-      ansible.builtin.slurp:
-        src: "{{ gitlab_root_token_file_path }}"
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+    - name: Read existing root API token from GitLab host (using sshpass)
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "cat {{ gitlab_root_token_file_path }}"
       register: _raw_root_token
       when: upgrade_path == 'path_a'
       no_log: true
+      failed_when: false
 
     - name: Set root token fact for API calls
       ansible.builtin.set_fact:
-        gitlab_root_token: "{{ _raw_root_token.content | b64decode | trim }}"
-      when: upgrade_path == 'path_a'
+        gitlab_root_token: "{{ _raw_root_token.stdout | trim }}"
+      when: 
+        - upgrade_path == 'path_a'
+        - _raw_root_token.rc == 0
       no_log: true
 
     - name: Resolve GitLab project by name
@@ -257,38 +313,27 @@
     # ════════════════════════════════════════════════════════════════════════
 
     # ── 4A.1: Backup GitLab configuration files ──
-    - name: "[Step 4A] Create GitLab backup directory"
+    - name: "[Step 4A] Create GitLab backup directory on OIM"
       ansible.builtin.file:
         path: "{{ backup_dir }}/configs/gitlab"
         state: directory
         mode: '0755'
-      delegate_to: "{{ gitlab_host }}"
-      become: true
       when: upgrade_path == 'path_a'
 
-    - name: "[Step 4A] Backup core GitLab configuration files"
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: "{{ backup_dir }}/configs/gitlab/{{ item | basename }}"
-        remote_src: true
-        mode: '0600'
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+    - name: "[Step 4A] Backup core GitLab configuration files (using scp)"
+      ansible.builtin.shell: |
+        sshpass -p '{{ provision_password }}' scp -o StrictHostKeyChecking=no root@{{ gitlab_host }}:{{ item }} {{ backup_dir }}/configs/gitlab/
       loop:
         - /etc/gitlab/gitlab.rb
         - /etc/gitlab/gitlab-secrets.json
       when: upgrade_path == 'path_a'
-      loop_control:
-        label: "{{ item | basename }}"
+      no_log: true
+      failed_when: false
+      register: _backup_core_files
 
     - name: "[Step 4A] Backup optional GitLab files (runner config, tokens, quadlet)"
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: "{{ backup_dir }}/configs/gitlab/{{ item | basename }}"
-        remote_src: true
-        mode: '0600'
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ provision_password }}' scp -o StrictHostKeyChecking=no root@{{ gitlab_host }}:{{ item }} {{ backup_dir }}/configs/gitlab/
       loop:
         - "{{ gitlab_runner_config_file }}"
         - "{{ gitlab_root_token_file_path }}"
@@ -296,48 +341,54 @@
         - "{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container"
       failed_when: false
       when: upgrade_path == 'path_a'
-      loop_control:
-        label: "{{ item | basename }}"
+      no_log: true
 
     # ── 4A.2: Update gitlab.rb and reconfigure GitLab ──
-    - name: "[Step 4A] Update gitlab.rb from 2.2 template"
+    - name: "[Step 4A] Generate gitlab.rb from 2.2 template locally"
       ansible.builtin.template:
         src: "{{ gitlab_role_path }}/templates/gitlab.rb.j2"
-        dest: "{{ gitlab_rb_path }}"
-        backup: true
+        dest: "/tmp/gitlab.rb.new"
         mode: '0600'
-      delegate_to: "{{ gitlab_host }}"
-      become: true
       when: upgrade_path == 'path_a'
 
-    - name: "[Step 4A] Reconfigure GitLab (gitlab-ctl reconfigure)"
-      ansible.builtin.command: "{{ gitlab_ctl_command }} reconfigure"
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+    - name: "[Step 4A] Backup existing gitlab.rb on GitLab host"
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "cp {{ gitlab_rb_path }} {{ gitlab_rb_path }}.backup.$(date +%s)"
       when: upgrade_path == 'path_a'
-      changed_when: false
+      no_log: true
+      failed_when: false
+
+    - name: "[Step 4A] Copy new gitlab.rb to GitLab host"
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' scp -o StrictHostKeyChecking=no /tmp/gitlab.rb.new root@{{ gitlab_host }}:{{ gitlab_rb_path }}
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    - name: "[Step 4A] Reconfigure GitLab (gitlab-ctl reconfigure)"
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "{{ gitlab_ctl_command }} reconfigure"
+      when: upgrade_path == 'path_a'
+      no_log: true
       async: "{{ gitlab_reconfigure_async }}"
       poll: "{{ gitlab_reconfigure_poll }}"
 
     - name: "[Step 4A] Wait for GitLab HTTPS port to be ready"
       ansible.builtin.wait_for:
-        host: 127.0.0.1
+        host: "{{ gitlab_host }}"
         port: "{{ gitlab_https_port | int }}"
         delay: "{{ gitlab_reconfigure_delay }}"
         timeout: "{{ (gitlab_startup_wait_minutes | int) * 60 }}"
-      delegate_to: "{{ gitlab_host }}"
       when: upgrade_path == 'path_a'
 
     - name: "[Step 4A] GitLab health check (gitlab-ctl status)"
-      ansible.builtin.command: "{{ gitlab_ctl_command }} status"
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "{{ gitlab_ctl_command }} status"
       register: _gitlab_health
       retries: "{{ gitlab_health_check_retries }}"
       delay: "{{ gitlab_health_check_delay }}"
       until: _gitlab_health.rc == 0
-      changed_when: false
       when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Wait for GitLab API to be ready after reconfigure"
       ansible.builtin.uri:
@@ -377,6 +428,19 @@
       when: upgrade_path == 'path_a'
 
     # ── 4A.5: Update CI/CD pipeline variables ──
+    - name: "[Step 4A] Decrypt and read BuildStream OAuth credentials"
+      ansible.builtin.shell: |
+        ansible-vault view {{ input_project_dir }}/build_stream_oauth_credentials.yml --vault-password-file {{ input_project_dir }}/.build_stream_oauth_credentials_key
+      register: _bs_oauth_raw
+      no_log: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Parse BuildStream OAuth credentials"
+      ansible.builtin.set_fact:
+        _bs_oauth_creds: "{{ _bs_oauth_raw.stdout | from_yaml }}"
+      no_log: true
+      when: upgrade_path == 'path_a'
+
     - name: "[Step 4A] Read BSM API certificate"
       ansible.builtin.slurp:
         src: "{{ gitlab_bs_cert_path }}"
@@ -386,8 +450,8 @@
     - name: "[Step 4A] Set pipeline variable source facts"
       ansible.builtin.set_fact:
         _gitlab_bsm_api_url: "https://{{ build_stream_host_ip }}:{{ build_stream_port | default('8010') }}"
-        _gitlab_bs_auth_username: "{{ hostvars['localhost']['build_stream_auth_username'] | default('') }}"
-        _gitlab_bs_auth_password: "{{ hostvars['localhost']['build_stream_auth_password'] | default('') }}"
+        _gitlab_bs_auth_username: "{{ _bs_oauth_creds.auth_registration.username | default('') }}"
+        _gitlab_bs_auth_password: "{{ _bs_oauth_creds.auth_registration.password | default('') }}"
         _gitlab_bs_api_cert: "{{ _bs_cert_content.content | b64decode }}"
       no_log: true
       when: upgrade_path == 'path_a'
@@ -454,30 +518,24 @@
 
     # ── 4A.6: Re-register GitLab Runner (BS-08) ──
     - name: "[Step 4A] Stop existing runner service"
-      ansible.builtin.systemd_service:
-        name: "{{ gitlab_runner_container_name }}.service"
-        state: stopped
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "systemctl stop {{ gitlab_runner_container_name }}.service"
       failed_when: false
       when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Remove existing runner container"
-      containers.podman.podman_container:
-        name: "{{ gitlab_runner_container_name }}"
-        state: absent
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "podman rm -f {{ gitlab_runner_container_name }}"
       failed_when: false
       when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Remove existing runner config (force re-registration)"
-      ansible.builtin.file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: absent
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "rm -f {{ gitlab_runner_config_file }}"
       when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Delete stale project runners via API"
       block:
@@ -547,12 +605,8 @@
       when: upgrade_path == 'path_a'
 
     - name: "[Step 4A] Pull runner images (may include updated 2.2 versions)"
-      containers.podman.podman_image:
-        name: "{{ item }}"
-        state: present
-        force: true
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "podman pull {{ item }}"
       loop:
         - "{{ gitlab_runner_image }}"
         - "{{ gitlab_runner_helper_image_resolved }}"
@@ -562,71 +616,44 @@
       until: _runner_pull is succeeded
       retries: "{{ gitlab_image_pull_retries }}"
       delay: "{{ gitlab_image_pull_delay }}"
+      no_log: true
 
     - name: "[Step 4A] Ensure runner config directory exists"
-      ansible.builtin.file:
-        path: "{{ gitlab_runner_config_path }}"
-        state: directory
-        mode: '0755'
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "mkdir -p {{ gitlab_runner_config_path }}"
       when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Register GitLab runner with new token (BS-08)"
-      containers.podman.podman_container:
-        name: gitlab-runner-register
-        image: "{{ gitlab_runner_image }}"
-        state: started
-        detach: false
-        rm: true
-        command:
-          - register
-          - --non-interactive
-          - --url
-          - "{{ gitlab_external_url_computed }}/"
-          - --token
-          - "{{ gitlab_runner_auth_token }}"
-          - --executor
-          - "{{ gitlab_runner_executor }}"
-          - --docker-image
-          - "{{ gitlab_runner_default_image }}"
-          - --docker-pull-policy
-          - "{{ gitlab_runner_pull_policy }}"
-          - --docker-helper-image
-          - "{{ gitlab_runner_helper_image_resolved }}"
-          - --docker-disable-cache
-          - --description
-          - "{{ gitlab_runner_description }}"
-        volume:
-          - "{{ gitlab_runner_config_path }}:/etc/gitlab-runner"
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "podman run --rm -v {{ gitlab_runner_config_path }}:/etc/gitlab-runner {{ gitlab_runner_image }} register --non-interactive --url {{ gitlab_external_url_computed }}/ --token {{ gitlab_runner_auth_token }} --executor {{ gitlab_runner_executor }} --docker-image {{ gitlab_runner_default_image }} --docker-pull-policy {{ gitlab_runner_pull_policy }} --docker-helper-image {{ gitlab_runner_helper_image_resolved }} --docker-disable-cache --description '{{ gitlab_runner_description }}'"
       when: upgrade_path == 'path_a'
+      no_log: true
 
-    - name: "[Step 4A] Deploy GitLab runner quadlet file"
+    - name: "[Step 4A] Generate GitLab runner quadlet file locally"
       ansible.builtin.template:
         src: "{{ gitlab_role_path }}/templates/gitlab_runner.container.j2"
-        dest: "{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container"
+        dest: "/tmp/gitlab_runner.container"
         mode: "{{ quadlet_file_mode }}"
-      delegate_to: "{{ gitlab_host }}"
-      become: true
       when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Deploy GitLab runner quadlet file to GitLab host"
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' scp -o StrictHostKeyChecking=no /tmp/gitlab_runner.container root@{{ gitlab_host }}:{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container
+      when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Reload systemd daemon"
-      ansible.builtin.systemd_service:
-        daemon_reload: true
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "systemctl daemon-reload"
       when: upgrade_path == 'path_a'
+      no_log: true
 
-    - name: "[Step 4A] Enable and start GitLab runner service"
-      ansible.builtin.systemd_service:
-        name: "{{ gitlab_runner_container_name }}.service"
-        enabled: true
-        state: started
-      delegate_to: "{{ gitlab_host }}"
-      become: true
+    - name: "[Step 4A] Start GitLab runner service (quadlet services auto-enable)"
+      ansible.builtin.shell: |
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "systemctl start {{ gitlab_runner_container_name }}.service"
       when: upgrade_path == 'path_a'
+      no_log: true
 
     - name: "[Step 4A] Wait for runner to appear online"
       ansible.builtin.uri:
@@ -672,6 +699,7 @@
     - name: Set proceed flag for subsequent plays
       ansible.builtin.set_fact:
         proceed_gitlab_upgrade: true
+        upgrade_mode: true
         cacheable: true
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/upgrade/playbooks/upgrade_build_stream.yml
+++ b/upgrade/playbooks/upgrade_build_stream.yml
@@ -26,6 +26,12 @@
 #
 # STATUS: Step 4 (GitLab config upgrade) fully implemented.
 #         Steps 1-3 (container + DB) are placeholders for other developer.
+#
+# DESIGN NOTE: This playbook is intentionally NOT structured as a role because:
+#   - Contains upgrade-specific orchestration (PATH detection, manifest mgmt)
+#   - Requires tight coupling with upgrade manifest and backup directories
+#   - Single-use upgrade context vs. reusable role pattern
+#   - Already uses include_tasks for modular components (CI files, input files)
 # ============================================================================
 
 - name: BuildStream upgrade / enablement (terminal gate)
@@ -175,7 +181,12 @@
         msg: >-
           [UPGRADE] GitLab upgrade path: {{ upgrade_path | upper }}
           ({{ 'upgrade existing GitLab' if upgrade_path == 'path_a' else 'fresh GitLab install' }})
-          [Source: {{ 'backup config (enable_build_stream=' + (_backup_enable_build_stream | default(false) | string) + ')' if _backup_bs_config_stat.stat.exists else 'gitlab-ctl detection' }}]
+          [Source: {{
+            'backup config (enable_build_stream=' +
+            (_backup_enable_build_stream | default(false) | string) + ')'
+            if _backup_bs_config_stat.stat.exists
+            else 'gitlab-ctl detection'
+          }}]
 
     # ── Register GitLab host for Ansible operations (PATH A only) ──
     - name: Register GitLab host for SSH access
@@ -187,14 +198,17 @@
         ansible_password: "{{ hostvars['localhost']['provision_password'] }}"
         ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
       no_log: true
-      when: 
+      when:
         - upgrade_path == 'path_a'
         - gitlab_host is defined and gitlab_host | length > 0
 
     # ── GL-01: Pipeline gate — abort if active pipelines exist (PATH A only) ──
     - name: Read existing root API token from GitLab host (using sshpass)
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "cat {{ gitlab_root_token_file_path }}"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "cat {{ gitlab_root_token_file_path }}"
+      changed_when: false
       register: _raw_root_token
       when: upgrade_path == 'path_a'
       no_log: true
@@ -203,7 +217,7 @@
     - name: Set root token fact for API calls
       ansible.builtin.set_fact:
         gitlab_root_token: "{{ _raw_root_token.stdout | trim }}"
-      when: 
+      when:
         - upgrade_path == 'path_a'
         - _raw_root_token.rc == 0
       no_log: true
@@ -322,7 +336,10 @@
 
     - name: "[Step 4A] Backup core GitLab configuration files (using scp)"
       ansible.builtin.shell: |
-        sshpass -p '{{ provision_password }}' scp -o StrictHostKeyChecking=no root@{{ gitlab_host }}:{{ item }} {{ backup_dir }}/configs/gitlab/
+        sshpass -p '{{ provision_password }}' \
+          scp -o StrictHostKeyChecking=no \
+          root@{{ gitlab_host }}:{{ item }} {{ backup_dir }}/configs/gitlab/
+      changed_when: true
       loop:
         - /etc/gitlab/gitlab.rb
         - /etc/gitlab/gitlab-secrets.json
@@ -333,7 +350,10 @@
 
     - name: "[Step 4A] Backup optional GitLab files (runner config, tokens, quadlet)"
       ansible.builtin.shell: |
-        sshpass -p '{{ provision_password }}' scp -o StrictHostKeyChecking=no root@{{ gitlab_host }}:{{ item }} {{ backup_dir }}/configs/gitlab/
+        sshpass -p '{{ provision_password }}' \
+          scp -o StrictHostKeyChecking=no \
+          root@{{ gitlab_host }}:{{ item }} {{ backup_dir }}/configs/gitlab/
+      changed_when: true
       loop:
         - "{{ gitlab_runner_config_file }}"
         - "{{ gitlab_root_token_file_path }}"
@@ -353,20 +373,29 @@
 
     - name: "[Step 4A] Backup existing gitlab.rb on GitLab host"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "cp {{ gitlab_rb_path }} {{ gitlab_rb_path }}.backup.$(date +%s)"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "cp {{ gitlab_rb_path }} {{ gitlab_rb_path }}.backup.$(date +%s)"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
       failed_when: false
 
     - name: "[Step 4A] Copy new gitlab.rb to GitLab host"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' scp -o StrictHostKeyChecking=no /tmp/gitlab.rb.new root@{{ gitlab_host }}:{{ gitlab_rb_path }}
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          scp -o StrictHostKeyChecking=no \
+          /tmp/gitlab.rb.new root@{{ gitlab_host }}:{{ gitlab_rb_path }}
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Reconfigure GitLab (gitlab-ctl reconfigure)"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "{{ gitlab_ctl_command }} reconfigure"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "{{ gitlab_ctl_command }} reconfigure"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
       async: "{{ gitlab_reconfigure_async }}"
@@ -382,7 +411,10 @@
 
     - name: "[Step 4A] GitLab health check (gitlab-ctl status)"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "{{ gitlab_ctl_command }} status"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "{{ gitlab_ctl_command }} status"
+      changed_when: false
       register: _gitlab_health
       retries: "{{ gitlab_health_check_retries }}"
       delay: "{{ gitlab_health_check_delay }}"
@@ -430,7 +462,9 @@
     # ── 4A.5: Update CI/CD pipeline variables ──
     - name: "[Step 4A] Decrypt and read BuildStream OAuth credentials"
       ansible.builtin.shell: |
-        ansible-vault view {{ input_project_dir }}/build_stream_oauth_credentials.yml --vault-password-file {{ input_project_dir }}/.build_stream_oauth_credentials_key
+        ansible-vault view {{ input_project_dir }}/build_stream_oauth_credentials.yml \
+          --vault-password-file {{ input_project_dir }}/.build_stream_oauth_credentials_key
+      changed_when: false
       register: _bs_oauth_raw
       no_log: true
       when: upgrade_path == 'path_a'
@@ -519,25 +553,35 @@
     # ── 4A.6: Re-register GitLab Runner (BS-08) ──
     - name: "[Step 4A] Stop existing runner service"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "systemctl stop {{ gitlab_runner_container_name }}.service"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "systemctl stop {{ gitlab_runner_container_name }}.service"
+      changed_when: true
       failed_when: false
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Remove existing runner container"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "podman rm -f {{ gitlab_runner_container_name }}"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "podman rm -f {{ gitlab_runner_container_name }}"
+      changed_when: true
       failed_when: false
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Remove existing runner config (force re-registration)"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "rm -f {{ gitlab_runner_config_file }}"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "rm -f {{ gitlab_runner_config_file }}"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Delete stale project runners via API"
+      when: upgrade_path == 'path_a'
       block:
         - name: List existing project runners
           ansible.builtin.uri:
@@ -563,7 +607,6 @@
             label: "Runner #{{ item.id }}"
           no_log: true
           when: _existing_runners.json | length > 0
-      when: upgrade_path == 'path_a'
 
     - name: "[Step 4A] Create new runner authentication token via API"
       ansible.builtin.uri:
@@ -606,7 +649,10 @@
 
     - name: "[Step 4A] Pull runner images (may include updated 2.2 versions)"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "podman pull {{ item }}"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "podman pull {{ item }}"
+      changed_when: true
       loop:
         - "{{ gitlab_runner_image }}"
         - "{{ gitlab_runner_helper_image_resolved }}"
@@ -620,13 +666,25 @@
 
     - name: "[Step 4A] Ensure runner config directory exists"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "mkdir -p {{ gitlab_runner_config_path }}"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "mkdir -p {{ gitlab_runner_config_path }}"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Register GitLab runner with new token (BS-08)"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "podman run --rm -v {{ gitlab_runner_config_path }}:/etc/gitlab-runner {{ gitlab_runner_image }} register --non-interactive --url {{ gitlab_external_url_computed }}/ --token {{ gitlab_runner_auth_token }} --executor {{ gitlab_runner_executor }} --docker-image {{ gitlab_runner_default_image }} --docker-pull-policy {{ gitlab_runner_pull_policy }} --docker-helper-image {{ gitlab_runner_helper_image_resolved }} --docker-disable-cache --description '{{ gitlab_runner_description }}'"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "podman run --rm -v {{ gitlab_runner_config_path }}:/etc/gitlab-runner \
+          {{ gitlab_runner_image }} register --non-interactive \
+          --url {{ gitlab_external_url_computed }}/ --token {{ gitlab_runner_auth_token }} \
+          --executor {{ gitlab_runner_executor }} --docker-image {{ gitlab_runner_default_image }} \
+          --docker-pull-policy {{ gitlab_runner_pull_policy }} \
+          --docker-helper-image {{ gitlab_runner_helper_image_resolved }} \
+          --docker-disable-cache --description '{{ gitlab_runner_description }}'"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 
@@ -639,19 +697,28 @@
 
     - name: "[Step 4A] Deploy GitLab runner quadlet file to GitLab host"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' scp -o StrictHostKeyChecking=no /tmp/gitlab_runner.container root@{{ gitlab_host }}:{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          scp -o StrictHostKeyChecking=no /tmp/gitlab_runner.container \
+          root@{{ gitlab_host }}:{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Reload systemd daemon"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "systemctl daemon-reload"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "systemctl daemon-reload"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 
     - name: "[Step 4A] Start GitLab runner service (quadlet services auto-enable)"
       ansible.builtin.shell: |
-        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} "systemctl start {{ gitlab_runner_container_name }}.service"
+        sshpass -p '{{ hostvars["localhost"]["provision_password"] }}' \
+          ssh -o StrictHostKeyChecking=no root@{{ gitlab_host }} \
+          "systemctl start {{ gitlab_runner_container_name }}.service"
+      changed_when: true
       when: upgrade_path == 'path_a'
       no_log: true
 

--- a/upgrade/playbooks/upgrade_build_stream.yml
+++ b/upgrade/playbooks/upgrade_build_stream.yml
@@ -24,8 +24,8 @@
 #
 # Constraints: BS-01 through BS-08
 #
-# STATUS: Framework only — debug statements outline the upgrade flow.
-#         Actual implementation to be added when BuildStream upgrade is ready.
+# STATUS: Step 4 (GitLab config upgrade) fully implemented.
+#         Steps 1-3 (container + DB) are placeholders for other developer.
 # ============================================================================
 
 - name: BuildStream upgrade / enablement (terminal gate)
@@ -36,6 +36,7 @@
     manifest_path: /opt/omnia/.data/upgrade_manifest.yml
     metadata_path: /opt/omnia/.data/oim_metadata.yml
     component_name: build_stream
+    gitlab_role_path: "{{ playbook_dir }}/../../gitlab/roles/hosted_gitlab"
   tasks:
     # ── Manifest read & idempotency guard ──
     - name: Read upgrade_manifest.yml
@@ -86,6 +87,141 @@
         msg: "BuildStream requires OIM upgrade to be completed first. Current OIM status: {{ manifest.component_status.oim | default('pending') }}"
       when: manifest.component_status.oim | default('pending') != 'completed'
 
+    # ── Load GitLab configuration for Step 4 ──
+    - name: Load gitlab_config.yml
+      ansible.builtin.include_vars:
+        file: "{{ input_project_dir }}/gitlab_config.yml"
+
+    - name: Load hosted_gitlab role default variables
+      ansible.builtin.include_vars:
+        file: "{{ gitlab_role_path }}/vars/main.yml"
+
+    - name: Set build stream host facts for GitLab variables
+      ansible.builtin.set_fact:
+        build_stream_host_ip: "{{ build_stream_config.build_stream_host_ip | default('') }}"
+        build_stream_port: "{{ build_stream_config.build_stream_port | default('8010') }}"
+
+    - name: Compute GitLab external URL
+      ansible.builtin.set_fact:
+        gitlab_external_url_computed: "https://{{ gitlab_host }}{% if gitlab_https_port | default(443) | int != 443 %}:{{ gitlab_https_port }}{% endif %}"
+
+    # ── BS-03: Detect 2.1 state — was GitLab already installed? ──
+    - name: Register GitLab host for SSH access
+      ansible.builtin.add_host:
+        name: "{{ gitlab_host }}"
+        groups: gitlab_server
+        ansible_host: "{{ gitlab_host }}"
+        ansible_user: "{{ gitlab_ansible_user | default('root') }}"
+        ansible_password: "{{ hostvars['localhost']['provision_password'] }}"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+      no_log: true
+      when: gitlab_host is defined and gitlab_host | length > 0
+
+    - name: Check if GitLab is installed on target host
+      ansible.builtin.command: which gitlab-ctl
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      register: _gitlab_ctl_check
+      failed_when: false
+      changed_when: false
+
+    - name: Set upgrade path (path_a=upgrade existing, path_b=fresh install)
+      ansible.builtin.set_fact:
+        upgrade_path: "{{ 'path_a' if _gitlab_ctl_check.rc == 0 else 'path_b' }}"
+        cacheable: true
+
+    - name: Display detected upgrade path
+      ansible.builtin.debug:
+        msg: >-
+          [UPGRADE] GitLab upgrade path: {{ upgrade_path | upper }}
+          ({{ 'upgrade existing GitLab' if upgrade_path == 'path_a' else 'fresh GitLab install' }})
+
+    # ── GL-01: Pipeline gate — abort if active pipelines exist (PATH A only) ──
+    - name: Read existing root API token from GitLab host
+      ansible.builtin.slurp:
+        src: "{{ gitlab_root_token_file_path }}"
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      register: _raw_root_token
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    - name: Set root token fact for API calls
+      ansible.builtin.set_fact:
+        gitlab_root_token: "{{ _raw_root_token.content | b64decode | trim }}"
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    - name: Resolve GitLab project by name
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/projects?search={{ gitlab_project_name }}"
+        method: GET
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        validate_certs: false
+        status_code: [200]
+      register: _project_search
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    - name: Set project ID fact
+      ansible.builtin.set_fact:
+        gitlab_project_id: >-
+          {{ (_project_search.json
+              | selectattr('name', 'equalto', gitlab_project_name)
+              | first).id | string }}
+      when:
+        - upgrade_path == 'path_a'
+        - _project_search.json | length > 0
+
+    - name: Check for active pipelines (running, pending, created)
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/pipelines?status={{ item }}&per_page=100"
+        method: GET
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        validate_certs: false
+        status_code: [200]
+      register: _active_pipelines_check
+      loop:
+        - running
+        - pending
+        - created
+      when:
+        - upgrade_path == 'path_a'
+        - gitlab_project_id is defined
+      no_log: true
+
+    - name: Aggregate active pipeline results
+      ansible.builtin.set_fact:
+        _active_pipeline_list: >-
+          {{ _active_pipelines_check.results
+             | selectattr('json', 'defined')
+             | map(attribute='json')
+             | flatten }}
+      when:
+        - upgrade_path == 'path_a'
+        - _active_pipelines_check is defined
+
+    - name: "GL-01 GATE: Abort if active pipelines found"
+      ansible.builtin.fail:
+        msg: |
+          ============================================================
+          ABORT: Cannot upgrade GitLab config while pipelines are active.
+          ============================================================
+
+          Active pipelines found: {{ _active_pipeline_list | length }}
+          {% for p in _active_pipeline_list %}
+          - Pipeline #{{ p.id }} | status={{ p.status }} | ref={{ p.ref }}
+          {% endfor %}
+
+          ACTION REQUIRED:
+            Wait for all pipelines to complete or cancel them before re-running.
+          ============================================================
+      when:
+        - upgrade_path == 'path_a'
+        - _active_pipeline_list | default([]) | length > 0
+
     - name: Set build_stream upgrade status to in-progress
       ansible.builtin.copy:
         content: >-
@@ -101,57 +237,483 @@
       ansible.builtin.debug:
         msg: "[UPGRADE] Component '{{ component_name }}' — status changed to: in-progress"
 
-    # ── Framework: Debug statements outlining the upgrade flow ──
-    - name: "[FRAMEWORK] BuildStream upgrade flow outline"
+    # ── Steps 1-3: BuildStream container + Postgres migration ──
+    # NOTE: Steps 1-3 are handled by another developer. The tasks below are
+    # placeholders that will be replaced with actual implementation for:
+    #   Step 1: Backup (pg_dump, quadlet files)
+    #   Step 2: Upgrade BuildStream container (update quadlet, restart)
+    #   Step 3: Postgres data migration (schema migration, restore)
+    - name: "[PLACEHOLDER] Steps 1-3 — BuildStream container + Postgres (other developer)"
       ansible.builtin.debug:
         msg:
-          - "============================================================"
-          - "  BuildStream Upgrade / Enablement — Framework (ESpec §4.6.4)"
-          - "============================================================"
-          - ""
-          - "Component: {{ component_name }}"
-          - "Manifest path: {{ manifest_path }}"
-          - "Backup dir: {{ backup_dir }}"
-          - "enable_build_stream: {{ enable_build_stream }}"
-          - ""
-          - "--- Pre-flight checks ---"
-          - "  [BS-01] OIM upgrade complete: {{ manifest.component_status.oim | default('pending') }}"
-          - "  [BS-02] Verify target container images available:"
-          - "    - BuildStream: {{ build_stream_config.buildstream_image | default('localhost/omnia_build_stream:<version>') }}"
-          - "    - Postgres: {{ build_stream_config.postgres_image | default('docker.io/library/postgres:16') }}"
-          - "    - GitLab: {{ build_stream_config.gitlab_image | default('docker.io/gitlab/gitlab-ce:latest') }}"
-          - "  [BS-03] Detect 2.1 state: check quadlet /etc/containers/systemd/buildstream.container"
-          - ""
-          - "--- PATH A: Upgrade existing BuildStream (if was enabled in 2.1) ---"
-          - "  Step 1: Backup (pg_dump, GitLab config, quadlet, build_stream_config.yml)"
-          - "  Step 2: Upgrade BuildStream container (update quadlet Image=, daemon-reload, restart)"
-          - "  Step 3: Postgres data migration (stop, update quadlet, start, run schema migration)"
-          - "  Step 4: Update GitLab config (update image, restart, re-register runner BS-08)"
-          - ""
-          - "--- PATH B: Fresh install BuildStream (if was NOT enabled in 2.1) ---"
-          - "  Step 1: NFS share cleanup guidance (C-26) — display instructions, prompt operator"
-          - "  Step 2: Fresh install Postgres (create quadlet, start, init schema)"
-          - "  Step 3: Fresh install BuildStream (create quadlet, start, health check)"
-          - "  Step 4: Fresh install GitLab (create quadlet, start, register runner BS-08)"
-          - ""
-          - "--- Post-completion (both paths) ---"
-          - "  Validate all three containers healthy"
-          - "  Store upgrade path metadata for rollback"
-          - "  Mark build_stream completed in manifest"
-          - "  Set build_stream_terminal = true"
-          - "  Display post-upgrade instruction banner (BS-05, C-27)"
-          - "============================================================"
+          - "Steps 1-3 placeholder — to be implemented by BuildStream container/DB developer"
+          - "  Step 1: Backup (pg_dump, quadlet files)"
+          - "  Step 2: Upgrade BuildStream container"
+          - "  Step 3: Postgres data migration"
+          - "  upgrade_path={{ upgrade_path }}"
 
-    - name: "[FRAMEWORK] Mark build_stream as completed and set terminal gate"
+    # ════════════════════════════════════════════════════════════════════════
+    # Step 4: GitLab Configuration Upgrade (ESpec §4.6.4, BS-08)
+    # ════════════════════════════════════════════════════════════════════════
+
+    # ── 4A.1: Backup GitLab configuration files ──
+    - name: "[Step 4A] Create GitLab backup directory"
+      ansible.builtin.file:
+        path: "{{ backup_dir }}/configs/gitlab"
+        state: directory
+        mode: '0755'
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Backup core GitLab configuration files"
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ backup_dir }}/configs/gitlab/{{ item | basename }}"
+        remote_src: true
+        mode: '0600'
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      loop:
+        - /etc/gitlab/gitlab.rb
+        - /etc/gitlab/gitlab-secrets.json
+      when: upgrade_path == 'path_a'
+      loop_control:
+        label: "{{ item | basename }}"
+
+    - name: "[Step 4A] Backup optional GitLab files (runner config, tokens, quadlet)"
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ backup_dir }}/configs/gitlab/{{ item | basename }}"
+        remote_src: true
+        mode: '0600'
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      loop:
+        - "{{ gitlab_runner_config_file }}"
+        - "{{ gitlab_root_token_file_path }}"
+        - /root/.gitlab_trigger_token
+        - "{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container"
+      failed_when: false
+      when: upgrade_path == 'path_a'
+      loop_control:
+        label: "{{ item | basename }}"
+
+    # ── 4A.2: Update gitlab.rb and reconfigure GitLab ──
+    - name: "[Step 4A] Update gitlab.rb from 2.2 template"
+      ansible.builtin.template:
+        src: "{{ gitlab_role_path }}/templates/gitlab.rb.j2"
+        dest: "{{ gitlab_rb_path }}"
+        backup: true
+        mode: '0600'
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Reconfigure GitLab (gitlab-ctl reconfigure)"
+      ansible.builtin.command: "{{ gitlab_ctl_command }} reconfigure"
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+      changed_when: false
+      async: "{{ gitlab_reconfigure_async }}"
+      poll: "{{ gitlab_reconfigure_poll }}"
+
+    - name: "[Step 4A] Wait for GitLab HTTPS port to be ready"
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ gitlab_https_port | int }}"
+        delay: "{{ gitlab_reconfigure_delay }}"
+        timeout: "{{ (gitlab_startup_wait_minutes | int) * 60 }}"
+      delegate_to: "{{ gitlab_host }}"
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] GitLab health check (gitlab-ctl status)"
+      ansible.builtin.command: "{{ gitlab_ctl_command }} status"
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      register: _gitlab_health
+      retries: "{{ gitlab_health_check_retries }}"
+      delay: "{{ gitlab_health_check_delay }}"
+      until: _gitlab_health.rc == 0
+      changed_when: false
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Wait for GitLab API to be ready after reconfigure"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/version"
+        method: GET
+        validate_certs: false
+        status_code: "{{ gitlab_default_status_codes.api_version }}"
+      register: _api_ready
+      retries: "{{ gitlab_api_check_retries }}"
+      delay: "{{ gitlab_api_check_delay }}"
+      until: _api_ready.status in gitlab_default_status_codes.api_version
+      when: upgrade_path == 'path_a'
+
+    # ── 4A.3: Update CI/CD pipeline files in repository ──
+    - name: "[Step 4A] Update CI/CD pipeline files to 2.2 versions"
+      ansible.builtin.include_tasks:
+        file: "{{ playbook_dir }}/tasks/upgrade_gitlab_ci_file.yml"
+      loop:
+        - .gitlab-ci.yml
+        - .gitlab-ci-build.yml
+        - .gitlab-ci-deploy.yml
+        - .gitlab-ci-deploy-child-template.yml
+        - .gitlab-ci-cleanup.yml
+        - .gitlab-ci-cleanup-child-template.yml
+      loop_control:
+        loop_var: _ci_file_name
+      when: upgrade_path == 'path_a'
+
+    # ── 4A.4: Sync input files to repository ──
+    - name: "[Step 4A] Sync Omnia input files to GitLab repository"
+      ansible.builtin.include_tasks:
+        file: "{{ playbook_dir }}/tasks/upgrade_gitlab_input_file.yml"
+      loop: "{{ gitlab_input_files }}"
+      loop_control:
+        loop_var: _input_file
+        label: "{{ _input_file.name }}"
+      when: upgrade_path == 'path_a'
+
+    # ── 4A.5: Update CI/CD pipeline variables ──
+    - name: "[Step 4A] Read BSM API certificate"
+      ansible.builtin.slurp:
+        src: "{{ gitlab_bs_cert_path }}"
+      register: _bs_cert_content
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Set pipeline variable source facts"
+      ansible.builtin.set_fact:
+        _gitlab_bsm_api_url: "https://{{ build_stream_host_ip }}:{{ build_stream_port | default('8010') }}"
+        _gitlab_bs_auth_username: "{{ hostvars['localhost']['build_stream_auth_username'] | default('') }}"
+        _gitlab_bs_auth_password: "{{ hostvars['localhost']['build_stream_auth_password'] | default('') }}"
+        _gitlab_bs_api_cert: "{{ _bs_cert_content.content | b64decode }}"
+      no_log: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Check existing pipeline variables"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/variables/{{ item.key }}"
+        method: GET
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        validate_certs: false
+        status_code: [200, 404]
+      register: _pipeline_var_check
+      loop: "{{ gitlab_pipeline_bs_variables }}"
+      loop_control:
+        label: "{{ item.key }}"
+      no_log: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Create pipeline variable when missing"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/variables"
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        body_format: json
+        body:
+          key: "{{ item.item.key }}"
+          value: "{{ item.item.value }}"
+          variable_type: "{{ item.item.variable_type }}"
+          masked: "{{ item.item.masked }}"
+          protected: false
+        validate_certs: false
+        status_code: [200, 201]
+      when:
+        - upgrade_path == 'path_a'
+        - item.status == 404
+      loop: "{{ _pipeline_var_check.results }}"
+      loop_control:
+        label: "{{ item.item.key }}"
+      no_log: true
+
+    - name: "[Step 4A] Update pipeline variable when it already exists"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/variables/{{ item.item.key }}"
+        method: PUT
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        body_format: json
+        body:
+          value: "{{ item.item.value }}"
+          variable_type: "{{ item.item.variable_type }}"
+          masked: "{{ item.item.masked }}"
+          protected: false
+        validate_certs: false
+        status_code: [200, 201]
+      when:
+        - upgrade_path == 'path_a'
+        - item.status == 200
+      loop: "{{ _pipeline_var_check.results }}"
+      loop_control:
+        label: "{{ item.item.key }}"
+      no_log: true
+
+    # ── 4A.6: Re-register GitLab Runner (BS-08) ──
+    - name: "[Step 4A] Stop existing runner service"
+      ansible.builtin.systemd_service:
+        name: "{{ gitlab_runner_container_name }}.service"
+        state: stopped
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      failed_when: false
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Remove existing runner container"
+      containers.podman.podman_container:
+        name: "{{ gitlab_runner_container_name }}"
+        state: absent
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      failed_when: false
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Remove existing runner config (force re-registration)"
+      ansible.builtin.file:
+        path: "{{ gitlab_runner_config_file }}"
+        state: absent
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Delete stale project runners via API"
+      block:
+        - name: List existing project runners
+          ansible.builtin.uri:
+            url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/runners"
+            method: GET
+            headers:
+              PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+            validate_certs: false
+            status_code: [200]
+          register: _existing_runners
+          no_log: true
+
+        - name: Delete each stale runner
+          ansible.builtin.uri:
+            url: "{{ gitlab_external_url_computed }}/api/v4/runners/{{ item.id }}"
+            method: DELETE
+            headers:
+              PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+            validate_certs: false
+            status_code: [202, 204]
+          loop: "{{ _existing_runners.json }}"
+          loop_control:
+            label: "Runner #{{ item.id }}"
+          no_log: true
+          when: _existing_runners.json | length > 0
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Create new runner authentication token via API"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/user/runners"
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        body_format: json
+        body:
+          runner_type: project_type
+          project_id: "{{ gitlab_project_id }}"
+          description: "{{ gitlab_runner_description }}"
+          tag_list:
+            - "{{ gitlab_runner_tags }}"
+          run_untagged: true
+        validate_certs: false
+        status_code: [200, 201]
+      register: _new_runner_token
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    - name: "[Step 4A] Set runner auth token fact"
+      ansible.builtin.set_fact:
+        gitlab_runner_auth_token: "{{ _new_runner_token.json.token }}"
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    - name: "[Step 4A] Resolve runner helper image tag"
+      ansible.builtin.set_fact:
+        gitlab_runner_volume_suffix: ""
+        gitlab_runner_helper_arch: "{{ 'arm64' if ansible_architecture | default('x86_64') == 'aarch64' else 'x86_64' }}"
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Set helper image full reference"
+      ansible.builtin.set_fact:
+        gitlab_runner_helper_image_resolved: >-
+          {{ gitlab_runner_helper_image_registry }}:{{ gitlab_runner_helper_arch
+            }}-{{ gitlab_runner_image | regex_search('v[0-9]+\.[0-9]+\.[0-9]+') | default(gitlab_runner_helper_image_version) }}
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Pull runner images (may include updated 2.2 versions)"
+      containers.podman.podman_image:
+        name: "{{ item }}"
+        state: present
+        force: true
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      loop:
+        - "{{ gitlab_runner_image }}"
+        - "{{ gitlab_runner_helper_image_resolved }}"
+        - "{{ gitlab_runner_default_image }}"
+      when: upgrade_path == 'path_a'
+      register: _runner_pull
+      until: _runner_pull is succeeded
+      retries: "{{ gitlab_image_pull_retries }}"
+      delay: "{{ gitlab_image_pull_delay }}"
+
+    - name: "[Step 4A] Ensure runner config directory exists"
+      ansible.builtin.file:
+        path: "{{ gitlab_runner_config_path }}"
+        state: directory
+        mode: '0755'
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Register GitLab runner with new token (BS-08)"
+      containers.podman.podman_container:
+        name: gitlab-runner-register
+        image: "{{ gitlab_runner_image }}"
+        state: started
+        detach: false
+        rm: true
+        command:
+          - register
+          - --non-interactive
+          - --url
+          - "{{ gitlab_external_url_computed }}/"
+          - --token
+          - "{{ gitlab_runner_auth_token }}"
+          - --executor
+          - "{{ gitlab_runner_executor }}"
+          - --docker-image
+          - "{{ gitlab_runner_default_image }}"
+          - --docker-pull-policy
+          - "{{ gitlab_runner_pull_policy }}"
+          - --docker-helper-image
+          - "{{ gitlab_runner_helper_image_resolved }}"
+          - --docker-disable-cache
+          - --description
+          - "{{ gitlab_runner_description }}"
+        volume:
+          - "{{ gitlab_runner_config_path }}:/etc/gitlab-runner"
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Deploy GitLab runner quadlet file"
+      ansible.builtin.template:
+        src: "{{ gitlab_role_path }}/templates/gitlab_runner.container.j2"
+        dest: "{{ quadlet_dir }}/{{ gitlab_runner_container_name }}.container"
+        mode: "{{ quadlet_file_mode }}"
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Reload systemd daemon"
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Enable and start GitLab runner service"
+      ansible.builtin.systemd_service:
+        name: "{{ gitlab_runner_container_name }}.service"
+        enabled: true
+        state: started
+      delegate_to: "{{ gitlab_host }}"
+      become: true
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Wait for runner to appear online"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/projects/{{ gitlab_project_id }}/runners"
+        method: GET
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        validate_certs: false
+        status_code: [200]
+      register: _runner_online
+      retries: "{{ gitlab_runner_online_check_retries }}"
+      delay: "{{ gitlab_runner_online_check_delay }}"
+      until: >-
+        (_runner_online.json
+         | selectattr('status', 'equalto', 'online')
+         | list | length) > 0
+      when: upgrade_path == 'path_a'
+      no_log: true
+
+    # ── 4A.7: Validate GitLab API accessible ──
+    - name: "[Step 4A] Validate GitLab API version endpoint"
+      ansible.builtin.uri:
+        url: "{{ gitlab_external_url_computed }}/api/v4/version"
+        method: GET
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        validate_certs: false
+        status_code: [200]
+      register: _gitlab_version
+      when: upgrade_path == 'path_a'
+
+    - name: "[Step 4A] Display PATH A upgrade results"
+      ansible.builtin.debug:
+        msg:
+          - "[UPGRADE] Step 4 GitLab config upgrade (PATH A) — COMPLETE"
+          - "  GitLab version: {{ _gitlab_version.json.version | default('unknown') }}"
+          - "  Runner: online"
+          - "  CI/CD pipeline files: updated to 2.2"
+          - "  Pipeline variables: refreshed"
+      when: upgrade_path == 'path_a'
+
+    # ── Set proceed flags for PATH B play and post-completion play ──
+    - name: Set proceed flag for subsequent plays
+      ansible.builtin.set_fact:
+        proceed_gitlab_upgrade: true
+        cacheable: true
+
+# ════════════════════════════════════════════════════════════════════════════
+# PATH B: GitLab Fresh Install
+# ════════════════════════════════════════════════════════════════════════════
+# Runs ONLY when BuildStream was NOT enabled in 2.1 (fresh install).
+# Imports the full gitlab.yml playbook which handles credential loading,
+# prerequisite validation, and the hosted_gitlab role deployment.
+
+- name: GitLab fresh install (PATH B — upgrade_build_stream Step 4)
+  ansible.builtin.import_playbook: ../../gitlab/gitlab.yml
+  when:
+    - hostvars['localhost']['proceed_gitlab_upgrade'] | default(false) | bool
+    - hostvars['localhost']['upgrade_path'] | default('') == 'path_b'
+
+# ════════════════════════════════════════════════════════════════════════════
+# Post-completion: Mark build_stream completed, set terminal gate, banner
+# ════════════════════════════════════════════════════════════════════════════
+
+- name: "BuildStream upgrade post-completion"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    manifest_path: /opt/omnia/.data/upgrade_manifest.yml
+    component_name: build_stream
+  tasks:
+    - name: Skip post-completion if upgrade did not proceed
+      ansible.builtin.meta: end_play
+      when: not (hostvars['localhost']['proceed_gitlab_upgrade'] | default(false) | bool)
+
+    - name: Set BuildStream terminal gate fact
       ansible.builtin.set_fact:
         build_stream_terminal: true
+        cacheable: true
 
-    - name: "[FRAMEWORK] Re-read manifest"
+    - name: Re-read manifest for final update
       ansible.builtin.slurp:
         src: "{{ manifest_path }}"
       register: raw_manifest_final
 
-    - name: "[FRAMEWORK] Write build_stream completed to manifest"
+    - name: Write build_stream completed to manifest
       ansible.builtin.copy:
         content: >-
           {{ (raw_manifest_final.content | b64decode | from_yaml) | combine({
@@ -166,11 +728,12 @@
       ansible.builtin.debug:
         msg: "[UPGRADE] Component '{{ component_name }}' — status changed to: completed"
 
-    - name: "[FRAMEWORK] Post-upgrade instruction banner (BS-05, C-27)"
+    - name: "Post-upgrade instruction banner (BS-05, C-27)"
       ansible.builtin.debug:
         msg:
           - "============================================================"
-          - "  BuildStream upgrade/enablement complete (FRAMEWORK MODE)."
+          - "  BuildStream upgrade/enablement complete."
+          - "  Upgrade path: {{ hostvars['localhost']['upgrade_path'] | default('unknown') | upper }}"
           - ""
           - "  NEXT STEP: Trigger the GitLab pipeline manually (BS-05):"
           - "    1. Navigate to GitLab UI → Project → CI/CD → Pipelines"

--- a/upgrade/upgrade.yml
+++ b/upgrade/upgrade.yml
@@ -285,6 +285,25 @@
     oim_group: true
 
 # ──────────────────────────────────────────────────────────────────────
+# Load credentials via credential utility (for build_stream and gitlab)
+# Set upgrade_mode to bypass upgrade_checkup guard within credential utility
+# ──────────────────────────────────────────────────────────────────────
+- name: Set upgrade mode flag for credential utility
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags: [build_stream, gitlab]
+  tasks:
+    - name: Enable upgrade_mode to bypass credential utility guard
+      ansible.builtin.set_fact:
+        upgrade_mode: true
+        cacheable: true
+
+- name: Load Omnia credential utility
+  ansible.builtin.import_playbook: ../utils/credential_utility/get_config_credentials.yml
+  tags: [build_stream, gitlab]
+
+# ──────────────────────────────────────────────────────────────────────
 # BuildStream Terminal Gate (C-24): Read build_stream_config.yml and
 # set build_stream_terminal fact. When enable_build_stream=true AND
 # build_stream tag completes, downstream tags (local_repo, build_image,

--- a/upgrade/upgrade.yml
+++ b/upgrade/upgrade.yml
@@ -287,17 +287,36 @@
 # ──────────────────────────────────────────────────────────────────────
 # Load credentials via credential utility (for build_stream and gitlab)
 # Set upgrade_mode to bypass upgrade_checkup guard within credential utility
+# Set dynamic run tags based on enable_build_stream flag
 # ──────────────────────────────────────────────────────────────────────
-- name: Set upgrade mode flag for credential utility
+- name: Set upgrade mode flag and dynamic tags for credential utility
   hosts: localhost
   connection: local
   gather_facts: false
   tags: [build_stream, gitlab]
   tasks:
+    - name: Read build_stream_config.yml to check enable_build_stream flag
+      ansible.builtin.include_vars:
+        file: "{{ input_project_dir }}/build_stream_config.yml"
+        name: _bs_config_check
+      failed_when: false
+
     - name: Enable upgrade_mode to bypass credential utility guard
       ansible.builtin.set_fact:
         upgrade_mode: true
         cacheable: true
+
+    - name: Set dynamic run tags including build_stream and gitlab
+      ansible.builtin.set_fact:
+        omnia_run_tags: >-
+          {{
+            (
+              ansible_run_tags | default([]) +
+              ['build_stream', 'gitlab']
+            ) | unique
+          }}
+        cacheable: true
+      when: _bs_config_check.enable_build_stream | default(false) | bool
 
 - name: Load Omnia credential utility
   ansible.builtin.import_playbook: ../utils/credential_utility/get_config_credentials.yml


### PR DESCRIPTION


### Description of the Solution

This PR implements critical enhancements to the BuildStream upgrade process from Omnia 2.1 to 2.2, focusing on reliable PATH detection and complete GitLab configuration upgrade for PATH A scenarios.

Key Changes
1. Enhanced PATH Detection Logic (Source of Truth: Backup Config)

Reads enable_build_stream flag from backup directory (/opt/omnia/backups/upgrade/version_2.1.0.0/input/project_default/build_stream_config.yml) as the primary source of truth
Implements dual detection mechanism:
Config-based detection: Based on enable_build_stream flag from backup
GitLab-based detection: Based on gitlab-ctl presence on target host
Adds conflict detection and resolution logic with clear warning messages
Config-based detection takes priority when methods disagree
Provides comprehensive debug logging showing detection source
2. Credential Utility Integration

Removed explicit --vault-password-file argument requirement from upgrade execution
Integrated credential utility (get_config_credentials.yml) in upgrade.yml with build_stream and gitlab tags
Set upgrade_mode: true flag to bypass credential utility guard checks
Updated all credential references in upgrade_build_stream.yml to use hostvars['localhost']['provision_password']
Removed manual credential loading tasks from upgrade_build_stream.yml
3. Complete GitLab Configuration Upgrade (Step 4 - PATH A)

4A.1: Backup GitLab configuration files (gitlab.rb, gitlab-secrets.json, runner config, tokens, quadlet files)
4A.2: Update gitlab.rb from 2.2 template and reconfigure GitLab with health checks
4A.3: Update CI/CD pipeline files (.gitlab-ci.yml, .gitlab-ci-build.yml, .gitlab-ci-deploy.yml, etc.)
4A.4: Sync Omnia input files to GitLab repository
4A.5: Update CI/CD pipeline variables with BuildStream OAuth credentials
4A.6: Re-register GitLab Runner (BS-08) with new authentication token and updated images
4A.7: Validate GitLab API accessibility post-upgrade
4. Additional Improvements

Added pipeline gate (GL-01) to abort upgrade if active pipelines exist
Implemented proper error handling and retry logic for GitLab operations
Added comprehensive debug output for troubleshooting
Updated status comments in playbook header
Testing
Verified PATH detection with conflict scenario (config=false, GitLab installed) → correctly chose PATH B based on config
Verified credential utility integration without explicit vault password file
Tested SSH operations using sshpass for GitLab host communication
Confirmed upgrade proceeds with internal credential loading
Impact
More reliable upgrade path determination based on actual pre-upgrade configuration state
Eliminates manual vault password file management during upgrade
Complete GitLab configuration upgrade for PATH A scenarios
Better conflict detection and resolution with clear logging
Improved upgrade process reliability and user experience

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@priti-parate @abhishek-sa1 @Venu-p1 