### PR TITLE
Create readable pkg ids in Catalog

### DIFF
--- a/build_stream/generate_catalog.py
+++ b/build_stream/generate_catalog.py
@@ -206,7 +206,7 @@ def _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids):
         sanitized = sanitized[:50]
     
     # Build base ID
-    version_part = pkg_version if pkg_version else 'latest'
+    version_part = pkg_version if pkg_version else 'na'
     base_id = f"{sanitized}_{version_part}_{pkg_type}"
     
     # Handle collisions

--- a/build_stream/generate_catalog.py
+++ b/build_stream/generate_catalog.py
@@ -174,6 +174,55 @@ def _merge_package_entries(dst, src):
     if not dst.get('url') and src.get('url'):
         dst['url'] = src['url']
 
+def _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids):
+    """Generate a human-readable package ID with collision handling.
+    
+    Format: {sanitized_name}_{version}_{type}
+    If collision occurs, append counter: {base_id}_{counter}
+    """
+    # Extract version from package name if present (e.g., PyMySQL==1.1.2)
+    name_for_id = pkg_name
+    if '==' in pkg_name and pkg_type == 'pip_module':
+        # For pip modules, name==version format
+        parts = pkg_name.split('==')
+        if len(parts) == 2:
+            name_for_id = parts[0]
+            if not pkg_version:
+                pkg_version = parts[1]
+    elif '-' in pkg_name and pkg_type == 'rpm' and not pkg_version:
+        # Some RPMs have version in name (e.g., python3-PyMySQL-1.1.2)
+        # Try to extract version if it looks like a version number
+        parts = pkg_name.rsplit('-', 1)
+        if len(parts) == 2 and re.match(r'^\d', parts[1]):
+            name_for_id = parts[0]
+            pkg_version = parts[1]
+    
+    # Sanitize package name: replace special chars with hyphens
+    sanitized = re.sub(r'[/@:.]', '-', name_for_id)
+    sanitized = re.sub(r'-+', '-', sanitized).strip('-')
+    
+    # Truncate very long names to reasonable length
+    if len(sanitized) > 50:
+        sanitized = sanitized[:50]
+    
+    # Build base ID
+    version_part = pkg_version if pkg_version else 'latest'
+    base_id = f"{sanitized}_{version_part}_{pkg_type}"
+    
+    # Handle collisions
+    if base_id not in used_ids:
+        used_ids.add(base_id)
+        return base_id
+    
+    # Collision detected - append counter
+    counter = 1
+    while True:
+        collision_id = f"{base_id}_{counter}"
+        if collision_id not in used_ids:
+            used_ids.add(collision_id)
+            return collision_id
+        counter += 1
+
 def _render_templated_url(template: str, bundle_name: str, versions_by_name: dict) -> str:
     """Render very simple Jinja-like templates used in config URLs.
 
@@ -405,8 +454,10 @@ def generate_catalog(input_dir, software_config_path, pxe_mapping_file):
     infra_packages = {}
     misc_package_ids = []
 
-    os_pkg_id_counter = 1
-    infra_pkg_id_counter = 1
+    # Track used IDs for collision detection across all package types
+    used_ids = set()
+    # Add functional package IDs to used_ids to avoid collisions
+    used_ids.update(package_id_map.values())
 
     # Precompute OS-role flags
     has_os_x86_64 = 'os_x86_64' in (pxe_groups or [])
@@ -434,8 +485,10 @@ def generate_catalog(input_dir, software_config_path, pxe_mapping_file):
 
         # --- Infrastructure ---
         if is_infra:
-            pkg_id = f"infrastructure_package_id_{infra_pkg_id_counter}"
-            infra_pkg_id_counter += 1
+            pkg_name = pkg_data['name']
+            pkg_type = pkg_data['type']
+            pkg_version = pkg_data.get('version') or pkg_data.get('tag')
+            pkg_id = _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids)
             infra_packages[pkg_id] = create_infra_package_entry(pkg_data)
             # Infra packages are exclusive; skip other sections
             continue
@@ -452,8 +505,10 @@ def generate_catalog(input_dir, software_config_path, pxe_mapping_file):
             func_pkg_id = package_id_map[key]
             functional_packages[func_pkg_id] = create_package_entry(pkg_data)
             # Also add to OS so adapter_policy can generate ldms.json from base_os.json
-            os_pkg_id = f"os_package_id_{os_pkg_id_counter}"
-            os_pkg_id_counter += 1
+            pkg_name = pkg_data['name']
+            pkg_type = pkg_data['type']
+            pkg_version = pkg_data.get('version') or pkg_data.get('tag')
+            os_pkg_id = _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids)
             os_packages[os_pkg_id] = create_package_entry(pkg_data)
             continue
 
@@ -462,14 +517,17 @@ def generate_catalog(input_dir, software_config_path, pxe_mapping_file):
         #   (a) it belongs to at least one non-functional, non-infra bundle, OR
         #   (b) it does not belong to any functional or infra bundle at all
         if has_base_os_bundle or (not is_functional and not is_infra):
-            os_pkg_id = f"os_package_id_{os_pkg_id_counter}"
-            os_pkg_id_counter += 1
+            pkg_name = pkg_data['name']
+            pkg_type = pkg_data['type']
+            pkg_version = pkg_data.get('version') or pkg_data.get('tag')
+            os_pkg_id = _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids)
             os_packages[os_pkg_id] = create_package_entry(pkg_data)
 
-    catalog["Catalog"]["FunctionalPackages"] = functional_packages
-    catalog["Catalog"]["OSPackages"] = os_packages
+    # Sort all package dictionaries alphabetically by key
+    catalog["Catalog"]["FunctionalPackages"] = dict(sorted(functional_packages.items()))
+    catalog["Catalog"]["OSPackages"] = dict(sorted(os_packages.items()))
+    catalog["Catalog"]["InfrastructurePackages"] = dict(sorted(infra_packages.items()))
     catalog["Catalog"]["Miscellaneous"] = sorted(list(set(misc_package_ids)))
-    catalog["Catalog"]["InfrastructurePackages"] = infra_packages
 
     # Add BaseOS section
     catalog["Catalog"]["BaseOS"] = [{
@@ -486,9 +544,11 @@ def generate_catalog(input_dir, software_config_path, pxe_mapping_file):
         }]
 
     # Build Functional Layers based on PXE mapping
-    catalog["Catalog"]["FunctionalLayer"] = build_functional_layers(
+    functional_layers = build_functional_layers(
         functional_packages, pxe_groups, role_package_map
     )
+    # Sort functional layers by Name
+    catalog["Catalog"]["FunctionalLayer"] = sorted(functional_layers, key=lambda x: x["Name"])
 
     return catalog
 
@@ -535,29 +595,9 @@ def build_functional_layers(functional_packages, pxe_groups, role_package_map):
             })
         generated.add(pxe_group)
 
-    # ── 2. Generate _first variant layers for PXE-listed role+arch combos ──
-    for role_name, pkg_ids in role_package_map.items():
-        if not role_name.endswith('_first'):
-            continue
-        base_role = role_name[:-6]  # strip "_first"
-        allowed_arches = pxe_role_arches.get(base_role, set())
-        for arch in allowed_arches:
-            layer_name = f"{role_name}_{arch}"
-            if layer_name in generated:
-                continue
-
-            filtered = [
-                pid for pid in pkg_ids
-                if pid in functional_packages
-                and arch in functional_packages[pid].get('Architecture', [])
-            ]
-
-            if filtered:
-                functional_layers.append({
-                    "Name": layer_name,
-                    "FunctionalPackages": sorted(filtered),
-                })
-            generated.add(layer_name)
+    # ── 2. Generate _first variant layers only if explicitly in PXE mapping ──
+    # Skip this step since PXE mapping doesn't include _first variants
+    # The adapter policy will handle _first variants during bundle expansion
 
     return functional_layers
 
@@ -567,7 +607,8 @@ def map_packages_to_roles(packages, config_dir, allowed_bundles, bundle_roles, p
     role_package_map = defaultdict(list)
     package_id_map = {}
 
-    pkg_id_counter = 1
+    # Track used IDs for collision detection
+    used_ids = set()
 
     # Check if os_x86_64 or os_aarch64 exist in PXE groups
     has_os_roles = any(g in (pxe_groups or []) for g in ['os_x86_64', 'os_aarch64'])
@@ -575,6 +616,7 @@ def map_packages_to_roles(packages, config_dir, allowed_bundles, bundle_roles, p
     # First pass: assign package IDs (functional bundles + infra if os_* roles exist)
     for key, pkg_data in packages.items():
         pkg_name = pkg_data['name']
+        pkg_type = pkg_data['type']
         bundles = set(pkg_data.get('bundles') or [])
         is_functional = bool(bundles & _FUNCTIONAL_BUNDLES)
         is_infra = bool(bundles & _INFRA_BUNDLES)
@@ -582,14 +624,21 @@ def map_packages_to_roles(packages, config_dir, allowed_bundles, bundle_roles, p
         # Include ldms packages in package_id_map when os_* roles exist
         is_os_layer_bundle = _OS_LAYER_BUNDLE in bundles
         
+        # Determine version for ID generation
+        pkg_version = None
+        if pkg_type == 'image' and pkg_data.get('tag'):
+            pkg_version = pkg_data['tag']
+        elif pkg_type == 'git' and pkg_data.get('version'):
+            pkg_version = pkg_data['version']
+        elif pkg_data.get('version'):
+            pkg_version = pkg_data['version']
+        
         if is_functional and not is_infra:
-            pkg_id = f"package_id_{pkg_id_counter}"
-            pkg_id_counter += 1
+            pkg_id = _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids)
             package_id_map[key] = pkg_id
         elif is_os_layer_bundle and has_os_roles:
             # ldms packages should be added to functional packages for os_* layers
-            pkg_id = f"package_id_{pkg_id_counter}"
-            pkg_id_counter += 1
+            pkg_id = _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids)
             package_id_map[key] = pkg_id
 
     # Second pass: map packages to roles by scanning config files

--- a/examples/catalog/catalog_rhel.json
+++ b/examples/catalog/catalog_rhel.json
@@ -7,74 +7,74 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "os_x86_64",
         "FunctionalPackages": [
-          "openssl-libs_latest_rpm",
-          "ovis-ldms_latest_rpm",
-          "python3-cython_latest_rpm",
-          "python3-devel_latest_rpm"
+          "openssl-libs_na_rpm",
+          "ovis-ldms_na_rpm",
+          "python3-cython_na_rpm",
+          "python3-devel_na_rpm"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
           "PyMySQL_1.1.2_pip_module",
-          "apptainer_latest_rpm",
-          "calico-v3-31-4_latest_manifest",
-          "cert-manager-v1-10-0_latest_tarball",
+          "apptainer_na_rpm",
+          "calico-v3-31-4_na_manifest",
+          "cert-manager-v1-10-0_na_tarball",
           "cffi_1.17.1_pip_module",
-          "container-selinux_latest_rpm",
+          "container-selinux_na_rpm",
           "cri-o_1.35.1_rpm",
           "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
           "docker-io-alpine-kubectl_1.35.1_image",
           "docker-io-calico-cni_v3.31.4_image",
           "docker-io-calico-kube-controllers_v3.31.4_image",
@@ -99,27 +99,27 @@
           "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_latest_rpm",
-          "fuse-overlayfs_latest_rpm",
+          "firewalld_na_rpm",
+          "fuse-overlayfs_na_rpm",
           "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
           "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_latest_rpm",
+          "git_na_rpm",
           "helm-charts_container-storage-modules-1.9.2_git",
-          "helm-v3-20-1-amd64_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
+          "helm-v3-20-1-amd64_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
           "karavi-observability_v1.12.0_git",
           "kubeadm_1.35.1_rpm",
           "kubectl_1.35.1_rpm",
           "kubelet_1.35.1_rpm",
           "kubernetes_33.1.0_pip_module",
-          "lsscsi_latest_rpm",
-          "metallb-native-v0-15-3_latest_manifest",
-          "nfs-subdir-external-provisioner-4-0-18_latest_tarball",
+          "lsscsi_na_rpm",
+          "metallb-native-v0-15-3_na_manifest",
+          "nfs-subdir-external-provisioner-4-0-18_na_tarball",
           "omsdk_1.2.518_pip_module",
-          "podman_latest_rpm",
+          "podman_na_rpm",
           "prettytable_3.14.0_pip_module",
           "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_latest_rpm",
+          "python3-firewall_na_rpm",
           "python3_3.12.9_rpm",
           "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
           "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
@@ -137,23 +137,23 @@
           "registry-k8s-io-kube-proxy_v1.35.1_image",
           "registry-k8s-io-kube-scheduler_v1.35.1_image",
           "registry-k8s-io-pause_3.10.1_image",
-          "sg3_utils_latest_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
-          "victoria-metrics-operator-0-59-3_latest_tarball",
-          "vim-enhanced_latest_rpm"
+          "sg3_utils_na_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
+          "victoria-metrics-operator-0-59-3_na_tarball",
+          "vim-enhanced_na_rpm"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "cert-manager-v1-10-0_latest_tarball",
+          "apptainer_na_rpm",
+          "cert-manager-v1-10-0_na_tarball",
           "cffi_1.17.1_pip_module",
-          "container-selinux_latest_rpm",
+          "container-selinux_na_rpm",
           "cri-o_1.35.1_rpm",
           "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
           "docker-io-alpine-kubectl_1.35.1_image",
           "docker-io-curlimages-curl_8.17.0_image",
           "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
@@ -175,21 +175,21 @@
           "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_latest_rpm",
-          "fuse-overlayfs_latest_rpm",
+          "firewalld_na_rpm",
+          "fuse-overlayfs_na_rpm",
           "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_latest_rpm",
+          "git_na_rpm",
           "helm-charts_container-storage-modules-1.9.2_git",
-          "iscsi-initiator-utils_latest_rpm",
+          "iscsi-initiator-utils_na_rpm",
           "karavi-observability_v1.12.0_git",
           "kubeadm_1.35.1_rpm",
           "kubelet_1.35.1_rpm",
           "kubernetes_33.1.0_pip_module",
-          "lsscsi_latest_rpm",
+          "lsscsi_na_rpm",
           "omsdk_1.2.518_pip_module",
-          "podman_latest_rpm",
+          "podman_na_rpm",
           "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_latest_rpm",
+          "python3-firewall_na_rpm",
           "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
           "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
           "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
@@ -201,64 +201,64 @@
           "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
           "quay-io-strimzi-operator_0.48.0_image",
           "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
-          "sg3_utils_latest_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
-          "victoria-metrics-operator-0-59-3_latest_tarball",
-          "vim-enhanced_latest_rpm"
+          "sg3_utils_na_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
+          "victoria-metrics-operator-0-59-3_na_tarball",
+          "vim-enhanced_na_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "mariadb-server_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "mariadb-server_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-PyMySQL_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmctld_latest_rpm",
-          "slurm-slurmdbd_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-PyMySQL_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmctld_na_rpm",
+          "slurm-slurmdbd_na_rpm"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "kernel-devel_latest_rpm",
-          "kernel-headers_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "kernel-devel_na_rpm",
+          "kernel-headers_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-pam_slurm_latest_rpm",
-          "slurm-slurmd_latest_rpm"
+          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_na_tarball",
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-pam_slurm_na_rpm",
+          "slurm-slurmd_na_rpm"
         ]
       }
     ],
@@ -267,106 +267,106 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_latest_rpm",
-          "authselect_latest_rpm",
-          "autoconf_latest_rpm",
-          "automake_latest_rpm",
-          "bash-completion_latest_rpm",
-          "bash_latest_rpm",
-          "binutils-devel_latest_rpm",
-          "binutils_latest_rpm",
-          "bzip2_latest_rpm",
-          "chrony_latest_rpm",
-          "cloud-init_latest_rpm",
-          "clustershell_latest_rpm",
-          "cmake_latest_rpm",
-          "coreutils_latest_rpm",
-          "cryptsetup_latest_rpm",
-          "curl_latest_rpm",
-          "device-mapper_latest_rpm",
-          "dmidecode_latest_rpm",
+          "NetworkManager_na_rpm",
+          "authselect_na_rpm",
+          "autoconf_na_rpm",
+          "automake_na_rpm",
+          "bash-completion_na_rpm",
+          "bash_na_rpm",
+          "binutils-devel_na_rpm",
+          "binutils_na_rpm",
+          "bzip2_na_rpm",
+          "chrony_na_rpm",
+          "cloud-init_na_rpm",
+          "clustershell_na_rpm",
+          "cmake_na_rpm",
+          "coreutils_na_rpm",
+          "cryptsetup_na_rpm",
+          "curl_na_rpm",
+          "device-mapper_na_rpm",
+          "dmidecode_na_rpm",
           "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
           "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_latest_rpm",
-          "dracut-network_latest_rpm",
-          "dracut_latest_rpm",
-          "emacs_latest_rpm",
-          "file_latest_rpm",
-          "findutils_latest_rpm",
-          "fping_latest_rpm",
-          "gawk_latest_rpm",
-          "gcc-c++_latest_rpm",
-          "gcc-gfortran_latest_rpm",
-          "gcc_latest_rpm",
-          "gdb-gdbserver_latest_rpm",
-          "gdb_latest_rpm",
-          "gedit_latest_rpm",
-          "glibc-langpack-en_latest_rpm",
-          "grep_latest_rpm",
-          "gzip_latest_rpm",
-          "hwloc-libs_latest_rpm",
-          "hwloc_latest_rpm",
-          "iperf3_latest_rpm",
-          "ipmitool_latest_rpm",
-          "iproute_latest_rpm",
-          "iputils_latest_rpm",
-          "kbd_latest_rpm",
-          "kernel-tools_latest_rpm",
-          "kernel_latest_rpm",
-          "kexec-tools_latest_rpm",
-          "libcurl_latest_rpm",
-          "libtool_latest_rpm",
-          "lldb-devel_latest_rpm",
-          "lldb_latest_rpm",
-          "lshw_latest_rpm",
-          "lsof_latest_rpm",
-          "ltrace_latest_rpm",
-          "lvm2_latest_rpm",
-          "make_latest_rpm",
-          "man-db_latest_rpm",
-          "man-pages_latest_rpm",
-          "munge-devel_latest_rpm",
-          "nfs-utils_latest_rpm",
-          "nfs4-acl-tools_latest_rpm",
-          "nm-connection-editor_latest_rpm",
-          "nss-pam-ldapd_latest_rpm",
-          "oddjob-mkhomedir_latest_rpm",
-          "openldap-clients_latest_rpm",
+          "dracut-live_na_rpm",
+          "dracut-network_na_rpm",
+          "dracut_na_rpm",
+          "emacs_na_rpm",
+          "file_na_rpm",
+          "findutils_na_rpm",
+          "fping_na_rpm",
+          "gawk_na_rpm",
+          "gcc-c++_na_rpm",
+          "gcc-gfortran_na_rpm",
+          "gcc_na_rpm",
+          "gdb-gdbserver_na_rpm",
+          "gdb_na_rpm",
+          "gedit_na_rpm",
+          "glibc-langpack-en_na_rpm",
+          "grep_na_rpm",
+          "gzip_na_rpm",
+          "hwloc-libs_na_rpm",
+          "hwloc_na_rpm",
+          "iperf3_na_rpm",
+          "ipmitool_na_rpm",
+          "iproute_na_rpm",
+          "iputils_na_rpm",
+          "kbd_na_rpm",
+          "kernel-tools_na_rpm",
+          "kernel_na_rpm",
+          "kexec-tools_na_rpm",
+          "libcurl_na_rpm",
+          "libtool_na_rpm",
+          "lldb-devel_na_rpm",
+          "lldb_na_rpm",
+          "lshw_na_rpm",
+          "lsof_na_rpm",
+          "ltrace_na_rpm",
+          "lvm2_na_rpm",
+          "make_na_rpm",
+          "man-db_na_rpm",
+          "man-pages_na_rpm",
+          "munge-devel_na_rpm",
+          "nfs-utils_na_rpm",
+          "nfs4-acl-tools_na_rpm",
+          "nm-connection-editor_na_rpm",
+          "nss-pam-ldapd_na_rpm",
+          "oddjob-mkhomedir_na_rpm",
+          "openldap-clients_na_rpm",
           "openmpi_5.0.8_tarball",
-          "openssh-clients_latest_rpm",
-          "openssh-server_latest_rpm",
-          "openssh_latest_rpm",
-          "openssl-devel_latest_rpm",
-          "openssl-libs_latest_rpm_1",
-          "ovis-ldms_latest_rpm_1",
-          "papi-devel_latest_rpm",
-          "papi-libs_latest_rpm",
-          "papi_latest_rpm",
-          "pciutils_latest_rpm",
-          "perf_latest_rpm",
-          "pmix-devel_latest_rpm",
-          "python3-cython_latest_rpm_1",
-          "python3-devel_latest_rpm_1",
-          "rsync_latest_rpm",
-          "rsyslog_latest_rpm",
-          "sed_latest_rpm",
-          "squashfs-tools_latest_rpm",
-          "sssd_latest_rpm",
-          "strace_latest_rpm",
-          "sudo_latest_rpm",
-          "systemd-udev_latest_rpm",
-          "systemd_latest_rpm",
-          "tar_latest_rpm",
-          "tcpdump_latest_rpm",
-          "traceroute_latest_rpm",
+          "openssh-clients_na_rpm",
+          "openssh-server_na_rpm",
+          "openssh_na_rpm",
+          "openssl-devel_na_rpm",
+          "openssl-libs_na_rpm_1",
+          "ovis-ldms_na_rpm_1",
+          "papi-devel_na_rpm",
+          "papi-libs_na_rpm",
+          "papi_na_rpm",
+          "pciutils_na_rpm",
+          "perf_na_rpm",
+          "pmix-devel_na_rpm",
+          "python3-cython_na_rpm_1",
+          "python3-devel_na_rpm_1",
+          "rsync_na_rpm",
+          "rsyslog_na_rpm",
+          "sed_na_rpm",
+          "squashfs-tools_na_rpm",
+          "sssd_na_rpm",
+          "strace_na_rpm",
+          "sudo_na_rpm",
+          "systemd-udev_na_rpm",
+          "systemd_na_rpm",
+          "tar_na_rpm",
+          "tcpdump_na_rpm",
+          "traceroute_na_rpm",
           "ucx_1.19.0_tarball",
-          "util-linux_latest_rpm",
-          "valgrind-devel_latest_rpm",
-          "valgrind_latest_rpm",
-          "vim-enhanced_latest_rpm_1",
-          "wget_latest_rpm",
-          "which_latest_rpm",
-          "zsh_latest_rpm"
+          "util-linux_na_rpm",
+          "valgrind-devel_na_rpm",
+          "valgrind_na_rpm",
+          "vim-enhanced_na_rpm_1",
+          "wget_na_rpm",
+          "which_na_rpm",
+          "zsh_na_rpm"
         ]
       }
     ],
@@ -409,7 +409,7 @@
         ],
         "Type": "pip_module"
       },
-      "apptainer_latest_rpm": {
+      "apptainer_na_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -433,7 +433,7 @@
           }
         ]
       },
-      "calico-v3-31-4_latest_manifest": {
+      "calico-v3-31-4_na_manifest": {
         "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
@@ -452,7 +452,7 @@
           }
         ]
       },
-      "cert-manager-v1-10-0_latest_tarball": {
+      "cert-manager-v1-10-0_na_tarball": {
         "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
@@ -484,7 +484,7 @@
         ],
         "Type": "pip_module"
       },
-      "container-selinux_latest_rpm": {
+      "container-selinux_na_rpm": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -535,7 +535,7 @@
         ],
         "Type": "pip_module"
       },
-      "device-mapper-multipath_latest_rpm": {
+      "device-mapper-multipath_na_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -559,7 +559,7 @@
           }
         ]
       },
-      "doca-ofed_latest_rpm_repo": {
+      "doca-ofed_na_rpm_repo": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -943,7 +943,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "firewalld_latest_rpm": {
+      "firewalld_na_rpm": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -967,7 +967,7 @@
           }
         ]
       },
-      "fuse-overlayfs_latest_rpm": {
+      "fuse-overlayfs_na_rpm": {
         "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
@@ -986,7 +986,7 @@
           }
         ]
       },
-      "geopm_latest_tarball": {
+      "geopm_na_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -1040,7 +1040,7 @@
         "Tag": "0.143.1",
         "Version": "0.143.1"
       },
-      "git_latest_rpm": {
+      "git_na_rpm": {
         "Name": "git",
         "SupportedOS": [
           {
@@ -1079,7 +1079,7 @@
           }
         ]
       },
-      "helm-v3-20-1-amd64_latest_tarball": {
+      "helm-v3-20-1-amd64_na_tarball": {
         "Name": "helm-v3.20.1-amd64",
         "SupportedOS": [
           {
@@ -1098,7 +1098,7 @@
           }
         ]
       },
-      "imb_latest_tarball": {
+      "imb_na_tarball": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -1122,7 +1122,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_latest_rpm": {
+      "iscsi-initiator-utils_na_rpm": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -1166,7 +1166,7 @@
           }
         ]
       },
-      "kernel-devel_latest_rpm": {
+      "kernel-devel_na_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1190,7 +1190,7 @@
           }
         ]
       },
-      "kernel-headers_latest_rpm": {
+      "kernel-headers_na_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1284,7 +1284,7 @@
         ],
         "Type": "pip_module"
       },
-      "likwid_latest_tarball": {
+      "likwid_na_tarball": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -1308,7 +1308,7 @@
           }
         ]
       },
-      "lsscsi_latest_rpm": {
+      "lsscsi_na_rpm": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -1332,7 +1332,7 @@
           }
         ]
       },
-      "mariadb-server_latest_rpm": {
+      "mariadb-server_na_rpm": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -1356,7 +1356,7 @@
           }
         ]
       },
-      "metallb-native-v0-15-3_latest_manifest": {
+      "metallb-native-v0-15-3_na_manifest": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -1375,7 +1375,7 @@
           }
         ]
       },
-      "msr-safe_latest_tarball": {
+      "msr-safe_na_tarball": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -1394,7 +1394,7 @@
           }
         ]
       },
-      "munge_latest_rpm": {
+      "munge_na_rpm": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -1418,7 +1418,7 @@
           }
         ]
       },
-      "nfs-subdir-external-provisioner-4-0-18_latest_tarball": {
+      "nfs-subdir-external-provisioner-4-0-18_na_tarball": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -1453,7 +1453,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
         "SupportedOS": [
           {
@@ -1472,7 +1472,7 @@
           }
         ]
       },
-      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -1504,7 +1504,7 @@
         ],
         "Type": "pip_module"
       },
-      "openssl-libs_latest_rpm": {
+      "openssl-libs_na_rpm": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -1528,7 +1528,7 @@
           }
         ]
       },
-      "osu-micro-benchmarks_latest_tarball": {
+      "osu-micro-benchmarks_na_tarball": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -1552,7 +1552,7 @@
           }
         ]
       },
-      "ovis-ldms_latest_rpm": {
+      "ovis-ldms_na_rpm": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -1576,7 +1576,7 @@
           }
         ]
       },
-      "papi_latest_tarball": {
+      "papi_na_tarball": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -1600,7 +1600,7 @@
           }
         ]
       },
-      "pmix_latest_rpm": {
+      "pmix_na_rpm": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -1624,7 +1624,7 @@
           }
         ]
       },
-      "podman_latest_rpm": {
+      "podman_na_rpm": {
         "Name": "podman",
         "SupportedOS": [
           {
@@ -1669,7 +1669,7 @@
         ],
         "Type": "pip_module"
       },
-      "python3-PyMySQL_latest_rpm": {
+      "python3-PyMySQL_na_rpm": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -1693,7 +1693,7 @@
           }
         ]
       },
-      "python3-cython_latest_rpm": {
+      "python3-cython_na_rpm": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -1717,7 +1717,7 @@
           }
         ]
       },
-      "python3-devel_latest_rpm": {
+      "python3-devel_na_rpm": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -1741,7 +1741,7 @@
           }
         ]
       },
-      "python3-firewall_latest_rpm": {
+      "python3-firewall_na_rpm": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -2054,7 +2054,7 @@
         "Tag": "v4.0.2",
         "Version": "v4.0.2"
       },
-      "sg3_utils_latest_rpm": {
+      "sg3_utils_na_rpm": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -2078,7 +2078,7 @@
           }
         ]
       },
-      "sionlib_latest_tarball": {
+      "sionlib_na_tarball": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -2102,7 +2102,7 @@
           }
         ]
       },
-      "slurm-pam_slurm_latest_rpm": {
+      "slurm-pam_slurm_na_rpm": {
         "Name": "slurm-pam_slurm",
         "SupportedOS": [
           {
@@ -2126,7 +2126,7 @@
           }
         ]
       },
-      "slurm-slurmctld_latest_rpm": {
+      "slurm-slurmctld_na_rpm": {
         "Name": "slurm-slurmctld",
         "SupportedOS": [
           {
@@ -2150,7 +2150,7 @@
           }
         ]
       },
-      "slurm-slurmd_latest_rpm": {
+      "slurm-slurmd_na_rpm": {
         "Name": "slurm-slurmd",
         "SupportedOS": [
           {
@@ -2174,7 +2174,7 @@
           }
         ]
       },
-      "slurm-slurmdbd_latest_rpm": {
+      "slurm-slurmdbd_na_rpm": {
         "Name": "slurm-slurmdbd",
         "SupportedOS": [
           {
@@ -2198,7 +2198,7 @@
           }
         ]
       },
-      "slurm_latest_rpm": {
+      "slurm_na_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -2222,7 +2222,7 @@
           }
         ]
       },
-      "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball": {
+      "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball": {
         "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
         "SupportedOS": [
           {
@@ -2241,7 +2241,7 @@
           }
         ]
       },
-      "victoria-metrics-operator-0-59-3_latest_tarball": {
+      "victoria-metrics-operator-0-59-3_na_tarball": {
         "Name": "victoria-metrics-operator-0.59.3",
         "SupportedOS": [
           {
@@ -2260,7 +2260,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm": {
+      "vim-enhanced_na_rpm": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2286,7 +2286,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_latest_rpm": {
+      "NetworkManager_na_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -2310,7 +2310,7 @@
           }
         ]
       },
-      "authselect_latest_rpm": {
+      "authselect_na_rpm": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -2334,7 +2334,7 @@
           }
         ]
       },
-      "autoconf_latest_rpm": {
+      "autoconf_na_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2358,7 +2358,7 @@
           }
         ]
       },
-      "automake_latest_rpm": {
+      "automake_na_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2382,7 +2382,7 @@
           }
         ]
       },
-      "bash-completion_latest_rpm": {
+      "bash-completion_na_rpm": {
         "Name": "bash-completion",
         "SupportedOS": [
           {
@@ -2406,7 +2406,7 @@
           }
         ]
       },
-      "bash_latest_rpm": {
+      "bash_na_rpm": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -2430,7 +2430,7 @@
           }
         ]
       },
-      "binutils-devel_latest_rpm": {
+      "binutils-devel_na_rpm": {
         "Name": "binutils-devel",
         "SupportedOS": [
           {
@@ -2454,7 +2454,7 @@
           }
         ]
       },
-      "binutils_latest_rpm": {
+      "binutils_na_rpm": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -2478,7 +2478,7 @@
           }
         ]
       },
-      "bzip2_latest_rpm": {
+      "bzip2_na_rpm": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -2502,7 +2502,7 @@
           }
         ]
       },
-      "chrony_latest_rpm": {
+      "chrony_na_rpm": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -2526,7 +2526,7 @@
           }
         ]
       },
-      "cloud-init_latest_rpm": {
+      "cloud-init_na_rpm": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -2550,7 +2550,7 @@
           }
         ]
       },
-      "clustershell_latest_rpm": {
+      "clustershell_na_rpm": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2574,7 +2574,7 @@
           }
         ]
       },
-      "cmake_latest_rpm": {
+      "cmake_na_rpm": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -2598,7 +2598,7 @@
           }
         ]
       },
-      "coreutils_latest_rpm": {
+      "coreutils_na_rpm": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -2622,7 +2622,7 @@
           }
         ]
       },
-      "cryptsetup_latest_rpm": {
+      "cryptsetup_na_rpm": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -2646,7 +2646,7 @@
           }
         ]
       },
-      "curl_latest_rpm": {
+      "curl_na_rpm": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -2670,7 +2670,7 @@
           }
         ]
       },
-      "device-mapper_latest_rpm": {
+      "device-mapper_na_rpm": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -2694,7 +2694,7 @@
           }
         ]
       },
-      "dmidecode_latest_rpm": {
+      "dmidecode_na_rpm": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -2748,7 +2748,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_latest_rpm": {
+      "dracut-live_na_rpm": {
         "Name": "dracut-live",
         "SupportedOS": [
           {
@@ -2772,7 +2772,7 @@
           }
         ]
       },
-      "dracut-network_latest_rpm": {
+      "dracut-network_na_rpm": {
         "Name": "dracut-network",
         "SupportedOS": [
           {
@@ -2796,7 +2796,7 @@
           }
         ]
       },
-      "dracut_latest_rpm": {
+      "dracut_na_rpm": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -2820,7 +2820,7 @@
           }
         ]
       },
-      "emacs_latest_rpm": {
+      "emacs_na_rpm": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -2844,7 +2844,7 @@
           }
         ]
       },
-      "file_latest_rpm": {
+      "file_na_rpm": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -2868,7 +2868,7 @@
           }
         ]
       },
-      "findutils_latest_rpm": {
+      "findutils_na_rpm": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -2892,7 +2892,7 @@
           }
         ]
       },
-      "fping_latest_rpm": {
+      "fping_na_rpm": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -2916,7 +2916,7 @@
           }
         ]
       },
-      "gawk_latest_rpm": {
+      "gawk_na_rpm": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -2940,7 +2940,7 @@
           }
         ]
       },
-      "gcc-c++_latest_rpm": {
+      "gcc-c++_na_rpm": {
         "Name": "gcc-c++",
         "SupportedOS": [
           {
@@ -2964,7 +2964,7 @@
           }
         ]
       },
-      "gcc-gfortran_latest_rpm": {
+      "gcc-gfortran_na_rpm": {
         "Name": "gcc-gfortran",
         "SupportedOS": [
           {
@@ -2988,7 +2988,7 @@
           }
         ]
       },
-      "gcc_latest_rpm": {
+      "gcc_na_rpm": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -3012,7 +3012,7 @@
           }
         ]
       },
-      "gdb-gdbserver_latest_rpm": {
+      "gdb-gdbserver_na_rpm": {
         "Name": "gdb-gdbserver",
         "SupportedOS": [
           {
@@ -3036,7 +3036,7 @@
           }
         ]
       },
-      "gdb_latest_rpm": {
+      "gdb_na_rpm": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -3060,7 +3060,7 @@
           }
         ]
       },
-      "gedit_latest_rpm": {
+      "gedit_na_rpm": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -3084,7 +3084,7 @@
           }
         ]
       },
-      "glibc-langpack-en_latest_rpm": {
+      "glibc-langpack-en_na_rpm": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -3108,7 +3108,7 @@
           }
         ]
       },
-      "grep_latest_rpm": {
+      "grep_na_rpm": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -3132,7 +3132,7 @@
           }
         ]
       },
-      "gzip_latest_rpm": {
+      "gzip_na_rpm": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -3156,7 +3156,7 @@
           }
         ]
       },
-      "hwloc-libs_latest_rpm": {
+      "hwloc-libs_na_rpm": {
         "Name": "hwloc-libs",
         "SupportedOS": [
           {
@@ -3180,7 +3180,7 @@
           }
         ]
       },
-      "hwloc_latest_rpm": {
+      "hwloc_na_rpm": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -3204,7 +3204,7 @@
           }
         ]
       },
-      "iperf3_latest_rpm": {
+      "iperf3_na_rpm": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -3228,7 +3228,7 @@
           }
         ]
       },
-      "ipmitool_latest_rpm": {
+      "ipmitool_na_rpm": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -3252,7 +3252,7 @@
           }
         ]
       },
-      "iproute_latest_rpm": {
+      "iproute_na_rpm": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -3276,7 +3276,7 @@
           }
         ]
       },
-      "iputils_latest_rpm": {
+      "iputils_na_rpm": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -3300,7 +3300,7 @@
           }
         ]
       },
-      "kbd_latest_rpm": {
+      "kbd_na_rpm": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -3324,7 +3324,7 @@
           }
         ]
       },
-      "kernel-tools_latest_rpm": {
+      "kernel-tools_na_rpm": {
         "Name": "kernel-tools",
         "SupportedOS": [
           {
@@ -3348,7 +3348,7 @@
           }
         ]
       },
-      "kernel_latest_rpm": {
+      "kernel_na_rpm": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -3372,7 +3372,7 @@
           }
         ]
       },
-      "kexec-tools_latest_rpm": {
+      "kexec-tools_na_rpm": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -3396,7 +3396,7 @@
           }
         ]
       },
-      "libcurl_latest_rpm": {
+      "libcurl_na_rpm": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -3420,7 +3420,7 @@
           }
         ]
       },
-      "libtool_latest_rpm": {
+      "libtool_na_rpm": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -3444,7 +3444,7 @@
           }
         ]
       },
-      "lldb-devel_latest_rpm": {
+      "lldb-devel_na_rpm": {
         "Name": "lldb-devel",
         "SupportedOS": [
           {
@@ -3468,7 +3468,7 @@
           }
         ]
       },
-      "lldb_latest_rpm": {
+      "lldb_na_rpm": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -3492,7 +3492,7 @@
           }
         ]
       },
-      "lshw_latest_rpm": {
+      "lshw_na_rpm": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -3516,7 +3516,7 @@
           }
         ]
       },
-      "lsof_latest_rpm": {
+      "lsof_na_rpm": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -3540,7 +3540,7 @@
           }
         ]
       },
-      "ltrace_latest_rpm": {
+      "ltrace_na_rpm": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -3564,7 +3564,7 @@
           }
         ]
       },
-      "lvm2_latest_rpm": {
+      "lvm2_na_rpm": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -3588,7 +3588,7 @@
           }
         ]
       },
-      "make_latest_rpm": {
+      "make_na_rpm": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -3612,7 +3612,7 @@
           }
         ]
       },
-      "man-db_latest_rpm": {
+      "man-db_na_rpm": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -3636,7 +3636,7 @@
           }
         ]
       },
-      "man-pages_latest_rpm": {
+      "man-pages_na_rpm": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -3660,7 +3660,7 @@
           }
         ]
       },
-      "munge-devel_latest_rpm": {
+      "munge-devel_na_rpm": {
         "Name": "munge-devel",
         "SupportedOS": [
           {
@@ -3684,7 +3684,7 @@
           }
         ]
       },
-      "nfs-utils_latest_rpm": {
+      "nfs-utils_na_rpm": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -3708,7 +3708,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_latest_rpm": {
+      "nfs4-acl-tools_na_rpm": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -3732,7 +3732,7 @@
           }
         ]
       },
-      "nm-connection-editor_latest_rpm": {
+      "nm-connection-editor_na_rpm": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -3756,7 +3756,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_latest_rpm": {
+      "nss-pam-ldapd_na_rpm": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -3780,7 +3780,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_latest_rpm": {
+      "oddjob-mkhomedir_na_rpm": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -3804,7 +3804,7 @@
           }
         ]
       },
-      "openldap-clients_latest_rpm": {
+      "openldap-clients_na_rpm": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -3853,7 +3853,7 @@
           }
         ]
       },
-      "openssh-clients_latest_rpm": {
+      "openssh-clients_na_rpm": {
         "Name": "openssh-clients",
         "SupportedOS": [
           {
@@ -3877,7 +3877,7 @@
           }
         ]
       },
-      "openssh-server_latest_rpm": {
+      "openssh-server_na_rpm": {
         "Name": "openssh-server",
         "SupportedOS": [
           {
@@ -3901,7 +3901,7 @@
           }
         ]
       },
-      "openssh_latest_rpm": {
+      "openssh_na_rpm": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -3925,7 +3925,7 @@
           }
         ]
       },
-      "openssl-devel_latest_rpm": {
+      "openssl-devel_na_rpm": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -3949,7 +3949,7 @@
           }
         ]
       },
-      "openssl-libs_latest_rpm_1": {
+      "openssl-libs_na_rpm_1": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -3973,7 +3973,7 @@
           }
         ]
       },
-      "ovis-ldms_latest_rpm_1": {
+      "ovis-ldms_na_rpm_1": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -3997,7 +3997,7 @@
           }
         ]
       },
-      "papi-devel_latest_rpm": {
+      "papi-devel_na_rpm": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -4021,7 +4021,7 @@
           }
         ]
       },
-      "papi-libs_latest_rpm": {
+      "papi-libs_na_rpm": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -4045,7 +4045,7 @@
           }
         ]
       },
-      "papi_latest_rpm": {
+      "papi_na_rpm": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -4069,7 +4069,7 @@
           }
         ]
       },
-      "pciutils_latest_rpm": {
+      "pciutils_na_rpm": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -4093,7 +4093,7 @@
           }
         ]
       },
-      "perf_latest_rpm": {
+      "perf_na_rpm": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -4117,7 +4117,7 @@
           }
         ]
       },
-      "pmix-devel_latest_rpm": {
+      "pmix-devel_na_rpm": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -4141,7 +4141,7 @@
           }
         ]
       },
-      "python3-cython_latest_rpm_1": {
+      "python3-cython_na_rpm_1": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -4165,7 +4165,7 @@
           }
         ]
       },
-      "python3-devel_latest_rpm_1": {
+      "python3-devel_na_rpm_1": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -4189,7 +4189,7 @@
           }
         ]
       },
-      "rsync_latest_rpm": {
+      "rsync_na_rpm": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -4213,7 +4213,7 @@
           }
         ]
       },
-      "rsyslog_latest_rpm": {
+      "rsyslog_na_rpm": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -4237,7 +4237,7 @@
           }
         ]
       },
-      "sed_latest_rpm": {
+      "sed_na_rpm": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -4261,7 +4261,7 @@
           }
         ]
       },
-      "squashfs-tools_latest_rpm": {
+      "squashfs-tools_na_rpm": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -4285,7 +4285,7 @@
           }
         ]
       },
-      "sssd_latest_rpm": {
+      "sssd_na_rpm": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -4309,7 +4309,7 @@
           }
         ]
       },
-      "strace_latest_rpm": {
+      "strace_na_rpm": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -4333,7 +4333,7 @@
           }
         ]
       },
-      "sudo_latest_rpm": {
+      "sudo_na_rpm": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -4357,7 +4357,7 @@
           }
         ]
       },
-      "systemd-udev_latest_rpm": {
+      "systemd-udev_na_rpm": {
         "Name": "systemd-udev",
         "SupportedOS": [
           {
@@ -4381,7 +4381,7 @@
           }
         ]
       },
-      "systemd_latest_rpm": {
+      "systemd_na_rpm": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -4405,7 +4405,7 @@
           }
         ]
       },
-      "tar_latest_rpm": {
+      "tar_na_rpm": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -4429,7 +4429,7 @@
           }
         ]
       },
-      "tcpdump_latest_rpm": {
+      "tcpdump_na_rpm": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -4453,7 +4453,7 @@
           }
         ]
       },
-      "traceroute_latest_rpm": {
+      "traceroute_na_rpm": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -4502,7 +4502,7 @@
           }
         ]
       },
-      "util-linux_latest_rpm": {
+      "util-linux_na_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -4526,7 +4526,7 @@
           }
         ]
       },
-      "valgrind-devel_latest_rpm": {
+      "valgrind-devel_na_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -4550,7 +4550,7 @@
           }
         ]
       },
-      "valgrind_latest_rpm": {
+      "valgrind_na_rpm": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -4574,7 +4574,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm_1": {
+      "vim-enhanced_na_rpm_1": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -4598,7 +4598,7 @@
           }
         ]
       },
-      "wget_latest_rpm": {
+      "wget_na_rpm": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -4622,7 +4622,7 @@
           }
         ]
       },
-      "which_latest_rpm": {
+      "which_na_rpm": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -4646,7 +4646,7 @@
           }
         ]
       },
-      "zsh_latest_rpm": {
+      "zsh_na_rpm": {
         "Name": "zsh",
         "SupportedOS": [
           {

--- a/examples/catalog/catalog_rhel.json
+++ b/examples/catalog/catalog_rhel.json
@@ -7,339 +7,258 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_22",
-          "package_id_27",
-          "package_id_32",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_27",
-          "package_id_32",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "os_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_2",
-          "package_id_3",
-          "package_id_4"
+          "openssl-libs_latest_rpm",
+          "ovis-ldms_latest_rpm",
+          "python3-cython_latest_rpm",
+          "python3-devel_latest_rpm"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_100",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_80",
-          "package_id_81",
-          "package_id_82",
-          "package_id_83",
-          "package_id_84",
-          "package_id_85",
-          "package_id_86",
-          "package_id_87",
-          "package_id_88",
-          "package_id_89",
-          "package_id_90",
-          "package_id_91",
-          "package_id_92",
-          "package_id_93",
-          "package_id_94",
-          "package_id_95",
-          "package_id_96",
-          "package_id_97",
-          "package_id_98",
-          "package_id_99"
+          "PyMySQL_1.1.2_pip_module",
+          "apptainer_latest_rpm",
+          "calico-v3-31-4_latest_manifest",
+          "cert-manager-v1-10-0_latest_tarball",
+          "cffi_1.17.1_pip_module",
+          "container-selinux_latest_rpm",
+          "cri-o_1.35.1_rpm",
+          "cryptography_45.0.7_pip_module",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "docker-io-alpine-kubectl_1.35.1_image",
+          "docker-io-calico-cni_v3.31.4_image",
+          "docker-io-calico-kube-controllers_v3.31.4_image",
+          "docker-io-calico-node_v3.31.4_image",
+          "docker-io-curlimages-curl_8.17.0_image",
+          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
+          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
+          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
+          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
+          "docker-io-library-busybox_1.36_image",
+          "docker-io-library-mysql_9.3.0_image",
+          "docker-io-library-python_3.12-slim_image",
+          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
+          "docker-io-rmohr-activemq_5.15.9_image",
+          "docker-io-timberio-vector_0.54.0-debian_image",
+          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
+          "docker-io-victoriametrics-operator_v0.68.3_image",
+          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
+          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
+          "docker-io-victoriametrics-vlagent_v1.50.0_image",
+          "docker-io-victoriametrics-vmagent_v1.128.0_image",
+          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
+          "firewalld_latest_rpm",
+          "fuse-overlayfs_latest_rpm",
+          "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
+          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
+          "git_latest_rpm",
+          "helm-charts_container-storage-modules-1.9.2_git",
+          "helm-v3-20-1-amd64_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "karavi-observability_v1.12.0_git",
+          "kubeadm_1.35.1_rpm",
+          "kubectl_1.35.1_rpm",
+          "kubelet_1.35.1_rpm",
+          "kubernetes_33.1.0_pip_module",
+          "lsscsi_latest_rpm",
+          "metallb-native-v0-15-3_latest_manifest",
+          "nfs-subdir-external-provisioner-4-0-18_latest_tarball",
+          "omsdk_1.2.518_pip_module",
+          "podman_latest_rpm",
+          "prettytable_3.14.0_pip_module",
+          "prometheus_client_0.20.0_pip_module",
+          "python3-firewall_latest_rpm",
+          "python3_3.12.9_rpm",
+          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
+          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
+          "quay-io-metallb-speaker_v0.15.3_image",
+          "quay-io-strimzi-kafka-bridge_0.33.1_image",
+          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
+          "quay-io-strimzi-operator_0.48.0_image",
+          "registry-k8s-io-coredns-coredns_v1.13.1_image",
+          "registry-k8s-io-etcd_3.6.6-0_image",
+          "registry-k8s-io-kube-apiserver_v1.35.1_image",
+          "registry-k8s-io-kube-controller-manager_v1.35.1_image",
+          "registry-k8s-io-kube-proxy_v1.35.1_image",
+          "registry-k8s-io-kube-scheduler_v1.35.1_image",
+          "registry-k8s-io-pause_3.10.1_image",
+          "sg3_utils_latest_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
+          "victoria-metrics-operator-0-59-3_latest_tarball",
+          "vim-enhanced_latest_rpm"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_101",
-          "package_id_102",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_80",
-          "package_id_92"
+          "apptainer_latest_rpm",
+          "cert-manager-v1-10-0_latest_tarball",
+          "cffi_1.17.1_pip_module",
+          "container-selinux_latest_rpm",
+          "cri-o_1.35.1_rpm",
+          "cryptography_45.0.7_pip_module",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "docker-io-alpine-kubectl_1.35.1_image",
+          "docker-io-curlimages-curl_8.17.0_image",
+          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
+          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
+          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
+          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
+          "docker-io-library-busybox_1.36_image",
+          "docker-io-library-mysql_9.3.0_image",
+          "docker-io-library-python_3.12-slim_image",
+          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
+          "docker-io-rmohr-activemq_5.15.9_image",
+          "docker-io-timberio-vector_0.54.0-debian_image",
+          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
+          "docker-io-victoriametrics-operator_v0.68.3_image",
+          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
+          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
+          "docker-io-victoriametrics-vlagent_v1.50.0_image",
+          "docker-io-victoriametrics-vmagent_v1.128.0_image",
+          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
+          "firewalld_latest_rpm",
+          "fuse-overlayfs_latest_rpm",
+          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
+          "git_latest_rpm",
+          "helm-charts_container-storage-modules-1.9.2_git",
+          "iscsi-initiator-utils_latest_rpm",
+          "karavi-observability_v1.12.0_git",
+          "kubeadm_1.35.1_rpm",
+          "kubelet_1.35.1_rpm",
+          "kubernetes_33.1.0_pip_module",
+          "lsscsi_latest_rpm",
+          "omsdk_1.2.518_pip_module",
+          "podman_latest_rpm",
+          "prometheus_client_0.20.0_pip_module",
+          "python3-firewall_latest_rpm",
+          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
+          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
+          "quay-io-metallb-controller_v0.15.3_image",
+          "quay-io-metallb-speaker_v0.15.3_image",
+          "quay-io-strimzi-kafka-bridge_0.33.1_image",
+          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
+          "quay-io-strimzi-operator_0.48.0_image",
+          "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
+          "sg3_utils_latest_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
+          "victoria-metrics-operator-0-59-3_latest_tarball",
+          "vim-enhanced_latest_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_23",
-          "package_id_24",
-          "package_id_25",
-          "package_id_26",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "mariadb-server_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-PyMySQL_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmctld_latest_rpm",
+          "slurm-slurmdbd_latest_rpm"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_103",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_22",
-          "package_id_27",
-          "package_id_28",
-          "package_id_29",
-          "package_id_30",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
-        ]
-      },
-      {
-        "Name": "service_kube_control_plane_first_x86_64",
-        "FunctionalPackages": [
-          "package_id_10",
-          "package_id_100",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_80",
-          "package_id_81",
-          "package_id_82",
-          "package_id_83",
-          "package_id_84",
-          "package_id_85",
-          "package_id_86",
-          "package_id_87",
-          "package_id_88",
-          "package_id_89",
-          "package_id_90",
-          "package_id_91",
-          "package_id_92",
-          "package_id_93",
-          "package_id_94",
-          "package_id_95",
-          "package_id_96",
-          "package_id_97",
-          "package_id_98",
-          "package_id_99"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "kernel-devel_latest_rpm",
+          "kernel-headers_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-pam_slurm_latest_rpm",
+          "slurm-slurmd_latest_rpm"
         ]
       }
     ],
@@ -348,106 +267,106 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "os_package_id_1",
-          "os_package_id_10",
-          "os_package_id_100",
-          "os_package_id_11",
-          "os_package_id_12",
-          "os_package_id_13",
-          "os_package_id_14",
-          "os_package_id_15",
-          "os_package_id_16",
-          "os_package_id_17",
-          "os_package_id_18",
-          "os_package_id_19",
-          "os_package_id_2",
-          "os_package_id_20",
-          "os_package_id_21",
-          "os_package_id_22",
-          "os_package_id_23",
-          "os_package_id_24",
-          "os_package_id_25",
-          "os_package_id_26",
-          "os_package_id_27",
-          "os_package_id_28",
-          "os_package_id_29",
-          "os_package_id_3",
-          "os_package_id_30",
-          "os_package_id_31",
-          "os_package_id_32",
-          "os_package_id_33",
-          "os_package_id_34",
-          "os_package_id_35",
-          "os_package_id_36",
-          "os_package_id_37",
-          "os_package_id_38",
-          "os_package_id_39",
-          "os_package_id_4",
-          "os_package_id_40",
-          "os_package_id_41",
-          "os_package_id_42",
-          "os_package_id_43",
-          "os_package_id_44",
-          "os_package_id_45",
-          "os_package_id_46",
-          "os_package_id_47",
-          "os_package_id_48",
-          "os_package_id_49",
-          "os_package_id_5",
-          "os_package_id_50",
-          "os_package_id_51",
-          "os_package_id_52",
-          "os_package_id_53",
-          "os_package_id_54",
-          "os_package_id_55",
-          "os_package_id_56",
-          "os_package_id_57",
-          "os_package_id_58",
-          "os_package_id_59",
-          "os_package_id_6",
-          "os_package_id_60",
-          "os_package_id_61",
-          "os_package_id_62",
-          "os_package_id_63",
-          "os_package_id_64",
-          "os_package_id_65",
-          "os_package_id_66",
-          "os_package_id_67",
-          "os_package_id_68",
-          "os_package_id_69",
-          "os_package_id_7",
-          "os_package_id_70",
-          "os_package_id_71",
-          "os_package_id_72",
-          "os_package_id_73",
-          "os_package_id_74",
-          "os_package_id_75",
-          "os_package_id_76",
-          "os_package_id_77",
-          "os_package_id_78",
-          "os_package_id_79",
-          "os_package_id_8",
-          "os_package_id_80",
-          "os_package_id_81",
-          "os_package_id_82",
-          "os_package_id_83",
-          "os_package_id_84",
-          "os_package_id_85",
-          "os_package_id_86",
-          "os_package_id_87",
-          "os_package_id_88",
-          "os_package_id_89",
-          "os_package_id_9",
-          "os_package_id_90",
-          "os_package_id_91",
-          "os_package_id_92",
-          "os_package_id_93",
-          "os_package_id_94",
-          "os_package_id_95",
-          "os_package_id_96",
-          "os_package_id_97",
-          "os_package_id_98",
-          "os_package_id_99"
+          "NetworkManager_latest_rpm",
+          "authselect_latest_rpm",
+          "autoconf_latest_rpm",
+          "automake_latest_rpm",
+          "bash-completion_latest_rpm",
+          "bash_latest_rpm",
+          "binutils-devel_latest_rpm",
+          "binutils_latest_rpm",
+          "bzip2_latest_rpm",
+          "chrony_latest_rpm",
+          "cloud-init_latest_rpm",
+          "clustershell_latest_rpm",
+          "cmake_latest_rpm",
+          "coreutils_latest_rpm",
+          "cryptsetup_latest_rpm",
+          "curl_latest_rpm",
+          "device-mapper_latest_rpm",
+          "dmidecode_latest_rpm",
+          "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
+          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
+          "dracut-live_latest_rpm",
+          "dracut-network_latest_rpm",
+          "dracut_latest_rpm",
+          "emacs_latest_rpm",
+          "file_latest_rpm",
+          "findutils_latest_rpm",
+          "fping_latest_rpm",
+          "gawk_latest_rpm",
+          "gcc-c++_latest_rpm",
+          "gcc-gfortran_latest_rpm",
+          "gcc_latest_rpm",
+          "gdb-gdbserver_latest_rpm",
+          "gdb_latest_rpm",
+          "gedit_latest_rpm",
+          "glibc-langpack-en_latest_rpm",
+          "grep_latest_rpm",
+          "gzip_latest_rpm",
+          "hwloc-libs_latest_rpm",
+          "hwloc_latest_rpm",
+          "iperf3_latest_rpm",
+          "ipmitool_latest_rpm",
+          "iproute_latest_rpm",
+          "iputils_latest_rpm",
+          "kbd_latest_rpm",
+          "kernel-tools_latest_rpm",
+          "kernel_latest_rpm",
+          "kexec-tools_latest_rpm",
+          "libcurl_latest_rpm",
+          "libtool_latest_rpm",
+          "lldb-devel_latest_rpm",
+          "lldb_latest_rpm",
+          "lshw_latest_rpm",
+          "lsof_latest_rpm",
+          "ltrace_latest_rpm",
+          "lvm2_latest_rpm",
+          "make_latest_rpm",
+          "man-db_latest_rpm",
+          "man-pages_latest_rpm",
+          "munge-devel_latest_rpm",
+          "nfs-utils_latest_rpm",
+          "nfs4-acl-tools_latest_rpm",
+          "nm-connection-editor_latest_rpm",
+          "nss-pam-ldapd_latest_rpm",
+          "oddjob-mkhomedir_latest_rpm",
+          "openldap-clients_latest_rpm",
+          "openmpi_5.0.8_tarball",
+          "openssh-clients_latest_rpm",
+          "openssh-server_latest_rpm",
+          "openssh_latest_rpm",
+          "openssl-devel_latest_rpm",
+          "openssl-libs_latest_rpm_1",
+          "ovis-ldms_latest_rpm_1",
+          "papi-devel_latest_rpm",
+          "papi-libs_latest_rpm",
+          "papi_latest_rpm",
+          "pciutils_latest_rpm",
+          "perf_latest_rpm",
+          "pmix-devel_latest_rpm",
+          "python3-cython_latest_rpm_1",
+          "python3-devel_latest_rpm_1",
+          "rsync_latest_rpm",
+          "rsyslog_latest_rpm",
+          "sed_latest_rpm",
+          "squashfs-tools_latest_rpm",
+          "sssd_latest_rpm",
+          "strace_latest_rpm",
+          "sudo_latest_rpm",
+          "systemd-udev_latest_rpm",
+          "systemd_latest_rpm",
+          "tar_latest_rpm",
+          "tcpdump_latest_rpm",
+          "traceroute_latest_rpm",
+          "ucx_1.19.0_tarball",
+          "util-linux_latest_rpm",
+          "valgrind-devel_latest_rpm",
+          "valgrind_latest_rpm",
+          "vim-enhanced_latest_rpm_1",
+          "wget_latest_rpm",
+          "which_latest_rpm",
+          "zsh_latest_rpm"
         ]
       }
     ],
@@ -455,30 +374,30 @@
       {
         "Name": "csi",
         "InfrastructurePackages": [
-          "infrastructure_package_id_1",
-          "infrastructure_package_id_10",
-          "infrastructure_package_id_11",
-          "infrastructure_package_id_12",
-          "infrastructure_package_id_13",
-          "infrastructure_package_id_14",
-          "infrastructure_package_id_15",
-          "infrastructure_package_id_16",
-          "infrastructure_package_id_2",
-          "infrastructure_package_id_3",
-          "infrastructure_package_id_4",
-          "infrastructure_package_id_5",
-          "infrastructure_package_id_6",
-          "infrastructure_package_id_7",
-          "infrastructure_package_id_8",
-          "infrastructure_package_id_9"
+          "csi-powerscale-v2-16-0_v2.16.0_git",
+          "docker-io-dellemc-csm-encryption_v0.6.0_image",
+          "external-snapshotter-v8-4-0_v8.4.0_git",
+          "helm-charts-2-16-0_csi-isilon-2.16.0_git",
+          "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image",
+          "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image",
+          "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image",
+          "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image",
+          "quay-io-dell-container-storage-modules-podmon_v1.15.0_image",
+          "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image",
+          "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image",
+          "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image",
+          "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image",
+          "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image",
+          "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image",
+          "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image"
         ]
       }
     ],
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "package_id_1": {
-        "Name": "python3-devel",
+      "PyMySQL_1.1.2_pip_module": {
+        "Name": "PyMySQL==1.1.2",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -486,206 +405,11 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
+        "Type": "pip_module"
       },
-      "package_id_2": {
-        "Name": "python3-cython",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "codeready-builder"
-          }
-        ]
-      },
-      "package_id_3": {
-        "Name": "openssl-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_4": {
-        "Name": "ovis-ldms",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "ldms"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "ldms"
-          }
-        ]
-      },
-      "package_id_5": {
-        "Name": "munge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_6": {
-        "Name": "firewalld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_7": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_8": {
-        "Name": "pmix",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_9": {
-        "Name": "nvcr.io/nvidia/hpc-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "25.09",
-        "Version": "25.09"
-      },
-      "package_id_10": {
+      "apptainer_latest_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -709,8 +433,8 @@
           }
         ]
       },
-      "package_id_11": {
-        "Name": "doca-ofed",
+      "calico-v3-31-4_latest_manifest": {
+        "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -718,23 +442,18 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm_repo",
+        "Type": "manifest",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "doca"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "doca"
+            "Uri": "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"
           }
         ]
       },
-      "package_id_12": {
-        "Name": "iscsi-initiator-utils",
+      "cert-manager-v1-10-0_latest_tarball": {
+        "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -742,22 +461,81 @@
           }
         ],
         "Architecture": [
-          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://charts.jetstack.io/charts/cert-manager-v1.10.0.tgz"
+          }
+        ]
+      },
+      "cffi_1.17.1_pip_module": {
+        "Name": "cffi==1.17.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "container-selinux_latest_rpm": {
+        "Name": "container-selinux",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_13": {
+      "cri-o_1.35.1_rpm": {
+        "Name": "cri-o-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "cri-o-v1-35"
+          }
+        ]
+      },
+      "cryptography_45.0.7_pip_module": {
+        "Name": "cryptography==45.0.7",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "device-mapper-multipath_latest_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -781,8 +559,392 @@
           }
         ]
       },
-      "package_id_14": {
-        "Name": "sg3_utils",
+      "doca-ofed_latest_rpm_repo": {
+        "Name": "doca-ofed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm_repo",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "doca"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "doca"
+          }
+        ]
+      },
+      "docker-io-alpine-kubectl_1.35.1_image": {
+        "Name": "docker.io/alpine/kubectl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.35.1",
+        "Version": "1.35.1"
+      },
+      "docker-io-calico-cni_v3.31.4_image": {
+        "Name": "docker.io/calico/cni",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-calico-kube-controllers_v3.31.4_image": {
+        "Name": "docker.io/calico/kube-controllers",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-calico-node_v3.31.4_image": {
+        "Name": "docker.io/calico/node",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-curlimages-curl_8.17.0_image": {
+        "Name": "docker.io/curlimages/curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "8.17.0",
+        "Version": "8.17.0"
+      },
+      "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.3",
+        "Version": "1.3"
+      },
+      "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.3",
+        "Version": "1.3"
+      },
+      "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.3",
+        "Version": "1.3"
+      },
+      "docker-io-library-busybox_1.36_image": {
+        "Name": "docker.io/library/busybox",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.36",
+        "Version": "1.36"
+      },
+      "docker-io-library-mysql_9.3.0_image": {
+        "Name": "docker.io/library/mysql",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "9.3.0",
+        "Version": "9.3.0"
+      },
+      "docker-io-library-python_3.12-slim_image": {
+        "Name": "docker.io/library/python",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.12-slim",
+        "Version": "3.12-slim"
+      },
+      "docker-io-nginxinc-nginx-unprivileged_1.29_image": {
+        "Name": "docker.io/nginxinc/nginx-unprivileged",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.29",
+        "Version": "1.29"
+      },
+      "docker-io-rmohr-activemq_5.15.9_image": {
+        "Name": "docker.io/rmohr/activemq",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "5.15.9",
+        "Version": "5.15.9"
+      },
+      "docker-io-timberio-vector_0.54.0-debian_image": {
+        "Name": "docker.io/timberio/vector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.54.0-debian",
+        "Version": "0.54.0-debian"
+      },
+      "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "config-reloader-v0.68.3",
+        "Version": "config-reloader-v0.68.3"
+      },
+      "docker-io-victoriametrics-operator_v0.68.3_image": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.68.3",
+        "Version": "v0.68.3"
+      },
+      "docker-io-victoriametrics-victoria-logs_v1.50.0_image": {
+        "Name": "docker.io/victoriametrics/victoria-logs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.50.0",
+        "Version": "v1.50.0"
+      },
+      "docker-io-victoriametrics-victoria-metrics_v1.128.0_image": {
+        "Name": "docker.io/victoriametrics/victoria-metrics",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0",
+        "Version": "v1.128.0"
+      },
+      "docker-io-victoriametrics-vlagent_v1.50.0_image": {
+        "Name": "docker.io/victoriametrics/vlagent",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.50.0",
+        "Version": "v1.50.0"
+      },
+      "docker-io-victoriametrics-vmagent_v1.128.0_image": {
+        "Name": "docker.io/victoriametrics/vmagent",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0",
+        "Version": "v1.128.0"
+      },
+      "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vminsert",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vmselect",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vmstorage",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "firewalld_latest_rpm": {
+        "Name": "firewalld",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -805,8 +967,8 @@
           }
         ]
       },
-      "package_id_15": {
-        "Name": "lsscsi",
+      "fuse-overlayfs_latest_rpm": {
+        "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -814,94 +976,17 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_16": {
-        "Name": "imb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          }
-        ]
-      },
-      "package_id_17": {
-        "Name": "osu-micro-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          }
-        ]
-      },
-      "package_id_18": {
-        "Name": "likwid",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          }
-        ]
-      },
-      "package_id_19": {
+      "geopm_latest_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -925,8 +1010,96 @@
           }
         ]
       },
-      "package_id_20": {
-        "Name": "papi",
+      "ghcr-io-kube-vip-kube-vip_v0.8.9_image": {
+        "Name": "ghcr.io/kube-vip/kube-vip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.8.9",
+        "Version": "v0.8.9"
+      },
+      "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image": {
+        "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.143.1",
+        "Version": "0.143.1"
+      },
+      "git_latest_rpm": {
+        "Name": "git",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "helm-charts_container-storage-modules-1.9.2_git": {
+        "Name": "helm-charts",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "git",
+        "Version": "container-storage-modules-1.9.2",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/dell/helm-charts.git"
+          }
+        ]
+      },
+      "helm-v3-20-1-amd64_latest_tarball": {
+        "Name": "helm-v3.20.1-amd64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
+          }
+        ]
+      },
+      "imb_latest_tarball": {
+        "Name": "imb",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -941,59 +1114,16 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           },
           {
             "Architecture": "aarch64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "package_id_21": {
-        "Name": "msr-safe",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_22": {
-        "Name": "sionlib",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "package_id_23": {
-        "Name": "slurm-slurmctld",
+      "iscsi-initiator-utils_latest_rpm": {
+        "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1008,16 +1138,16 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           },
           {
             "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_24": {
-        "Name": "slurm-slurmdbd",
+      "karavi-observability_v1.12.0_git": {
+        "Name": "karavi-observability",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1025,118 +1155,18 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm",
+        "Type": "git",
+        "Version": "v1.12.0",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
+            "Uri": "https://github.com/dell/karavi-observability.git"
           }
         ]
       },
-      "package_id_25": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_26": {
-        "Name": "mariadb-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_27": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_28": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_29": {
+      "kernel-devel_latest_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1160,7 +1190,7 @@
           }
         ]
       },
-      "package_id_30": {
+      "kernel-headers_latest_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1184,146 +1214,7 @@
           }
         ]
       },
-      "package_id_31": {
-        "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_x86_64_cuda_13.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_32": {
-        "Name": "slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_33": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_34": {
-        "Name": "docker.io/library/busybox",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.36",
-        "Version": "1.36"
-      },
-      "package_id_35": {
-        "Name": "git",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_36": {
-        "Name": "fuse-overlayfs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_37": {
-        "Name": "podman",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_38": {
+      "kubeadm_1.35.1_rpm": {
         "Name": "kubeadm-1.35.1",
         "SupportedOS": [
           {
@@ -1342,841 +1233,7 @@
           }
         ]
       },
-      "package_id_39": {
-        "Name": "kubelet-1.35.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
-          }
-        ]
-      },
-      "package_id_40": {
-        "Name": "container-selinux",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_41": {
-        "Name": "cri-o-1.35.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "cri-o-v1-35"
-          }
-        ]
-      },
-      "package_id_42": {
-        "Name": "docker.io/victoriametrics/victoria-metrics",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0",
-        "Version": "v1.128.0"
-      },
-      "package_id_43": {
-        "Name": "docker.io/victoriametrics/vmagent",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0",
-        "Version": "v1.128.0"
-      },
-      "package_id_44": {
-        "Name": "docker.io/victoriametrics/vmstorage",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_45": {
-        "Name": "docker.io/victoriametrics/vminsert",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_46": {
-        "Name": "docker.io/victoriametrics/vmselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_47": {
-        "Name": "docker.io/victoriametrics/victoria-logs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.50.0",
-        "Version": "v1.50.0"
-      },
-      "package_id_48": {
-        "Name": "docker.io/victoriametrics/vlagent",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.50.0",
-        "Version": "v1.50.0"
-      },
-      "package_id_49": {
-        "Name": "docker.io/alpine/kubectl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.35.1",
-        "Version": "1.35.1"
-      },
-      "package_id_50": {
-        "Name": "docker.io/curlimages/curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "8.17.0",
-        "Version": "8.17.0"
-      },
-      "package_id_51": {
-        "Name": "docker.io/rmohr/activemq",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "5.15.9",
-        "Version": "5.15.9"
-      },
-      "package_id_52": {
-        "Name": "docker.io/library/mysql",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "9.3.0",
-        "Version": "9.3.0"
-      },
-      "package_id_53": {
-        "Name": "docker.io/library/python",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.12-slim",
-        "Version": "3.12-slim"
-      },
-      "package_id_54": {
-        "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_55": {
-        "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_56": {
-        "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_57": {
-        "Name": "cryptography==45.0.7",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_58": {
-        "Name": "omsdk==1.2.518",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_59": {
-        "Name": "cffi==1.17.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_60": {
-        "Name": "prometheus_client==0.20.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_61": {
-        "Name": "kubernetes==33.1.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_62": {
-        "Name": "quay.io/strimzi/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.48.0",
-        "Version": "0.48.0"
-      },
-      "package_id_63": {
-        "Name": "quay.io/strimzi/kafka",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.48.0-kafka-4.1.0",
-        "Version": "0.48.0-kafka-4.1.0"
-      },
-      "package_id_64": {
-        "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
-      },
-      "package_id_65": {
-        "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.11.0",
-        "Version": "v1.11.0"
-      },
-      "package_id_66": {
-        "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.143.1",
-        "Version": "0.143.1"
-      },
-      "package_id_67": {
-        "Name": "docker.io/nginxinc/nginx-unprivileged",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.29",
-        "Version": "1.29"
-      },
-      "package_id_68": {
-        "Name": "karavi-observability",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "git",
-        "Version": "v1.12.0",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/dell/karavi-observability.git"
-          }
-        ]
-      },
-      "package_id_69": {
-        "Name": "helm-charts",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "git",
-        "Version": "container-storage-modules-1.9.2",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/dell/helm-charts.git"
-          }
-        ]
-      },
-      "package_id_70": {
-        "Name": "quay.io/jetstack/cert-manager-controller",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_71": {
-        "Name": "quay.io/jetstack/cert-manager-cainjector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_72": {
-        "Name": "quay.io/jetstack/cert-manager-webhook",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_73": {
-        "Name": "quay.io/jetstack/cert-manager-acmesolver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_74": {
-        "Name": "cert-manager-v1.10.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://charts.jetstack.io/charts/cert-manager-v1.10.0.tgz"
-          }
-        ]
-      },
-      "package_id_75": {
-        "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-kafka-operator-helm-3-chart-0.48.0.tgz"
-          }
-        ]
-      },
-      "package_id_76": {
-        "Name": "quay.io/strimzi/kafka-bridge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.33.1",
-        "Version": "0.33.1"
-      },
-      "package_id_77": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.68.3",
-        "Version": "v0.68.3"
-      },
-      "package_id_78": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "config-reloader-v0.68.3",
-        "Version": "config-reloader-v0.68.3"
-      },
-      "package_id_79": {
-        "Name": "victoria-metrics-operator-0.59.3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/VictoriaMetrics/helm-charts/releases/download/victoria-metrics-operator-0.59.3/victoria-metrics-operator-0.59.3.tgz"
-          }
-        ]
-      },
-      "package_id_80": {
-        "Name": "docker.io/timberio/vector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.54.0-debian",
-        "Version": "0.54.0-debian"
-      },
-      "package_id_81": {
-        "Name": "ghcr.io/kube-vip/kube-vip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.8.9",
-        "Version": "v0.8.9"
-      },
-      "package_id_82": {
-        "Name": "registry.k8s.io/kube-apiserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_83": {
-        "Name": "registry.k8s.io/kube-controller-manager",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_84": {
-        "Name": "registry.k8s.io/kube-scheduler",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_85": {
-        "Name": "registry.k8s.io/kube-proxy",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_86": {
-        "Name": "registry.k8s.io/coredns/coredns",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.13.1",
-        "Version": "v1.13.1"
-      },
-      "package_id_87": {
-        "Name": "registry.k8s.io/pause",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.10.1",
-        "Version": "3.10.1"
-      },
-      "package_id_88": {
-        "Name": "registry.k8s.io/etcd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.6.6-0",
-        "Version": "3.6.6-0"
-      },
-      "package_id_89": {
-        "Name": "docker.io/calico/cni",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_90": {
-        "Name": "docker.io/calico/kube-controllers",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_91": {
-        "Name": "docker.io/calico/node",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_92": {
-        "Name": "quay.io/metallb/speaker",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.15.3",
-        "Version": "v0.15.3"
-      },
-      "package_id_93": {
+      "kubectl_1.35.1_rpm": {
         "Name": "kubectl-1.35.1",
         "SupportedOS": [
           {
@@ -2195,21 +1252,8 @@
           }
         ]
       },
-      "package_id_94": {
-        "Name": "prettytable==3.14.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_95": {
-        "Name": "python3-3.12.9",
+      "kubelet_1.35.1_rpm": {
+        "Name": "kubelet-1.35.1",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2223,12 +1267,12 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "baseos"
+            "RepoName": "kubernetes-v1-35"
           }
         ]
       },
-      "package_id_96": {
-        "Name": "PyMySQL==1.1.2",
+      "kubernetes_33.1.0_pip_module": {
+        "Name": "kubernetes==33.1.0",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2240,8 +1284,8 @@
         ],
         "Type": "pip_module"
       },
-      "package_id_97": {
-        "Name": "calico-v3.31.4",
+      "likwid_latest_tarball": {
+        "Name": "likwid",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2249,17 +1293,70 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
-        "Type": "manifest",
+        "Type": "tarball",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           }
         ]
       },
-      "package_id_98": {
+      "lsscsi_latest_rpm": {
+        "Name": "lsscsi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "mariadb-server_latest_rpm": {
+        "Name": "mariadb-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "metallb-native-v0-15-3_latest_manifest": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -2278,8 +1375,8 @@
           }
         ]
       },
-      "package_id_99": {
-        "Name": "helm-v3.20.1-amd64",
+      "msr-safe_latest_tarball": {
+        "Name": "msr-safe",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2293,11 +1390,35 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
+            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
           }
         ]
       },
-      "package_id_100": {
+      "munge_latest_rpm": {
+        "Name": "munge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nfs-subdir-external-provisioner-4-0-18_latest_tarball": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -2316,8 +1437,8 @@
           }
         ]
       },
-      "package_id_101": {
-        "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+        "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2325,28 +1446,14 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "image",
-        "Tag": "v4.0.2",
-        "Version": "v4.0.2"
+        "Tag": "25.09",
+        "Version": "25.09"
       },
-      "package_id_102": {
-        "Name": "quay.io/metallb/controller",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.15.3",
-        "Version": "v0.15.3"
-      },
-      "package_id_103": {
+      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball": {
         "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
         "SupportedOS": [
           {
@@ -2364,11 +1471,9 @@
             "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_aarch64_cuda_13.0.tar.gz"
           }
         ]
-      }
-    },
-    "OSPackages": {
-      "os_package_id_1": {
-        "Name": "python3-devel",
+      },
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+        "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2376,23 +1481,18 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm",
+        "Type": "tarball",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
+            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_x86_64_cuda_13.0.tar.gz"
           }
         ]
       },
-      "os_package_id_2": {
-        "Name": "python3-cython",
+      "omsdk_1.2.518_pip_module": {
+        "Name": "omsdk==1.2.518",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2400,22 +1500,11 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "codeready-builder"
-          }
-        ]
+        "Type": "pip_module"
       },
-      "os_package_id_3": {
+      "openssl-libs_latest_rpm": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -2439,7 +1528,31 @@
           }
         ]
       },
-      "os_package_id_4": {
+      "osu-micro-benchmarks_latest_tarball": {
+        "Name": "osu-micro-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          }
+        ]
+      },
+      "ovis-ldms_latest_rpm": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -2463,7 +1576,2259 @@
           }
         ]
       },
-      "os_package_id_5": {
+      "papi_latest_tarball": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          }
+        ]
+      },
+      "pmix_latest_rpm": {
+        "Name": "pmix",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "podman_latest_rpm": {
+        "Name": "podman",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "prettytable_3.14.0_pip_module": {
+        "Name": "prettytable==3.14.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "prometheus_client_0.20.0_pip_module": {
+        "Name": "prometheus_client==0.20.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "python3-PyMySQL_latest_rpm": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-cython_latest_rpm": {
+        "Name": "python3-cython",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "python3-devel_latest_rpm": {
+        "Name": "python3-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall_latest_rpm": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "python3_3.12.9_rpm": {
+        "Name": "python3-3.12.9",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.11.0",
+        "Version": "v1.11.0"
+      },
+      "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-acmesolver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-cainjector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-controller_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-controller",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-webhook_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-webhook",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-metallb-controller_v0.15.3_image": {
+        "Name": "quay.io/metallb/controller",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.15.3",
+        "Version": "v0.15.3"
+      },
+      "quay-io-metallb-speaker_v0.15.3_image": {
+        "Name": "quay.io/metallb/speaker",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.15.3",
+        "Version": "v0.15.3"
+      },
+      "quay-io-strimzi-kafka-bridge_0.33.1_image": {
+        "Name": "quay.io/strimzi/kafka-bridge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.33.1",
+        "Version": "0.33.1"
+      },
+      "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image": {
+        "Name": "quay.io/strimzi/kafka",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.48.0-kafka-4.1.0",
+        "Version": "0.48.0-kafka-4.1.0"
+      },
+      "quay-io-strimzi-operator_0.48.0_image": {
+        "Name": "quay.io/strimzi/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.48.0",
+        "Version": "0.48.0"
+      },
+      "registry-k8s-io-coredns-coredns_v1.13.1_image": {
+        "Name": "registry.k8s.io/coredns/coredns",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.13.1",
+        "Version": "v1.13.1"
+      },
+      "registry-k8s-io-etcd_3.6.6-0_image": {
+        "Name": "registry.k8s.io/etcd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.6.6-0",
+        "Version": "3.6.6-0"
+      },
+      "registry-k8s-io-kube-apiserver_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-apiserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-controller-manager_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-controller-manager",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-proxy_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-proxy",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-scheduler_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-scheduler",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-pause_3.10.1_image": {
+        "Name": "registry.k8s.io/pause",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.10.1",
+        "Version": "3.10.1"
+      },
+      "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image": {
+        "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v4.0.2",
+        "Version": "v4.0.2"
+      },
+      "sg3_utils_latest_rpm": {
+        "Name": "sg3_utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sionlib_latest_tarball": {
+        "Name": "sionlib",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          }
+        ]
+      },
+      "slurm-pam_slurm_latest_rpm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld_latest_rpm": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd_latest_rpm": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd_latest_rpm": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm_latest_rpm": {
+        "Name": "slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball": {
+        "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-kafka-operator-helm-3-chart-0.48.0.tgz"
+          }
+        ]
+      },
+      "victoria-metrics-operator-0-59-3_latest_tarball": {
+        "Name": "victoria-metrics-operator-0.59.3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/VictoriaMetrics/helm-charts/releases/download/victoria-metrics-operator-0.59.3/victoria-metrics-operator-0.59.3.tgz"
+          }
+        ]
+      },
+      "vim-enhanced_latest_rpm": {
+        "Name": "vim-enhanced",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      }
+    },
+    "OSPackages": {
+      "NetworkManager_latest_rpm": {
+        "Name": "NetworkManager",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "authselect_latest_rpm": {
+        "Name": "authselect",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "autoconf_latest_rpm": {
+        "Name": "autoconf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "automake_latest_rpm": {
+        "Name": "automake",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bash-completion_latest_rpm": {
+        "Name": "bash-completion",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bash_latest_rpm": {
+        "Name": "bash",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "binutils-devel_latest_rpm": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "binutils_latest_rpm": {
+        "Name": "binutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bzip2_latest_rpm": {
+        "Name": "bzip2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "chrony_latest_rpm": {
+        "Name": "chrony",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cloud-init_latest_rpm": {
+        "Name": "cloud-init",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "clustershell_latest_rpm": {
+        "Name": "clustershell",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "cmake_latest_rpm": {
+        "Name": "cmake",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "coreutils_latest_rpm": {
+        "Name": "coreutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cryptsetup_latest_rpm": {
+        "Name": "cryptsetup",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "curl_latest_rpm": {
+        "Name": "curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "device-mapper_latest_rpm": {
+        "Name": "device-mapper",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dmidecode_latest_rpm": {
+        "Name": "dmidecode",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "dracut-live_latest_rpm": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network_latest_rpm": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dracut_latest_rpm": {
+        "Name": "dracut",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs_latest_rpm": {
+        "Name": "emacs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "file_latest_rpm": {
+        "Name": "file",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "findutils_latest_rpm": {
+        "Name": "findutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "fping_latest_rpm": {
+        "Name": "fping",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "gawk_latest_rpm": {
+        "Name": "gawk",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gcc-c++_latest_rpm": {
+        "Name": "gcc-c++",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc-gfortran_latest_rpm": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc_latest_rpm": {
+        "Name": "gcc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb-gdbserver_latest_rpm": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb_latest_rpm": {
+        "Name": "gdb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit_latest_rpm": {
+        "Name": "gedit",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "glibc-langpack-en_latest_rpm": {
+        "Name": "glibc-langpack-en",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "grep_latest_rpm": {
+        "Name": "grep",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gzip_latest_rpm": {
+        "Name": "gzip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc-libs_latest_rpm": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc_latest_rpm": {
+        "Name": "hwloc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3_latest_rpm": {
+        "Name": "iperf3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "ipmitool_latest_rpm": {
+        "Name": "ipmitool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "iproute_latest_rpm": {
+        "Name": "iproute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iputils_latest_rpm": {
+        "Name": "iputils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kbd_latest_rpm": {
+        "Name": "kbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel-tools_latest_rpm": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel_latest_rpm": {
+        "Name": "kernel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools_latest_rpm": {
+        "Name": "kexec-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libcurl_latest_rpm": {
+        "Name": "libcurl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libtool_latest_rpm": {
+        "Name": "libtool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb-devel_latest_rpm": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb_latest_rpm": {
+        "Name": "lldb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw_latest_rpm": {
+        "Name": "lshw",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "lsof_latest_rpm": {
+        "Name": "lsof",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ltrace_latest_rpm": {
+        "Name": "ltrace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lvm2_latest_rpm": {
+        "Name": "lvm2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "make_latest_rpm": {
+        "Name": "make",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-db_latest_rpm": {
+        "Name": "man-db",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-pages_latest_rpm": {
+        "Name": "man-pages",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "munge-devel_latest_rpm": {
+        "Name": "munge-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "nfs-utils_latest_rpm": {
+        "Name": "nfs-utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs4-acl-tools_latest_rpm": {
+        "Name": "nfs4-acl-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nm-connection-editor_latest_rpm": {
+        "Name": "nm-connection-editor",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nss-pam-ldapd_latest_rpm": {
+        "Name": "nss-pam-ldapd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "oddjob-mkhomedir_latest_rpm": {
+        "Name": "oddjob-mkhomedir",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openldap-clients_latest_rpm": {
+        "Name": "openldap-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openmpi_5.0.8_tarball": {
         "Name": "openmpi",
         "SupportedOS": [
           {
@@ -2488,7 +3853,271 @@
           }
         ]
       },
-      "os_package_id_6": {
+      "openssh-clients_latest_rpm": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server_latest_rpm": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh_latest_rpm": {
+        "Name": "openssh",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel_latest_rpm": {
+        "Name": "openssl-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openssl-libs_latest_rpm_1": {
+        "Name": "openssl-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ovis-ldms_latest_rpm_1": {
+        "Name": "ovis-ldms",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "ldms"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "ldms"
+          }
+        ]
+      },
+      "papi-devel_latest_rpm": {
+        "Name": "papi-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-libs_latest_rpm": {
+        "Name": "papi-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi_latest_rpm": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pciutils_latest_rpm": {
+        "Name": "pciutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "perf_latest_rpm": {
+        "Name": "perf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pmix-devel_latest_rpm": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -2512,8 +4141,8 @@
           }
         ]
       },
-      "os_package_id_7": {
-        "Name": "munge-devel",
+      "python3-cython_latest_rpm_1": {
+        "Name": "python3-cython",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2536,8 +4165,8 @@
           }
         ]
       },
-      "os_package_id_8": {
-        "Name": "gcc-c++",
+      "python3-devel_latest_rpm_1": {
+        "Name": "python3-devel",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2560,8 +4189,8 @@
           }
         ]
       },
-      "os_package_id_9": {
-        "Name": "make",
+      "rsync_latest_rpm": {
+        "Name": "rsync",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2584,7 +4213,271 @@
           }
         ]
       },
-      "os_package_id_10": {
+      "rsyslog_latest_rpm": {
+        "Name": "rsyslog",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "sed_latest_rpm": {
+        "Name": "sed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "squashfs-tools_latest_rpm": {
+        "Name": "squashfs-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sssd_latest_rpm": {
+        "Name": "sssd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "strace_latest_rpm": {
+        "Name": "strace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sudo_latest_rpm": {
+        "Name": "sudo",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd-udev_latest_rpm": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd_latest_rpm": {
+        "Name": "systemd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar_latest_rpm": {
+        "Name": "tar",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tcpdump_latest_rpm": {
+        "Name": "tcpdump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "traceroute_latest_rpm": {
+        "Name": "traceroute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ucx_1.19.0_tarball": {
         "Name": "ucx",
         "SupportedOS": [
           {
@@ -2609,607 +4502,7 @@
           }
         ]
       },
-      "os_package_id_11": {
-        "Name": "openldap-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_12": {
-        "Name": "nss-pam-ldapd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_13": {
-        "Name": "sssd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_14": {
-        "Name": "oddjob-mkhomedir",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_15": {
-        "Name": "authselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_16": {
-        "Name": "systemd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_17": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_18": {
-        "Name": "kernel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_19": {
-        "Name": "dracut",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_20": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_21": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_22": {
-        "Name": "squashfs-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_23": {
-        "Name": "nfs-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_24": {
-        "Name": "nfs4-acl-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_25": {
-        "Name": "NetworkManager",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_26": {
-        "Name": "nm-connection-editor",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_27": {
-        "Name": "iproute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_28": {
-        "Name": "iputils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_29": {
-        "Name": "curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_30": {
-        "Name": "bash",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_31": {
-        "Name": "coreutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_32": {
-        "Name": "grep",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_33": {
-        "Name": "sed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_34": {
-        "Name": "gawk",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_35": {
-        "Name": "findutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_36": {
+      "util-linux_latest_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -3233,1102 +4526,7 @@
           }
         ]
       },
-      "os_package_id_37": {
-        "Name": "kbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_38": {
-        "Name": "lsof",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_39": {
-        "Name": "cryptsetup",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_40": {
-        "Name": "lvm2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_41": {
-        "Name": "device-mapper",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_42": {
-        "Name": "rsyslog",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_43": {
-        "Name": "chrony",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_44": {
-        "Name": "sudo",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_45": {
-        "Name": "gzip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_46": {
-        "Name": "wget",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_47": {
-        "Name": "cloud-init",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_48": {
-        "Name": "glibc-langpack-en",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_49": {
-        "Name": "gedit",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_50": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
-      },
-      "os_package_id_51": {
-        "Name": "which",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_52": {
-        "Name": "tcpdump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_53": {
-        "Name": "traceroute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_54": {
-        "Name": "iperf3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_55": {
-        "Name": "fping",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_56": {
-        "Name": "dmidecode",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_57": {
-        "Name": "hwloc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_58": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_59": {
-        "Name": "lshw",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_60": {
-        "Name": "pciutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_61": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_62": {
-        "Name": "emacs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_63": {
-        "Name": "zsh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_64": {
-        "Name": "openssh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_65": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_66": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_67": {
-        "Name": "rsync",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_68": {
-        "Name": "file",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_69": {
-        "Name": "libcurl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_70": {
-        "Name": "tar",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_71": {
-        "Name": "bzip2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_72": {
-        "Name": "man-db",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_73": {
-        "Name": "man-pages",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_74": {
-        "Name": "strace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_75": {
-        "Name": "kexec-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_76": {
-        "Name": "openssl-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_77": {
-        "Name": "ipmitool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_78": {
-        "Name": "gdb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_79": {
-        "Name": "gdb-gdbserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_80": {
-        "Name": "lldb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_81": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_82": {
-        "Name": "valgrind",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_83": {
+      "valgrind-devel_latest_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -4352,8 +4550,8 @@
           }
         ]
       },
-      "os_package_id_84": {
-        "Name": "ltrace",
+      "valgrind_latest_rpm": {
+        "Name": "valgrind",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4376,32 +4574,8 @@
           }
         ]
       },
-      "os_package_id_85": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_86": {
-        "Name": "perf",
+      "vim-enhanced_latest_rpm_1": {
+        "Name": "vim-enhanced",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4424,8 +4598,8 @@
           }
         ]
       },
-      "os_package_id_87": {
-        "Name": "papi",
+      "wget_latest_rpm": {
+        "Name": "wget",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4448,200 +4622,8 @@
           }
         ]
       },
-      "os_package_id_88": {
-        "Name": "papi-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_89": {
-        "Name": "papi-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_90": {
-        "Name": "cmake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_91": {
-        "Name": "autoconf",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_92": {
-        "Name": "automake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_93": {
-        "Name": "libtool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_94": {
-        "Name": "gcc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_95": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_96": {
-        "Name": "binutils",
+      "which_latest_rpm": {
+        "Name": "which",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4664,56 +4646,8 @@
           }
         ]
       },
-      "os_package_id_97": {
-        "Name": "binutils-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_98": {
-        "Name": "clustershell",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_99": {
-        "Name": "bash-completion",
+      "zsh_latest_rpm": {
+        "Name": "zsh",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4735,26 +4669,11 @@
             "RepoName": "baseos"
           }
         ]
-      },
-      "os_package_id_100": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
       }
     },
     "Miscellaneous": [],
     "InfrastructurePackages": {
-      "infrastructure_package_id_1": {
+      "csi-powerscale-v2-16-0_v2.16.0_git": {
         "Name": "csi-powerscale-v2.16.0",
         "Type": "git",
         "Version": "v2.16.0",
@@ -4773,7 +4692,21 @@
           }
         ]
       },
-      "infrastructure_package_id_2": {
+      "docker-io-dellemc-csm-encryption_v0.6.0_image": {
+        "Name": "docker.io/dellemc/csm-encryption",
+        "Type": "image",
+        "Version": "v0.6.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v0.6.0"
+      },
+      "external-snapshotter-v8-4-0_v8.4.0_git": {
         "Name": "external-snapshotter-v8.4.0",
         "Type": "git",
         "Version": "v8.4.0",
@@ -4792,7 +4725,7 @@
           }
         ]
       },
-      "infrastructure_package_id_3": {
+      "helm-charts-2-16-0_csi-isilon-2.16.0_git": {
         "Name": "helm-charts-2.16.0",
         "Type": "git",
         "Version": "csi-isilon-2.16.0",
@@ -4811,7 +4744,7 @@
           }
         ]
       },
-      "infrastructure_package_id_4": {
+      "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image": {
         "Name": "quay.io/dell/container-storage-modules/csi-isilon",
         "Type": "image",
         "Version": "v2.16.0",
@@ -4825,133 +4758,7 @@
         ],
         "Tag": "v2.16.0"
       },
-      "infrastructure_package_id_5": {
-        "Name": "registry.k8s.io/sig-storage/csi-attacher",
-        "Type": "image",
-        "Version": "v4.10.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v4.10.0"
-      },
-      "infrastructure_package_id_6": {
-        "Name": "registry.k8s.io/sig-storage/csi-provisioner",
-        "Type": "image",
-        "Version": "v6.1.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v6.1.0"
-      },
-      "infrastructure_package_id_7": {
-        "Name": "registry.k8s.io/sig-storage/csi-snapshotter",
-        "Type": "image",
-        "Version": "v8.4.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v8.4.0"
-      },
-      "infrastructure_package_id_8": {
-        "Name": "registry.k8s.io/sig-storage/csi-resizer",
-        "Type": "image",
-        "Version": "v2.0.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v2.0.0"
-      },
-      "infrastructure_package_id_9": {
-        "Name": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
-        "Type": "image",
-        "Version": "v2.15.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v2.15.0"
-      },
-      "infrastructure_package_id_10": {
-        "Name": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
-        "Type": "image",
-        "Version": "v0.16.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v0.16.0"
-      },
-      "infrastructure_package_id_11": {
-        "Name": "quay.io/dell/container-storage-modules/dell-csi-replicator",
-        "Type": "image",
-        "Version": "v1.14.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v1.14.0"
-      },
-      "infrastructure_package_id_12": {
-        "Name": "quay.io/dell/container-storage-modules/podmon",
-        "Type": "image",
-        "Version": "v1.15.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v1.15.0"
-      },
-      "infrastructure_package_id_13": {
-        "Name": "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
-        "Type": "image",
-        "Version": "v2.4.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v2.4.0"
-      },
-      "infrastructure_package_id_14": {
+      "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image": {
         "Name": "quay.io/dell/container-storage-modules/csi-metadata-retriever",
         "Type": "image",
         "Version": "v1.13.0",
@@ -4965,8 +4772,120 @@
         ],
         "Tag": "v1.13.0"
       },
-      "infrastructure_package_id_15": {
-        "Name": "registry.k8s.io/sig-storage/snapshot-controller",
+      "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
+        "Type": "image",
+        "Version": "v2.4.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v2.4.0"
+      },
+      "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/dell-csi-replicator",
+        "Type": "image",
+        "Version": "v1.14.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v1.14.0"
+      },
+      "quay-io-dell-container-storage-modules-podmon_v1.15.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/podmon",
+        "Type": "image",
+        "Version": "v1.15.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v1.15.0"
+      },
+      "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-attacher",
+        "Type": "image",
+        "Version": "v4.10.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v4.10.0"
+      },
+      "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
+        "Type": "image",
+        "Version": "v0.16.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v0.16.0"
+      },
+      "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+        "Type": "image",
+        "Version": "v2.15.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v2.15.0"
+      },
+      "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-provisioner",
+        "Type": "image",
+        "Version": "v6.1.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v6.1.0"
+      },
+      "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-resizer",
+        "Type": "image",
+        "Version": "v2.0.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v2.0.0"
+      },
+      "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-snapshotter",
         "Type": "image",
         "Version": "v8.4.0",
         "SupportedFunctions": [
@@ -4979,10 +4898,10 @@
         ],
         "Tag": "v8.4.0"
       },
-      "infrastructure_package_id_16": {
-        "Name": "docker.io/dellemc/csm-encryption",
+      "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image": {
+        "Name": "registry.k8s.io/sig-storage/snapshot-controller",
         "Type": "image",
-        "Version": "v0.6.0",
+        "Version": "v8.4.0",
         "SupportedFunctions": [
           {
             "Name": "csi"
@@ -4991,7 +4910,7 @@
         "Architecture": [
           "x86_64"
         ],
-        "Tag": "v0.6.0"
+        "Tag": "v8.4.0"
       }
     }
   }

--- a/examples/catalog/catalog_rhel_aarch64_with_slurm_only.json
+++ b/examples/catalog/catalog_rhel_aarch64_with_slurm_only.json
@@ -7,104 +7,104 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "mariadb-server_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "mariadb-server_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-PyMySQL_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmctld_latest_rpm",
-          "slurm-slurmdbd_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-PyMySQL_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmctld_na_rpm",
+          "slurm-slurmdbd_na_rpm"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "kernel-devel_latest_rpm",
-          "kernel-headers_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "kernel-devel_na_rpm",
+          "kernel-headers_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-pam_slurm_latest_rpm",
-          "slurm-slurmd_latest_rpm"
+          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_na_tarball",
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-pam_slurm_na_rpm",
+          "slurm-slurmd_na_rpm"
         ]
       }
     ],
@@ -113,98 +113,98 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_latest_rpm",
-          "authselect_latest_rpm",
-          "autoconf_latest_rpm",
-          "automake_latest_rpm",
-          "bash-completion_latest_rpm",
-          "bash_latest_rpm",
-          "binutils-devel_latest_rpm",
-          "binutils_latest_rpm",
-          "bzip2_latest_rpm",
-          "chrony_latest_rpm",
-          "cloud-init_latest_rpm",
-          "clustershell_latest_rpm",
-          "cmake_latest_rpm",
-          "coreutils_latest_rpm",
-          "cryptsetup_latest_rpm",
-          "curl_latest_rpm",
-          "device-mapper_latest_rpm",
-          "dmidecode_latest_rpm",
+          "NetworkManager_na_rpm",
+          "authselect_na_rpm",
+          "autoconf_na_rpm",
+          "automake_na_rpm",
+          "bash-completion_na_rpm",
+          "bash_na_rpm",
+          "binutils-devel_na_rpm",
+          "binutils_na_rpm",
+          "bzip2_na_rpm",
+          "chrony_na_rpm",
+          "cloud-init_na_rpm",
+          "clustershell_na_rpm",
+          "cmake_na_rpm",
+          "coreutils_na_rpm",
+          "cryptsetup_na_rpm",
+          "curl_na_rpm",
+          "device-mapper_na_rpm",
+          "dmidecode_na_rpm",
           "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
           "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_latest_rpm",
-          "dracut-network_latest_rpm",
-          "dracut_latest_rpm",
-          "emacs_latest_rpm",
-          "file_latest_rpm",
-          "findutils_latest_rpm",
-          "fping_latest_rpm",
-          "gawk_latest_rpm",
-          "gcc-c++_latest_rpm",
-          "gcc-gfortran_latest_rpm",
-          "gcc_latest_rpm",
-          "gdb-gdbserver_latest_rpm",
-          "gdb_latest_rpm",
-          "gedit_latest_rpm",
-          "glibc-langpack-en_latest_rpm",
-          "grep_latest_rpm",
-          "gzip_latest_rpm",
-          "hwloc-libs_latest_rpm",
-          "hwloc_latest_rpm",
-          "iperf3_latest_rpm",
-          "ipmitool_latest_rpm",
-          "iproute_latest_rpm",
-          "iputils_latest_rpm",
-          "kbd_latest_rpm",
-          "kernel-tools_latest_rpm",
-          "kernel_latest_rpm",
-          "kexec-tools_latest_rpm",
-          "libcurl_latest_rpm",
-          "libtool_latest_rpm",
-          "lldb-devel_latest_rpm",
-          "lldb_latest_rpm",
-          "lshw_latest_rpm",
-          "lsof_latest_rpm",
-          "ltrace_latest_rpm",
-          "lvm2_latest_rpm",
-          "make_latest_rpm",
-          "man-db_latest_rpm",
-          "man-pages_latest_rpm",
-          "nfs-utils_latest_rpm",
-          "nfs4-acl-tools_latest_rpm",
-          "nm-connection-editor_latest_rpm",
-          "nss-pam-ldapd_latest_rpm",
-          "oddjob-mkhomedir_latest_rpm",
-          "openldap-clients_latest_rpm",
-          "openssh-clients_latest_rpm",
-          "openssh-server_latest_rpm",
-          "openssh_latest_rpm",
-          "openssl-devel_latest_rpm",
-          "papi-devel_latest_rpm",
-          "papi-libs_latest_rpm",
-          "papi_latest_rpm",
-          "pciutils_latest_rpm",
-          "perf_latest_rpm",
-          "rsync_latest_rpm",
-          "rsyslog_latest_rpm",
-          "sed_latest_rpm",
-          "squashfs-tools_latest_rpm",
-          "sssd_latest_rpm",
-          "strace_latest_rpm",
-          "sudo_latest_rpm",
-          "systemd-udev_latest_rpm",
-          "systemd_latest_rpm",
-          "tar_latest_rpm",
-          "tcpdump_latest_rpm",
-          "traceroute_latest_rpm",
-          "util-linux_latest_rpm",
-          "valgrind-devel_latest_rpm",
-          "valgrind_latest_rpm",
-          "vim-enhanced_latest_rpm",
-          "wget_latest_rpm",
-          "which_latest_rpm",
-          "zsh_latest_rpm"
+          "dracut-live_na_rpm",
+          "dracut-network_na_rpm",
+          "dracut_na_rpm",
+          "emacs_na_rpm",
+          "file_na_rpm",
+          "findutils_na_rpm",
+          "fping_na_rpm",
+          "gawk_na_rpm",
+          "gcc-c++_na_rpm",
+          "gcc-gfortran_na_rpm",
+          "gcc_na_rpm",
+          "gdb-gdbserver_na_rpm",
+          "gdb_na_rpm",
+          "gedit_na_rpm",
+          "glibc-langpack-en_na_rpm",
+          "grep_na_rpm",
+          "gzip_na_rpm",
+          "hwloc-libs_na_rpm",
+          "hwloc_na_rpm",
+          "iperf3_na_rpm",
+          "ipmitool_na_rpm",
+          "iproute_na_rpm",
+          "iputils_na_rpm",
+          "kbd_na_rpm",
+          "kernel-tools_na_rpm",
+          "kernel_na_rpm",
+          "kexec-tools_na_rpm",
+          "libcurl_na_rpm",
+          "libtool_na_rpm",
+          "lldb-devel_na_rpm",
+          "lldb_na_rpm",
+          "lshw_na_rpm",
+          "lsof_na_rpm",
+          "ltrace_na_rpm",
+          "lvm2_na_rpm",
+          "make_na_rpm",
+          "man-db_na_rpm",
+          "man-pages_na_rpm",
+          "nfs-utils_na_rpm",
+          "nfs4-acl-tools_na_rpm",
+          "nm-connection-editor_na_rpm",
+          "nss-pam-ldapd_na_rpm",
+          "oddjob-mkhomedir_na_rpm",
+          "openldap-clients_na_rpm",
+          "openssh-clients_na_rpm",
+          "openssh-server_na_rpm",
+          "openssh_na_rpm",
+          "openssl-devel_na_rpm",
+          "papi-devel_na_rpm",
+          "papi-libs_na_rpm",
+          "papi_na_rpm",
+          "pciutils_na_rpm",
+          "perf_na_rpm",
+          "rsync_na_rpm",
+          "rsyslog_na_rpm",
+          "sed_na_rpm",
+          "squashfs-tools_na_rpm",
+          "sssd_na_rpm",
+          "strace_na_rpm",
+          "sudo_na_rpm",
+          "systemd-udev_na_rpm",
+          "systemd_na_rpm",
+          "tar_na_rpm",
+          "tcpdump_na_rpm",
+          "traceroute_na_rpm",
+          "util-linux_na_rpm",
+          "valgrind-devel_na_rpm",
+          "valgrind_na_rpm",
+          "vim-enhanced_na_rpm",
+          "wget_na_rpm",
+          "which_na_rpm",
+          "zsh_na_rpm"
         ]
       }
     ],
@@ -212,7 +212,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "apptainer_latest_rpm": {
+      "apptainer_na_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -236,7 +236,7 @@
           }
         ]
       },
-      "device-mapper-multipath_latest_rpm": {
+      "device-mapper-multipath_na_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -260,7 +260,7 @@
           }
         ]
       },
-      "doca-ofed_latest_rpm_repo": {
+      "doca-ofed_na_rpm_repo": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -284,7 +284,7 @@
           }
         ]
       },
-      "firewalld_latest_rpm": {
+      "firewalld_na_rpm": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "geopm_latest_tarball": {
+      "geopm_na_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -332,7 +332,7 @@
           }
         ]
       },
-      "imb_latest_tarball": {
+      "imb_na_tarball": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -356,7 +356,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_latest_rpm": {
+      "iscsi-initiator-utils_na_rpm": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -380,7 +380,7 @@
           }
         ]
       },
-      "kernel-devel_latest_rpm": {
+      "kernel-devel_na_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -404,7 +404,7 @@
           }
         ]
       },
-      "kernel-headers_latest_rpm": {
+      "kernel-headers_na_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -428,7 +428,7 @@
           }
         ]
       },
-      "likwid_latest_tarball": {
+      "likwid_na_tarball": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -452,7 +452,7 @@
           }
         ]
       },
-      "lsscsi_latest_rpm": {
+      "lsscsi_na_rpm": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -476,7 +476,7 @@
           }
         ]
       },
-      "mariadb-server_latest_rpm": {
+      "mariadb-server_na_rpm": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -500,7 +500,7 @@
           }
         ]
       },
-      "msr-safe_latest_tarball": {
+      "msr-safe_na_tarball": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -519,7 +519,7 @@
           }
         ]
       },
-      "munge_latest_rpm": {
+      "munge_na_rpm": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -559,7 +559,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
         "SupportedOS": [
           {
@@ -578,7 +578,7 @@
           }
         ]
       },
-      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -597,7 +597,7 @@
           }
         ]
       },
-      "osu-micro-benchmarks_latest_tarball": {
+      "osu-micro-benchmarks_na_tarball": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -621,7 +621,7 @@
           }
         ]
       },
-      "papi_latest_tarball": {
+      "papi_na_tarball": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -645,7 +645,7 @@
           }
         ]
       },
-      "pmix_latest_rpm": {
+      "pmix_na_rpm": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -669,7 +669,7 @@
           }
         ]
       },
-      "python3-PyMySQL_latest_rpm": {
+      "python3-PyMySQL_na_rpm": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -693,7 +693,7 @@
           }
         ]
       },
-      "python3-firewall_latest_rpm": {
+      "python3-firewall_na_rpm": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -717,7 +717,7 @@
           }
         ]
       },
-      "sg3_utils_latest_rpm": {
+      "sg3_utils_na_rpm": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -741,7 +741,7 @@
           }
         ]
       },
-      "sionlib_latest_tarball": {
+      "sionlib_na_tarball": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -765,7 +765,7 @@
           }
         ]
       },
-      "slurm-pam_slurm_latest_rpm": {
+      "slurm-pam_slurm_na_rpm": {
         "Name": "slurm-pam_slurm",
         "SupportedOS": [
           {
@@ -789,7 +789,7 @@
           }
         ]
       },
-      "slurm-slurmctld_latest_rpm": {
+      "slurm-slurmctld_na_rpm": {
         "Name": "slurm-slurmctld",
         "SupportedOS": [
           {
@@ -813,7 +813,7 @@
           }
         ]
       },
-      "slurm-slurmd_latest_rpm": {
+      "slurm-slurmd_na_rpm": {
         "Name": "slurm-slurmd",
         "SupportedOS": [
           {
@@ -837,7 +837,7 @@
           }
         ]
       },
-      "slurm-slurmdbd_latest_rpm": {
+      "slurm-slurmdbd_na_rpm": {
         "Name": "slurm-slurmdbd",
         "SupportedOS": [
           {
@@ -861,7 +861,7 @@
           }
         ]
       },
-      "slurm_latest_rpm": {
+      "slurm_na_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -887,7 +887,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_latest_rpm": {
+      "NetworkManager_na_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -911,7 +911,7 @@
           }
         ]
       },
-      "authselect_latest_rpm": {
+      "authselect_na_rpm": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -935,7 +935,7 @@
           }
         ]
       },
-      "autoconf_latest_rpm": {
+      "autoconf_na_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -959,7 +959,7 @@
           }
         ]
       },
-      "automake_latest_rpm": {
+      "automake_na_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -983,7 +983,7 @@
           }
         ]
       },
-      "bash-completion_latest_rpm": {
+      "bash-completion_na_rpm": {
         "Name": "bash-completion",
         "SupportedOS": [
           {
@@ -1007,7 +1007,7 @@
           }
         ]
       },
-      "bash_latest_rpm": {
+      "bash_na_rpm": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -1031,7 +1031,7 @@
           }
         ]
       },
-      "binutils-devel_latest_rpm": {
+      "binutils-devel_na_rpm": {
         "Name": "binutils-devel",
         "SupportedOS": [
           {
@@ -1055,7 +1055,7 @@
           }
         ]
       },
-      "binutils_latest_rpm": {
+      "binutils_na_rpm": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -1079,7 +1079,7 @@
           }
         ]
       },
-      "bzip2_latest_rpm": {
+      "bzip2_na_rpm": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -1103,7 +1103,7 @@
           }
         ]
       },
-      "chrony_latest_rpm": {
+      "chrony_na_rpm": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -1127,7 +1127,7 @@
           }
         ]
       },
-      "cloud-init_latest_rpm": {
+      "cloud-init_na_rpm": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -1151,7 +1151,7 @@
           }
         ]
       },
-      "clustershell_latest_rpm": {
+      "clustershell_na_rpm": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -1175,7 +1175,7 @@
           }
         ]
       },
-      "cmake_latest_rpm": {
+      "cmake_na_rpm": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -1199,7 +1199,7 @@
           }
         ]
       },
-      "coreutils_latest_rpm": {
+      "coreutils_na_rpm": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -1223,7 +1223,7 @@
           }
         ]
       },
-      "cryptsetup_latest_rpm": {
+      "cryptsetup_na_rpm": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -1247,7 +1247,7 @@
           }
         ]
       },
-      "curl_latest_rpm": {
+      "curl_na_rpm": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -1271,7 +1271,7 @@
           }
         ]
       },
-      "device-mapper_latest_rpm": {
+      "device-mapper_na_rpm": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -1295,7 +1295,7 @@
           }
         ]
       },
-      "dmidecode_latest_rpm": {
+      "dmidecode_na_rpm": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -1349,7 +1349,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_latest_rpm": {
+      "dracut-live_na_rpm": {
         "Name": "dracut-live",
         "SupportedOS": [
           {
@@ -1373,7 +1373,7 @@
           }
         ]
       },
-      "dracut-network_latest_rpm": {
+      "dracut-network_na_rpm": {
         "Name": "dracut-network",
         "SupportedOS": [
           {
@@ -1397,7 +1397,7 @@
           }
         ]
       },
-      "dracut_latest_rpm": {
+      "dracut_na_rpm": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -1421,7 +1421,7 @@
           }
         ]
       },
-      "emacs_latest_rpm": {
+      "emacs_na_rpm": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -1445,7 +1445,7 @@
           }
         ]
       },
-      "file_latest_rpm": {
+      "file_na_rpm": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -1469,7 +1469,7 @@
           }
         ]
       },
-      "findutils_latest_rpm": {
+      "findutils_na_rpm": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -1493,7 +1493,7 @@
           }
         ]
       },
-      "fping_latest_rpm": {
+      "fping_na_rpm": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -1517,7 +1517,7 @@
           }
         ]
       },
-      "gawk_latest_rpm": {
+      "gawk_na_rpm": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -1541,7 +1541,7 @@
           }
         ]
       },
-      "gcc-c++_latest_rpm": {
+      "gcc-c++_na_rpm": {
         "Name": "gcc-c++",
         "SupportedOS": [
           {
@@ -1565,7 +1565,7 @@
           }
         ]
       },
-      "gcc-gfortran_latest_rpm": {
+      "gcc-gfortran_na_rpm": {
         "Name": "gcc-gfortran",
         "SupportedOS": [
           {
@@ -1589,7 +1589,7 @@
           }
         ]
       },
-      "gcc_latest_rpm": {
+      "gcc_na_rpm": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -1613,7 +1613,7 @@
           }
         ]
       },
-      "gdb-gdbserver_latest_rpm": {
+      "gdb-gdbserver_na_rpm": {
         "Name": "gdb-gdbserver",
         "SupportedOS": [
           {
@@ -1637,7 +1637,7 @@
           }
         ]
       },
-      "gdb_latest_rpm": {
+      "gdb_na_rpm": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -1661,7 +1661,7 @@
           }
         ]
       },
-      "gedit_latest_rpm": {
+      "gedit_na_rpm": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -1685,7 +1685,7 @@
           }
         ]
       },
-      "glibc-langpack-en_latest_rpm": {
+      "glibc-langpack-en_na_rpm": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -1709,7 +1709,7 @@
           }
         ]
       },
-      "grep_latest_rpm": {
+      "grep_na_rpm": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -1733,7 +1733,7 @@
           }
         ]
       },
-      "gzip_latest_rpm": {
+      "gzip_na_rpm": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -1757,7 +1757,7 @@
           }
         ]
       },
-      "hwloc-libs_latest_rpm": {
+      "hwloc-libs_na_rpm": {
         "Name": "hwloc-libs",
         "SupportedOS": [
           {
@@ -1781,7 +1781,7 @@
           }
         ]
       },
-      "hwloc_latest_rpm": {
+      "hwloc_na_rpm": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -1805,7 +1805,7 @@
           }
         ]
       },
-      "iperf3_latest_rpm": {
+      "iperf3_na_rpm": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -1829,7 +1829,7 @@
           }
         ]
       },
-      "ipmitool_latest_rpm": {
+      "ipmitool_na_rpm": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -1853,7 +1853,7 @@
           }
         ]
       },
-      "iproute_latest_rpm": {
+      "iproute_na_rpm": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -1877,7 +1877,7 @@
           }
         ]
       },
-      "iputils_latest_rpm": {
+      "iputils_na_rpm": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -1901,7 +1901,7 @@
           }
         ]
       },
-      "kbd_latest_rpm": {
+      "kbd_na_rpm": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -1925,7 +1925,7 @@
           }
         ]
       },
-      "kernel-tools_latest_rpm": {
+      "kernel-tools_na_rpm": {
         "Name": "kernel-tools",
         "SupportedOS": [
           {
@@ -1949,7 +1949,7 @@
           }
         ]
       },
-      "kernel_latest_rpm": {
+      "kernel_na_rpm": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -1973,7 +1973,7 @@
           }
         ]
       },
-      "kexec-tools_latest_rpm": {
+      "kexec-tools_na_rpm": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -1997,7 +1997,7 @@
           }
         ]
       },
-      "libcurl_latest_rpm": {
+      "libcurl_na_rpm": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -2021,7 +2021,7 @@
           }
         ]
       },
-      "libtool_latest_rpm": {
+      "libtool_na_rpm": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -2045,7 +2045,7 @@
           }
         ]
       },
-      "lldb-devel_latest_rpm": {
+      "lldb-devel_na_rpm": {
         "Name": "lldb-devel",
         "SupportedOS": [
           {
@@ -2069,7 +2069,7 @@
           }
         ]
       },
-      "lldb_latest_rpm": {
+      "lldb_na_rpm": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -2093,7 +2093,7 @@
           }
         ]
       },
-      "lshw_latest_rpm": {
+      "lshw_na_rpm": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -2117,7 +2117,7 @@
           }
         ]
       },
-      "lsof_latest_rpm": {
+      "lsof_na_rpm": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -2141,7 +2141,7 @@
           }
         ]
       },
-      "ltrace_latest_rpm": {
+      "ltrace_na_rpm": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -2165,7 +2165,7 @@
           }
         ]
       },
-      "lvm2_latest_rpm": {
+      "lvm2_na_rpm": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -2189,7 +2189,7 @@
           }
         ]
       },
-      "make_latest_rpm": {
+      "make_na_rpm": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -2213,7 +2213,7 @@
           }
         ]
       },
-      "man-db_latest_rpm": {
+      "man-db_na_rpm": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -2237,7 +2237,7 @@
           }
         ]
       },
-      "man-pages_latest_rpm": {
+      "man-pages_na_rpm": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -2261,7 +2261,7 @@
           }
         ]
       },
-      "nfs-utils_latest_rpm": {
+      "nfs-utils_na_rpm": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -2285,7 +2285,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_latest_rpm": {
+      "nfs4-acl-tools_na_rpm": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -2309,7 +2309,7 @@
           }
         ]
       },
-      "nm-connection-editor_latest_rpm": {
+      "nm-connection-editor_na_rpm": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -2333,7 +2333,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_latest_rpm": {
+      "nss-pam-ldapd_na_rpm": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -2357,7 +2357,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_latest_rpm": {
+      "oddjob-mkhomedir_na_rpm": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -2381,7 +2381,7 @@
           }
         ]
       },
-      "openldap-clients_latest_rpm": {
+      "openldap-clients_na_rpm": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -2405,7 +2405,7 @@
           }
         ]
       },
-      "openssh-clients_latest_rpm": {
+      "openssh-clients_na_rpm": {
         "Name": "openssh-clients",
         "SupportedOS": [
           {
@@ -2429,7 +2429,7 @@
           }
         ]
       },
-      "openssh-server_latest_rpm": {
+      "openssh-server_na_rpm": {
         "Name": "openssh-server",
         "SupportedOS": [
           {
@@ -2453,7 +2453,7 @@
           }
         ]
       },
-      "openssh_latest_rpm": {
+      "openssh_na_rpm": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -2477,7 +2477,7 @@
           }
         ]
       },
-      "openssl-devel_latest_rpm": {
+      "openssl-devel_na_rpm": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -2501,7 +2501,7 @@
           }
         ]
       },
-      "papi-devel_latest_rpm": {
+      "papi-devel_na_rpm": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -2525,7 +2525,7 @@
           }
         ]
       },
-      "papi-libs_latest_rpm": {
+      "papi-libs_na_rpm": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -2549,7 +2549,7 @@
           }
         ]
       },
-      "papi_latest_rpm": {
+      "papi_na_rpm": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -2573,7 +2573,7 @@
           }
         ]
       },
-      "pciutils_latest_rpm": {
+      "pciutils_na_rpm": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -2597,7 +2597,7 @@
           }
         ]
       },
-      "perf_latest_rpm": {
+      "perf_na_rpm": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -2621,7 +2621,7 @@
           }
         ]
       },
-      "rsync_latest_rpm": {
+      "rsync_na_rpm": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -2645,7 +2645,7 @@
           }
         ]
       },
-      "rsyslog_latest_rpm": {
+      "rsyslog_na_rpm": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -2669,7 +2669,7 @@
           }
         ]
       },
-      "sed_latest_rpm": {
+      "sed_na_rpm": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -2693,7 +2693,7 @@
           }
         ]
       },
-      "squashfs-tools_latest_rpm": {
+      "squashfs-tools_na_rpm": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -2717,7 +2717,7 @@
           }
         ]
       },
-      "sssd_latest_rpm": {
+      "sssd_na_rpm": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -2741,7 +2741,7 @@
           }
         ]
       },
-      "strace_latest_rpm": {
+      "strace_na_rpm": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -2765,7 +2765,7 @@
           }
         ]
       },
-      "sudo_latest_rpm": {
+      "sudo_na_rpm": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -2789,7 +2789,7 @@
           }
         ]
       },
-      "systemd-udev_latest_rpm": {
+      "systemd-udev_na_rpm": {
         "Name": "systemd-udev",
         "SupportedOS": [
           {
@@ -2813,7 +2813,7 @@
           }
         ]
       },
-      "systemd_latest_rpm": {
+      "systemd_na_rpm": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -2837,7 +2837,7 @@
           }
         ]
       },
-      "tar_latest_rpm": {
+      "tar_na_rpm": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -2861,7 +2861,7 @@
           }
         ]
       },
-      "tcpdump_latest_rpm": {
+      "tcpdump_na_rpm": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -2885,7 +2885,7 @@
           }
         ]
       },
-      "traceroute_latest_rpm": {
+      "traceroute_na_rpm": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -2909,7 +2909,7 @@
           }
         ]
       },
-      "util-linux_latest_rpm": {
+      "util-linux_na_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -2933,7 +2933,7 @@
           }
         ]
       },
-      "valgrind-devel_latest_rpm": {
+      "valgrind-devel_na_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -2957,7 +2957,7 @@
           }
         ]
       },
-      "valgrind_latest_rpm": {
+      "valgrind_na_rpm": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -2981,7 +2981,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm": {
+      "vim-enhanced_na_rpm": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -3005,7 +3005,7 @@
           }
         ]
       },
-      "wget_latest_rpm": {
+      "wget_na_rpm": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -3029,7 +3029,7 @@
           }
         ]
       },
-      "which_latest_rpm": {
+      "which_na_rpm": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -3053,7 +3053,7 @@
           }
         ]
       },
-      "zsh_latest_rpm": {
+      "zsh_na_rpm": {
         "Name": "zsh",
         "SupportedOS": [
           {

--- a/examples/catalog/catalog_rhel_aarch64_with_slurm_only.json
+++ b/examples/catalog/catalog_rhel_aarch64_with_slurm_only.json
@@ -7,104 +7,104 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_28",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_28",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_2",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "mariadb-server_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-PyMySQL_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmctld_latest_rpm",
+          "slurm-slurmdbd_latest_rpm"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_24",
-          "package_id_25",
-          "package_id_26",
-          "package_id_29",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "kernel-devel_latest_rpm",
+          "kernel-headers_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-pam_slurm_latest_rpm",
+          "slurm-slurmd_latest_rpm"
         ]
       }
     ],
@@ -113,98 +113,98 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "os_package_id_1",
-          "os_package_id_10",
-          "os_package_id_11",
-          "os_package_id_12",
-          "os_package_id_13",
-          "os_package_id_14",
-          "os_package_id_15",
-          "os_package_id_16",
-          "os_package_id_17",
-          "os_package_id_18",
-          "os_package_id_19",
-          "os_package_id_2",
-          "os_package_id_20",
-          "os_package_id_21",
-          "os_package_id_22",
-          "os_package_id_23",
-          "os_package_id_24",
-          "os_package_id_25",
-          "os_package_id_26",
-          "os_package_id_27",
-          "os_package_id_28",
-          "os_package_id_29",
-          "os_package_id_3",
-          "os_package_id_30",
-          "os_package_id_31",
-          "os_package_id_32",
-          "os_package_id_33",
-          "os_package_id_34",
-          "os_package_id_35",
-          "os_package_id_36",
-          "os_package_id_37",
-          "os_package_id_38",
-          "os_package_id_39",
-          "os_package_id_4",
-          "os_package_id_40",
-          "os_package_id_41",
-          "os_package_id_42",
-          "os_package_id_43",
-          "os_package_id_44",
-          "os_package_id_45",
-          "os_package_id_46",
-          "os_package_id_47",
-          "os_package_id_48",
-          "os_package_id_49",
-          "os_package_id_5",
-          "os_package_id_50",
-          "os_package_id_51",
-          "os_package_id_52",
-          "os_package_id_53",
-          "os_package_id_54",
-          "os_package_id_55",
-          "os_package_id_56",
-          "os_package_id_57",
-          "os_package_id_58",
-          "os_package_id_59",
-          "os_package_id_6",
-          "os_package_id_60",
-          "os_package_id_61",
-          "os_package_id_62",
-          "os_package_id_63",
-          "os_package_id_64",
-          "os_package_id_65",
-          "os_package_id_66",
-          "os_package_id_67",
-          "os_package_id_68",
-          "os_package_id_69",
-          "os_package_id_7",
-          "os_package_id_70",
-          "os_package_id_71",
-          "os_package_id_72",
-          "os_package_id_73",
-          "os_package_id_74",
-          "os_package_id_75",
-          "os_package_id_76",
-          "os_package_id_77",
-          "os_package_id_78",
-          "os_package_id_79",
-          "os_package_id_8",
-          "os_package_id_80",
-          "os_package_id_81",
-          "os_package_id_82",
-          "os_package_id_83",
-          "os_package_id_84",
-          "os_package_id_85",
-          "os_package_id_86",
-          "os_package_id_87",
-          "os_package_id_88",
-          "os_package_id_89",
-          "os_package_id_9",
-          "os_package_id_90",
-          "os_package_id_91",
-          "os_package_id_92"
+          "NetworkManager_latest_rpm",
+          "authselect_latest_rpm",
+          "autoconf_latest_rpm",
+          "automake_latest_rpm",
+          "bash-completion_latest_rpm",
+          "bash_latest_rpm",
+          "binutils-devel_latest_rpm",
+          "binutils_latest_rpm",
+          "bzip2_latest_rpm",
+          "chrony_latest_rpm",
+          "cloud-init_latest_rpm",
+          "clustershell_latest_rpm",
+          "cmake_latest_rpm",
+          "coreutils_latest_rpm",
+          "cryptsetup_latest_rpm",
+          "curl_latest_rpm",
+          "device-mapper_latest_rpm",
+          "dmidecode_latest_rpm",
+          "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
+          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
+          "dracut-live_latest_rpm",
+          "dracut-network_latest_rpm",
+          "dracut_latest_rpm",
+          "emacs_latest_rpm",
+          "file_latest_rpm",
+          "findutils_latest_rpm",
+          "fping_latest_rpm",
+          "gawk_latest_rpm",
+          "gcc-c++_latest_rpm",
+          "gcc-gfortran_latest_rpm",
+          "gcc_latest_rpm",
+          "gdb-gdbserver_latest_rpm",
+          "gdb_latest_rpm",
+          "gedit_latest_rpm",
+          "glibc-langpack-en_latest_rpm",
+          "grep_latest_rpm",
+          "gzip_latest_rpm",
+          "hwloc-libs_latest_rpm",
+          "hwloc_latest_rpm",
+          "iperf3_latest_rpm",
+          "ipmitool_latest_rpm",
+          "iproute_latest_rpm",
+          "iputils_latest_rpm",
+          "kbd_latest_rpm",
+          "kernel-tools_latest_rpm",
+          "kernel_latest_rpm",
+          "kexec-tools_latest_rpm",
+          "libcurl_latest_rpm",
+          "libtool_latest_rpm",
+          "lldb-devel_latest_rpm",
+          "lldb_latest_rpm",
+          "lshw_latest_rpm",
+          "lsof_latest_rpm",
+          "ltrace_latest_rpm",
+          "lvm2_latest_rpm",
+          "make_latest_rpm",
+          "man-db_latest_rpm",
+          "man-pages_latest_rpm",
+          "nfs-utils_latest_rpm",
+          "nfs4-acl-tools_latest_rpm",
+          "nm-connection-editor_latest_rpm",
+          "nss-pam-ldapd_latest_rpm",
+          "oddjob-mkhomedir_latest_rpm",
+          "openldap-clients_latest_rpm",
+          "openssh-clients_latest_rpm",
+          "openssh-server_latest_rpm",
+          "openssh_latest_rpm",
+          "openssl-devel_latest_rpm",
+          "papi-devel_latest_rpm",
+          "papi-libs_latest_rpm",
+          "papi_latest_rpm",
+          "pciutils_latest_rpm",
+          "perf_latest_rpm",
+          "rsync_latest_rpm",
+          "rsyslog_latest_rpm",
+          "sed_latest_rpm",
+          "squashfs-tools_latest_rpm",
+          "sssd_latest_rpm",
+          "strace_latest_rpm",
+          "sudo_latest_rpm",
+          "systemd-udev_latest_rpm",
+          "systemd_latest_rpm",
+          "tar_latest_rpm",
+          "tcpdump_latest_rpm",
+          "traceroute_latest_rpm",
+          "util-linux_latest_rpm",
+          "valgrind-devel_latest_rpm",
+          "valgrind_latest_rpm",
+          "vim-enhanced_latest_rpm",
+          "wget_latest_rpm",
+          "which_latest_rpm",
+          "zsh_latest_rpm"
         ]
       }
     ],
@@ -212,119 +212,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "package_id_1": {
-        "Name": "munge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_2": {
-        "Name": "firewalld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_3": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_4": {
-        "Name": "pmix",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_5": {
-        "Name": "nvcr.io/nvidia/hpc-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "25.09",
-        "Version": "25.09"
-      },
-      "package_id_6": {
+      "apptainer_latest_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -348,55 +236,7 @@
           }
         ]
       },
-      "package_id_7": {
-        "Name": "doca-ofed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm_repo",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "doca"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "doca"
-          }
-        ]
-      },
-      "package_id_8": {
-        "Name": "iscsi-initiator-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_9": {
+      "device-mapper-multipath_latest_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -420,8 +260,32 @@
           }
         ]
       },
-      "package_id_10": {
-        "Name": "sg3_utils",
+      "doca-ofed_latest_rpm_repo": {
+        "Name": "doca-ofed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm_repo",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "doca"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "doca"
+          }
+        ]
+      },
+      "firewalld_latest_rpm": {
+        "Name": "firewalld",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -444,103 +308,7 @@
           }
         ]
       },
-      "package_id_11": {
-        "Name": "lsscsi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_12": {
-        "Name": "imb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          }
-        ]
-      },
-      "package_id_13": {
-        "Name": "osu-micro-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          }
-        ]
-      },
-      "package_id_14": {
-        "Name": "likwid",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          }
-        ]
-      },
-      "package_id_15": {
+      "geopm_latest_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -564,8 +332,8 @@
           }
         ]
       },
-      "package_id_16": {
-        "Name": "papi",
+      "imb_latest_tarball": {
+        "Name": "imb",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -580,59 +348,16 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           },
           {
             "Architecture": "aarch64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "package_id_17": {
-        "Name": "msr-safe",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_18": {
-        "Name": "sionlib",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "package_id_19": {
-        "Name": "slurm-slurmctld",
+      "iscsi-initiator-utils_latest_rpm": {
+        "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -647,135 +372,15 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           },
           {
             "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_20": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_21": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_22": {
-        "Name": "mariadb-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_23": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_24": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_25": {
+      "kernel-devel_latest_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -799,7 +404,7 @@
           }
         ]
       },
-      "package_id_26": {
+      "kernel-headers_latest_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -823,7 +428,157 @@
           }
         ]
       },
-      "package_id_27": {
+      "likwid_latest_tarball": {
+        "Name": "likwid",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          }
+        ]
+      },
+      "lsscsi_latest_rpm": {
+        "Name": "lsscsi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "mariadb-server_latest_rpm": {
+        "Name": "mariadb-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "msr-safe_latest_tarball": {
+        "Name": "msr-safe",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
+          }
+        ]
+      },
+      "munge_latest_rpm": {
+        "Name": "munge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+        "Name": "nvcr.io/nvidia/hpc-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "25.09",
+        "Version": "25.09"
+      },
+      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball": {
+        "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_aarch64_cuda_13.0.tar.gz"
+          }
+        ]
+      },
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -842,7 +597,271 @@
           }
         ]
       },
-      "package_id_28": {
+      "osu-micro-benchmarks_latest_tarball": {
+        "Name": "osu-micro-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          }
+        ]
+      },
+      "papi_latest_tarball": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          }
+        ]
+      },
+      "pmix_latest_rpm": {
+        "Name": "pmix",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-PyMySQL_latest_rpm": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall_latest_rpm": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sg3_utils_latest_rpm": {
+        "Name": "sg3_utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sionlib_latest_tarball": {
+        "Name": "sionlib",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          }
+        ]
+      },
+      "slurm-pam_slurm_latest_rpm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld_latest_rpm": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd_latest_rpm": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd_latest_rpm": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm_latest_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -865,365 +884,10 @@
             "RepoName": "slurm_custom"
           }
         ]
-      },
-      "package_id_29": {
-        "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_aarch64_cuda_13.0.tar.gz"
-          }
-        ]
       }
     },
     "OSPackages": {
-      "os_package_id_1": {
-        "Name": "openldap-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_2": {
-        "Name": "nss-pam-ldapd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_3": {
-        "Name": "sssd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_4": {
-        "Name": "oddjob-mkhomedir",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_5": {
-        "Name": "authselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_6": {
-        "Name": "systemd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_7": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_8": {
-        "Name": "kernel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_9": {
-        "Name": "dracut",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_10": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_11": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_12": {
-        "Name": "squashfs-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_13": {
-        "Name": "nfs-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_14": {
-        "Name": "nfs4-acl-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_15": {
+      "NetworkManager_latest_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -1247,8 +911,8 @@
           }
         ]
       },
-      "os_package_id_16": {
-        "Name": "nm-connection-editor",
+      "authselect_latest_rpm": {
+        "Name": "authselect",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1263,1557 +927,6 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_17": {
-        "Name": "iproute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_18": {
-        "Name": "iputils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_19": {
-        "Name": "curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_20": {
-        "Name": "bash",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_21": {
-        "Name": "coreutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_22": {
-        "Name": "grep",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_23": {
-        "Name": "sed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_24": {
-        "Name": "gawk",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_25": {
-        "Name": "findutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_26": {
-        "Name": "util-linux",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_27": {
-        "Name": "kbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_28": {
-        "Name": "lsof",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_29": {
-        "Name": "cryptsetup",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_30": {
-        "Name": "lvm2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_31": {
-        "Name": "device-mapper",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_32": {
-        "Name": "rsyslog",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_33": {
-        "Name": "chrony",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_34": {
-        "Name": "sudo",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_35": {
-        "Name": "gzip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_36": {
-        "Name": "wget",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_37": {
-        "Name": "cloud-init",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_38": {
-        "Name": "glibc-langpack-en",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_39": {
-        "Name": "gedit",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_40": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
-      },
-      "os_package_id_41": {
-        "Name": "which",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_42": {
-        "Name": "tcpdump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_43": {
-        "Name": "traceroute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_44": {
-        "Name": "iperf3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_45": {
-        "Name": "fping",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_46": {
-        "Name": "dmidecode",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_47": {
-        "Name": "hwloc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_48": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_49": {
-        "Name": "lshw",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_50": {
-        "Name": "pciutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_51": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_52": {
-        "Name": "emacs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_53": {
-        "Name": "zsh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_54": {
-        "Name": "openssh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_55": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_56": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_57": {
-        "Name": "rsync",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_58": {
-        "Name": "file",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_59": {
-        "Name": "libcurl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_60": {
-        "Name": "tar",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_61": {
-        "Name": "bzip2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_62": {
-        "Name": "man-db",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_63": {
-        "Name": "man-pages",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_64": {
-        "Name": "strace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_65": {
-        "Name": "kexec-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_66": {
-        "Name": "openssl-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_67": {
-        "Name": "ipmitool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_68": {
-        "Name": "gdb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_69": {
-        "Name": "gdb-gdbserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_70": {
-        "Name": "lldb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_71": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_72": {
-        "Name": "valgrind",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_73": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_74": {
-        "Name": "ltrace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_75": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_76": {
-        "Name": "perf",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_77": {
-        "Name": "papi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_78": {
-        "Name": "papi-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_79": {
-        "Name": "papi-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_80": {
-        "Name": "cmake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_81": {
-        "Name": "make",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
@@ -2822,7 +935,7 @@
           }
         ]
       },
-      "os_package_id_82": {
+      "autoconf_latest_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2846,7 +959,7 @@
           }
         ]
       },
-      "os_package_id_83": {
+      "automake_latest_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2870,175 +983,7 @@
           }
         ]
       },
-      "os_package_id_84": {
-        "Name": "libtool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_85": {
-        "Name": "gcc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_86": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_87": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_88": {
-        "Name": "binutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_89": {
-        "Name": "binutils-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_90": {
-        "Name": "clustershell",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_91": {
+      "bash-completion_latest_rpm": {
         "Name": "bash-completion",
         "SupportedOS": [
           {
@@ -3062,7 +1007,319 @@
           }
         ]
       },
-      "os_package_id_92": {
+      "bash_latest_rpm": {
+        "Name": "bash",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "binutils-devel_latest_rpm": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "binutils_latest_rpm": {
+        "Name": "binutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bzip2_latest_rpm": {
+        "Name": "bzip2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "chrony_latest_rpm": {
+        "Name": "chrony",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cloud-init_latest_rpm": {
+        "Name": "cloud-init",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "clustershell_latest_rpm": {
+        "Name": "clustershell",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "cmake_latest_rpm": {
+        "Name": "cmake",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "coreutils_latest_rpm": {
+        "Name": "coreutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cryptsetup_latest_rpm": {
+        "Name": "cryptsetup",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "curl_latest_rpm": {
+        "Name": "curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "device-mapper_latest_rpm": {
+        "Name": "device-mapper",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dmidecode_latest_rpm": {
+        "Name": "dmidecode",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
         "SupportedOS": [
           {
@@ -3076,6 +1333,1749 @@
         "Type": "image",
         "Tag": "1.1",
         "Version": "1.1"
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "dracut-live_latest_rpm": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network_latest_rpm": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dracut_latest_rpm": {
+        "Name": "dracut",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs_latest_rpm": {
+        "Name": "emacs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "file_latest_rpm": {
+        "Name": "file",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "findutils_latest_rpm": {
+        "Name": "findutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "fping_latest_rpm": {
+        "Name": "fping",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "gawk_latest_rpm": {
+        "Name": "gawk",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gcc-c++_latest_rpm": {
+        "Name": "gcc-c++",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc-gfortran_latest_rpm": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc_latest_rpm": {
+        "Name": "gcc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb-gdbserver_latest_rpm": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb_latest_rpm": {
+        "Name": "gdb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit_latest_rpm": {
+        "Name": "gedit",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "glibc-langpack-en_latest_rpm": {
+        "Name": "glibc-langpack-en",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "grep_latest_rpm": {
+        "Name": "grep",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gzip_latest_rpm": {
+        "Name": "gzip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc-libs_latest_rpm": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc_latest_rpm": {
+        "Name": "hwloc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3_latest_rpm": {
+        "Name": "iperf3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "ipmitool_latest_rpm": {
+        "Name": "ipmitool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "iproute_latest_rpm": {
+        "Name": "iproute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iputils_latest_rpm": {
+        "Name": "iputils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kbd_latest_rpm": {
+        "Name": "kbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel-tools_latest_rpm": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel_latest_rpm": {
+        "Name": "kernel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools_latest_rpm": {
+        "Name": "kexec-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libcurl_latest_rpm": {
+        "Name": "libcurl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libtool_latest_rpm": {
+        "Name": "libtool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb-devel_latest_rpm": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb_latest_rpm": {
+        "Name": "lldb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw_latest_rpm": {
+        "Name": "lshw",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "lsof_latest_rpm": {
+        "Name": "lsof",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ltrace_latest_rpm": {
+        "Name": "ltrace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lvm2_latest_rpm": {
+        "Name": "lvm2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "make_latest_rpm": {
+        "Name": "make",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-db_latest_rpm": {
+        "Name": "man-db",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-pages_latest_rpm": {
+        "Name": "man-pages",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs-utils_latest_rpm": {
+        "Name": "nfs-utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs4-acl-tools_latest_rpm": {
+        "Name": "nfs4-acl-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nm-connection-editor_latest_rpm": {
+        "Name": "nm-connection-editor",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nss-pam-ldapd_latest_rpm": {
+        "Name": "nss-pam-ldapd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "oddjob-mkhomedir_latest_rpm": {
+        "Name": "oddjob-mkhomedir",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openldap-clients_latest_rpm": {
+        "Name": "openldap-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-clients_latest_rpm": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server_latest_rpm": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh_latest_rpm": {
+        "Name": "openssh",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel_latest_rpm": {
+        "Name": "openssl-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-devel_latest_rpm": {
+        "Name": "papi-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-libs_latest_rpm": {
+        "Name": "papi-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi_latest_rpm": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pciutils_latest_rpm": {
+        "Name": "pciutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "perf_latest_rpm": {
+        "Name": "perf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "rsync_latest_rpm": {
+        "Name": "rsync",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "rsyslog_latest_rpm": {
+        "Name": "rsyslog",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "sed_latest_rpm": {
+        "Name": "sed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "squashfs-tools_latest_rpm": {
+        "Name": "squashfs-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sssd_latest_rpm": {
+        "Name": "sssd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "strace_latest_rpm": {
+        "Name": "strace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sudo_latest_rpm": {
+        "Name": "sudo",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd-udev_latest_rpm": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd_latest_rpm": {
+        "Name": "systemd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar_latest_rpm": {
+        "Name": "tar",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tcpdump_latest_rpm": {
+        "Name": "tcpdump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "traceroute_latest_rpm": {
+        "Name": "traceroute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "util-linux_latest_rpm": {
+        "Name": "util-linux",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "valgrind-devel_latest_rpm": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "valgrind_latest_rpm": {
+        "Name": "valgrind",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced_latest_rpm": {
+        "Name": "vim-enhanced",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "wget_latest_rpm": {
+        "Name": "wget",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "which_latest_rpm": {
+        "Name": "which",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "zsh_latest_rpm": {
+        "Name": "zsh",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
       }
     },
     "Miscellaneous": [],

--- a/examples/catalog/catalog_rhel_with_nfs_provisioner.json
+++ b/examples/catalog/catalog_rhel_with_nfs_provisioner.json
@@ -7,65 +7,65 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
           "PyMySQL_1.1.2_pip_module",
-          "apptainer_latest_rpm",
-          "calico-v3-31-4_latest_manifest",
-          "cert-manager-v1-10-0_latest_tarball",
+          "apptainer_na_rpm",
+          "calico-v3-31-4_na_manifest",
+          "cert-manager-v1-10-0_na_tarball",
           "cffi_1.17.1_pip_module",
-          "container-selinux_latest_rpm",
+          "container-selinux_na_rpm",
           "cri-o_1.35.1_rpm",
           "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
           "docker-io-alpine-kubectl_1.35.1_image",
           "docker-io-calico-cni_v3.31.4_image",
           "docker-io-calico-kube-controllers_v3.31.4_image",
@@ -90,27 +90,27 @@
           "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_latest_rpm",
-          "fuse-overlayfs_latest_rpm",
+          "firewalld_na_rpm",
+          "fuse-overlayfs_na_rpm",
           "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
           "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_latest_rpm",
+          "git_na_rpm",
           "helm-charts_container-storage-modules-1.9.2_git",
-          "helm-v3-20-1-amd64_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
+          "helm-v3-20-1-amd64_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
           "karavi-observability_v1.12.0_git",
           "kubeadm_1.35.1_rpm",
           "kubectl_1.35.1_rpm",
           "kubelet_1.35.1_rpm",
           "kubernetes_33.1.0_pip_module",
-          "lsscsi_latest_rpm",
-          "metallb-native-v0-15-3_latest_manifest",
-          "nfs-subdir-external-provisioner-4-0-18_latest_tarball",
+          "lsscsi_na_rpm",
+          "metallb-native-v0-15-3_na_manifest",
+          "nfs-subdir-external-provisioner-4-0-18_na_tarball",
           "omsdk_1.2.518_pip_module",
-          "podman_latest_rpm",
+          "podman_na_rpm",
           "prettytable_3.14.0_pip_module",
           "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_latest_rpm",
+          "python3-firewall_na_rpm",
           "python3_3.12.9_rpm",
           "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
           "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
@@ -128,23 +128,23 @@
           "registry-k8s-io-kube-proxy_v1.35.1_image",
           "registry-k8s-io-kube-scheduler_v1.35.1_image",
           "registry-k8s-io-pause_3.10.1_image",
-          "sg3_utils_latest_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
-          "victoria-metrics-operator-0-59-3_latest_tarball",
-          "vim-enhanced_latest_rpm"
+          "sg3_utils_na_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
+          "victoria-metrics-operator-0-59-3_na_tarball",
+          "vim-enhanced_na_rpm"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "cert-manager-v1-10-0_latest_tarball",
+          "apptainer_na_rpm",
+          "cert-manager-v1-10-0_na_tarball",
           "cffi_1.17.1_pip_module",
-          "container-selinux_latest_rpm",
+          "container-selinux_na_rpm",
           "cri-o_1.35.1_rpm",
           "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
           "docker-io-alpine-kubectl_1.35.1_image",
           "docker-io-curlimages-curl_8.17.0_image",
           "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
@@ -166,21 +166,21 @@
           "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_latest_rpm",
-          "fuse-overlayfs_latest_rpm",
+          "firewalld_na_rpm",
+          "fuse-overlayfs_na_rpm",
           "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_latest_rpm",
+          "git_na_rpm",
           "helm-charts_container-storage-modules-1.9.2_git",
-          "iscsi-initiator-utils_latest_rpm",
+          "iscsi-initiator-utils_na_rpm",
           "karavi-observability_v1.12.0_git",
           "kubeadm_1.35.1_rpm",
           "kubelet_1.35.1_rpm",
           "kubernetes_33.1.0_pip_module",
-          "lsscsi_latest_rpm",
+          "lsscsi_na_rpm",
           "omsdk_1.2.518_pip_module",
-          "podman_latest_rpm",
+          "podman_na_rpm",
           "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_latest_rpm",
+          "python3-firewall_na_rpm",
           "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
           "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
           "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
@@ -192,64 +192,64 @@
           "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
           "quay-io-strimzi-operator_0.48.0_image",
           "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
-          "sg3_utils_latest_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
-          "victoria-metrics-operator-0-59-3_latest_tarball",
-          "vim-enhanced_latest_rpm"
+          "sg3_utils_na_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
+          "victoria-metrics-operator-0-59-3_na_tarball",
+          "vim-enhanced_na_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "mariadb-server_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "mariadb-server_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-PyMySQL_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmctld_latest_rpm",
-          "slurm-slurmdbd_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-PyMySQL_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmctld_na_rpm",
+          "slurm-slurmdbd_na_rpm"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "kernel-devel_latest_rpm",
-          "kernel-headers_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "kernel-devel_na_rpm",
+          "kernel-headers_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-pam_slurm_latest_rpm",
-          "slurm-slurmd_latest_rpm"
+          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_na_tarball",
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-pam_slurm_na_rpm",
+          "slurm-slurmd_na_rpm"
         ]
       }
     ],
@@ -258,106 +258,106 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_latest_rpm",
-          "authselect_latest_rpm",
-          "autoconf_latest_rpm",
-          "automake_latest_rpm",
-          "bash-completion_latest_rpm",
-          "bash_latest_rpm",
-          "binutils-devel_latest_rpm",
-          "binutils_latest_rpm",
-          "bzip2_latest_rpm",
-          "chrony_latest_rpm",
-          "cloud-init_latest_rpm",
-          "clustershell_latest_rpm",
-          "cmake_latest_rpm",
-          "coreutils_latest_rpm",
-          "cryptsetup_latest_rpm",
-          "curl_latest_rpm",
-          "device-mapper_latest_rpm",
-          "dmidecode_latest_rpm",
+          "NetworkManager_na_rpm",
+          "authselect_na_rpm",
+          "autoconf_na_rpm",
+          "automake_na_rpm",
+          "bash-completion_na_rpm",
+          "bash_na_rpm",
+          "binutils-devel_na_rpm",
+          "binutils_na_rpm",
+          "bzip2_na_rpm",
+          "chrony_na_rpm",
+          "cloud-init_na_rpm",
+          "clustershell_na_rpm",
+          "cmake_na_rpm",
+          "coreutils_na_rpm",
+          "cryptsetup_na_rpm",
+          "curl_na_rpm",
+          "device-mapper_na_rpm",
+          "dmidecode_na_rpm",
           "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
           "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_latest_rpm",
-          "dracut-network_latest_rpm",
-          "dracut_latest_rpm",
-          "emacs_latest_rpm",
-          "file_latest_rpm",
-          "findutils_latest_rpm",
-          "fping_latest_rpm",
-          "gawk_latest_rpm",
-          "gcc-c++_latest_rpm",
-          "gcc-gfortran_latest_rpm",
-          "gcc_latest_rpm",
-          "gdb-gdbserver_latest_rpm",
-          "gdb_latest_rpm",
-          "gedit_latest_rpm",
-          "glibc-langpack-en_latest_rpm",
-          "grep_latest_rpm",
-          "gzip_latest_rpm",
-          "hwloc-libs_latest_rpm",
-          "hwloc_latest_rpm",
-          "iperf3_latest_rpm",
-          "ipmitool_latest_rpm",
-          "iproute_latest_rpm",
-          "iputils_latest_rpm",
-          "kbd_latest_rpm",
-          "kernel-tools_latest_rpm",
-          "kernel_latest_rpm",
-          "kexec-tools_latest_rpm",
-          "libcurl_latest_rpm",
-          "libtool_latest_rpm",
-          "lldb-devel_latest_rpm",
-          "lldb_latest_rpm",
-          "lshw_latest_rpm",
-          "lsof_latest_rpm",
-          "ltrace_latest_rpm",
-          "lvm2_latest_rpm",
-          "make_latest_rpm",
-          "man-db_latest_rpm",
-          "man-pages_latest_rpm",
-          "munge-devel_latest_rpm",
-          "nfs-utils_latest_rpm",
-          "nfs4-acl-tools_latest_rpm",
-          "nm-connection-editor_latest_rpm",
-          "nss-pam-ldapd_latest_rpm",
-          "oddjob-mkhomedir_latest_rpm",
-          "openldap-clients_latest_rpm",
+          "dracut-live_na_rpm",
+          "dracut-network_na_rpm",
+          "dracut_na_rpm",
+          "emacs_na_rpm",
+          "file_na_rpm",
+          "findutils_na_rpm",
+          "fping_na_rpm",
+          "gawk_na_rpm",
+          "gcc-c++_na_rpm",
+          "gcc-gfortran_na_rpm",
+          "gcc_na_rpm",
+          "gdb-gdbserver_na_rpm",
+          "gdb_na_rpm",
+          "gedit_na_rpm",
+          "glibc-langpack-en_na_rpm",
+          "grep_na_rpm",
+          "gzip_na_rpm",
+          "hwloc-libs_na_rpm",
+          "hwloc_na_rpm",
+          "iperf3_na_rpm",
+          "ipmitool_na_rpm",
+          "iproute_na_rpm",
+          "iputils_na_rpm",
+          "kbd_na_rpm",
+          "kernel-tools_na_rpm",
+          "kernel_na_rpm",
+          "kexec-tools_na_rpm",
+          "libcurl_na_rpm",
+          "libtool_na_rpm",
+          "lldb-devel_na_rpm",
+          "lldb_na_rpm",
+          "lshw_na_rpm",
+          "lsof_na_rpm",
+          "ltrace_na_rpm",
+          "lvm2_na_rpm",
+          "make_na_rpm",
+          "man-db_na_rpm",
+          "man-pages_na_rpm",
+          "munge-devel_na_rpm",
+          "nfs-utils_na_rpm",
+          "nfs4-acl-tools_na_rpm",
+          "nm-connection-editor_na_rpm",
+          "nss-pam-ldapd_na_rpm",
+          "oddjob-mkhomedir_na_rpm",
+          "openldap-clients_na_rpm",
           "openmpi_5.0.8_tarball",
-          "openssh-clients_latest_rpm",
-          "openssh-server_latest_rpm",
-          "openssh_latest_rpm",
-          "openssl-devel_latest_rpm",
-          "openssl-libs_latest_rpm",
-          "ovis-ldms_latest_rpm",
-          "papi-devel_latest_rpm",
-          "papi-libs_latest_rpm",
-          "papi_latest_rpm",
-          "pciutils_latest_rpm",
-          "perf_latest_rpm",
-          "pmix-devel_latest_rpm",
-          "python3-cython_latest_rpm",
-          "python3-devel_latest_rpm",
-          "rsync_latest_rpm",
-          "rsyslog_latest_rpm",
-          "sed_latest_rpm",
-          "squashfs-tools_latest_rpm",
-          "sssd_latest_rpm",
-          "strace_latest_rpm",
-          "sudo_latest_rpm",
-          "systemd-udev_latest_rpm",
-          "systemd_latest_rpm",
-          "tar_latest_rpm",
-          "tcpdump_latest_rpm",
-          "traceroute_latest_rpm",
+          "openssh-clients_na_rpm",
+          "openssh-server_na_rpm",
+          "openssh_na_rpm",
+          "openssl-devel_na_rpm",
+          "openssl-libs_na_rpm",
+          "ovis-ldms_na_rpm",
+          "papi-devel_na_rpm",
+          "papi-libs_na_rpm",
+          "papi_na_rpm",
+          "pciutils_na_rpm",
+          "perf_na_rpm",
+          "pmix-devel_na_rpm",
+          "python3-cython_na_rpm",
+          "python3-devel_na_rpm",
+          "rsync_na_rpm",
+          "rsyslog_na_rpm",
+          "sed_na_rpm",
+          "squashfs-tools_na_rpm",
+          "sssd_na_rpm",
+          "strace_na_rpm",
+          "sudo_na_rpm",
+          "systemd-udev_na_rpm",
+          "systemd_na_rpm",
+          "tar_na_rpm",
+          "tcpdump_na_rpm",
+          "traceroute_na_rpm",
           "ucx_1.19.0_tarball",
-          "util-linux_latest_rpm",
-          "valgrind-devel_latest_rpm",
-          "valgrind_latest_rpm",
-          "vim-enhanced_latest_rpm_1",
-          "wget_latest_rpm",
-          "which_latest_rpm",
-          "zsh_latest_rpm"
+          "util-linux_na_rpm",
+          "valgrind-devel_na_rpm",
+          "valgrind_na_rpm",
+          "vim-enhanced_na_rpm_1",
+          "wget_na_rpm",
+          "which_na_rpm",
+          "zsh_na_rpm"
         ]
       }
     ],
@@ -378,7 +378,7 @@
         ],
         "Type": "pip_module"
       },
-      "apptainer_latest_rpm": {
+      "apptainer_na_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -402,7 +402,7 @@
           }
         ]
       },
-      "calico-v3-31-4_latest_manifest": {
+      "calico-v3-31-4_na_manifest": {
         "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
@@ -421,7 +421,7 @@
           }
         ]
       },
-      "cert-manager-v1-10-0_latest_tarball": {
+      "cert-manager-v1-10-0_na_tarball": {
         "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
@@ -453,7 +453,7 @@
         ],
         "Type": "pip_module"
       },
-      "container-selinux_latest_rpm": {
+      "container-selinux_na_rpm": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -504,7 +504,7 @@
         ],
         "Type": "pip_module"
       },
-      "device-mapper-multipath_latest_rpm": {
+      "device-mapper-multipath_na_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -528,7 +528,7 @@
           }
         ]
       },
-      "doca-ofed_latest_rpm_repo": {
+      "doca-ofed_na_rpm_repo": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -912,7 +912,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "firewalld_latest_rpm": {
+      "firewalld_na_rpm": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -936,7 +936,7 @@
           }
         ]
       },
-      "fuse-overlayfs_latest_rpm": {
+      "fuse-overlayfs_na_rpm": {
         "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
@@ -955,7 +955,7 @@
           }
         ]
       },
-      "geopm_latest_tarball": {
+      "geopm_na_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -1009,7 +1009,7 @@
         "Tag": "0.143.1",
         "Version": "0.143.1"
       },
-      "git_latest_rpm": {
+      "git_na_rpm": {
         "Name": "git",
         "SupportedOS": [
           {
@@ -1048,7 +1048,7 @@
           }
         ]
       },
-      "helm-v3-20-1-amd64_latest_tarball": {
+      "helm-v3-20-1-amd64_na_tarball": {
         "Name": "helm-v3.20.1-amd64",
         "SupportedOS": [
           {
@@ -1067,7 +1067,7 @@
           }
         ]
       },
-      "imb_latest_tarball": {
+      "imb_na_tarball": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -1091,7 +1091,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_latest_rpm": {
+      "iscsi-initiator-utils_na_rpm": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -1135,7 +1135,7 @@
           }
         ]
       },
-      "kernel-devel_latest_rpm": {
+      "kernel-devel_na_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1159,7 +1159,7 @@
           }
         ]
       },
-      "kernel-headers_latest_rpm": {
+      "kernel-headers_na_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1253,7 +1253,7 @@
         ],
         "Type": "pip_module"
       },
-      "likwid_latest_tarball": {
+      "likwid_na_tarball": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -1277,7 +1277,7 @@
           }
         ]
       },
-      "lsscsi_latest_rpm": {
+      "lsscsi_na_rpm": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -1301,7 +1301,7 @@
           }
         ]
       },
-      "mariadb-server_latest_rpm": {
+      "mariadb-server_na_rpm": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -1325,7 +1325,7 @@
           }
         ]
       },
-      "metallb-native-v0-15-3_latest_manifest": {
+      "metallb-native-v0-15-3_na_manifest": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -1344,7 +1344,7 @@
           }
         ]
       },
-      "msr-safe_latest_tarball": {
+      "msr-safe_na_tarball": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -1363,7 +1363,7 @@
           }
         ]
       },
-      "munge_latest_rpm": {
+      "munge_na_rpm": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -1387,7 +1387,7 @@
           }
         ]
       },
-      "nfs-subdir-external-provisioner-4-0-18_latest_tarball": {
+      "nfs-subdir-external-provisioner-4-0-18_na_tarball": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -1422,7 +1422,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
         "SupportedOS": [
           {
@@ -1441,7 +1441,7 @@
           }
         ]
       },
-      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -1473,7 +1473,7 @@
         ],
         "Type": "pip_module"
       },
-      "osu-micro-benchmarks_latest_tarball": {
+      "osu-micro-benchmarks_na_tarball": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -1497,7 +1497,7 @@
           }
         ]
       },
-      "papi_latest_tarball": {
+      "papi_na_tarball": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -1521,7 +1521,7 @@
           }
         ]
       },
-      "pmix_latest_rpm": {
+      "pmix_na_rpm": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -1545,7 +1545,7 @@
           }
         ]
       },
-      "podman_latest_rpm": {
+      "podman_na_rpm": {
         "Name": "podman",
         "SupportedOS": [
           {
@@ -1590,7 +1590,7 @@
         ],
         "Type": "pip_module"
       },
-      "python3-PyMySQL_latest_rpm": {
+      "python3-PyMySQL_na_rpm": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -1614,7 +1614,7 @@
           }
         ]
       },
-      "python3-firewall_latest_rpm": {
+      "python3-firewall_na_rpm": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -1927,7 +1927,7 @@
         "Tag": "v4.0.2",
         "Version": "v4.0.2"
       },
-      "sg3_utils_latest_rpm": {
+      "sg3_utils_na_rpm": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -1951,7 +1951,7 @@
           }
         ]
       },
-      "sionlib_latest_tarball": {
+      "sionlib_na_tarball": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -1975,7 +1975,7 @@
           }
         ]
       },
-      "slurm-pam_slurm_latest_rpm": {
+      "slurm-pam_slurm_na_rpm": {
         "Name": "slurm-pam_slurm",
         "SupportedOS": [
           {
@@ -1999,7 +1999,7 @@
           }
         ]
       },
-      "slurm-slurmctld_latest_rpm": {
+      "slurm-slurmctld_na_rpm": {
         "Name": "slurm-slurmctld",
         "SupportedOS": [
           {
@@ -2023,7 +2023,7 @@
           }
         ]
       },
-      "slurm-slurmd_latest_rpm": {
+      "slurm-slurmd_na_rpm": {
         "Name": "slurm-slurmd",
         "SupportedOS": [
           {
@@ -2047,7 +2047,7 @@
           }
         ]
       },
-      "slurm-slurmdbd_latest_rpm": {
+      "slurm-slurmdbd_na_rpm": {
         "Name": "slurm-slurmdbd",
         "SupportedOS": [
           {
@@ -2071,7 +2071,7 @@
           }
         ]
       },
-      "slurm_latest_rpm": {
+      "slurm_na_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -2095,7 +2095,7 @@
           }
         ]
       },
-      "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball": {
+      "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball": {
         "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
         "SupportedOS": [
           {
@@ -2114,7 +2114,7 @@
           }
         ]
       },
-      "victoria-metrics-operator-0-59-3_latest_tarball": {
+      "victoria-metrics-operator-0-59-3_na_tarball": {
         "Name": "victoria-metrics-operator-0.59.3",
         "SupportedOS": [
           {
@@ -2133,7 +2133,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm": {
+      "vim-enhanced_na_rpm": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2159,7 +2159,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_latest_rpm": {
+      "NetworkManager_na_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -2183,7 +2183,7 @@
           }
         ]
       },
-      "authselect_latest_rpm": {
+      "authselect_na_rpm": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -2207,7 +2207,7 @@
           }
         ]
       },
-      "autoconf_latest_rpm": {
+      "autoconf_na_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2231,7 +2231,7 @@
           }
         ]
       },
-      "automake_latest_rpm": {
+      "automake_na_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2255,7 +2255,7 @@
           }
         ]
       },
-      "bash-completion_latest_rpm": {
+      "bash-completion_na_rpm": {
         "Name": "bash-completion",
         "SupportedOS": [
           {
@@ -2279,7 +2279,7 @@
           }
         ]
       },
-      "bash_latest_rpm": {
+      "bash_na_rpm": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -2303,7 +2303,7 @@
           }
         ]
       },
-      "binutils-devel_latest_rpm": {
+      "binutils-devel_na_rpm": {
         "Name": "binutils-devel",
         "SupportedOS": [
           {
@@ -2327,7 +2327,7 @@
           }
         ]
       },
-      "binutils_latest_rpm": {
+      "binutils_na_rpm": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -2351,7 +2351,7 @@
           }
         ]
       },
-      "bzip2_latest_rpm": {
+      "bzip2_na_rpm": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -2375,7 +2375,7 @@
           }
         ]
       },
-      "chrony_latest_rpm": {
+      "chrony_na_rpm": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -2399,7 +2399,7 @@
           }
         ]
       },
-      "cloud-init_latest_rpm": {
+      "cloud-init_na_rpm": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -2423,7 +2423,7 @@
           }
         ]
       },
-      "clustershell_latest_rpm": {
+      "clustershell_na_rpm": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2447,7 +2447,7 @@
           }
         ]
       },
-      "cmake_latest_rpm": {
+      "cmake_na_rpm": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -2471,7 +2471,7 @@
           }
         ]
       },
-      "coreutils_latest_rpm": {
+      "coreutils_na_rpm": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -2495,7 +2495,7 @@
           }
         ]
       },
-      "cryptsetup_latest_rpm": {
+      "cryptsetup_na_rpm": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -2519,7 +2519,7 @@
           }
         ]
       },
-      "curl_latest_rpm": {
+      "curl_na_rpm": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -2543,7 +2543,7 @@
           }
         ]
       },
-      "device-mapper_latest_rpm": {
+      "device-mapper_na_rpm": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -2567,7 +2567,7 @@
           }
         ]
       },
-      "dmidecode_latest_rpm": {
+      "dmidecode_na_rpm": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -2621,7 +2621,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_latest_rpm": {
+      "dracut-live_na_rpm": {
         "Name": "dracut-live",
         "SupportedOS": [
           {
@@ -2645,7 +2645,7 @@
           }
         ]
       },
-      "dracut-network_latest_rpm": {
+      "dracut-network_na_rpm": {
         "Name": "dracut-network",
         "SupportedOS": [
           {
@@ -2669,7 +2669,7 @@
           }
         ]
       },
-      "dracut_latest_rpm": {
+      "dracut_na_rpm": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -2693,7 +2693,7 @@
           }
         ]
       },
-      "emacs_latest_rpm": {
+      "emacs_na_rpm": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -2717,7 +2717,7 @@
           }
         ]
       },
-      "file_latest_rpm": {
+      "file_na_rpm": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -2741,7 +2741,7 @@
           }
         ]
       },
-      "findutils_latest_rpm": {
+      "findutils_na_rpm": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -2765,7 +2765,7 @@
           }
         ]
       },
-      "fping_latest_rpm": {
+      "fping_na_rpm": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -2789,7 +2789,7 @@
           }
         ]
       },
-      "gawk_latest_rpm": {
+      "gawk_na_rpm": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -2813,7 +2813,7 @@
           }
         ]
       },
-      "gcc-c++_latest_rpm": {
+      "gcc-c++_na_rpm": {
         "Name": "gcc-c++",
         "SupportedOS": [
           {
@@ -2837,7 +2837,7 @@
           }
         ]
       },
-      "gcc-gfortran_latest_rpm": {
+      "gcc-gfortran_na_rpm": {
         "Name": "gcc-gfortran",
         "SupportedOS": [
           {
@@ -2861,7 +2861,7 @@
           }
         ]
       },
-      "gcc_latest_rpm": {
+      "gcc_na_rpm": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -2885,7 +2885,7 @@
           }
         ]
       },
-      "gdb-gdbserver_latest_rpm": {
+      "gdb-gdbserver_na_rpm": {
         "Name": "gdb-gdbserver",
         "SupportedOS": [
           {
@@ -2909,7 +2909,7 @@
           }
         ]
       },
-      "gdb_latest_rpm": {
+      "gdb_na_rpm": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -2933,7 +2933,7 @@
           }
         ]
       },
-      "gedit_latest_rpm": {
+      "gedit_na_rpm": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -2957,7 +2957,7 @@
           }
         ]
       },
-      "glibc-langpack-en_latest_rpm": {
+      "glibc-langpack-en_na_rpm": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -2981,7 +2981,7 @@
           }
         ]
       },
-      "grep_latest_rpm": {
+      "grep_na_rpm": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -3005,7 +3005,7 @@
           }
         ]
       },
-      "gzip_latest_rpm": {
+      "gzip_na_rpm": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -3029,7 +3029,7 @@
           }
         ]
       },
-      "hwloc-libs_latest_rpm": {
+      "hwloc-libs_na_rpm": {
         "Name": "hwloc-libs",
         "SupportedOS": [
           {
@@ -3053,7 +3053,7 @@
           }
         ]
       },
-      "hwloc_latest_rpm": {
+      "hwloc_na_rpm": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -3077,7 +3077,7 @@
           }
         ]
       },
-      "iperf3_latest_rpm": {
+      "iperf3_na_rpm": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -3101,7 +3101,7 @@
           }
         ]
       },
-      "ipmitool_latest_rpm": {
+      "ipmitool_na_rpm": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -3125,7 +3125,7 @@
           }
         ]
       },
-      "iproute_latest_rpm": {
+      "iproute_na_rpm": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -3149,7 +3149,7 @@
           }
         ]
       },
-      "iputils_latest_rpm": {
+      "iputils_na_rpm": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -3173,7 +3173,7 @@
           }
         ]
       },
-      "kbd_latest_rpm": {
+      "kbd_na_rpm": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -3197,7 +3197,7 @@
           }
         ]
       },
-      "kernel-tools_latest_rpm": {
+      "kernel-tools_na_rpm": {
         "Name": "kernel-tools",
         "SupportedOS": [
           {
@@ -3221,7 +3221,7 @@
           }
         ]
       },
-      "kernel_latest_rpm": {
+      "kernel_na_rpm": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -3245,7 +3245,7 @@
           }
         ]
       },
-      "kexec-tools_latest_rpm": {
+      "kexec-tools_na_rpm": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -3269,7 +3269,7 @@
           }
         ]
       },
-      "libcurl_latest_rpm": {
+      "libcurl_na_rpm": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -3293,7 +3293,7 @@
           }
         ]
       },
-      "libtool_latest_rpm": {
+      "libtool_na_rpm": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -3317,7 +3317,7 @@
           }
         ]
       },
-      "lldb-devel_latest_rpm": {
+      "lldb-devel_na_rpm": {
         "Name": "lldb-devel",
         "SupportedOS": [
           {
@@ -3341,7 +3341,7 @@
           }
         ]
       },
-      "lldb_latest_rpm": {
+      "lldb_na_rpm": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -3365,7 +3365,7 @@
           }
         ]
       },
-      "lshw_latest_rpm": {
+      "lshw_na_rpm": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -3389,7 +3389,7 @@
           }
         ]
       },
-      "lsof_latest_rpm": {
+      "lsof_na_rpm": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -3413,7 +3413,7 @@
           }
         ]
       },
-      "ltrace_latest_rpm": {
+      "ltrace_na_rpm": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -3437,7 +3437,7 @@
           }
         ]
       },
-      "lvm2_latest_rpm": {
+      "lvm2_na_rpm": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -3461,7 +3461,7 @@
           }
         ]
       },
-      "make_latest_rpm": {
+      "make_na_rpm": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -3485,7 +3485,7 @@
           }
         ]
       },
-      "man-db_latest_rpm": {
+      "man-db_na_rpm": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -3509,7 +3509,7 @@
           }
         ]
       },
-      "man-pages_latest_rpm": {
+      "man-pages_na_rpm": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -3533,7 +3533,7 @@
           }
         ]
       },
-      "munge-devel_latest_rpm": {
+      "munge-devel_na_rpm": {
         "Name": "munge-devel",
         "SupportedOS": [
           {
@@ -3557,7 +3557,7 @@
           }
         ]
       },
-      "nfs-utils_latest_rpm": {
+      "nfs-utils_na_rpm": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -3581,7 +3581,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_latest_rpm": {
+      "nfs4-acl-tools_na_rpm": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -3605,7 +3605,7 @@
           }
         ]
       },
-      "nm-connection-editor_latest_rpm": {
+      "nm-connection-editor_na_rpm": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -3629,7 +3629,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_latest_rpm": {
+      "nss-pam-ldapd_na_rpm": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -3653,7 +3653,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_latest_rpm": {
+      "oddjob-mkhomedir_na_rpm": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -3677,7 +3677,7 @@
           }
         ]
       },
-      "openldap-clients_latest_rpm": {
+      "openldap-clients_na_rpm": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -3726,7 +3726,7 @@
           }
         ]
       },
-      "openssh-clients_latest_rpm": {
+      "openssh-clients_na_rpm": {
         "Name": "openssh-clients",
         "SupportedOS": [
           {
@@ -3750,7 +3750,7 @@
           }
         ]
       },
-      "openssh-server_latest_rpm": {
+      "openssh-server_na_rpm": {
         "Name": "openssh-server",
         "SupportedOS": [
           {
@@ -3774,7 +3774,7 @@
           }
         ]
       },
-      "openssh_latest_rpm": {
+      "openssh_na_rpm": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -3798,7 +3798,7 @@
           }
         ]
       },
-      "openssl-devel_latest_rpm": {
+      "openssl-devel_na_rpm": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -3822,7 +3822,7 @@
           }
         ]
       },
-      "openssl-libs_latest_rpm": {
+      "openssl-libs_na_rpm": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -3846,7 +3846,7 @@
           }
         ]
       },
-      "ovis-ldms_latest_rpm": {
+      "ovis-ldms_na_rpm": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -3870,7 +3870,7 @@
           }
         ]
       },
-      "papi-devel_latest_rpm": {
+      "papi-devel_na_rpm": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -3894,7 +3894,7 @@
           }
         ]
       },
-      "papi-libs_latest_rpm": {
+      "papi-libs_na_rpm": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -3918,7 +3918,7 @@
           }
         ]
       },
-      "papi_latest_rpm": {
+      "papi_na_rpm": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -3942,7 +3942,7 @@
           }
         ]
       },
-      "pciutils_latest_rpm": {
+      "pciutils_na_rpm": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -3966,7 +3966,7 @@
           }
         ]
       },
-      "perf_latest_rpm": {
+      "perf_na_rpm": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -3990,7 +3990,7 @@
           }
         ]
       },
-      "pmix-devel_latest_rpm": {
+      "pmix-devel_na_rpm": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -4014,7 +4014,7 @@
           }
         ]
       },
-      "python3-cython_latest_rpm": {
+      "python3-cython_na_rpm": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -4038,7 +4038,7 @@
           }
         ]
       },
-      "python3-devel_latest_rpm": {
+      "python3-devel_na_rpm": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -4062,7 +4062,7 @@
           }
         ]
       },
-      "rsync_latest_rpm": {
+      "rsync_na_rpm": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -4086,7 +4086,7 @@
           }
         ]
       },
-      "rsyslog_latest_rpm": {
+      "rsyslog_na_rpm": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -4110,7 +4110,7 @@
           }
         ]
       },
-      "sed_latest_rpm": {
+      "sed_na_rpm": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -4134,7 +4134,7 @@
           }
         ]
       },
-      "squashfs-tools_latest_rpm": {
+      "squashfs-tools_na_rpm": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -4158,7 +4158,7 @@
           }
         ]
       },
-      "sssd_latest_rpm": {
+      "sssd_na_rpm": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -4182,7 +4182,7 @@
           }
         ]
       },
-      "strace_latest_rpm": {
+      "strace_na_rpm": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -4206,7 +4206,7 @@
           }
         ]
       },
-      "sudo_latest_rpm": {
+      "sudo_na_rpm": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -4230,7 +4230,7 @@
           }
         ]
       },
-      "systemd-udev_latest_rpm": {
+      "systemd-udev_na_rpm": {
         "Name": "systemd-udev",
         "SupportedOS": [
           {
@@ -4254,7 +4254,7 @@
           }
         ]
       },
-      "systemd_latest_rpm": {
+      "systemd_na_rpm": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -4278,7 +4278,7 @@
           }
         ]
       },
-      "tar_latest_rpm": {
+      "tar_na_rpm": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -4302,7 +4302,7 @@
           }
         ]
       },
-      "tcpdump_latest_rpm": {
+      "tcpdump_na_rpm": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -4326,7 +4326,7 @@
           }
         ]
       },
-      "traceroute_latest_rpm": {
+      "traceroute_na_rpm": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -4375,7 +4375,7 @@
           }
         ]
       },
-      "util-linux_latest_rpm": {
+      "util-linux_na_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -4399,7 +4399,7 @@
           }
         ]
       },
-      "valgrind-devel_latest_rpm": {
+      "valgrind-devel_na_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -4423,7 +4423,7 @@
           }
         ]
       },
-      "valgrind_latest_rpm": {
+      "valgrind_na_rpm": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -4447,7 +4447,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm_1": {
+      "vim-enhanced_na_rpm_1": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -4471,7 +4471,7 @@
           }
         ]
       },
-      "wget_latest_rpm": {
+      "wget_na_rpm": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -4495,7 +4495,7 @@
           }
         ]
       },
-      "which_latest_rpm": {
+      "which_na_rpm": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -4519,7 +4519,7 @@
           }
         ]
       },
-      "zsh_latest_rpm": {
+      "zsh_na_rpm": {
         "Name": "zsh",
         "SupportedOS": [
           {

--- a/examples/catalog/catalog_rhel_with_nfs_provisioner.json
+++ b/examples/catalog/catalog_rhel_with_nfs_provisioner.json
@@ -7,330 +7,249 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_28",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_28",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_2",
-          "package_id_29",
-          "package_id_3",
-          "package_id_30",
-          "package_id_31",
-          "package_id_32",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_8",
-          "package_id_80",
-          "package_id_81",
-          "package_id_82",
-          "package_id_83",
-          "package_id_84",
-          "package_id_85",
-          "package_id_86",
-          "package_id_87",
-          "package_id_88",
-          "package_id_89",
-          "package_id_9",
-          "package_id_90",
-          "package_id_91",
-          "package_id_92",
-          "package_id_93",
-          "package_id_94",
-          "package_id_95",
-          "package_id_96"
+          "PyMySQL_1.1.2_pip_module",
+          "apptainer_latest_rpm",
+          "calico-v3-31-4_latest_manifest",
+          "cert-manager-v1-10-0_latest_tarball",
+          "cffi_1.17.1_pip_module",
+          "container-selinux_latest_rpm",
+          "cri-o_1.35.1_rpm",
+          "cryptography_45.0.7_pip_module",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "docker-io-alpine-kubectl_1.35.1_image",
+          "docker-io-calico-cni_v3.31.4_image",
+          "docker-io-calico-kube-controllers_v3.31.4_image",
+          "docker-io-calico-node_v3.31.4_image",
+          "docker-io-curlimages-curl_8.17.0_image",
+          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
+          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
+          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
+          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
+          "docker-io-library-busybox_1.36_image",
+          "docker-io-library-mysql_9.3.0_image",
+          "docker-io-library-python_3.12-slim_image",
+          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
+          "docker-io-rmohr-activemq_5.15.9_image",
+          "docker-io-timberio-vector_0.54.0-debian_image",
+          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
+          "docker-io-victoriametrics-operator_v0.68.3_image",
+          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
+          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
+          "docker-io-victoriametrics-vlagent_v1.50.0_image",
+          "docker-io-victoriametrics-vmagent_v1.128.0_image",
+          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
+          "firewalld_latest_rpm",
+          "fuse-overlayfs_latest_rpm",
+          "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
+          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
+          "git_latest_rpm",
+          "helm-charts_container-storage-modules-1.9.2_git",
+          "helm-v3-20-1-amd64_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "karavi-observability_v1.12.0_git",
+          "kubeadm_1.35.1_rpm",
+          "kubectl_1.35.1_rpm",
+          "kubelet_1.35.1_rpm",
+          "kubernetes_33.1.0_pip_module",
+          "lsscsi_latest_rpm",
+          "metallb-native-v0-15-3_latest_manifest",
+          "nfs-subdir-external-provisioner-4-0-18_latest_tarball",
+          "omsdk_1.2.518_pip_module",
+          "podman_latest_rpm",
+          "prettytable_3.14.0_pip_module",
+          "prometheus_client_0.20.0_pip_module",
+          "python3-firewall_latest_rpm",
+          "python3_3.12.9_rpm",
+          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
+          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
+          "quay-io-metallb-speaker_v0.15.3_image",
+          "quay-io-strimzi-kafka-bridge_0.33.1_image",
+          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
+          "quay-io-strimzi-operator_0.48.0_image",
+          "registry-k8s-io-coredns-coredns_v1.13.1_image",
+          "registry-k8s-io-etcd_3.6.6-0_image",
+          "registry-k8s-io-kube-apiserver_v1.35.1_image",
+          "registry-k8s-io-kube-controller-manager_v1.35.1_image",
+          "registry-k8s-io-kube-proxy_v1.35.1_image",
+          "registry-k8s-io-kube-scheduler_v1.35.1_image",
+          "registry-k8s-io-pause_3.10.1_image",
+          "sg3_utils_latest_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
+          "victoria-metrics-operator-0-59-3_latest_tarball",
+          "vim-enhanced_latest_rpm"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_2",
-          "package_id_29",
-          "package_id_3",
-          "package_id_30",
-          "package_id_31",
-          "package_id_32",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_8",
-          "package_id_88",
-          "package_id_9",
-          "package_id_97",
-          "package_id_98"
+          "apptainer_latest_rpm",
+          "cert-manager-v1-10-0_latest_tarball",
+          "cffi_1.17.1_pip_module",
+          "container-selinux_latest_rpm",
+          "cri-o_1.35.1_rpm",
+          "cryptography_45.0.7_pip_module",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "docker-io-alpine-kubectl_1.35.1_image",
+          "docker-io-curlimages-curl_8.17.0_image",
+          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
+          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
+          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
+          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
+          "docker-io-library-busybox_1.36_image",
+          "docker-io-library-mysql_9.3.0_image",
+          "docker-io-library-python_3.12-slim_image",
+          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
+          "docker-io-rmohr-activemq_5.15.9_image",
+          "docker-io-timberio-vector_0.54.0-debian_image",
+          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
+          "docker-io-victoriametrics-operator_v0.68.3_image",
+          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
+          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
+          "docker-io-victoriametrics-vlagent_v1.50.0_image",
+          "docker-io-victoriametrics-vmagent_v1.128.0_image",
+          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
+          "firewalld_latest_rpm",
+          "fuse-overlayfs_latest_rpm",
+          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
+          "git_latest_rpm",
+          "helm-charts_container-storage-modules-1.9.2_git",
+          "iscsi-initiator-utils_latest_rpm",
+          "karavi-observability_v1.12.0_git",
+          "kubeadm_1.35.1_rpm",
+          "kubelet_1.35.1_rpm",
+          "kubernetes_33.1.0_pip_module",
+          "lsscsi_latest_rpm",
+          "omsdk_1.2.518_pip_module",
+          "podman_latest_rpm",
+          "prometheus_client_0.20.0_pip_module",
+          "python3-firewall_latest_rpm",
+          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
+          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
+          "quay-io-metallb-controller_v0.15.3_image",
+          "quay-io-metallb-speaker_v0.15.3_image",
+          "quay-io-strimzi-kafka-bridge_0.33.1_image",
+          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
+          "quay-io-strimzi-operator_0.48.0_image",
+          "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
+          "sg3_utils_latest_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
+          "victoria-metrics-operator-0-59-3_latest_tarball",
+          "vim-enhanced_latest_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_2",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "mariadb-server_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-PyMySQL_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmctld_latest_rpm",
+          "slurm-slurmdbd_latest_rpm"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_24",
-          "package_id_25",
-          "package_id_26",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9",
-          "package_id_99"
-        ]
-      },
-      {
-        "Name": "service_kube_control_plane_first_x86_64",
-        "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_2",
-          "package_id_29",
-          "package_id_3",
-          "package_id_30",
-          "package_id_31",
-          "package_id_32",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_8",
-          "package_id_80",
-          "package_id_81",
-          "package_id_82",
-          "package_id_83",
-          "package_id_84",
-          "package_id_85",
-          "package_id_86",
-          "package_id_87",
-          "package_id_88",
-          "package_id_89",
-          "package_id_9",
-          "package_id_90",
-          "package_id_91",
-          "package_id_92",
-          "package_id_93",
-          "package_id_94",
-          "package_id_95",
-          "package_id_96"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "kernel-devel_latest_rpm",
+          "kernel-headers_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-pam_slurm_latest_rpm",
+          "slurm-slurmd_latest_rpm"
         ]
       }
     ],
@@ -339,106 +258,106 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "os_package_id_1",
-          "os_package_id_10",
-          "os_package_id_100",
-          "os_package_id_11",
-          "os_package_id_12",
-          "os_package_id_13",
-          "os_package_id_14",
-          "os_package_id_15",
-          "os_package_id_16",
-          "os_package_id_17",
-          "os_package_id_18",
-          "os_package_id_19",
-          "os_package_id_2",
-          "os_package_id_20",
-          "os_package_id_21",
-          "os_package_id_22",
-          "os_package_id_23",
-          "os_package_id_24",
-          "os_package_id_25",
-          "os_package_id_26",
-          "os_package_id_27",
-          "os_package_id_28",
-          "os_package_id_29",
-          "os_package_id_3",
-          "os_package_id_30",
-          "os_package_id_31",
-          "os_package_id_32",
-          "os_package_id_33",
-          "os_package_id_34",
-          "os_package_id_35",
-          "os_package_id_36",
-          "os_package_id_37",
-          "os_package_id_38",
-          "os_package_id_39",
-          "os_package_id_4",
-          "os_package_id_40",
-          "os_package_id_41",
-          "os_package_id_42",
-          "os_package_id_43",
-          "os_package_id_44",
-          "os_package_id_45",
-          "os_package_id_46",
-          "os_package_id_47",
-          "os_package_id_48",
-          "os_package_id_49",
-          "os_package_id_5",
-          "os_package_id_50",
-          "os_package_id_51",
-          "os_package_id_52",
-          "os_package_id_53",
-          "os_package_id_54",
-          "os_package_id_55",
-          "os_package_id_56",
-          "os_package_id_57",
-          "os_package_id_58",
-          "os_package_id_59",
-          "os_package_id_6",
-          "os_package_id_60",
-          "os_package_id_61",
-          "os_package_id_62",
-          "os_package_id_63",
-          "os_package_id_64",
-          "os_package_id_65",
-          "os_package_id_66",
-          "os_package_id_67",
-          "os_package_id_68",
-          "os_package_id_69",
-          "os_package_id_7",
-          "os_package_id_70",
-          "os_package_id_71",
-          "os_package_id_72",
-          "os_package_id_73",
-          "os_package_id_74",
-          "os_package_id_75",
-          "os_package_id_76",
-          "os_package_id_77",
-          "os_package_id_78",
-          "os_package_id_79",
-          "os_package_id_8",
-          "os_package_id_80",
-          "os_package_id_81",
-          "os_package_id_82",
-          "os_package_id_83",
-          "os_package_id_84",
-          "os_package_id_85",
-          "os_package_id_86",
-          "os_package_id_87",
-          "os_package_id_88",
-          "os_package_id_89",
-          "os_package_id_9",
-          "os_package_id_90",
-          "os_package_id_91",
-          "os_package_id_92",
-          "os_package_id_93",
-          "os_package_id_94",
-          "os_package_id_95",
-          "os_package_id_96",
-          "os_package_id_97",
-          "os_package_id_98",
-          "os_package_id_99"
+          "NetworkManager_latest_rpm",
+          "authselect_latest_rpm",
+          "autoconf_latest_rpm",
+          "automake_latest_rpm",
+          "bash-completion_latest_rpm",
+          "bash_latest_rpm",
+          "binutils-devel_latest_rpm",
+          "binutils_latest_rpm",
+          "bzip2_latest_rpm",
+          "chrony_latest_rpm",
+          "cloud-init_latest_rpm",
+          "clustershell_latest_rpm",
+          "cmake_latest_rpm",
+          "coreutils_latest_rpm",
+          "cryptsetup_latest_rpm",
+          "curl_latest_rpm",
+          "device-mapper_latest_rpm",
+          "dmidecode_latest_rpm",
+          "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
+          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
+          "dracut-live_latest_rpm",
+          "dracut-network_latest_rpm",
+          "dracut_latest_rpm",
+          "emacs_latest_rpm",
+          "file_latest_rpm",
+          "findutils_latest_rpm",
+          "fping_latest_rpm",
+          "gawk_latest_rpm",
+          "gcc-c++_latest_rpm",
+          "gcc-gfortran_latest_rpm",
+          "gcc_latest_rpm",
+          "gdb-gdbserver_latest_rpm",
+          "gdb_latest_rpm",
+          "gedit_latest_rpm",
+          "glibc-langpack-en_latest_rpm",
+          "grep_latest_rpm",
+          "gzip_latest_rpm",
+          "hwloc-libs_latest_rpm",
+          "hwloc_latest_rpm",
+          "iperf3_latest_rpm",
+          "ipmitool_latest_rpm",
+          "iproute_latest_rpm",
+          "iputils_latest_rpm",
+          "kbd_latest_rpm",
+          "kernel-tools_latest_rpm",
+          "kernel_latest_rpm",
+          "kexec-tools_latest_rpm",
+          "libcurl_latest_rpm",
+          "libtool_latest_rpm",
+          "lldb-devel_latest_rpm",
+          "lldb_latest_rpm",
+          "lshw_latest_rpm",
+          "lsof_latest_rpm",
+          "ltrace_latest_rpm",
+          "lvm2_latest_rpm",
+          "make_latest_rpm",
+          "man-db_latest_rpm",
+          "man-pages_latest_rpm",
+          "munge-devel_latest_rpm",
+          "nfs-utils_latest_rpm",
+          "nfs4-acl-tools_latest_rpm",
+          "nm-connection-editor_latest_rpm",
+          "nss-pam-ldapd_latest_rpm",
+          "oddjob-mkhomedir_latest_rpm",
+          "openldap-clients_latest_rpm",
+          "openmpi_5.0.8_tarball",
+          "openssh-clients_latest_rpm",
+          "openssh-server_latest_rpm",
+          "openssh_latest_rpm",
+          "openssl-devel_latest_rpm",
+          "openssl-libs_latest_rpm",
+          "ovis-ldms_latest_rpm",
+          "papi-devel_latest_rpm",
+          "papi-libs_latest_rpm",
+          "papi_latest_rpm",
+          "pciutils_latest_rpm",
+          "perf_latest_rpm",
+          "pmix-devel_latest_rpm",
+          "python3-cython_latest_rpm",
+          "python3-devel_latest_rpm",
+          "rsync_latest_rpm",
+          "rsyslog_latest_rpm",
+          "sed_latest_rpm",
+          "squashfs-tools_latest_rpm",
+          "sssd_latest_rpm",
+          "strace_latest_rpm",
+          "sudo_latest_rpm",
+          "systemd-udev_latest_rpm",
+          "systemd_latest_rpm",
+          "tar_latest_rpm",
+          "tcpdump_latest_rpm",
+          "traceroute_latest_rpm",
+          "ucx_1.19.0_tarball",
+          "util-linux_latest_rpm",
+          "valgrind-devel_latest_rpm",
+          "valgrind_latest_rpm",
+          "vim-enhanced_latest_rpm_1",
+          "wget_latest_rpm",
+          "which_latest_rpm",
+          "zsh_latest_rpm"
         ]
       }
     ],
@@ -446,8 +365,8 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "package_id_1": {
-        "Name": "munge",
+      "PyMySQL_1.1.2_pip_module": {
+        "Name": "PyMySQL==1.1.2",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -455,110 +374,11 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
+        "Type": "pip_module"
       },
-      "package_id_2": {
-        "Name": "firewalld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_3": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_4": {
-        "Name": "pmix",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_5": {
-        "Name": "nvcr.io/nvidia/hpc-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "25.09",
-        "Version": "25.09"
-      },
-      "package_id_6": {
+      "apptainer_latest_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -582,8 +402,8 @@
           }
         ]
       },
-      "package_id_7": {
-        "Name": "doca-ofed",
+      "calico-v3-31-4_latest_manifest": {
+        "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -591,23 +411,18 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm_repo",
+        "Type": "manifest",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "doca"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "doca"
+            "Uri": "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"
           }
         ]
       },
-      "package_id_8": {
-        "Name": "iscsi-initiator-utils",
+      "cert-manager-v1-10-0_latest_tarball": {
+        "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -615,22 +430,81 @@
           }
         ],
         "Architecture": [
-          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://charts.jetstack.io/charts/cert-manager-v1.10.0.tgz"
+          }
+        ]
+      },
+      "cffi_1.17.1_pip_module": {
+        "Name": "cffi==1.17.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "container-selinux_latest_rpm": {
+        "Name": "container-selinux",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_9": {
+      "cri-o_1.35.1_rpm": {
+        "Name": "cri-o-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "cri-o-v1-35"
+          }
+        ]
+      },
+      "cryptography_45.0.7_pip_module": {
+        "Name": "cryptography==45.0.7",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "device-mapper-multipath_latest_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -654,8 +528,392 @@
           }
         ]
       },
-      "package_id_10": {
-        "Name": "sg3_utils",
+      "doca-ofed_latest_rpm_repo": {
+        "Name": "doca-ofed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm_repo",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "doca"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "doca"
+          }
+        ]
+      },
+      "docker-io-alpine-kubectl_1.35.1_image": {
+        "Name": "docker.io/alpine/kubectl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.35.1",
+        "Version": "1.35.1"
+      },
+      "docker-io-calico-cni_v3.31.4_image": {
+        "Name": "docker.io/calico/cni",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-calico-kube-controllers_v3.31.4_image": {
+        "Name": "docker.io/calico/kube-controllers",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-calico-node_v3.31.4_image": {
+        "Name": "docker.io/calico/node",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-curlimages-curl_8.17.0_image": {
+        "Name": "docker.io/curlimages/curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "8.17.0",
+        "Version": "8.17.0"
+      },
+      "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.3",
+        "Version": "1.3"
+      },
+      "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.3",
+        "Version": "1.3"
+      },
+      "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.3",
+        "Version": "1.3"
+      },
+      "docker-io-library-busybox_1.36_image": {
+        "Name": "docker.io/library/busybox",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.36",
+        "Version": "1.36"
+      },
+      "docker-io-library-mysql_9.3.0_image": {
+        "Name": "docker.io/library/mysql",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "9.3.0",
+        "Version": "9.3.0"
+      },
+      "docker-io-library-python_3.12-slim_image": {
+        "Name": "docker.io/library/python",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.12-slim",
+        "Version": "3.12-slim"
+      },
+      "docker-io-nginxinc-nginx-unprivileged_1.29_image": {
+        "Name": "docker.io/nginxinc/nginx-unprivileged",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.29",
+        "Version": "1.29"
+      },
+      "docker-io-rmohr-activemq_5.15.9_image": {
+        "Name": "docker.io/rmohr/activemq",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "5.15.9",
+        "Version": "5.15.9"
+      },
+      "docker-io-timberio-vector_0.54.0-debian_image": {
+        "Name": "docker.io/timberio/vector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.54.0-debian",
+        "Version": "0.54.0-debian"
+      },
+      "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "config-reloader-v0.68.3",
+        "Version": "config-reloader-v0.68.3"
+      },
+      "docker-io-victoriametrics-operator_v0.68.3_image": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.68.3",
+        "Version": "v0.68.3"
+      },
+      "docker-io-victoriametrics-victoria-logs_v1.50.0_image": {
+        "Name": "docker.io/victoriametrics/victoria-logs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.50.0",
+        "Version": "v1.50.0"
+      },
+      "docker-io-victoriametrics-victoria-metrics_v1.128.0_image": {
+        "Name": "docker.io/victoriametrics/victoria-metrics",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0",
+        "Version": "v1.128.0"
+      },
+      "docker-io-victoriametrics-vlagent_v1.50.0_image": {
+        "Name": "docker.io/victoriametrics/vlagent",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.50.0",
+        "Version": "v1.50.0"
+      },
+      "docker-io-victoriametrics-vmagent_v1.128.0_image": {
+        "Name": "docker.io/victoriametrics/vmagent",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0",
+        "Version": "v1.128.0"
+      },
+      "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vminsert",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vmselect",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vmstorage",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "firewalld_latest_rpm": {
+        "Name": "firewalld",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -678,8 +936,8 @@
           }
         ]
       },
-      "package_id_11": {
-        "Name": "lsscsi",
+      "fuse-overlayfs_latest_rpm": {
+        "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -687,94 +945,17 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_12": {
-        "Name": "imb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          }
-        ]
-      },
-      "package_id_13": {
-        "Name": "osu-micro-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          }
-        ]
-      },
-      "package_id_14": {
-        "Name": "likwid",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          }
-        ]
-      },
-      "package_id_15": {
+      "geopm_latest_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -798,8 +979,96 @@
           }
         ]
       },
-      "package_id_16": {
-        "Name": "papi",
+      "ghcr-io-kube-vip-kube-vip_v0.8.9_image": {
+        "Name": "ghcr.io/kube-vip/kube-vip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.8.9",
+        "Version": "v0.8.9"
+      },
+      "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image": {
+        "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.143.1",
+        "Version": "0.143.1"
+      },
+      "git_latest_rpm": {
+        "Name": "git",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "helm-charts_container-storage-modules-1.9.2_git": {
+        "Name": "helm-charts",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "git",
+        "Version": "container-storage-modules-1.9.2",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/dell/helm-charts.git"
+          }
+        ]
+      },
+      "helm-v3-20-1-amd64_latest_tarball": {
+        "Name": "helm-v3.20.1-amd64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
+          }
+        ]
+      },
+      "imb_latest_tarball": {
+        "Name": "imb",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -814,59 +1083,16 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           },
           {
             "Architecture": "aarch64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "package_id_17": {
-        "Name": "msr-safe",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_18": {
-        "Name": "sionlib",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          },
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "package_id_19": {
-        "Name": "slurm-slurmctld",
+      "iscsi-initiator-utils_latest_rpm": {
+        "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -881,16 +1107,16 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           },
           {
             "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_20": {
-        "Name": "slurm-slurmdbd",
+      "karavi-observability_v1.12.0_git": {
+        "Name": "karavi-observability",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -898,118 +1124,18 @@
           }
         ],
         "Architecture": [
-          "aarch64",
           "x86_64"
         ],
-        "Type": "rpm",
+        "Type": "git",
+        "Version": "v1.12.0",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
+            "Uri": "https://github.com/dell/karavi-observability.git"
           }
         ]
       },
-      "package_id_21": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_22": {
-        "Name": "mariadb-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_23": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_24": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_25": {
+      "kernel-devel_latest_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1033,7 +1159,7 @@
           }
         ]
       },
-      "package_id_26": {
+      "kernel-headers_latest_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1057,7 +1183,265 @@
           }
         ]
       },
-      "package_id_27": {
+      "kubeadm_1.35.1_rpm": {
+        "Name": "kubeadm-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "kubernetes-v1-35"
+          }
+        ]
+      },
+      "kubectl_1.35.1_rpm": {
+        "Name": "kubectl-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "kubernetes-v1-35"
+          }
+        ]
+      },
+      "kubelet_1.35.1_rpm": {
+        "Name": "kubelet-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "kubernetes-v1-35"
+          }
+        ]
+      },
+      "kubernetes_33.1.0_pip_module": {
+        "Name": "kubernetes==33.1.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "likwid_latest_tarball": {
+        "Name": "likwid",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          }
+        ]
+      },
+      "lsscsi_latest_rpm": {
+        "Name": "lsscsi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "mariadb-server_latest_rpm": {
+        "Name": "mariadb-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "metallb-native-v0-15-3_latest_manifest": {
+        "Name": "metallb-native-v0.15.3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "manifest",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml"
+          }
+        ]
+      },
+      "msr-safe_latest_tarball": {
+        "Name": "msr-safe",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
+          }
+        ]
+      },
+      "munge_latest_rpm": {
+        "Name": "munge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nfs-subdir-external-provisioner-4-0-18_latest_tarball": {
+        "Name": "nfs-subdir-external-provisioner-4.0.18",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/releases/download/nfs-subdir-external-provisioner-4.0.18/nfs-subdir-external-provisioner-4.0.18.tgz"
+          }
+        ]
+      },
+      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+        "Name": "nvcr.io/nvidia/hpc-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "25.09",
+        "Version": "25.09"
+      },
+      "nvhpc_2025_2511_Linux_aarch64_cuda_13-0_latest_tarball": {
+        "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_aarch64_cuda_13.0.tar.gz"
+          }
+        ]
+      },
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -1076,7 +1460,618 @@
           }
         ]
       },
-      "package_id_28": {
+      "omsdk_1.2.518_pip_module": {
+        "Name": "omsdk==1.2.518",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "osu-micro-benchmarks_latest_tarball": {
+        "Name": "osu-micro-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          }
+        ]
+      },
+      "papi_latest_tarball": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          }
+        ]
+      },
+      "pmix_latest_rpm": {
+        "Name": "pmix",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "podman_latest_rpm": {
+        "Name": "podman",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "prettytable_3.14.0_pip_module": {
+        "Name": "prettytable==3.14.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "prometheus_client_0.20.0_pip_module": {
+        "Name": "prometheus_client==0.20.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "python3-PyMySQL_latest_rpm": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall_latest_rpm": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "python3_3.12.9_rpm": {
+        "Name": "python3-3.12.9",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.11.0",
+        "Version": "v1.11.0"
+      },
+      "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-acmesolver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-cainjector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-controller_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-controller",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-webhook_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-webhook",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-metallb-controller_v0.15.3_image": {
+        "Name": "quay.io/metallb/controller",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.15.3",
+        "Version": "v0.15.3"
+      },
+      "quay-io-metallb-speaker_v0.15.3_image": {
+        "Name": "quay.io/metallb/speaker",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.15.3",
+        "Version": "v0.15.3"
+      },
+      "quay-io-strimzi-kafka-bridge_0.33.1_image": {
+        "Name": "quay.io/strimzi/kafka-bridge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.33.1",
+        "Version": "0.33.1"
+      },
+      "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image": {
+        "Name": "quay.io/strimzi/kafka",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.48.0-kafka-4.1.0",
+        "Version": "0.48.0-kafka-4.1.0"
+      },
+      "quay-io-strimzi-operator_0.48.0_image": {
+        "Name": "quay.io/strimzi/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.48.0",
+        "Version": "0.48.0"
+      },
+      "registry-k8s-io-coredns-coredns_v1.13.1_image": {
+        "Name": "registry.k8s.io/coredns/coredns",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.13.1",
+        "Version": "v1.13.1"
+      },
+      "registry-k8s-io-etcd_3.6.6-0_image": {
+        "Name": "registry.k8s.io/etcd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.6.6-0",
+        "Version": "3.6.6-0"
+      },
+      "registry-k8s-io-kube-apiserver_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-apiserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-controller-manager_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-controller-manager",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-proxy_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-proxy",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-scheduler_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-scheduler",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-pause_3.10.1_image": {
+        "Name": "registry.k8s.io/pause",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.10.1",
+        "Version": "3.10.1"
+      },
+      "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image": {
+        "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v4.0.2",
+        "Version": "v4.0.2"
+      },
+      "sg3_utils_latest_rpm": {
+        "Name": "sg3_utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sionlib_latest_tarball": {
+        "Name": "sionlib",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          },
+          {
+            "Architecture": "aarch64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          }
+        ]
+      },
+      "slurm-pam_slurm_latest_rpm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld_latest_rpm": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd_latest_rpm": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd_latest_rpm": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm_latest_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -1100,7 +2095,45 @@
           }
         ]
       },
-      "package_id_29": {
+      "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball": {
+        "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-kafka-operator-helm-3-chart-0.48.0.tgz"
+          }
+        ]
+      },
+      "victoria-metrics-operator-0-59-3_latest_tarball": {
+        "Name": "victoria-metrics-operator-0.59.3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/VictoriaMetrics/helm-charts/releases/download/victoria-metrics-operator-0.59.3/victoria-metrics-operator-0.59.3.tgz"
+          }
+        ]
+      },
+      "vim-enhanced_latest_rpm": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -1123,9 +2156,11 @@
             "RepoName": "appstream"
           }
         ]
-      },
-      "package_id_30": {
-        "Name": "docker.io/library/busybox",
+      }
+    },
+    "OSPackages": {
+      "NetworkManager_latest_rpm": {
+        "Name": "NetworkManager",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1133,14 +2168,23 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
-        "Type": "image",
-        "Tag": "1.36",
-        "Version": "1.36"
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
       },
-      "package_id_31": {
-        "Name": "git",
+      "authselect_latest_rpm": {
+        "Name": "authselect",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1148,6 +2192,31 @@
           }
         ],
         "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "autoconf_latest_rpm": {
+        "Name": "autoconf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
@@ -1155,11 +2224,15 @@
           {
             "Architecture": "x86_64",
             "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_32": {
-        "Name": "fuse-overlayfs",
+      "automake_latest_rpm": {
+        "Name": "automake",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1167,6 +2240,7 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
@@ -1174,11 +2248,15 @@
           {
             "Architecture": "x86_64",
             "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_33": {
-        "Name": "podman",
+      "bash-completion_latest_rpm": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1186,6 +2264,55 @@
           }
         ],
         "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bash_latest_rpm": {
+        "Name": "bash",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "binutils-devel_latest_rpm": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
@@ -1193,11 +2320,15 @@
           {
             "Architecture": "x86_64",
             "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_34": {
-        "Name": "kubeadm-1.35.1",
+      "binutils_latest_rpm": {
+        "Name": "binutils",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1205,18 +2336,23 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_35": {
-        "Name": "kubelet-1.35.1",
+      "bzip2_latest_rpm": {
+        "Name": "bzip2",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1224,18 +2360,23 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_36": {
-        "Name": "container-selinux",
+      "chrony_latest_rpm": {
+        "Name": "chrony",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1243,6 +2384,31 @@
           }
         ],
         "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cloud-init_latest_rpm": {
+        "Name": "cloud-init",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
@@ -1250,11 +2416,15 @@
           {
             "Architecture": "x86_64",
             "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
           }
         ]
       },
-      "package_id_37": {
-        "Name": "cri-o-1.35.1",
+      "clustershell_latest_rpm": {
+        "Name": "clustershell",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1262,18 +2432,23 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
         ],
         "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "cri-o-v1-35"
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
           }
         ]
       },
-      "package_id_38": {
-        "Name": "docker.io/victoriametrics/victoria-metrics",
+      "cmake_latest_rpm": {
+        "Name": "cmake",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1281,319 +2456,158 @@
           }
         ],
         "Architecture": [
+          "aarch64",
           "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "coreutils_latest_rpm": {
+        "Name": "coreutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cryptsetup_latest_rpm": {
+        "Name": "cryptsetup",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "curl_latest_rpm": {
+        "Name": "curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "device-mapper_latest_rpm": {
+        "Name": "device-mapper",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dmidecode_latest_rpm": {
+        "Name": "dmidecode",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64"
         ],
         "Type": "image",
-        "Tag": "v1.128.0",
-        "Version": "v1.128.0"
+        "Tag": "1.1",
+        "Version": "1.1"
       },
-      "package_id_39": {
-        "Name": "docker.io/victoriametrics/vmagent",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0",
-        "Version": "v1.128.0"
-      },
-      "package_id_40": {
-        "Name": "docker.io/victoriametrics/vmstorage",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_41": {
-        "Name": "docker.io/victoriametrics/vminsert",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_42": {
-        "Name": "docker.io/victoriametrics/vmselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_43": {
-        "Name": "docker.io/victoriametrics/victoria-logs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.50.0",
-        "Version": "v1.50.0"
-      },
-      "package_id_44": {
-        "Name": "docker.io/victoriametrics/vlagent",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.50.0",
-        "Version": "v1.50.0"
-      },
-      "package_id_45": {
-        "Name": "docker.io/alpine/kubectl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.35.1",
-        "Version": "1.35.1"
-      },
-      "package_id_46": {
-        "Name": "docker.io/curlimages/curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "8.17.0",
-        "Version": "8.17.0"
-      },
-      "package_id_47": {
-        "Name": "docker.io/rmohr/activemq",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "5.15.9",
-        "Version": "5.15.9"
-      },
-      "package_id_48": {
-        "Name": "docker.io/library/mysql",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "9.3.0",
-        "Version": "9.3.0"
-      },
-      "package_id_49": {
-        "Name": "docker.io/library/python",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.12-slim",
-        "Version": "3.12-slim"
-      },
-      "package_id_50": {
-        "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_51": {
-        "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_52": {
-        "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_53": {
-        "Name": "cryptography==45.0.7",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_54": {
-        "Name": "omsdk==1.2.518",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_55": {
-        "Name": "cffi==1.17.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_56": {
-        "Name": "prometheus_client==0.20.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_57": {
-        "Name": "kubernetes==33.1.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_58": {
-        "Name": "quay.io/strimzi/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.48.0",
-        "Version": "0.48.0"
-      },
-      "package_id_59": {
-        "Name": "quay.io/strimzi/kafka",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.48.0-kafka-4.1.0",
-        "Version": "0.48.0-kafka-4.1.0"
-      },
-      "package_id_60": {
-        "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1607,641 +2621,8 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "package_id_61": {
-        "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.11.0",
-        "Version": "v1.11.0"
-      },
-      "package_id_62": {
-        "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.143.1",
-        "Version": "0.143.1"
-      },
-      "package_id_63": {
-        "Name": "docker.io/nginxinc/nginx-unprivileged",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.29",
-        "Version": "1.29"
-      },
-      "package_id_64": {
-        "Name": "karavi-observability",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "git",
-        "Version": "v1.12.0",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/dell/karavi-observability.git"
-          }
-        ]
-      },
-      "package_id_65": {
-        "Name": "helm-charts",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "git",
-        "Version": "container-storage-modules-1.9.2",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/dell/helm-charts.git"
-          }
-        ]
-      },
-      "package_id_66": {
-        "Name": "quay.io/jetstack/cert-manager-controller",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_67": {
-        "Name": "quay.io/jetstack/cert-manager-cainjector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_68": {
-        "Name": "quay.io/jetstack/cert-manager-webhook",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_69": {
-        "Name": "quay.io/jetstack/cert-manager-acmesolver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_70": {
-        "Name": "cert-manager-v1.10.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://charts.jetstack.io/charts/cert-manager-v1.10.0.tgz"
-          }
-        ]
-      },
-      "package_id_71": {
-        "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-kafka-operator-helm-3-chart-0.48.0.tgz"
-          }
-        ]
-      },
-      "package_id_72": {
-        "Name": "quay.io/strimzi/kafka-bridge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.33.1",
-        "Version": "0.33.1"
-      },
-      "package_id_73": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.68.3",
-        "Version": "v0.68.3"
-      },
-      "package_id_74": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "config-reloader-v0.68.3",
-        "Version": "config-reloader-v0.68.3"
-      },
-      "package_id_75": {
-        "Name": "victoria-metrics-operator-0.59.3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/VictoriaMetrics/helm-charts/releases/download/victoria-metrics-operator-0.59.3/victoria-metrics-operator-0.59.3.tgz"
-          }
-        ]
-      },
-      "package_id_76": {
-        "Name": "docker.io/timberio/vector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.54.0-debian",
-        "Version": "0.54.0-debian"
-      },
-      "package_id_77": {
-        "Name": "ghcr.io/kube-vip/kube-vip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.8.9",
-        "Version": "v0.8.9"
-      },
-      "package_id_78": {
-        "Name": "registry.k8s.io/kube-apiserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_79": {
-        "Name": "registry.k8s.io/kube-controller-manager",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_80": {
-        "Name": "registry.k8s.io/kube-scheduler",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_81": {
-        "Name": "registry.k8s.io/kube-proxy",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_82": {
-        "Name": "registry.k8s.io/coredns/coredns",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.13.1",
-        "Version": "v1.13.1"
-      },
-      "package_id_83": {
-        "Name": "registry.k8s.io/pause",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.10.1",
-        "Version": "3.10.1"
-      },
-      "package_id_84": {
-        "Name": "registry.k8s.io/etcd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.6.6-0",
-        "Version": "3.6.6-0"
-      },
-      "package_id_85": {
-        "Name": "docker.io/calico/cni",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_86": {
-        "Name": "docker.io/calico/kube-controllers",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_87": {
-        "Name": "docker.io/calico/node",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_88": {
-        "Name": "quay.io/metallb/speaker",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.15.3",
-        "Version": "v0.15.3"
-      },
-      "package_id_89": {
-        "Name": "kubectl-1.35.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
-          }
-        ]
-      },
-      "package_id_90": {
-        "Name": "prettytable==3.14.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_91": {
-        "Name": "python3-3.12.9",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_92": {
-        "Name": "PyMySQL==1.1.2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_93": {
-        "Name": "calico-v3.31.4",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "manifest",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"
-          }
-        ]
-      },
-      "package_id_94": {
-        "Name": "metallb-native-v0.15.3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "manifest",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml"
-          }
-        ]
-      },
-      "package_id_95": {
-        "Name": "helm-v3.20.1-amd64",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
-          }
-        ]
-      },
-      "package_id_96": {
-        "Name": "nfs-subdir-external-provisioner-4.0.18",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/releases/download/nfs-subdir-external-provisioner-4.0.18/nfs-subdir-external-provisioner-4.0.18.tgz"
-          }
-        ]
-      },
-      "package_id_97": {
-        "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v4.0.2",
-        "Version": "v4.0.2"
-      },
-      "package_id_98": {
-        "Name": "quay.io/metallb/controller",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.15.3",
-        "Version": "v0.15.3"
-      },
-      "package_id_99": {
-        "Name": "nvhpc_2025_2511_Linux_aarch64_cuda_13.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_aarch64_cuda_13.0.tar.gz"
-          }
-        ]
-      }
-    },
-    "OSPackages": {
-      "os_package_id_1": {
-        "Name": "python3-devel",
+      "dracut-live_latest_rpm": {
+        "Name": "dracut-live",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2264,32 +2645,8 @@
           }
         ]
       },
-      "os_package_id_2": {
-        "Name": "python3-cython",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "codeready-builder"
-          }
-        ]
-      },
-      "os_package_id_3": {
-        "Name": "openssl-libs",
+      "dracut-network_latest_rpm": {
+        "Name": "dracut-network",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2312,8 +2669,8 @@
           }
         ]
       },
-      "os_package_id_4": {
-        "Name": "ovis-ldms",
+      "dracut_latest_rpm": {
+        "Name": "dracut",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2328,15 +2685,1023 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "ldms"
+            "RepoName": "baseos"
           },
           {
             "Architecture": "aarch64",
-            "RepoName": "ldms"
+            "RepoName": "baseos"
           }
         ]
       },
-      "os_package_id_5": {
+      "emacs_latest_rpm": {
+        "Name": "emacs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "file_latest_rpm": {
+        "Name": "file",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "findutils_latest_rpm": {
+        "Name": "findutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "fping_latest_rpm": {
+        "Name": "fping",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "gawk_latest_rpm": {
+        "Name": "gawk",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gcc-c++_latest_rpm": {
+        "Name": "gcc-c++",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc-gfortran_latest_rpm": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc_latest_rpm": {
+        "Name": "gcc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb-gdbserver_latest_rpm": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb_latest_rpm": {
+        "Name": "gdb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit_latest_rpm": {
+        "Name": "gedit",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "glibc-langpack-en_latest_rpm": {
+        "Name": "glibc-langpack-en",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "grep_latest_rpm": {
+        "Name": "grep",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gzip_latest_rpm": {
+        "Name": "gzip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc-libs_latest_rpm": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc_latest_rpm": {
+        "Name": "hwloc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3_latest_rpm": {
+        "Name": "iperf3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "ipmitool_latest_rpm": {
+        "Name": "ipmitool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "iproute_latest_rpm": {
+        "Name": "iproute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iputils_latest_rpm": {
+        "Name": "iputils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kbd_latest_rpm": {
+        "Name": "kbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel-tools_latest_rpm": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel_latest_rpm": {
+        "Name": "kernel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools_latest_rpm": {
+        "Name": "kexec-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libcurl_latest_rpm": {
+        "Name": "libcurl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libtool_latest_rpm": {
+        "Name": "libtool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb-devel_latest_rpm": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb_latest_rpm": {
+        "Name": "lldb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw_latest_rpm": {
+        "Name": "lshw",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "lsof_latest_rpm": {
+        "Name": "lsof",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ltrace_latest_rpm": {
+        "Name": "ltrace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lvm2_latest_rpm": {
+        "Name": "lvm2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "make_latest_rpm": {
+        "Name": "make",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-db_latest_rpm": {
+        "Name": "man-db",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-pages_latest_rpm": {
+        "Name": "man-pages",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "munge-devel_latest_rpm": {
+        "Name": "munge-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "nfs-utils_latest_rpm": {
+        "Name": "nfs-utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs4-acl-tools_latest_rpm": {
+        "Name": "nfs4-acl-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nm-connection-editor_latest_rpm": {
+        "Name": "nm-connection-editor",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nss-pam-ldapd_latest_rpm": {
+        "Name": "nss-pam-ldapd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "oddjob-mkhomedir_latest_rpm": {
+        "Name": "oddjob-mkhomedir",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openldap-clients_latest_rpm": {
+        "Name": "openldap-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openmpi_5.0.8_tarball": {
         "Name": "openmpi",
         "SupportedOS": [
           {
@@ -2361,7 +3726,271 @@
           }
         ]
       },
-      "os_package_id_6": {
+      "openssh-clients_latest_rpm": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server_latest_rpm": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh_latest_rpm": {
+        "Name": "openssh",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel_latest_rpm": {
+        "Name": "openssl-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openssl-libs_latest_rpm": {
+        "Name": "openssl-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ovis-ldms_latest_rpm": {
+        "Name": "ovis-ldms",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "ldms"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "ldms"
+          }
+        ]
+      },
+      "papi-devel_latest_rpm": {
+        "Name": "papi-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-libs_latest_rpm": {
+        "Name": "papi-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi_latest_rpm": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pciutils_latest_rpm": {
+        "Name": "pciutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "perf_latest_rpm": {
+        "Name": "perf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pmix-devel_latest_rpm": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -2385,8 +4014,8 @@
           }
         ]
       },
-      "os_package_id_7": {
-        "Name": "munge-devel",
+      "python3-cython_latest_rpm": {
+        "Name": "python3-cython",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2409,8 +4038,8 @@
           }
         ]
       },
-      "os_package_id_8": {
-        "Name": "gcc-c++",
+      "python3-devel_latest_rpm": {
+        "Name": "python3-devel",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2433,8 +4062,8 @@
           }
         ]
       },
-      "os_package_id_9": {
-        "Name": "make",
+      "rsync_latest_rpm": {
+        "Name": "rsync",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2457,7 +4086,271 @@
           }
         ]
       },
-      "os_package_id_10": {
+      "rsyslog_latest_rpm": {
+        "Name": "rsyslog",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "sed_latest_rpm": {
+        "Name": "sed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "squashfs-tools_latest_rpm": {
+        "Name": "squashfs-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sssd_latest_rpm": {
+        "Name": "sssd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "strace_latest_rpm": {
+        "Name": "strace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sudo_latest_rpm": {
+        "Name": "sudo",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd-udev_latest_rpm": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd_latest_rpm": {
+        "Name": "systemd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar_latest_rpm": {
+        "Name": "tar",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tcpdump_latest_rpm": {
+        "Name": "tcpdump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "traceroute_latest_rpm": {
+        "Name": "traceroute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ucx_1.19.0_tarball": {
         "Name": "ucx",
         "SupportedOS": [
           {
@@ -2482,607 +4375,7 @@
           }
         ]
       },
-      "os_package_id_11": {
-        "Name": "openldap-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_12": {
-        "Name": "nss-pam-ldapd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_13": {
-        "Name": "sssd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_14": {
-        "Name": "oddjob-mkhomedir",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_15": {
-        "Name": "authselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_16": {
-        "Name": "systemd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_17": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_18": {
-        "Name": "kernel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_19": {
-        "Name": "dracut",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_20": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_21": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_22": {
-        "Name": "squashfs-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_23": {
-        "Name": "nfs-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_24": {
-        "Name": "nfs4-acl-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_25": {
-        "Name": "NetworkManager",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_26": {
-        "Name": "nm-connection-editor",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_27": {
-        "Name": "iproute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_28": {
-        "Name": "iputils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_29": {
-        "Name": "curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_30": {
-        "Name": "bash",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_31": {
-        "Name": "coreutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_32": {
-        "Name": "grep",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_33": {
-        "Name": "sed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_34": {
-        "Name": "gawk",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_35": {
-        "Name": "findutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_36": {
+      "util-linux_latest_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -3106,1102 +4399,7 @@
           }
         ]
       },
-      "os_package_id_37": {
-        "Name": "kbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_38": {
-        "Name": "lsof",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_39": {
-        "Name": "cryptsetup",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_40": {
-        "Name": "lvm2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_41": {
-        "Name": "device-mapper",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_42": {
-        "Name": "rsyslog",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_43": {
-        "Name": "chrony",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_44": {
-        "Name": "sudo",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_45": {
-        "Name": "gzip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_46": {
-        "Name": "wget",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_47": {
-        "Name": "cloud-init",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_48": {
-        "Name": "glibc-langpack-en",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_49": {
-        "Name": "gedit",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_50": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
-      },
-      "os_package_id_51": {
-        "Name": "which",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_52": {
-        "Name": "tcpdump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_53": {
-        "Name": "traceroute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_54": {
-        "Name": "iperf3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_55": {
-        "Name": "fping",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_56": {
-        "Name": "dmidecode",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_57": {
-        "Name": "hwloc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_58": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_59": {
-        "Name": "lshw",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_60": {
-        "Name": "pciutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_61": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_62": {
-        "Name": "emacs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_63": {
-        "Name": "zsh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_64": {
-        "Name": "openssh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_65": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_66": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_67": {
-        "Name": "rsync",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_68": {
-        "Name": "file",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_69": {
-        "Name": "libcurl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_70": {
-        "Name": "tar",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_71": {
-        "Name": "bzip2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_72": {
-        "Name": "man-db",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_73": {
-        "Name": "man-pages",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_74": {
-        "Name": "strace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_75": {
-        "Name": "kexec-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_76": {
-        "Name": "openssl-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_77": {
-        "Name": "ipmitool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_78": {
-        "Name": "gdb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_79": {
-        "Name": "gdb-gdbserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_80": {
-        "Name": "lldb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_81": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_82": {
-        "Name": "valgrind",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_83": {
+      "valgrind-devel_latest_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -4225,8 +4423,8 @@
           }
         ]
       },
-      "os_package_id_84": {
-        "Name": "ltrace",
+      "valgrind_latest_rpm": {
+        "Name": "valgrind",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4249,32 +4447,8 @@
           }
         ]
       },
-      "os_package_id_85": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_86": {
-        "Name": "perf",
+      "vim-enhanced_latest_rpm_1": {
+        "Name": "vim-enhanced",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4297,8 +4471,8 @@
           }
         ]
       },
-      "os_package_id_87": {
-        "Name": "papi",
+      "wget_latest_rpm": {
+        "Name": "wget",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4321,200 +4495,8 @@
           }
         ]
       },
-      "os_package_id_88": {
-        "Name": "papi-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_89": {
-        "Name": "papi-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_90": {
-        "Name": "cmake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_91": {
-        "Name": "autoconf",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_92": {
-        "Name": "automake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_93": {
-        "Name": "libtool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_94": {
-        "Name": "gcc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_95": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_96": {
-        "Name": "binutils",
+      "which_latest_rpm": {
+        "Name": "which",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4537,56 +4519,8 @@
           }
         ]
       },
-      "os_package_id_97": {
-        "Name": "binutils-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_98": {
-        "Name": "clustershell",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          },
-          {
-            "Architecture": "aarch64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_99": {
-        "Name": "bash-completion",
+      "zsh_latest_rpm": {
+        "Name": "zsh",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4608,21 +4542,6 @@
             "RepoName": "baseos"
           }
         ]
-      },
-      "os_package_id_100": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
       }
     },
     "Miscellaneous": [],

--- a/examples/catalog/catalog_rhel_x86_64.json
+++ b/examples/catalog/catalog_rhel_x86_64.json
@@ -7,341 +7,260 @@
       {
         "Name": "login_compiler_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_27",
-          "package_id_32",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_27",
-          "package_id_32",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "os_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_2",
-          "package_id_3",
-          "package_id_4"
+          "openssl-libs_latest_rpm",
+          "ovis-ldms_latest_rpm",
+          "python3-cython_latest_rpm",
+          "python3-devel_latest_rpm"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_100",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_80",
-          "package_id_81",
-          "package_id_82",
-          "package_id_83",
-          "package_id_84",
-          "package_id_85",
-          "package_id_86",
-          "package_id_87",
-          "package_id_88",
-          "package_id_89",
-          "package_id_90",
-          "package_id_91",
-          "package_id_92",
-          "package_id_93",
-          "package_id_94",
-          "package_id_95",
-          "package_id_96",
-          "package_id_97",
-          "package_id_98",
-          "package_id_99"
+          "PyMySQL_1.1.2_pip_module",
+          "apptainer_latest_rpm",
+          "calico-v3-31-4_latest_manifest",
+          "cert-manager-v1-10-0_latest_tarball",
+          "cffi_1.17.1_pip_module",
+          "container-selinux_latest_rpm",
+          "cri-o_1.35.1_rpm",
+          "cryptography_45.0.7_pip_module",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "docker-io-alpine-kubectl_1.35.1_image",
+          "docker-io-calico-cni_v3.31.4_image",
+          "docker-io-calico-kube-controllers_v3.31.4_image",
+          "docker-io-calico-node_v3.31.4_image",
+          "docker-io-curlimages-curl_8.17.0_image",
+          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
+          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
+          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
+          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
+          "docker-io-library-busybox_1.36_image",
+          "docker-io-library-mysql_9.3.0_image",
+          "docker-io-library-python_3.12-slim_image",
+          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
+          "docker-io-rmohr-activemq_5.15.9_image",
+          "docker-io-timberio-vector_0.54.0-debian_image",
+          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
+          "docker-io-victoriametrics-operator_v0.68.3_image",
+          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
+          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
+          "docker-io-victoriametrics-vlagent_v1.50.0_image",
+          "docker-io-victoriametrics-vmagent_v1.128.0_image",
+          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
+          "firewalld_latest_rpm",
+          "fuse-overlayfs_latest_rpm",
+          "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
+          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
+          "git_latest_rpm",
+          "helm-charts_container-storage-modules-1.9.2_git",
+          "helm-v3-20-1-amd64_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "karavi-observability_v1.12.0_git",
+          "kubeadm_1.35.1_rpm",
+          "kubectl_1.35.1_rpm",
+          "kubelet_1.35.1_rpm",
+          "kubernetes_33.1.0_pip_module",
+          "lsscsi_latest_rpm",
+          "metallb-native-v0-15-3_latest_manifest",
+          "nfs-subdir-external-provisioner-4-0-18_latest_tarball",
+          "omsdk_1.2.518_pip_module",
+          "podman_latest_rpm",
+          "prettytable_3.14.0_pip_module",
+          "prometheus_client_0.20.0_pip_module",
+          "python3-firewall_latest_rpm",
+          "python3_3.12.9_rpm",
+          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
+          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
+          "quay-io-metallb-speaker_v0.15.3_image",
+          "quay-io-strimzi-kafka-bridge_0.33.1_image",
+          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
+          "quay-io-strimzi-operator_0.48.0_image",
+          "registry-k8s-io-coredns-coredns_v1.13.1_image",
+          "registry-k8s-io-etcd_3.6.6-0_image",
+          "registry-k8s-io-kube-apiserver_v1.35.1_image",
+          "registry-k8s-io-kube-controller-manager_v1.35.1_image",
+          "registry-k8s-io-kube-proxy_v1.35.1_image",
+          "registry-k8s-io-kube-scheduler_v1.35.1_image",
+          "registry-k8s-io-pause_3.10.1_image",
+          "sg3_utils_latest_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
+          "victoria-metrics-operator-0-59-3_latest_tarball",
+          "vim-enhanced_latest_rpm"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_101",
-          "package_id_102",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_80",
-          "package_id_92"
+          "apptainer_latest_rpm",
+          "cert-manager-v1-10-0_latest_tarball",
+          "cffi_1.17.1_pip_module",
+          "container-selinux_latest_rpm",
+          "cri-o_1.35.1_rpm",
+          "cryptography_45.0.7_pip_module",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "docker-io-alpine-kubectl_1.35.1_image",
+          "docker-io-curlimages-curl_8.17.0_image",
+          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
+          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
+          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
+          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
+          "docker-io-library-busybox_1.36_image",
+          "docker-io-library-mysql_9.3.0_image",
+          "docker-io-library-python_3.12-slim_image",
+          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
+          "docker-io-rmohr-activemq_5.15.9_image",
+          "docker-io-timberio-vector_0.54.0-debian_image",
+          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
+          "docker-io-victoriametrics-operator_v0.68.3_image",
+          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
+          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
+          "docker-io-victoriametrics-vlagent_v1.50.0_image",
+          "docker-io-victoriametrics-vmagent_v1.128.0_image",
+          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
+          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
+          "firewalld_latest_rpm",
+          "fuse-overlayfs_latest_rpm",
+          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
+          "git_latest_rpm",
+          "helm-charts_container-storage-modules-1.9.2_git",
+          "iscsi-initiator-utils_latest_rpm",
+          "karavi-observability_v1.12.0_git",
+          "kubeadm_1.35.1_rpm",
+          "kubelet_1.35.1_rpm",
+          "kubernetes_33.1.0_pip_module",
+          "lsscsi_latest_rpm",
+          "omsdk_1.2.518_pip_module",
+          "podman_latest_rpm",
+          "prometheus_client_0.20.0_pip_module",
+          "python3-firewall_latest_rpm",
+          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
+          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
+          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
+          "quay-io-metallb-controller_v0.15.3_image",
+          "quay-io-metallb-speaker_v0.15.3_image",
+          "quay-io-strimzi-kafka-bridge_0.33.1_image",
+          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
+          "quay-io-strimzi-operator_0.48.0_image",
+          "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
+          "sg3_utils_latest_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
+          "victoria-metrics-operator-0-59-3_latest_tarball",
+          "vim-enhanced_latest_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_23",
-          "package_id_24",
-          "package_id_25",
-          "package_id_26",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "mariadb-server_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-PyMySQL_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmctld_latest_rpm",
+          "slurm-slurmdbd_latest_rpm"
         ]
       },
       {
         "Name": "slurm_node_x86_64",
         "FunctionalPackages": [
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_27",
-          "package_id_28",
-          "package_id_29",
-          "package_id_30",
-          "package_id_31",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
-        ]
-      },
-      {
-        "Name": "service_kube_control_plane_first_x86_64",
-        "FunctionalPackages": [
-          "package_id_10",
-          "package_id_100",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_33",
-          "package_id_34",
-          "package_id_35",
-          "package_id_36",
-          "package_id_37",
-          "package_id_38",
-          "package_id_39",
-          "package_id_40",
-          "package_id_41",
-          "package_id_42",
-          "package_id_43",
-          "package_id_44",
-          "package_id_45",
-          "package_id_46",
-          "package_id_47",
-          "package_id_48",
-          "package_id_49",
-          "package_id_50",
-          "package_id_51",
-          "package_id_52",
-          "package_id_53",
-          "package_id_54",
-          "package_id_55",
-          "package_id_56",
-          "package_id_57",
-          "package_id_58",
-          "package_id_59",
-          "package_id_6",
-          "package_id_60",
-          "package_id_61",
-          "package_id_62",
-          "package_id_63",
-          "package_id_64",
-          "package_id_65",
-          "package_id_66",
-          "package_id_67",
-          "package_id_68",
-          "package_id_69",
-          "package_id_7",
-          "package_id_70",
-          "package_id_71",
-          "package_id_72",
-          "package_id_73",
-          "package_id_74",
-          "package_id_75",
-          "package_id_76",
-          "package_id_77",
-          "package_id_78",
-          "package_id_79",
-          "package_id_80",
-          "package_id_81",
-          "package_id_82",
-          "package_id_83",
-          "package_id_84",
-          "package_id_85",
-          "package_id_86",
-          "package_id_87",
-          "package_id_88",
-          "package_id_89",
-          "package_id_90",
-          "package_id_91",
-          "package_id_92",
-          "package_id_93",
-          "package_id_94",
-          "package_id_95",
-          "package_id_96",
-          "package_id_97",
-          "package_id_98",
-          "package_id_99"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "kernel-devel_latest_rpm",
+          "kernel-headers_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-pam_slurm_latest_rpm",
+          "slurm-slurmd_latest_rpm"
         ]
       }
     ],
@@ -350,105 +269,105 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "os_package_id_1",
-          "os_package_id_10",
-          "os_package_id_11",
-          "os_package_id_12",
-          "os_package_id_13",
-          "os_package_id_14",
-          "os_package_id_15",
-          "os_package_id_16",
-          "os_package_id_17",
-          "os_package_id_18",
-          "os_package_id_19",
-          "os_package_id_2",
-          "os_package_id_20",
-          "os_package_id_21",
-          "os_package_id_22",
-          "os_package_id_23",
-          "os_package_id_24",
-          "os_package_id_25",
-          "os_package_id_26",
-          "os_package_id_27",
-          "os_package_id_28",
-          "os_package_id_29",
-          "os_package_id_3",
-          "os_package_id_30",
-          "os_package_id_31",
-          "os_package_id_32",
-          "os_package_id_33",
-          "os_package_id_34",
-          "os_package_id_35",
-          "os_package_id_36",
-          "os_package_id_37",
-          "os_package_id_38",
-          "os_package_id_39",
-          "os_package_id_4",
-          "os_package_id_40",
-          "os_package_id_41",
-          "os_package_id_42",
-          "os_package_id_43",
-          "os_package_id_44",
-          "os_package_id_45",
-          "os_package_id_46",
-          "os_package_id_47",
-          "os_package_id_48",
-          "os_package_id_49",
-          "os_package_id_5",
-          "os_package_id_50",
-          "os_package_id_51",
-          "os_package_id_52",
-          "os_package_id_53",
-          "os_package_id_54",
-          "os_package_id_55",
-          "os_package_id_56",
-          "os_package_id_57",
-          "os_package_id_58",
-          "os_package_id_59",
-          "os_package_id_6",
-          "os_package_id_60",
-          "os_package_id_61",
-          "os_package_id_62",
-          "os_package_id_63",
-          "os_package_id_64",
-          "os_package_id_65",
-          "os_package_id_66",
-          "os_package_id_67",
-          "os_package_id_68",
-          "os_package_id_69",
-          "os_package_id_7",
-          "os_package_id_70",
-          "os_package_id_71",
-          "os_package_id_72",
-          "os_package_id_73",
-          "os_package_id_74",
-          "os_package_id_75",
-          "os_package_id_76",
-          "os_package_id_77",
-          "os_package_id_78",
-          "os_package_id_79",
-          "os_package_id_8",
-          "os_package_id_80",
-          "os_package_id_81",
-          "os_package_id_82",
-          "os_package_id_83",
-          "os_package_id_84",
-          "os_package_id_85",
-          "os_package_id_86",
-          "os_package_id_87",
-          "os_package_id_88",
-          "os_package_id_89",
-          "os_package_id_9",
-          "os_package_id_90",
-          "os_package_id_91",
-          "os_package_id_92",
-          "os_package_id_93",
-          "os_package_id_94",
-          "os_package_id_95",
-          "os_package_id_96",
-          "os_package_id_97",
-          "os_package_id_98",
-          "os_package_id_99"
+          "NetworkManager_latest_rpm",
+          "authselect_latest_rpm",
+          "autoconf_latest_rpm",
+          "automake_latest_rpm",
+          "bash-completion_latest_rpm",
+          "bash_latest_rpm",
+          "binutils-devel_latest_rpm",
+          "binutils_latest_rpm",
+          "bzip2_latest_rpm",
+          "chrony_latest_rpm",
+          "cloud-init_latest_rpm",
+          "clustershell_latest_rpm",
+          "cmake_latest_rpm",
+          "coreutils_latest_rpm",
+          "cryptsetup_latest_rpm",
+          "curl_latest_rpm",
+          "device-mapper_latest_rpm",
+          "dmidecode_latest_rpm",
+          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
+          "dracut-live_latest_rpm",
+          "dracut-network_latest_rpm",
+          "dracut_latest_rpm",
+          "emacs_latest_rpm",
+          "file_latest_rpm",
+          "findutils_latest_rpm",
+          "fping_latest_rpm",
+          "gawk_latest_rpm",
+          "gcc-c++_latest_rpm",
+          "gcc-gfortran_latest_rpm",
+          "gcc_latest_rpm",
+          "gdb-gdbserver_latest_rpm",
+          "gdb_latest_rpm",
+          "gedit_latest_rpm",
+          "glibc-langpack-en_latest_rpm",
+          "grep_latest_rpm",
+          "gzip_latest_rpm",
+          "hwloc-libs_latest_rpm",
+          "hwloc_latest_rpm",
+          "iperf3_latest_rpm",
+          "ipmitool_latest_rpm",
+          "iproute_latest_rpm",
+          "iputils_latest_rpm",
+          "kbd_latest_rpm",
+          "kernel-tools_latest_rpm",
+          "kernel_latest_rpm",
+          "kexec-tools_latest_rpm",
+          "libcurl_latest_rpm",
+          "libtool_latest_rpm",
+          "lldb-devel_latest_rpm",
+          "lldb_latest_rpm",
+          "lshw_latest_rpm",
+          "lsof_latest_rpm",
+          "ltrace_latest_rpm",
+          "lvm2_latest_rpm",
+          "make_latest_rpm",
+          "man-db_latest_rpm",
+          "man-pages_latest_rpm",
+          "munge-devel_latest_rpm",
+          "nfs-utils_latest_rpm",
+          "nfs4-acl-tools_latest_rpm",
+          "nm-connection-editor_latest_rpm",
+          "nss-pam-ldapd_latest_rpm",
+          "oddjob-mkhomedir_latest_rpm",
+          "openldap-clients_latest_rpm",
+          "openmpi_5.0.8_tarball",
+          "openssh-clients_latest_rpm",
+          "openssh-server_latest_rpm",
+          "openssh_latest_rpm",
+          "openssl-devel_latest_rpm",
+          "openssl-libs_latest_rpm_1",
+          "ovis-ldms_latest_rpm_1",
+          "papi-devel_latest_rpm",
+          "papi-libs_latest_rpm",
+          "papi_latest_rpm",
+          "pciutils_latest_rpm",
+          "perf_latest_rpm",
+          "pmix-devel_latest_rpm",
+          "python3-cython_latest_rpm_1",
+          "python3-devel_latest_rpm_1",
+          "rsync_latest_rpm",
+          "rsyslog_latest_rpm",
+          "sed_latest_rpm",
+          "squashfs-tools_latest_rpm",
+          "sssd_latest_rpm",
+          "strace_latest_rpm",
+          "sudo_latest_rpm",
+          "systemd-udev_latest_rpm",
+          "systemd_latest_rpm",
+          "tar_latest_rpm",
+          "tcpdump_latest_rpm",
+          "traceroute_latest_rpm",
+          "ucx_1.19.0_tarball",
+          "util-linux_latest_rpm",
+          "valgrind-devel_latest_rpm",
+          "valgrind_latest_rpm",
+          "vim-enhanced_latest_rpm_1",
+          "wget_latest_rpm",
+          "which_latest_rpm",
+          "zsh_latest_rpm"
         ]
       }
     ],
@@ -456,30 +375,30 @@
       {
         "Name": "csi",
         "InfrastructurePackages": [
-          "infrastructure_package_id_1",
-          "infrastructure_package_id_10",
-          "infrastructure_package_id_11",
-          "infrastructure_package_id_12",
-          "infrastructure_package_id_13",
-          "infrastructure_package_id_14",
-          "infrastructure_package_id_15",
-          "infrastructure_package_id_16",
-          "infrastructure_package_id_2",
-          "infrastructure_package_id_3",
-          "infrastructure_package_id_4",
-          "infrastructure_package_id_5",
-          "infrastructure_package_id_6",
-          "infrastructure_package_id_7",
-          "infrastructure_package_id_8",
-          "infrastructure_package_id_9"
+          "csi-powerscale-v2-16-0_v2.16.0_git",
+          "docker-io-dellemc-csm-encryption_v0.6.0_image",
+          "external-snapshotter-v8-4-0_v8.4.0_git",
+          "helm-charts-2-16-0_csi-isilon-2.16.0_git",
+          "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image",
+          "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image",
+          "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image",
+          "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image",
+          "quay-io-dell-container-storage-modules-podmon_v1.15.0_image",
+          "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image",
+          "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image",
+          "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image",
+          "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image",
+          "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image",
+          "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image",
+          "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image"
         ]
       }
     ],
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "package_id_1": {
-        "Name": "python3-devel",
+      "PyMySQL_1.1.2_pip_module": {
+        "Name": "PyMySQL==1.1.2",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -489,163 +408,9 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
+        "Type": "pip_module"
       },
-      "package_id_2": {
-        "Name": "python3-cython",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          }
-        ]
-      },
-      "package_id_3": {
-        "Name": "openssl-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_4": {
-        "Name": "ovis-ldms",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "ldms"
-          }
-        ]
-      },
-      "package_id_5": {
-        "Name": "munge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_6": {
-        "Name": "firewalld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_7": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_8": {
-        "Name": "pmix",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_9": {
-        "Name": "nvcr.io/nvidia/hpc-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "25.09",
-        "Version": "25.09"
-      },
-      "package_id_10": {
+      "apptainer_latest_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -664,8 +429,8 @@
           }
         ]
       },
-      "package_id_11": {
-        "Name": "doca-ofed",
+      "calico-v3-31-4_latest_manifest": {
+        "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -675,92 +440,16 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "rpm_repo",
+        "Type": "manifest",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "doca"
+            "Uri": "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"
           }
         ]
       },
-      "package_id_12": {
-        "Name": "iscsi-initiator-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_13": {
-        "Name": "device-mapper-multipath",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_14": {
-        "Name": "sg3_utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_15": {
-        "Name": "lsscsi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_16": {
-        "Name": "imb",
+      "cert-manager-v1-10-0_latest_tarball": {
+        "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -774,12 +463,12 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
+            "Uri": "https://charts.jetstack.io/charts/cert-manager-v1.10.0.tgz"
           }
         ]
       },
-      "package_id_17": {
-        "Name": "osu-micro-benchmarks",
+      "cffi_1.17.1_pip_module": {
+        "Name": "cffi==1.17.1",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -789,429 +478,9 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          }
-        ]
+        "Type": "pip_module"
       },
-      "package_id_18": {
-        "Name": "likwid",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          }
-        ]
-      },
-      "package_id_19": {
-        "Name": "geopm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_20": {
-        "Name": "papi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_21": {
-        "Name": "msr-safe",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_22": {
-        "Name": "sionlib",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "package_id_23": {
-        "Name": "slurm-slurmctld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_24": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_25": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_26": {
-        "Name": "mariadb-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_27": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_28": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_29": {
-        "Name": "kernel-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_30": {
-        "Name": "kernel-headers",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_31": {
-        "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_x86_64_cuda_13.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_32": {
-        "Name": "slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_33": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_34": {
-        "Name": "docker.io/library/busybox",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.36",
-        "Version": "1.36"
-      },
-      "package_id_35": {
-        "Name": "git",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_36": {
-        "Name": "fuse-overlayfs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_37": {
-        "Name": "podman",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_38": {
-        "Name": "kubeadm-1.35.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
-          }
-        ]
-      },
-      "package_id_39": {
-        "Name": "kubelet-1.35.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
-          }
-        ]
-      },
-      "package_id_40": {
+      "container-selinux_latest_rpm": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -1230,7 +499,7 @@
           }
         ]
       },
-      "package_id_41": {
+      "cri-o_1.35.1_rpm": {
         "Name": "cri-o-1.35.1",
         "SupportedOS": [
           {
@@ -1249,8 +518,8 @@
           }
         ]
       },
-      "package_id_42": {
-        "Name": "docker.io/victoriametrics/victoria-metrics",
+      "cryptography_45.0.7_pip_module": {
+        "Name": "cryptography==45.0.7",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1260,12 +529,10 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "image",
-        "Tag": "v1.128.0",
-        "Version": "v1.128.0"
+        "Type": "pip_module"
       },
-      "package_id_43": {
-        "Name": "docker.io/victoriametrics/vmagent",
+      "device-mapper-multipath_latest_rpm": {
+        "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1275,12 +542,16 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "image",
-        "Tag": "v1.128.0",
-        "Version": "v1.128.0"
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
       },
-      "package_id_44": {
-        "Name": "docker.io/victoriametrics/vmstorage",
+      "doca-ofed_latest_rpm_repo": {
+        "Name": "doca-ofed",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1290,71 +561,15 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_45": {
-        "Name": "docker.io/victoriametrics/vminsert",
-        "SupportedOS": [
+        "Type": "rpm_repo",
+        "Sources": [
           {
-            "Name": "RHEL",
-            "Version": "10.0"
+            "Architecture": "x86_64",
+            "RepoName": "doca"
           }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
+        ]
       },
-      "package_id_46": {
-        "Name": "docker.io/victoriametrics/vmselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.128.0-cluster",
-        "Version": "v1.128.0-cluster"
-      },
-      "package_id_47": {
-        "Name": "docker.io/victoriametrics/victoria-logs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.50.0",
-        "Version": "v1.50.0"
-      },
-      "package_id_48": {
-        "Name": "docker.io/victoriametrics/vlagent",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.50.0",
-        "Version": "v1.50.0"
-      },
-      "package_id_49": {
+      "docker-io-alpine-kubectl_1.35.1_image": {
         "Name": "docker.io/alpine/kubectl",
         "SupportedOS": [
           {
@@ -1369,7 +584,52 @@
         "Tag": "1.35.1",
         "Version": "1.35.1"
       },
-      "package_id_50": {
+      "docker-io-calico-cni_v3.31.4_image": {
+        "Name": "docker.io/calico/cni",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-calico-kube-controllers_v3.31.4_image": {
+        "Name": "docker.io/calico/kube-controllers",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-calico-node_v3.31.4_image": {
+        "Name": "docker.io/calico/node",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v3.31.4",
+        "Version": "v3.31.4"
+      },
+      "docker-io-curlimages-curl_8.17.0_image": {
         "Name": "docker.io/curlimages/curl",
         "SupportedOS": [
           {
@@ -1384,52 +644,7 @@
         "Tag": "8.17.0",
         "Version": "8.17.0"
       },
-      "package_id_51": {
-        "Name": "docker.io/rmohr/activemq",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "5.15.9",
-        "Version": "5.15.9"
-      },
-      "package_id_52": {
-        "Name": "docker.io/library/mysql",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "9.3.0",
-        "Version": "9.3.0"
-      },
-      "package_id_53": {
-        "Name": "docker.io/library/python",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.12-slim",
-        "Version": "3.12-slim"
-      },
-      "package_id_54": {
+      "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image": {
         "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
         "SupportedOS": [
           {
@@ -1444,7 +659,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "package_id_55": {
+      "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image": {
         "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
         "SupportedOS": [
           {
@@ -1459,117 +674,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "package_id_56": {
-        "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.3",
-        "Version": "1.3"
-      },
-      "package_id_57": {
-        "Name": "cryptography==45.0.7",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_58": {
-        "Name": "omsdk==1.2.518",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_59": {
-        "Name": "cffi==1.17.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_60": {
-        "Name": "prometheus_client==0.20.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_61": {
-        "Name": "kubernetes==33.1.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_62": {
-        "Name": "quay.io/strimzi/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.48.0",
-        "Version": "0.48.0"
-      },
-      "package_id_63": {
-        "Name": "quay.io/strimzi/kafka",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.48.0-kafka-4.1.0",
-        "Version": "0.48.0-kafka-4.1.0"
-      },
-      "package_id_64": {
+      "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image": {
         "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
         "SupportedOS": [
           {
@@ -1584,8 +689,8 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "package_id_65": {
-        "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+      "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1596,11 +701,11 @@
           "x86_64"
         ],
         "Type": "image",
-        "Tag": "v1.11.0",
-        "Version": "v1.11.0"
+        "Tag": "1.3",
+        "Version": "1.3"
       },
-      "package_id_66": {
-        "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+      "docker-io-library-busybox_1.36_image": {
+        "Name": "docker.io/library/busybox",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1611,10 +716,40 @@
           "x86_64"
         ],
         "Type": "image",
-        "Tag": "0.143.1",
-        "Version": "0.143.1"
+        "Tag": "1.36",
+        "Version": "1.36"
       },
-      "package_id_67": {
+      "docker-io-library-mysql_9.3.0_image": {
+        "Name": "docker.io/library/mysql",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "9.3.0",
+        "Version": "9.3.0"
+      },
+      "docker-io-library-python_3.12-slim_image": {
+        "Name": "docker.io/library/python",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.12-slim",
+        "Version": "3.12-slim"
+      },
+      "docker-io-nginxinc-nginx-unprivileged_1.29_image": {
         "Name": "docker.io/nginxinc/nginx-unprivileged",
         "SupportedOS": [
           {
@@ -1629,8 +764,8 @@
         "Tag": "1.29",
         "Version": "1.29"
       },
-      "package_id_68": {
-        "Name": "karavi-observability",
+      "docker-io-rmohr-activemq_5.15.9_image": {
+        "Name": "docker.io/rmohr/activemq",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1640,16 +775,267 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "git",
-        "Version": "v1.12.0",
+        "Type": "image",
+        "Tag": "5.15.9",
+        "Version": "5.15.9"
+      },
+      "docker-io-timberio-vector_0.54.0-debian_image": {
+        "Name": "docker.io/timberio/vector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.54.0-debian",
+        "Version": "0.54.0-debian"
+      },
+      "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "config-reloader-v0.68.3",
+        "Version": "config-reloader-v0.68.3"
+      },
+      "docker-io-victoriametrics-operator_v0.68.3_image": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.68.3",
+        "Version": "v0.68.3"
+      },
+      "docker-io-victoriametrics-victoria-logs_v1.50.0_image": {
+        "Name": "docker.io/victoriametrics/victoria-logs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.50.0",
+        "Version": "v1.50.0"
+      },
+      "docker-io-victoriametrics-victoria-metrics_v1.128.0_image": {
+        "Name": "docker.io/victoriametrics/victoria-metrics",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0",
+        "Version": "v1.128.0"
+      },
+      "docker-io-victoriametrics-vlagent_v1.50.0_image": {
+        "Name": "docker.io/victoriametrics/vlagent",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.50.0",
+        "Version": "v1.50.0"
+      },
+      "docker-io-victoriametrics-vmagent_v1.128.0_image": {
+        "Name": "docker.io/victoriametrics/vmagent",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0",
+        "Version": "v1.128.0"
+      },
+      "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vminsert",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vmselect",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image": {
+        "Name": "docker.io/victoriametrics/vmstorage",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.128.0-cluster",
+        "Version": "v1.128.0-cluster"
+      },
+      "firewalld_latest_rpm": {
+        "Name": "firewalld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://github.com/dell/karavi-observability.git"
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_69": {
+      "fuse-overlayfs_latest_rpm": {
+        "Name": "fuse-overlayfs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "geopm_latest_tarball": {
+        "Name": "geopm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
+          }
+        ]
+      },
+      "ghcr-io-kube-vip-kube-vip_v0.8.9_image": {
+        "Name": "ghcr.io/kube-vip/kube-vip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.8.9",
+        "Version": "v0.8.9"
+      },
+      "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image": {
+        "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.143.1",
+        "Version": "0.143.1"
+      },
+      "git_latest_rpm": {
+        "Name": "git",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "helm-charts_container-storage-modules-1.9.2_git": {
         "Name": "helm-charts",
         "SupportedOS": [
           {
@@ -1669,466 +1055,7 @@
           }
         ]
       },
-      "package_id_70": {
-        "Name": "quay.io/jetstack/cert-manager-controller",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_71": {
-        "Name": "quay.io/jetstack/cert-manager-cainjector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_72": {
-        "Name": "quay.io/jetstack/cert-manager-webhook",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_73": {
-        "Name": "quay.io/jetstack/cert-manager-acmesolver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.10.0",
-        "Version": "v1.10.0"
-      },
-      "package_id_74": {
-        "Name": "cert-manager-v1.10.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://charts.jetstack.io/charts/cert-manager-v1.10.0.tgz"
-          }
-        ]
-      },
-      "package_id_75": {
-        "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-kafka-operator-helm-3-chart-0.48.0.tgz"
-          }
-        ]
-      },
-      "package_id_76": {
-        "Name": "quay.io/strimzi/kafka-bridge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.33.1",
-        "Version": "0.33.1"
-      },
-      "package_id_77": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.68.3",
-        "Version": "v0.68.3"
-      },
-      "package_id_78": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "config-reloader-v0.68.3",
-        "Version": "config-reloader-v0.68.3"
-      },
-      "package_id_79": {
-        "Name": "victoria-metrics-operator-0.59.3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/VictoriaMetrics/helm-charts/releases/download/victoria-metrics-operator-0.59.3/victoria-metrics-operator-0.59.3.tgz"
-          }
-        ]
-      },
-      "package_id_80": {
-        "Name": "docker.io/timberio/vector",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.54.0-debian",
-        "Version": "0.54.0-debian"
-      },
-      "package_id_81": {
-        "Name": "ghcr.io/kube-vip/kube-vip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.8.9",
-        "Version": "v0.8.9"
-      },
-      "package_id_82": {
-        "Name": "registry.k8s.io/kube-apiserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_83": {
-        "Name": "registry.k8s.io/kube-controller-manager",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_84": {
-        "Name": "registry.k8s.io/kube-scheduler",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_85": {
-        "Name": "registry.k8s.io/kube-proxy",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.35.1",
-        "Version": "v1.35.1"
-      },
-      "package_id_86": {
-        "Name": "registry.k8s.io/coredns/coredns",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v1.13.1",
-        "Version": "v1.13.1"
-      },
-      "package_id_87": {
-        "Name": "registry.k8s.io/pause",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.10.1",
-        "Version": "3.10.1"
-      },
-      "package_id_88": {
-        "Name": "registry.k8s.io/etcd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "3.6.6-0",
-        "Version": "3.6.6-0"
-      },
-      "package_id_89": {
-        "Name": "docker.io/calico/cni",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_90": {
-        "Name": "docker.io/calico/kube-controllers",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_91": {
-        "Name": "docker.io/calico/node",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v3.31.4",
-        "Version": "v3.31.4"
-      },
-      "package_id_92": {
-        "Name": "quay.io/metallb/speaker",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "v0.15.3",
-        "Version": "v0.15.3"
-      },
-      "package_id_93": {
-        "Name": "kubectl-1.35.1",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "kubernetes-v1-35"
-          }
-        ]
-      },
-      "package_id_94": {
-        "Name": "prettytable==3.14.0",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_95": {
-        "Name": "python3-3.12.9",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_96": {
-        "Name": "PyMySQL==1.1.2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "pip_module"
-      },
-      "package_id_97": {
-        "Name": "calico-v3.31.4",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "manifest",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://raw.githubusercontent.com/projectcalico/calico/v3.31.4/manifests/calico.yaml"
-          }
-        ]
-      },
-      "package_id_98": {
-        "Name": "metallb-native-v0.15.3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "manifest",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml"
-          }
-        ]
-      },
-      "package_id_99": {
+      "helm-v3-20-1-amd64_latest_tarball": {
         "Name": "helm-v3.20.1-amd64",
         "SupportedOS": [
           {
@@ -2147,7 +1074,287 @@
           }
         ]
       },
-      "package_id_100": {
+      "imb_latest_tarball": {
+        "Name": "imb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
+          }
+        ]
+      },
+      "iscsi-initiator-utils_latest_rpm": {
+        "Name": "iscsi-initiator-utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "karavi-observability_v1.12.0_git": {
+        "Name": "karavi-observability",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "git",
+        "Version": "v1.12.0",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/dell/karavi-observability.git"
+          }
+        ]
+      },
+      "kernel-devel_latest_rpm": {
+        "Name": "kernel-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "kernel-headers_latest_rpm": {
+        "Name": "kernel-headers",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "kubeadm_1.35.1_rpm": {
+        "Name": "kubeadm-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "kubernetes-v1-35"
+          }
+        ]
+      },
+      "kubectl_1.35.1_rpm": {
+        "Name": "kubectl-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "kubernetes-v1-35"
+          }
+        ]
+      },
+      "kubelet_1.35.1_rpm": {
+        "Name": "kubelet-1.35.1",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "kubernetes-v1-35"
+          }
+        ]
+      },
+      "kubernetes_33.1.0_pip_module": {
+        "Name": "kubernetes==33.1.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "likwid_latest_tarball": {
+        "Name": "likwid",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          }
+        ]
+      },
+      "lsscsi_latest_rpm": {
+        "Name": "lsscsi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "mariadb-server_latest_rpm": {
+        "Name": "mariadb-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "metallb-native-v0-15-3_latest_manifest": {
+        "Name": "metallb-native-v0.15.3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "manifest",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://raw.githubusercontent.com/metallb/metallb/v0.15.3/config/manifests/metallb-native.yaml"
+          }
+        ]
+      },
+      "msr-safe_latest_tarball": {
+        "Name": "msr-safe",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
+          }
+        ]
+      },
+      "munge_latest_rpm": {
+        "Name": "munge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nfs-subdir-external-provisioner-4-0-18_latest_tarball": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -2166,8 +1373,8 @@
           }
         ]
       },
-      "package_id_101": {
-        "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+        "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2178,11 +1385,11 @@
           "x86_64"
         ],
         "Type": "image",
-        "Tag": "v4.0.2",
-        "Version": "v4.0.2"
+        "Tag": "25.09",
+        "Version": "25.09"
       },
-      "package_id_102": {
-        "Name": "quay.io/metallb/controller",
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+        "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2192,33 +1399,16 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "image",
-        "Tag": "v0.15.3",
-        "Version": "v0.15.3"
-      }
-    },
-    "OSPackages": {
-      "os_package_id_1": {
-        "Name": "python3-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
+        "Type": "tarball",
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "Uri": "https://developer.download.nvidia.com/hpc-sdk/25.11/nvhpc_2025_2511_Linux_x86_64_cuda_13.0.tar.gz"
           }
         ]
       },
-      "os_package_id_2": {
-        "Name": "python3-cython",
+      "omsdk_1.2.518_pip_module": {
+        "Name": "omsdk==1.2.518",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2228,15 +1418,9 @@
         "Architecture": [
           "x86_64"
         ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          }
-        ]
+        "Type": "pip_module"
       },
-      "os_package_id_3": {
+      "openssl-libs_latest_rpm": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -2255,7 +1439,26 @@
           }
         ]
       },
-      "os_package_id_4": {
+      "osu-micro-benchmarks_latest_tarball": {
+        "Name": "osu-micro-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          }
+        ]
+      },
+      "ovis-ldms_latest_rpm": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -2274,7 +1477,1859 @@
           }
         ]
       },
-      "os_package_id_5": {
+      "papi_latest_tarball": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          }
+        ]
+      },
+      "pmix_latest_rpm": {
+        "Name": "pmix",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "podman_latest_rpm": {
+        "Name": "podman",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "prettytable_3.14.0_pip_module": {
+        "Name": "prettytable==3.14.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "prometheus_client_0.20.0_pip_module": {
+        "Name": "prometheus_client==0.20.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "pip_module"
+      },
+      "python3-PyMySQL_latest_rpm": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-cython_latest_rpm": {
+        "Name": "python3-cython",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "python3-devel_latest_rpm": {
+        "Name": "python3-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall_latest_rpm": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "python3_3.12.9_rpm": {
+        "Name": "python3-3.12.9",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.11.0",
+        "Version": "v1.11.0"
+      },
+      "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-acmesolver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-cainjector",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-controller_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-controller",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-jetstack-cert-manager-webhook_v1.10.0_image": {
+        "Name": "quay.io/jetstack/cert-manager-webhook",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.10.0",
+        "Version": "v1.10.0"
+      },
+      "quay-io-metallb-controller_v0.15.3_image": {
+        "Name": "quay.io/metallb/controller",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.15.3",
+        "Version": "v0.15.3"
+      },
+      "quay-io-metallb-speaker_v0.15.3_image": {
+        "Name": "quay.io/metallb/speaker",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v0.15.3",
+        "Version": "v0.15.3"
+      },
+      "quay-io-strimzi-kafka-bridge_0.33.1_image": {
+        "Name": "quay.io/strimzi/kafka-bridge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.33.1",
+        "Version": "0.33.1"
+      },
+      "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image": {
+        "Name": "quay.io/strimzi/kafka",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.48.0-kafka-4.1.0",
+        "Version": "0.48.0-kafka-4.1.0"
+      },
+      "quay-io-strimzi-operator_0.48.0_image": {
+        "Name": "quay.io/strimzi/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.48.0",
+        "Version": "0.48.0"
+      },
+      "registry-k8s-io-coredns-coredns_v1.13.1_image": {
+        "Name": "registry.k8s.io/coredns/coredns",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.13.1",
+        "Version": "v1.13.1"
+      },
+      "registry-k8s-io-etcd_3.6.6-0_image": {
+        "Name": "registry.k8s.io/etcd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.6.6-0",
+        "Version": "3.6.6-0"
+      },
+      "registry-k8s-io-kube-apiserver_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-apiserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-controller-manager_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-controller-manager",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-proxy_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-proxy",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-kube-scheduler_v1.35.1_image": {
+        "Name": "registry.k8s.io/kube-scheduler",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v1.35.1",
+        "Version": "v1.35.1"
+      },
+      "registry-k8s-io-pause_3.10.1_image": {
+        "Name": "registry.k8s.io/pause",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "3.10.1",
+        "Version": "3.10.1"
+      },
+      "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image": {
+        "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "v4.0.2",
+        "Version": "v4.0.2"
+      },
+      "sg3_utils_latest_rpm": {
+        "Name": "sg3_utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sionlib_latest_tarball": {
+        "Name": "sionlib",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          }
+        ]
+      },
+      "slurm-pam_slurm_latest_rpm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld_latest_rpm": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd_latest_rpm": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd_latest_rpm": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm_latest_rpm": {
+        "Name": "slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball": {
+        "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.48.0/strimzi-kafka-operator-helm-3-chart-0.48.0.tgz"
+          }
+        ]
+      },
+      "victoria-metrics-operator-0-59-3_latest_tarball": {
+        "Name": "victoria-metrics-operator-0.59.3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/VictoriaMetrics/helm-charts/releases/download/victoria-metrics-operator-0.59.3/victoria-metrics-operator-0.59.3.tgz"
+          }
+        ]
+      },
+      "vim-enhanced_latest_rpm": {
+        "Name": "vim-enhanced",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      }
+    },
+    "OSPackages": {
+      "NetworkManager_latest_rpm": {
+        "Name": "NetworkManager",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "authselect_latest_rpm": {
+        "Name": "authselect",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "autoconf_latest_rpm": {
+        "Name": "autoconf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "automake_latest_rpm": {
+        "Name": "automake",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bash-completion_latest_rpm": {
+        "Name": "bash-completion",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bash_latest_rpm": {
+        "Name": "bash",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "binutils-devel_latest_rpm": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "binutils_latest_rpm": {
+        "Name": "binutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bzip2_latest_rpm": {
+        "Name": "bzip2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "chrony_latest_rpm": {
+        "Name": "chrony",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cloud-init_latest_rpm": {
+        "Name": "cloud-init",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "clustershell_latest_rpm": {
+        "Name": "clustershell",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "cmake_latest_rpm": {
+        "Name": "cmake",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "coreutils_latest_rpm": {
+        "Name": "coreutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cryptsetup_latest_rpm": {
+        "Name": "cryptsetup",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "curl_latest_rpm": {
+        "Name": "curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "device-mapper_latest_rpm": {
+        "Name": "device-mapper",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dmidecode_latest_rpm": {
+        "Name": "dmidecode",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "dracut-live_latest_rpm": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network_latest_rpm": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dracut_latest_rpm": {
+        "Name": "dracut",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs_latest_rpm": {
+        "Name": "emacs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "file_latest_rpm": {
+        "Name": "file",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "findutils_latest_rpm": {
+        "Name": "findutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "fping_latest_rpm": {
+        "Name": "fping",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "gawk_latest_rpm": {
+        "Name": "gawk",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gcc-c++_latest_rpm": {
+        "Name": "gcc-c++",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc-gfortran_latest_rpm": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc_latest_rpm": {
+        "Name": "gcc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb-gdbserver_latest_rpm": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb_latest_rpm": {
+        "Name": "gdb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit_latest_rpm": {
+        "Name": "gedit",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "glibc-langpack-en_latest_rpm": {
+        "Name": "glibc-langpack-en",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "grep_latest_rpm": {
+        "Name": "grep",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gzip_latest_rpm": {
+        "Name": "gzip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc-libs_latest_rpm": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc_latest_rpm": {
+        "Name": "hwloc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3_latest_rpm": {
+        "Name": "iperf3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "ipmitool_latest_rpm": {
+        "Name": "ipmitool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "iproute_latest_rpm": {
+        "Name": "iproute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iputils_latest_rpm": {
+        "Name": "iputils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kbd_latest_rpm": {
+        "Name": "kbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel-tools_latest_rpm": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel_latest_rpm": {
+        "Name": "kernel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools_latest_rpm": {
+        "Name": "kexec-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libcurl_latest_rpm": {
+        "Name": "libcurl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libtool_latest_rpm": {
+        "Name": "libtool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb-devel_latest_rpm": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb_latest_rpm": {
+        "Name": "lldb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw_latest_rpm": {
+        "Name": "lshw",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "lsof_latest_rpm": {
+        "Name": "lsof",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ltrace_latest_rpm": {
+        "Name": "ltrace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lvm2_latest_rpm": {
+        "Name": "lvm2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "make_latest_rpm": {
+        "Name": "make",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-db_latest_rpm": {
+        "Name": "man-db",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-pages_latest_rpm": {
+        "Name": "man-pages",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "munge-devel_latest_rpm": {
+        "Name": "munge-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "nfs-utils_latest_rpm": {
+        "Name": "nfs-utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs4-acl-tools_latest_rpm": {
+        "Name": "nfs4-acl-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nm-connection-editor_latest_rpm": {
+        "Name": "nm-connection-editor",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nss-pam-ldapd_latest_rpm": {
+        "Name": "nss-pam-ldapd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "oddjob-mkhomedir_latest_rpm": {
+        "Name": "oddjob-mkhomedir",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openldap-clients_latest_rpm": {
+        "Name": "openldap-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openmpi_5.0.8_tarball": {
         "Name": "openmpi",
         "SupportedOS": [
           {
@@ -2294,7 +3349,216 @@
           }
         ]
       },
-      "os_package_id_6": {
+      "openssh-clients_latest_rpm": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server_latest_rpm": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh_latest_rpm": {
+        "Name": "openssh",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel_latest_rpm": {
+        "Name": "openssl-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openssl-libs_latest_rpm_1": {
+        "Name": "openssl-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ovis-ldms_latest_rpm_1": {
+        "Name": "ovis-ldms",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "ldms"
+          }
+        ]
+      },
+      "papi-devel_latest_rpm": {
+        "Name": "papi-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-libs_latest_rpm": {
+        "Name": "papi-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi_latest_rpm": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pciutils_latest_rpm": {
+        "Name": "pciutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "perf_latest_rpm": {
+        "Name": "perf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pmix-devel_latest_rpm": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -2313,8 +3577,8 @@
           }
         ]
       },
-      "os_package_id_7": {
-        "Name": "munge-devel",
+      "python3-cython_latest_rpm_1": {
+        "Name": "python3-cython",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2332,8 +3596,8 @@
           }
         ]
       },
-      "os_package_id_8": {
-        "Name": "gcc-c++",
+      "python3-devel_latest_rpm_1": {
+        "Name": "python3-devel",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2351,8 +3615,8 @@
           }
         ]
       },
-      "os_package_id_9": {
-        "Name": "make",
+      "rsync_latest_rpm": {
+        "Name": "rsync",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2370,7 +3634,216 @@
           }
         ]
       },
-      "os_package_id_10": {
+      "rsyslog_latest_rpm": {
+        "Name": "rsyslog",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "sed_latest_rpm": {
+        "Name": "sed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "squashfs-tools_latest_rpm": {
+        "Name": "squashfs-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sssd_latest_rpm": {
+        "Name": "sssd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "strace_latest_rpm": {
+        "Name": "strace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sudo_latest_rpm": {
+        "Name": "sudo",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd-udev_latest_rpm": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd_latest_rpm": {
+        "Name": "systemd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar_latest_rpm": {
+        "Name": "tar",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tcpdump_latest_rpm": {
+        "Name": "tcpdump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "traceroute_latest_rpm": {
+        "Name": "traceroute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ucx_1.19.0_tarball": {
         "Name": "ucx",
         "SupportedOS": [
           {
@@ -2390,482 +3863,7 @@
           }
         ]
       },
-      "os_package_id_11": {
-        "Name": "openldap-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_12": {
-        "Name": "nss-pam-ldapd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_13": {
-        "Name": "sssd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_14": {
-        "Name": "oddjob-mkhomedir",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_15": {
-        "Name": "authselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_16": {
-        "Name": "systemd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_17": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_18": {
-        "Name": "kernel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_19": {
-        "Name": "dracut",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_20": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_21": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_22": {
-        "Name": "squashfs-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_23": {
-        "Name": "nfs-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_24": {
-        "Name": "nfs4-acl-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_25": {
-        "Name": "NetworkManager",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_26": {
-        "Name": "nm-connection-editor",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_27": {
-        "Name": "iproute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_28": {
-        "Name": "iputils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_29": {
-        "Name": "curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_30": {
-        "Name": "bash",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_31": {
-        "Name": "coreutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_32": {
-        "Name": "grep",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_33": {
-        "Name": "sed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_34": {
-        "Name": "gawk",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_35": {
-        "Name": "findutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_36": {
+      "util-linux_latest_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -2884,877 +3882,7 @@
           }
         ]
       },
-      "os_package_id_37": {
-        "Name": "kbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_38": {
-        "Name": "lsof",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_39": {
-        "Name": "cryptsetup",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_40": {
-        "Name": "lvm2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_41": {
-        "Name": "device-mapper",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_42": {
-        "Name": "rsyslog",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_43": {
-        "Name": "chrony",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_44": {
-        "Name": "sudo",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_45": {
-        "Name": "gzip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_46": {
-        "Name": "wget",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_47": {
-        "Name": "cloud-init",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_48": {
-        "Name": "glibc-langpack-en",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_49": {
-        "Name": "gedit",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_50": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
-      },
-      "os_package_id_51": {
-        "Name": "which",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_52": {
-        "Name": "tcpdump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_53": {
-        "Name": "traceroute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_54": {
-        "Name": "iperf3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_55": {
-        "Name": "fping",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_56": {
-        "Name": "dmidecode",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_57": {
-        "Name": "hwloc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_58": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_59": {
-        "Name": "lshw",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_60": {
-        "Name": "pciutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_61": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_62": {
-        "Name": "emacs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_63": {
-        "Name": "zsh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_64": {
-        "Name": "openssh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_65": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_66": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_67": {
-        "Name": "rsync",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_68": {
-        "Name": "file",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_69": {
-        "Name": "libcurl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_70": {
-        "Name": "tar",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_71": {
-        "Name": "bzip2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_72": {
-        "Name": "man-db",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_73": {
-        "Name": "man-pages",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_74": {
-        "Name": "strace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_75": {
-        "Name": "kexec-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_76": {
-        "Name": "openssl-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_77": {
-        "Name": "ipmitool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_78": {
-        "Name": "gdb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_79": {
-        "Name": "gdb-gdbserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_80": {
-        "Name": "lldb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_81": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_82": {
-        "Name": "valgrind",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_83": {
+      "valgrind-devel_latest_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -3773,8 +3901,8 @@
           }
         ]
       },
-      "os_package_id_84": {
-        "Name": "ltrace",
+      "valgrind_latest_rpm": {
+        "Name": "valgrind",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -3792,8 +3920,46 @@
           }
         ]
       },
-      "os_package_id_85": {
-        "Name": "kernel-tools",
+      "vim-enhanced_latest_rpm_1": {
+        "Name": "vim-enhanced",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "wget_latest_rpm": {
+        "Name": "wget",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "which_latest_rpm": {
+        "Name": "which",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -3811,255 +3977,8 @@
           }
         ]
       },
-      "os_package_id_86": {
-        "Name": "perf",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_87": {
-        "Name": "papi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_88": {
-        "Name": "papi-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_89": {
-        "Name": "papi-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_90": {
-        "Name": "cmake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_91": {
-        "Name": "autoconf",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_92": {
-        "Name": "automake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_93": {
-        "Name": "libtool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_94": {
-        "Name": "gcc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_95": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_96": {
-        "Name": "binutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_97": {
-        "Name": "binutils-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_98": {
-        "Name": "clustershell",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_99": {
-        "Name": "bash-completion",
+      "zsh_latest_rpm": {
+        "Name": "zsh",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -4080,7 +3999,7 @@
     },
     "Miscellaneous": [],
     "InfrastructurePackages": {
-      "infrastructure_package_id_1": {
+      "csi-powerscale-v2-16-0_v2.16.0_git": {
         "Name": "csi-powerscale-v2.16.0",
         "Type": "git",
         "Version": "v2.16.0",
@@ -4099,7 +4018,21 @@
           }
         ]
       },
-      "infrastructure_package_id_2": {
+      "docker-io-dellemc-csm-encryption_v0.6.0_image": {
+        "Name": "docker.io/dellemc/csm-encryption",
+        "Type": "image",
+        "Version": "v0.6.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v0.6.0"
+      },
+      "external-snapshotter-v8-4-0_v8.4.0_git": {
         "Name": "external-snapshotter-v8.4.0",
         "Type": "git",
         "Version": "v8.4.0",
@@ -4118,7 +4051,7 @@
           }
         ]
       },
-      "infrastructure_package_id_3": {
+      "helm-charts-2-16-0_csi-isilon-2.16.0_git": {
         "Name": "helm-charts-2.16.0",
         "Type": "git",
         "Version": "csi-isilon-2.16.0",
@@ -4137,7 +4070,7 @@
           }
         ]
       },
-      "infrastructure_package_id_4": {
+      "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image": {
         "Name": "quay.io/dell/container-storage-modules/csi-isilon",
         "Type": "image",
         "Version": "v2.16.0",
@@ -4151,133 +4084,7 @@
         ],
         "Tag": "v2.16.0"
       },
-      "infrastructure_package_id_5": {
-        "Name": "registry.k8s.io/sig-storage/csi-attacher",
-        "Type": "image",
-        "Version": "v4.10.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v4.10.0"
-      },
-      "infrastructure_package_id_6": {
-        "Name": "registry.k8s.io/sig-storage/csi-provisioner",
-        "Type": "image",
-        "Version": "v6.1.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v6.1.0"
-      },
-      "infrastructure_package_id_7": {
-        "Name": "registry.k8s.io/sig-storage/csi-snapshotter",
-        "Type": "image",
-        "Version": "v8.4.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v8.4.0"
-      },
-      "infrastructure_package_id_8": {
-        "Name": "registry.k8s.io/sig-storage/csi-resizer",
-        "Type": "image",
-        "Version": "v2.0.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v2.0.0"
-      },
-      "infrastructure_package_id_9": {
-        "Name": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
-        "Type": "image",
-        "Version": "v2.15.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v2.15.0"
-      },
-      "infrastructure_package_id_10": {
-        "Name": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
-        "Type": "image",
-        "Version": "v0.16.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v0.16.0"
-      },
-      "infrastructure_package_id_11": {
-        "Name": "quay.io/dell/container-storage-modules/dell-csi-replicator",
-        "Type": "image",
-        "Version": "v1.14.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v1.14.0"
-      },
-      "infrastructure_package_id_12": {
-        "Name": "quay.io/dell/container-storage-modules/podmon",
-        "Type": "image",
-        "Version": "v1.15.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v1.15.0"
-      },
-      "infrastructure_package_id_13": {
-        "Name": "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
-        "Type": "image",
-        "Version": "v2.4.0",
-        "SupportedFunctions": [
-          {
-            "Name": "csi"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Tag": "v2.4.0"
-      },
-      "infrastructure_package_id_14": {
+      "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image": {
         "Name": "quay.io/dell/container-storage-modules/csi-metadata-retriever",
         "Type": "image",
         "Version": "v1.13.0",
@@ -4291,8 +4098,120 @@
         ],
         "Tag": "v1.13.0"
       },
-      "infrastructure_package_id_15": {
-        "Name": "registry.k8s.io/sig-storage/snapshot-controller",
+      "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
+        "Type": "image",
+        "Version": "v2.4.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v2.4.0"
+      },
+      "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/dell-csi-replicator",
+        "Type": "image",
+        "Version": "v1.14.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v1.14.0"
+      },
+      "quay-io-dell-container-storage-modules-podmon_v1.15.0_image": {
+        "Name": "quay.io/dell/container-storage-modules/podmon",
+        "Type": "image",
+        "Version": "v1.15.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v1.15.0"
+      },
+      "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-attacher",
+        "Type": "image",
+        "Version": "v4.10.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v4.10.0"
+      },
+      "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
+        "Type": "image",
+        "Version": "v0.16.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v0.16.0"
+      },
+      "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+        "Type": "image",
+        "Version": "v2.15.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v2.15.0"
+      },
+      "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-provisioner",
+        "Type": "image",
+        "Version": "v6.1.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v6.1.0"
+      },
+      "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-resizer",
+        "Type": "image",
+        "Version": "v2.0.0",
+        "SupportedFunctions": [
+          {
+            "Name": "csi"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Tag": "v2.0.0"
+      },
+      "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image": {
+        "Name": "registry.k8s.io/sig-storage/csi-snapshotter",
         "Type": "image",
         "Version": "v8.4.0",
         "SupportedFunctions": [
@@ -4305,10 +4224,10 @@
         ],
         "Tag": "v8.4.0"
       },
-      "infrastructure_package_id_16": {
-        "Name": "docker.io/dellemc/csm-encryption",
+      "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image": {
+        "Name": "registry.k8s.io/sig-storage/snapshot-controller",
         "Type": "image",
-        "Version": "v0.6.0",
+        "Version": "v8.4.0",
         "SupportedFunctions": [
           {
             "Name": "csi"
@@ -4317,7 +4236,7 @@
         "Architecture": [
           "x86_64"
         ],
-        "Tag": "v0.6.0"
+        "Tag": "v8.4.0"
       }
     }
   }

--- a/examples/catalog/catalog_rhel_x86_64.json
+++ b/examples/catalog/catalog_rhel_x86_64.json
@@ -7,75 +7,75 @@
       {
         "Name": "login_compiler_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "os_x86_64",
         "FunctionalPackages": [
-          "openssl-libs_latest_rpm",
-          "ovis-ldms_latest_rpm",
-          "python3-cython_latest_rpm",
-          "python3-devel_latest_rpm"
+          "openssl-libs_na_rpm",
+          "ovis-ldms_na_rpm",
+          "python3-cython_na_rpm",
+          "python3-devel_na_rpm"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
           "PyMySQL_1.1.2_pip_module",
-          "apptainer_latest_rpm",
-          "calico-v3-31-4_latest_manifest",
-          "cert-manager-v1-10-0_latest_tarball",
+          "apptainer_na_rpm",
+          "calico-v3-31-4_na_manifest",
+          "cert-manager-v1-10-0_na_tarball",
           "cffi_1.17.1_pip_module",
-          "container-selinux_latest_rpm",
+          "container-selinux_na_rpm",
           "cri-o_1.35.1_rpm",
           "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
           "docker-io-alpine-kubectl_1.35.1_image",
           "docker-io-calico-cni_v3.31.4_image",
           "docker-io-calico-kube-controllers_v3.31.4_image",
@@ -100,27 +100,27 @@
           "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_latest_rpm",
-          "fuse-overlayfs_latest_rpm",
+          "firewalld_na_rpm",
+          "fuse-overlayfs_na_rpm",
           "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
           "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_latest_rpm",
+          "git_na_rpm",
           "helm-charts_container-storage-modules-1.9.2_git",
-          "helm-v3-20-1-amd64_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
+          "helm-v3-20-1-amd64_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
           "karavi-observability_v1.12.0_git",
           "kubeadm_1.35.1_rpm",
           "kubectl_1.35.1_rpm",
           "kubelet_1.35.1_rpm",
           "kubernetes_33.1.0_pip_module",
-          "lsscsi_latest_rpm",
-          "metallb-native-v0-15-3_latest_manifest",
-          "nfs-subdir-external-provisioner-4-0-18_latest_tarball",
+          "lsscsi_na_rpm",
+          "metallb-native-v0-15-3_na_manifest",
+          "nfs-subdir-external-provisioner-4-0-18_na_tarball",
           "omsdk_1.2.518_pip_module",
-          "podman_latest_rpm",
+          "podman_na_rpm",
           "prettytable_3.14.0_pip_module",
           "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_latest_rpm",
+          "python3-firewall_na_rpm",
           "python3_3.12.9_rpm",
           "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
           "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
@@ -138,23 +138,23 @@
           "registry-k8s-io-kube-proxy_v1.35.1_image",
           "registry-k8s-io-kube-scheduler_v1.35.1_image",
           "registry-k8s-io-pause_3.10.1_image",
-          "sg3_utils_latest_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
-          "victoria-metrics-operator-0-59-3_latest_tarball",
-          "vim-enhanced_latest_rpm"
+          "sg3_utils_na_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
+          "victoria-metrics-operator-0-59-3_na_tarball",
+          "vim-enhanced_na_rpm"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "cert-manager-v1-10-0_latest_tarball",
+          "apptainer_na_rpm",
+          "cert-manager-v1-10-0_na_tarball",
           "cffi_1.17.1_pip_module",
-          "container-selinux_latest_rpm",
+          "container-selinux_na_rpm",
           "cri-o_1.35.1_rpm",
           "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
           "docker-io-alpine-kubectl_1.35.1_image",
           "docker-io-curlimages-curl_8.17.0_image",
           "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
@@ -176,21 +176,21 @@
           "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
           "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_latest_rpm",
-          "fuse-overlayfs_latest_rpm",
+          "firewalld_na_rpm",
+          "fuse-overlayfs_na_rpm",
           "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_latest_rpm",
+          "git_na_rpm",
           "helm-charts_container-storage-modules-1.9.2_git",
-          "iscsi-initiator-utils_latest_rpm",
+          "iscsi-initiator-utils_na_rpm",
           "karavi-observability_v1.12.0_git",
           "kubeadm_1.35.1_rpm",
           "kubelet_1.35.1_rpm",
           "kubernetes_33.1.0_pip_module",
-          "lsscsi_latest_rpm",
+          "lsscsi_na_rpm",
           "omsdk_1.2.518_pip_module",
-          "podman_latest_rpm",
+          "podman_na_rpm",
           "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_latest_rpm",
+          "python3-firewall_na_rpm",
           "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
           "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
           "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
@@ -202,65 +202,65 @@
           "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
           "quay-io-strimzi-operator_0.48.0_image",
           "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
-          "sg3_utils_latest_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball",
-          "victoria-metrics-operator-0-59-3_latest_tarball",
-          "vim-enhanced_latest_rpm"
+          "sg3_utils_na_rpm",
+          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
+          "victoria-metrics-operator-0-59-3_na_tarball",
+          "vim-enhanced_na_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "mariadb-server_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "mariadb-server_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-PyMySQL_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmctld_latest_rpm",
-          "slurm-slurmdbd_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-PyMySQL_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmctld_na_rpm",
+          "slurm-slurmdbd_na_rpm"
         ]
       },
       {
         "Name": "slurm_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "kernel-devel_latest_rpm",
-          "kernel-headers_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "kernel-devel_na_rpm",
+          "kernel-headers_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-pam_slurm_latest_rpm",
-          "slurm-slurmd_latest_rpm"
+          "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball",
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-pam_slurm_na_rpm",
+          "slurm-slurmd_na_rpm"
         ]
       }
     ],
@@ -269,105 +269,105 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_latest_rpm",
-          "authselect_latest_rpm",
-          "autoconf_latest_rpm",
-          "automake_latest_rpm",
-          "bash-completion_latest_rpm",
-          "bash_latest_rpm",
-          "binutils-devel_latest_rpm",
-          "binutils_latest_rpm",
-          "bzip2_latest_rpm",
-          "chrony_latest_rpm",
-          "cloud-init_latest_rpm",
-          "clustershell_latest_rpm",
-          "cmake_latest_rpm",
-          "coreutils_latest_rpm",
-          "cryptsetup_latest_rpm",
-          "curl_latest_rpm",
-          "device-mapper_latest_rpm",
-          "dmidecode_latest_rpm",
+          "NetworkManager_na_rpm",
+          "authselect_na_rpm",
+          "autoconf_na_rpm",
+          "automake_na_rpm",
+          "bash-completion_na_rpm",
+          "bash_na_rpm",
+          "binutils-devel_na_rpm",
+          "binutils_na_rpm",
+          "bzip2_na_rpm",
+          "chrony_na_rpm",
+          "cloud-init_na_rpm",
+          "clustershell_na_rpm",
+          "cmake_na_rpm",
+          "coreutils_na_rpm",
+          "cryptsetup_na_rpm",
+          "curl_na_rpm",
+          "device-mapper_na_rpm",
+          "dmidecode_na_rpm",
           "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_latest_rpm",
-          "dracut-network_latest_rpm",
-          "dracut_latest_rpm",
-          "emacs_latest_rpm",
-          "file_latest_rpm",
-          "findutils_latest_rpm",
-          "fping_latest_rpm",
-          "gawk_latest_rpm",
-          "gcc-c++_latest_rpm",
-          "gcc-gfortran_latest_rpm",
-          "gcc_latest_rpm",
-          "gdb-gdbserver_latest_rpm",
-          "gdb_latest_rpm",
-          "gedit_latest_rpm",
-          "glibc-langpack-en_latest_rpm",
-          "grep_latest_rpm",
-          "gzip_latest_rpm",
-          "hwloc-libs_latest_rpm",
-          "hwloc_latest_rpm",
-          "iperf3_latest_rpm",
-          "ipmitool_latest_rpm",
-          "iproute_latest_rpm",
-          "iputils_latest_rpm",
-          "kbd_latest_rpm",
-          "kernel-tools_latest_rpm",
-          "kernel_latest_rpm",
-          "kexec-tools_latest_rpm",
-          "libcurl_latest_rpm",
-          "libtool_latest_rpm",
-          "lldb-devel_latest_rpm",
-          "lldb_latest_rpm",
-          "lshw_latest_rpm",
-          "lsof_latest_rpm",
-          "ltrace_latest_rpm",
-          "lvm2_latest_rpm",
-          "make_latest_rpm",
-          "man-db_latest_rpm",
-          "man-pages_latest_rpm",
-          "munge-devel_latest_rpm",
-          "nfs-utils_latest_rpm",
-          "nfs4-acl-tools_latest_rpm",
-          "nm-connection-editor_latest_rpm",
-          "nss-pam-ldapd_latest_rpm",
-          "oddjob-mkhomedir_latest_rpm",
-          "openldap-clients_latest_rpm",
+          "dracut-live_na_rpm",
+          "dracut-network_na_rpm",
+          "dracut_na_rpm",
+          "emacs_na_rpm",
+          "file_na_rpm",
+          "findutils_na_rpm",
+          "fping_na_rpm",
+          "gawk_na_rpm",
+          "gcc-c++_na_rpm",
+          "gcc-gfortran_na_rpm",
+          "gcc_na_rpm",
+          "gdb-gdbserver_na_rpm",
+          "gdb_na_rpm",
+          "gedit_na_rpm",
+          "glibc-langpack-en_na_rpm",
+          "grep_na_rpm",
+          "gzip_na_rpm",
+          "hwloc-libs_na_rpm",
+          "hwloc_na_rpm",
+          "iperf3_na_rpm",
+          "ipmitool_na_rpm",
+          "iproute_na_rpm",
+          "iputils_na_rpm",
+          "kbd_na_rpm",
+          "kernel-tools_na_rpm",
+          "kernel_na_rpm",
+          "kexec-tools_na_rpm",
+          "libcurl_na_rpm",
+          "libtool_na_rpm",
+          "lldb-devel_na_rpm",
+          "lldb_na_rpm",
+          "lshw_na_rpm",
+          "lsof_na_rpm",
+          "ltrace_na_rpm",
+          "lvm2_na_rpm",
+          "make_na_rpm",
+          "man-db_na_rpm",
+          "man-pages_na_rpm",
+          "munge-devel_na_rpm",
+          "nfs-utils_na_rpm",
+          "nfs4-acl-tools_na_rpm",
+          "nm-connection-editor_na_rpm",
+          "nss-pam-ldapd_na_rpm",
+          "oddjob-mkhomedir_na_rpm",
+          "openldap-clients_na_rpm",
           "openmpi_5.0.8_tarball",
-          "openssh-clients_latest_rpm",
-          "openssh-server_latest_rpm",
-          "openssh_latest_rpm",
-          "openssl-devel_latest_rpm",
-          "openssl-libs_latest_rpm_1",
-          "ovis-ldms_latest_rpm_1",
-          "papi-devel_latest_rpm",
-          "papi-libs_latest_rpm",
-          "papi_latest_rpm",
-          "pciutils_latest_rpm",
-          "perf_latest_rpm",
-          "pmix-devel_latest_rpm",
-          "python3-cython_latest_rpm_1",
-          "python3-devel_latest_rpm_1",
-          "rsync_latest_rpm",
-          "rsyslog_latest_rpm",
-          "sed_latest_rpm",
-          "squashfs-tools_latest_rpm",
-          "sssd_latest_rpm",
-          "strace_latest_rpm",
-          "sudo_latest_rpm",
-          "systemd-udev_latest_rpm",
-          "systemd_latest_rpm",
-          "tar_latest_rpm",
-          "tcpdump_latest_rpm",
-          "traceroute_latest_rpm",
+          "openssh-clients_na_rpm",
+          "openssh-server_na_rpm",
+          "openssh_na_rpm",
+          "openssl-devel_na_rpm",
+          "openssl-libs_na_rpm_1",
+          "ovis-ldms_na_rpm_1",
+          "papi-devel_na_rpm",
+          "papi-libs_na_rpm",
+          "papi_na_rpm",
+          "pciutils_na_rpm",
+          "perf_na_rpm",
+          "pmix-devel_na_rpm",
+          "python3-cython_na_rpm_1",
+          "python3-devel_na_rpm_1",
+          "rsync_na_rpm",
+          "rsyslog_na_rpm",
+          "sed_na_rpm",
+          "squashfs-tools_na_rpm",
+          "sssd_na_rpm",
+          "strace_na_rpm",
+          "sudo_na_rpm",
+          "systemd-udev_na_rpm",
+          "systemd_na_rpm",
+          "tar_na_rpm",
+          "tcpdump_na_rpm",
+          "traceroute_na_rpm",
           "ucx_1.19.0_tarball",
-          "util-linux_latest_rpm",
-          "valgrind-devel_latest_rpm",
-          "valgrind_latest_rpm",
-          "vim-enhanced_latest_rpm_1",
-          "wget_latest_rpm",
-          "which_latest_rpm",
-          "zsh_latest_rpm"
+          "util-linux_na_rpm",
+          "valgrind-devel_na_rpm",
+          "valgrind_na_rpm",
+          "vim-enhanced_na_rpm_1",
+          "wget_na_rpm",
+          "which_na_rpm",
+          "zsh_na_rpm"
         ]
       }
     ],
@@ -410,7 +410,7 @@
         ],
         "Type": "pip_module"
       },
-      "apptainer_latest_rpm": {
+      "apptainer_na_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -429,7 +429,7 @@
           }
         ]
       },
-      "calico-v3-31-4_latest_manifest": {
+      "calico-v3-31-4_na_manifest": {
         "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
@@ -448,7 +448,7 @@
           }
         ]
       },
-      "cert-manager-v1-10-0_latest_tarball": {
+      "cert-manager-v1-10-0_na_tarball": {
         "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
@@ -480,7 +480,7 @@
         ],
         "Type": "pip_module"
       },
-      "container-selinux_latest_rpm": {
+      "container-selinux_na_rpm": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -531,7 +531,7 @@
         ],
         "Type": "pip_module"
       },
-      "device-mapper-multipath_latest_rpm": {
+      "device-mapper-multipath_na_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -550,7 +550,7 @@
           }
         ]
       },
-      "doca-ofed_latest_rpm_repo": {
+      "doca-ofed_na_rpm_repo": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -929,7 +929,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "firewalld_latest_rpm": {
+      "firewalld_na_rpm": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -948,7 +948,7 @@
           }
         ]
       },
-      "fuse-overlayfs_latest_rpm": {
+      "fuse-overlayfs_na_rpm": {
         "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
@@ -967,7 +967,7 @@
           }
         ]
       },
-      "geopm_latest_tarball": {
+      "geopm_na_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -1016,7 +1016,7 @@
         "Tag": "0.143.1",
         "Version": "0.143.1"
       },
-      "git_latest_rpm": {
+      "git_na_rpm": {
         "Name": "git",
         "SupportedOS": [
           {
@@ -1055,7 +1055,7 @@
           }
         ]
       },
-      "helm-v3-20-1-amd64_latest_tarball": {
+      "helm-v3-20-1-amd64_na_tarball": {
         "Name": "helm-v3.20.1-amd64",
         "SupportedOS": [
           {
@@ -1074,7 +1074,7 @@
           }
         ]
       },
-      "imb_latest_tarball": {
+      "imb_na_tarball": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -1093,7 +1093,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_latest_rpm": {
+      "iscsi-initiator-utils_na_rpm": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -1132,7 +1132,7 @@
           }
         ]
       },
-      "kernel-devel_latest_rpm": {
+      "kernel-devel_na_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1151,7 +1151,7 @@
           }
         ]
       },
-      "kernel-headers_latest_rpm": {
+      "kernel-headers_na_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1240,7 +1240,7 @@
         ],
         "Type": "pip_module"
       },
-      "likwid_latest_tarball": {
+      "likwid_na_tarball": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -1259,7 +1259,7 @@
           }
         ]
       },
-      "lsscsi_latest_rpm": {
+      "lsscsi_na_rpm": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -1278,7 +1278,7 @@
           }
         ]
       },
-      "mariadb-server_latest_rpm": {
+      "mariadb-server_na_rpm": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -1297,7 +1297,7 @@
           }
         ]
       },
-      "metallb-native-v0-15-3_latest_manifest": {
+      "metallb-native-v0-15-3_na_manifest": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -1316,7 +1316,7 @@
           }
         ]
       },
-      "msr-safe_latest_tarball": {
+      "msr-safe_na_tarball": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -1335,7 +1335,7 @@
           }
         ]
       },
-      "munge_latest_rpm": {
+      "munge_na_rpm": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -1354,7 +1354,7 @@
           }
         ]
       },
-      "nfs-subdir-external-provisioner-4-0-18_latest_tarball": {
+      "nfs-subdir-external-provisioner-4-0-18_na_tarball": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -1388,7 +1388,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -1420,7 +1420,7 @@
         ],
         "Type": "pip_module"
       },
-      "openssl-libs_latest_rpm": {
+      "openssl-libs_na_rpm": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -1439,7 +1439,7 @@
           }
         ]
       },
-      "osu-micro-benchmarks_latest_tarball": {
+      "osu-micro-benchmarks_na_tarball": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -1458,7 +1458,7 @@
           }
         ]
       },
-      "ovis-ldms_latest_rpm": {
+      "ovis-ldms_na_rpm": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -1477,7 +1477,7 @@
           }
         ]
       },
-      "papi_latest_tarball": {
+      "papi_na_tarball": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -1496,7 +1496,7 @@
           }
         ]
       },
-      "pmix_latest_rpm": {
+      "pmix_na_rpm": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -1515,7 +1515,7 @@
           }
         ]
       },
-      "podman_latest_rpm": {
+      "podman_na_rpm": {
         "Name": "podman",
         "SupportedOS": [
           {
@@ -1560,7 +1560,7 @@
         ],
         "Type": "pip_module"
       },
-      "python3-PyMySQL_latest_rpm": {
+      "python3-PyMySQL_na_rpm": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -1579,7 +1579,7 @@
           }
         ]
       },
-      "python3-cython_latest_rpm": {
+      "python3-cython_na_rpm": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -1598,7 +1598,7 @@
           }
         ]
       },
-      "python3-devel_latest_rpm": {
+      "python3-devel_na_rpm": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -1617,7 +1617,7 @@
           }
         ]
       },
-      "python3-firewall_latest_rpm": {
+      "python3-firewall_na_rpm": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -1925,7 +1925,7 @@
         "Tag": "v4.0.2",
         "Version": "v4.0.2"
       },
-      "sg3_utils_latest_rpm": {
+      "sg3_utils_na_rpm": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -1944,7 +1944,7 @@
           }
         ]
       },
-      "sionlib_latest_tarball": {
+      "sionlib_na_tarball": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -1963,7 +1963,7 @@
           }
         ]
       },
-      "slurm-pam_slurm_latest_rpm": {
+      "slurm-pam_slurm_na_rpm": {
         "Name": "slurm-pam_slurm",
         "SupportedOS": [
           {
@@ -1982,7 +1982,7 @@
           }
         ]
       },
-      "slurm-slurmctld_latest_rpm": {
+      "slurm-slurmctld_na_rpm": {
         "Name": "slurm-slurmctld",
         "SupportedOS": [
           {
@@ -2001,7 +2001,7 @@
           }
         ]
       },
-      "slurm-slurmd_latest_rpm": {
+      "slurm-slurmd_na_rpm": {
         "Name": "slurm-slurmd",
         "SupportedOS": [
           {
@@ -2020,7 +2020,7 @@
           }
         ]
       },
-      "slurm-slurmdbd_latest_rpm": {
+      "slurm-slurmdbd_na_rpm": {
         "Name": "slurm-slurmdbd",
         "SupportedOS": [
           {
@@ -2039,7 +2039,7 @@
           }
         ]
       },
-      "slurm_latest_rpm": {
+      "slurm_na_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -2058,7 +2058,7 @@
           }
         ]
       },
-      "strimzi-kafka-operator-helm-3-chart-0-48-0_latest_tarball": {
+      "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball": {
         "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
         "SupportedOS": [
           {
@@ -2077,7 +2077,7 @@
           }
         ]
       },
-      "victoria-metrics-operator-0-59-3_latest_tarball": {
+      "victoria-metrics-operator-0-59-3_na_tarball": {
         "Name": "victoria-metrics-operator-0.59.3",
         "SupportedOS": [
           {
@@ -2096,7 +2096,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm": {
+      "vim-enhanced_na_rpm": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2117,7 +2117,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_latest_rpm": {
+      "NetworkManager_na_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -2136,7 +2136,7 @@
           }
         ]
       },
-      "authselect_latest_rpm": {
+      "authselect_na_rpm": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -2155,7 +2155,7 @@
           }
         ]
       },
-      "autoconf_latest_rpm": {
+      "autoconf_na_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2174,7 +2174,7 @@
           }
         ]
       },
-      "automake_latest_rpm": {
+      "automake_na_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2193,7 +2193,7 @@
           }
         ]
       },
-      "bash-completion_latest_rpm": {
+      "bash-completion_na_rpm": {
         "Name": "bash-completion",
         "SupportedOS": [
           {
@@ -2212,7 +2212,7 @@
           }
         ]
       },
-      "bash_latest_rpm": {
+      "bash_na_rpm": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -2231,7 +2231,7 @@
           }
         ]
       },
-      "binutils-devel_latest_rpm": {
+      "binutils-devel_na_rpm": {
         "Name": "binutils-devel",
         "SupportedOS": [
           {
@@ -2250,7 +2250,7 @@
           }
         ]
       },
-      "binutils_latest_rpm": {
+      "binutils_na_rpm": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -2269,7 +2269,7 @@
           }
         ]
       },
-      "bzip2_latest_rpm": {
+      "bzip2_na_rpm": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -2288,7 +2288,7 @@
           }
         ]
       },
-      "chrony_latest_rpm": {
+      "chrony_na_rpm": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -2307,7 +2307,7 @@
           }
         ]
       },
-      "cloud-init_latest_rpm": {
+      "cloud-init_na_rpm": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -2326,7 +2326,7 @@
           }
         ]
       },
-      "clustershell_latest_rpm": {
+      "clustershell_na_rpm": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2345,7 +2345,7 @@
           }
         ]
       },
-      "cmake_latest_rpm": {
+      "cmake_na_rpm": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -2364,7 +2364,7 @@
           }
         ]
       },
-      "coreutils_latest_rpm": {
+      "coreutils_na_rpm": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -2383,7 +2383,7 @@
           }
         ]
       },
-      "cryptsetup_latest_rpm": {
+      "cryptsetup_na_rpm": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -2402,7 +2402,7 @@
           }
         ]
       },
-      "curl_latest_rpm": {
+      "curl_na_rpm": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -2421,7 +2421,7 @@
           }
         ]
       },
-      "device-mapper_latest_rpm": {
+      "device-mapper_na_rpm": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -2440,7 +2440,7 @@
           }
         ]
       },
-      "dmidecode_latest_rpm": {
+      "dmidecode_na_rpm": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -2474,7 +2474,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_latest_rpm": {
+      "dracut-live_na_rpm": {
         "Name": "dracut-live",
         "SupportedOS": [
           {
@@ -2493,7 +2493,7 @@
           }
         ]
       },
-      "dracut-network_latest_rpm": {
+      "dracut-network_na_rpm": {
         "Name": "dracut-network",
         "SupportedOS": [
           {
@@ -2512,7 +2512,7 @@
           }
         ]
       },
-      "dracut_latest_rpm": {
+      "dracut_na_rpm": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -2531,7 +2531,7 @@
           }
         ]
       },
-      "emacs_latest_rpm": {
+      "emacs_na_rpm": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -2550,7 +2550,7 @@
           }
         ]
       },
-      "file_latest_rpm": {
+      "file_na_rpm": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -2569,7 +2569,7 @@
           }
         ]
       },
-      "findutils_latest_rpm": {
+      "findutils_na_rpm": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -2588,7 +2588,7 @@
           }
         ]
       },
-      "fping_latest_rpm": {
+      "fping_na_rpm": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -2607,7 +2607,7 @@
           }
         ]
       },
-      "gawk_latest_rpm": {
+      "gawk_na_rpm": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -2626,7 +2626,7 @@
           }
         ]
       },
-      "gcc-c++_latest_rpm": {
+      "gcc-c++_na_rpm": {
         "Name": "gcc-c++",
         "SupportedOS": [
           {
@@ -2645,7 +2645,7 @@
           }
         ]
       },
-      "gcc-gfortran_latest_rpm": {
+      "gcc-gfortran_na_rpm": {
         "Name": "gcc-gfortran",
         "SupportedOS": [
           {
@@ -2664,7 +2664,7 @@
           }
         ]
       },
-      "gcc_latest_rpm": {
+      "gcc_na_rpm": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -2683,7 +2683,7 @@
           }
         ]
       },
-      "gdb-gdbserver_latest_rpm": {
+      "gdb-gdbserver_na_rpm": {
         "Name": "gdb-gdbserver",
         "SupportedOS": [
           {
@@ -2702,7 +2702,7 @@
           }
         ]
       },
-      "gdb_latest_rpm": {
+      "gdb_na_rpm": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -2721,7 +2721,7 @@
           }
         ]
       },
-      "gedit_latest_rpm": {
+      "gedit_na_rpm": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -2740,7 +2740,7 @@
           }
         ]
       },
-      "glibc-langpack-en_latest_rpm": {
+      "glibc-langpack-en_na_rpm": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -2759,7 +2759,7 @@
           }
         ]
       },
-      "grep_latest_rpm": {
+      "grep_na_rpm": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -2778,7 +2778,7 @@
           }
         ]
       },
-      "gzip_latest_rpm": {
+      "gzip_na_rpm": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -2797,7 +2797,7 @@
           }
         ]
       },
-      "hwloc-libs_latest_rpm": {
+      "hwloc-libs_na_rpm": {
         "Name": "hwloc-libs",
         "SupportedOS": [
           {
@@ -2816,7 +2816,7 @@
           }
         ]
       },
-      "hwloc_latest_rpm": {
+      "hwloc_na_rpm": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -2835,7 +2835,7 @@
           }
         ]
       },
-      "iperf3_latest_rpm": {
+      "iperf3_na_rpm": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -2854,7 +2854,7 @@
           }
         ]
       },
-      "ipmitool_latest_rpm": {
+      "ipmitool_na_rpm": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -2873,7 +2873,7 @@
           }
         ]
       },
-      "iproute_latest_rpm": {
+      "iproute_na_rpm": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -2892,7 +2892,7 @@
           }
         ]
       },
-      "iputils_latest_rpm": {
+      "iputils_na_rpm": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -2911,7 +2911,7 @@
           }
         ]
       },
-      "kbd_latest_rpm": {
+      "kbd_na_rpm": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -2930,7 +2930,7 @@
           }
         ]
       },
-      "kernel-tools_latest_rpm": {
+      "kernel-tools_na_rpm": {
         "Name": "kernel-tools",
         "SupportedOS": [
           {
@@ -2949,7 +2949,7 @@
           }
         ]
       },
-      "kernel_latest_rpm": {
+      "kernel_na_rpm": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -2968,7 +2968,7 @@
           }
         ]
       },
-      "kexec-tools_latest_rpm": {
+      "kexec-tools_na_rpm": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -2987,7 +2987,7 @@
           }
         ]
       },
-      "libcurl_latest_rpm": {
+      "libcurl_na_rpm": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -3006,7 +3006,7 @@
           }
         ]
       },
-      "libtool_latest_rpm": {
+      "libtool_na_rpm": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -3025,7 +3025,7 @@
           }
         ]
       },
-      "lldb-devel_latest_rpm": {
+      "lldb-devel_na_rpm": {
         "Name": "lldb-devel",
         "SupportedOS": [
           {
@@ -3044,7 +3044,7 @@
           }
         ]
       },
-      "lldb_latest_rpm": {
+      "lldb_na_rpm": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -3063,7 +3063,7 @@
           }
         ]
       },
-      "lshw_latest_rpm": {
+      "lshw_na_rpm": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -3082,7 +3082,7 @@
           }
         ]
       },
-      "lsof_latest_rpm": {
+      "lsof_na_rpm": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -3101,7 +3101,7 @@
           }
         ]
       },
-      "ltrace_latest_rpm": {
+      "ltrace_na_rpm": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -3120,7 +3120,7 @@
           }
         ]
       },
-      "lvm2_latest_rpm": {
+      "lvm2_na_rpm": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -3139,7 +3139,7 @@
           }
         ]
       },
-      "make_latest_rpm": {
+      "make_na_rpm": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -3158,7 +3158,7 @@
           }
         ]
       },
-      "man-db_latest_rpm": {
+      "man-db_na_rpm": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -3177,7 +3177,7 @@
           }
         ]
       },
-      "man-pages_latest_rpm": {
+      "man-pages_na_rpm": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -3196,7 +3196,7 @@
           }
         ]
       },
-      "munge-devel_latest_rpm": {
+      "munge-devel_na_rpm": {
         "Name": "munge-devel",
         "SupportedOS": [
           {
@@ -3215,7 +3215,7 @@
           }
         ]
       },
-      "nfs-utils_latest_rpm": {
+      "nfs-utils_na_rpm": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -3234,7 +3234,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_latest_rpm": {
+      "nfs4-acl-tools_na_rpm": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -3253,7 +3253,7 @@
           }
         ]
       },
-      "nm-connection-editor_latest_rpm": {
+      "nm-connection-editor_na_rpm": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -3272,7 +3272,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_latest_rpm": {
+      "nss-pam-ldapd_na_rpm": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -3291,7 +3291,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_latest_rpm": {
+      "oddjob-mkhomedir_na_rpm": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -3310,7 +3310,7 @@
           }
         ]
       },
-      "openldap-clients_latest_rpm": {
+      "openldap-clients_na_rpm": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -3349,7 +3349,7 @@
           }
         ]
       },
-      "openssh-clients_latest_rpm": {
+      "openssh-clients_na_rpm": {
         "Name": "openssh-clients",
         "SupportedOS": [
           {
@@ -3368,7 +3368,7 @@
           }
         ]
       },
-      "openssh-server_latest_rpm": {
+      "openssh-server_na_rpm": {
         "Name": "openssh-server",
         "SupportedOS": [
           {
@@ -3387,7 +3387,7 @@
           }
         ]
       },
-      "openssh_latest_rpm": {
+      "openssh_na_rpm": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -3406,7 +3406,7 @@
           }
         ]
       },
-      "openssl-devel_latest_rpm": {
+      "openssl-devel_na_rpm": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -3425,7 +3425,7 @@
           }
         ]
       },
-      "openssl-libs_latest_rpm_1": {
+      "openssl-libs_na_rpm_1": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -3444,7 +3444,7 @@
           }
         ]
       },
-      "ovis-ldms_latest_rpm_1": {
+      "ovis-ldms_na_rpm_1": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -3463,7 +3463,7 @@
           }
         ]
       },
-      "papi-devel_latest_rpm": {
+      "papi-devel_na_rpm": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -3482,7 +3482,7 @@
           }
         ]
       },
-      "papi-libs_latest_rpm": {
+      "papi-libs_na_rpm": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -3501,7 +3501,7 @@
           }
         ]
       },
-      "papi_latest_rpm": {
+      "papi_na_rpm": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -3520,7 +3520,7 @@
           }
         ]
       },
-      "pciutils_latest_rpm": {
+      "pciutils_na_rpm": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -3539,7 +3539,7 @@
           }
         ]
       },
-      "perf_latest_rpm": {
+      "perf_na_rpm": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -3558,7 +3558,7 @@
           }
         ]
       },
-      "pmix-devel_latest_rpm": {
+      "pmix-devel_na_rpm": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -3577,7 +3577,7 @@
           }
         ]
       },
-      "python3-cython_latest_rpm_1": {
+      "python3-cython_na_rpm_1": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -3596,7 +3596,7 @@
           }
         ]
       },
-      "python3-devel_latest_rpm_1": {
+      "python3-devel_na_rpm_1": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -3615,7 +3615,7 @@
           }
         ]
       },
-      "rsync_latest_rpm": {
+      "rsync_na_rpm": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -3634,7 +3634,7 @@
           }
         ]
       },
-      "rsyslog_latest_rpm": {
+      "rsyslog_na_rpm": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -3653,7 +3653,7 @@
           }
         ]
       },
-      "sed_latest_rpm": {
+      "sed_na_rpm": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -3672,7 +3672,7 @@
           }
         ]
       },
-      "squashfs-tools_latest_rpm": {
+      "squashfs-tools_na_rpm": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -3691,7 +3691,7 @@
           }
         ]
       },
-      "sssd_latest_rpm": {
+      "sssd_na_rpm": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -3710,7 +3710,7 @@
           }
         ]
       },
-      "strace_latest_rpm": {
+      "strace_na_rpm": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -3729,7 +3729,7 @@
           }
         ]
       },
-      "sudo_latest_rpm": {
+      "sudo_na_rpm": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -3748,7 +3748,7 @@
           }
         ]
       },
-      "systemd-udev_latest_rpm": {
+      "systemd-udev_na_rpm": {
         "Name": "systemd-udev",
         "SupportedOS": [
           {
@@ -3767,7 +3767,7 @@
           }
         ]
       },
-      "systemd_latest_rpm": {
+      "systemd_na_rpm": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -3786,7 +3786,7 @@
           }
         ]
       },
-      "tar_latest_rpm": {
+      "tar_na_rpm": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -3805,7 +3805,7 @@
           }
         ]
       },
-      "tcpdump_latest_rpm": {
+      "tcpdump_na_rpm": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -3824,7 +3824,7 @@
           }
         ]
       },
-      "traceroute_latest_rpm": {
+      "traceroute_na_rpm": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -3863,7 +3863,7 @@
           }
         ]
       },
-      "util-linux_latest_rpm": {
+      "util-linux_na_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -3882,7 +3882,7 @@
           }
         ]
       },
-      "valgrind-devel_latest_rpm": {
+      "valgrind-devel_na_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -3901,7 +3901,7 @@
           }
         ]
       },
-      "valgrind_latest_rpm": {
+      "valgrind_na_rpm": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -3920,7 +3920,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm_1": {
+      "vim-enhanced_na_rpm_1": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -3939,7 +3939,7 @@
           }
         ]
       },
-      "wget_latest_rpm": {
+      "wget_na_rpm": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -3958,7 +3958,7 @@
           }
         ]
       },
-      "which_latest_rpm": {
+      "which_na_rpm": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -3977,7 +3977,7 @@
           }
         ]
       },
-      "zsh_latest_rpm": {
+      "zsh_na_rpm": {
         "Name": "zsh",
         "SupportedOS": [
           {

--- a/examples/catalog/catalog_rhel_x86_64_with_slurm_only.json
+++ b/examples/catalog/catalog_rhel_x86_64_with_slurm_only.json
@@ -7,106 +7,106 @@
       {
         "Name": "login_compiler_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_28",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_28",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmd_latest_rpm",
+          "slurm_latest_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_19",
-          "package_id_2",
-          "package_id_20",
-          "package_id_21",
-          "package_id_22",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "mariadb-server_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-PyMySQL_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-slurmctld_latest_rpm",
+          "slurm-slurmdbd_latest_rpm"
         ]
       },
       {
         "Name": "slurm_node_x86_64",
         "FunctionalPackages": [
-          "package_id_1",
-          "package_id_10",
-          "package_id_11",
-          "package_id_12",
-          "package_id_13",
-          "package_id_14",
-          "package_id_15",
-          "package_id_16",
-          "package_id_17",
-          "package_id_18",
-          "package_id_2",
-          "package_id_23",
-          "package_id_24",
-          "package_id_25",
-          "package_id_26",
-          "package_id_27",
-          "package_id_3",
-          "package_id_4",
-          "package_id_5",
-          "package_id_6",
-          "package_id_7",
-          "package_id_8",
-          "package_id_9"
+          "apptainer_latest_rpm",
+          "device-mapper-multipath_latest_rpm",
+          "doca-ofed_latest_rpm_repo",
+          "firewalld_latest_rpm",
+          "geopm_latest_tarball",
+          "imb_latest_tarball",
+          "iscsi-initiator-utils_latest_rpm",
+          "kernel-devel_latest_rpm",
+          "kernel-headers_latest_rpm",
+          "likwid_latest_tarball",
+          "lsscsi_latest_rpm",
+          "msr-safe_latest_tarball",
+          "munge_latest_rpm",
+          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
+          "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball",
+          "osu-micro-benchmarks_latest_tarball",
+          "papi_latest_tarball",
+          "pmix_latest_rpm",
+          "python3-firewall_latest_rpm",
+          "sg3_utils_latest_rpm",
+          "sionlib_latest_tarball",
+          "slurm-pam_slurm_latest_rpm",
+          "slurm-slurmd_latest_rpm"
         ]
       }
     ],
@@ -115,97 +115,97 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "os_package_id_1",
-          "os_package_id_10",
-          "os_package_id_11",
-          "os_package_id_12",
-          "os_package_id_13",
-          "os_package_id_14",
-          "os_package_id_15",
-          "os_package_id_16",
-          "os_package_id_17",
-          "os_package_id_18",
-          "os_package_id_19",
-          "os_package_id_2",
-          "os_package_id_20",
-          "os_package_id_21",
-          "os_package_id_22",
-          "os_package_id_23",
-          "os_package_id_24",
-          "os_package_id_25",
-          "os_package_id_26",
-          "os_package_id_27",
-          "os_package_id_28",
-          "os_package_id_29",
-          "os_package_id_3",
-          "os_package_id_30",
-          "os_package_id_31",
-          "os_package_id_32",
-          "os_package_id_33",
-          "os_package_id_34",
-          "os_package_id_35",
-          "os_package_id_36",
-          "os_package_id_37",
-          "os_package_id_38",
-          "os_package_id_39",
-          "os_package_id_4",
-          "os_package_id_40",
-          "os_package_id_41",
-          "os_package_id_42",
-          "os_package_id_43",
-          "os_package_id_44",
-          "os_package_id_45",
-          "os_package_id_46",
-          "os_package_id_47",
-          "os_package_id_48",
-          "os_package_id_49",
-          "os_package_id_5",
-          "os_package_id_50",
-          "os_package_id_51",
-          "os_package_id_52",
-          "os_package_id_53",
-          "os_package_id_54",
-          "os_package_id_55",
-          "os_package_id_56",
-          "os_package_id_57",
-          "os_package_id_58",
-          "os_package_id_59",
-          "os_package_id_6",
-          "os_package_id_60",
-          "os_package_id_61",
-          "os_package_id_62",
-          "os_package_id_63",
-          "os_package_id_64",
-          "os_package_id_65",
-          "os_package_id_66",
-          "os_package_id_67",
-          "os_package_id_68",
-          "os_package_id_69",
-          "os_package_id_7",
-          "os_package_id_70",
-          "os_package_id_71",
-          "os_package_id_72",
-          "os_package_id_73",
-          "os_package_id_74",
-          "os_package_id_75",
-          "os_package_id_76",
-          "os_package_id_77",
-          "os_package_id_78",
-          "os_package_id_79",
-          "os_package_id_8",
-          "os_package_id_80",
-          "os_package_id_81",
-          "os_package_id_82",
-          "os_package_id_83",
-          "os_package_id_84",
-          "os_package_id_85",
-          "os_package_id_86",
-          "os_package_id_87",
-          "os_package_id_88",
-          "os_package_id_89",
-          "os_package_id_9",
-          "os_package_id_90",
-          "os_package_id_91"
+          "NetworkManager_latest_rpm",
+          "authselect_latest_rpm",
+          "autoconf_latest_rpm",
+          "automake_latest_rpm",
+          "bash-completion_latest_rpm",
+          "bash_latest_rpm",
+          "binutils-devel_latest_rpm",
+          "binutils_latest_rpm",
+          "bzip2_latest_rpm",
+          "chrony_latest_rpm",
+          "cloud-init_latest_rpm",
+          "clustershell_latest_rpm",
+          "cmake_latest_rpm",
+          "coreutils_latest_rpm",
+          "cryptsetup_latest_rpm",
+          "curl_latest_rpm",
+          "device-mapper_latest_rpm",
+          "dmidecode_latest_rpm",
+          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
+          "dracut-live_latest_rpm",
+          "dracut-network_latest_rpm",
+          "dracut_latest_rpm",
+          "emacs_latest_rpm",
+          "file_latest_rpm",
+          "findutils_latest_rpm",
+          "fping_latest_rpm",
+          "gawk_latest_rpm",
+          "gcc-c++_latest_rpm",
+          "gcc-gfortran_latest_rpm",
+          "gcc_latest_rpm",
+          "gdb-gdbserver_latest_rpm",
+          "gdb_latest_rpm",
+          "gedit_latest_rpm",
+          "glibc-langpack-en_latest_rpm",
+          "grep_latest_rpm",
+          "gzip_latest_rpm",
+          "hwloc-libs_latest_rpm",
+          "hwloc_latest_rpm",
+          "iperf3_latest_rpm",
+          "ipmitool_latest_rpm",
+          "iproute_latest_rpm",
+          "iputils_latest_rpm",
+          "kbd_latest_rpm",
+          "kernel-tools_latest_rpm",
+          "kernel_latest_rpm",
+          "kexec-tools_latest_rpm",
+          "libcurl_latest_rpm",
+          "libtool_latest_rpm",
+          "lldb-devel_latest_rpm",
+          "lldb_latest_rpm",
+          "lshw_latest_rpm",
+          "lsof_latest_rpm",
+          "ltrace_latest_rpm",
+          "lvm2_latest_rpm",
+          "make_latest_rpm",
+          "man-db_latest_rpm",
+          "man-pages_latest_rpm",
+          "nfs-utils_latest_rpm",
+          "nfs4-acl-tools_latest_rpm",
+          "nm-connection-editor_latest_rpm",
+          "nss-pam-ldapd_latest_rpm",
+          "oddjob-mkhomedir_latest_rpm",
+          "openldap-clients_latest_rpm",
+          "openssh-clients_latest_rpm",
+          "openssh-server_latest_rpm",
+          "openssh_latest_rpm",
+          "openssl-devel_latest_rpm",
+          "papi-devel_latest_rpm",
+          "papi-libs_latest_rpm",
+          "papi_latest_rpm",
+          "pciutils_latest_rpm",
+          "perf_latest_rpm",
+          "rsync_latest_rpm",
+          "rsyslog_latest_rpm",
+          "sed_latest_rpm",
+          "squashfs-tools_latest_rpm",
+          "sssd_latest_rpm",
+          "strace_latest_rpm",
+          "sudo_latest_rpm",
+          "systemd-udev_latest_rpm",
+          "systemd_latest_rpm",
+          "tar_latest_rpm",
+          "tcpdump_latest_rpm",
+          "traceroute_latest_rpm",
+          "util-linux_latest_rpm",
+          "valgrind-devel_latest_rpm",
+          "valgrind_latest_rpm",
+          "vim-enhanced_latest_rpm",
+          "wget_latest_rpm",
+          "which_latest_rpm",
+          "zsh_latest_rpm"
         ]
       }
     ],
@@ -213,98 +213,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "package_id_1": {
-        "Name": "munge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_2": {
-        "Name": "firewalld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_3": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_4": {
-        "Name": "pmix",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_5": {
-        "Name": "nvcr.io/nvidia/hpc-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "25.09",
-        "Version": "25.09"
-      },
-      "package_id_6": {
+      "apptainer_latest_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -323,45 +232,7 @@
           }
         ]
       },
-      "package_id_7": {
-        "Name": "doca-ofed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm_repo",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "doca"
-          }
-        ]
-      },
-      "package_id_8": {
-        "Name": "iscsi-initiator-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_9": {
+      "device-mapper-multipath_latest_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -380,8 +251,27 @@
           }
         ]
       },
-      "package_id_10": {
-        "Name": "sg3_utils",
+      "doca-ofed_latest_rpm_repo": {
+        "Name": "doca-ofed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm_repo",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "doca"
+          }
+        ]
+      },
+      "firewalld_latest_rpm": {
+        "Name": "firewalld",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -399,83 +289,7 @@
           }
         ]
       },
-      "package_id_11": {
-        "Name": "lsscsi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "package_id_12": {
-        "Name": "imb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
-          }
-        ]
-      },
-      "package_id_13": {
-        "Name": "osu-micro-benchmarks",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
-          }
-        ]
-      },
-      "package_id_14": {
-        "Name": "likwid",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
-          }
-        ]
-      },
-      "package_id_15": {
+      "geopm_latest_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -494,8 +308,8 @@
           }
         ]
       },
-      "package_id_16": {
-        "Name": "papi",
+      "imb_latest_tarball": {
+        "Name": "imb",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -509,50 +323,12 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+            "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "package_id_17": {
-        "Name": "msr-safe",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
-          }
-        ]
-      },
-      "package_id_18": {
-        "Name": "sionlib",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "package_id_19": {
-        "Name": "slurm-slurmctld",
+      "iscsi-initiator-utils_latest_rpm": {
+        "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -566,106 +342,11 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "RepoName": "baseos"
           }
         ]
       },
-      "package_id_20": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_21": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_22": {
-        "Name": "mariadb-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "package_id_23": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_24": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "package_id_25": {
+      "kernel-devel_latest_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -684,7 +365,7 @@
           }
         ]
       },
-      "package_id_26": {
+      "kernel-headers_latest_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -703,7 +384,117 @@
           }
         ]
       },
-      "package_id_27": {
+      "likwid_latest_tarball": {
+        "Name": "likwid",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
+          }
+        ]
+      },
+      "lsscsi_latest_rpm": {
+        "Name": "lsscsi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "mariadb-server_latest_rpm": {
+        "Name": "mariadb-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "msr-safe_latest_tarball": {
+        "Name": "msr-safe",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/llnl/msr-safe/archive/refs/tags/v1.7.0.tar.gz"
+          }
+        ]
+      },
+      "munge_latest_rpm": {
+        "Name": "munge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+        "Name": "nvcr.io/nvidia/hpc-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "25.09",
+        "Version": "25.09"
+      },
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -722,7 +513,216 @@
           }
         ]
       },
-      "package_id_28": {
+      "osu-micro-benchmarks_latest_tarball": {
+        "Name": "osu-micro-benchmarks",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
+          }
+        ]
+      },
+      "papi_latest_tarball": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
+          }
+        ]
+      },
+      "pmix_latest_rpm": {
+        "Name": "pmix",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-PyMySQL_latest_rpm": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall_latest_rpm": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sg3_utils_latest_rpm": {
+        "Name": "sg3_utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sionlib_latest_tarball": {
+        "Name": "sionlib",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
+          }
+        ]
+      },
+      "slurm-pam_slurm_latest_rpm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld_latest_rpm": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd_latest_rpm": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd_latest_rpm": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm_latest_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -743,273 +743,7 @@
       }
     },
     "OSPackages": {
-      "os_package_id_1": {
-        "Name": "openldap-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_2": {
-        "Name": "nss-pam-ldapd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_3": {
-        "Name": "sssd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_4": {
-        "Name": "oddjob-mkhomedir",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_5": {
-        "Name": "authselect",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_6": {
-        "Name": "systemd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_7": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_8": {
-        "Name": "kernel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_9": {
-        "Name": "dracut",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_10": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_11": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_12": {
-        "Name": "squashfs-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_13": {
-        "Name": "nfs-utils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_14": {
-        "Name": "nfs4-acl-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_15": {
+      "NetworkManager_latest_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -1028,27 +762,8 @@
           }
         ]
       },
-      "os_package_id_16": {
-        "Name": "nm-connection-editor",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_17": {
-        "Name": "iproute",
+      "authselect_latest_rpm": {
+        "Name": "authselect",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1066,1219 +781,7 @@
           }
         ]
       },
-      "os_package_id_18": {
-        "Name": "iputils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_19": {
-        "Name": "curl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_20": {
-        "Name": "bash",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_21": {
-        "Name": "coreutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_22": {
-        "Name": "grep",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_23": {
-        "Name": "sed",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_24": {
-        "Name": "gawk",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_25": {
-        "Name": "findutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_26": {
-        "Name": "util-linux",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_27": {
-        "Name": "kbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_28": {
-        "Name": "lsof",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_29": {
-        "Name": "cryptsetup",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_30": {
-        "Name": "lvm2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_31": {
-        "Name": "device-mapper",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_32": {
-        "Name": "rsyslog",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_33": {
-        "Name": "chrony",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_34": {
-        "Name": "sudo",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_35": {
-        "Name": "gzip",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_36": {
-        "Name": "wget",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_37": {
-        "Name": "cloud-init",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_38": {
-        "Name": "glibc-langpack-en",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_39": {
-        "Name": "gedit",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_40": {
-        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "1.1",
-        "Version": "1.1"
-      },
-      "os_package_id_41": {
-        "Name": "which",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_42": {
-        "Name": "tcpdump",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_43": {
-        "Name": "traceroute",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_44": {
-        "Name": "iperf3",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_45": {
-        "Name": "fping",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "epel"
-          }
-        ]
-      },
-      "os_package_id_46": {
-        "Name": "dmidecode",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_47": {
-        "Name": "hwloc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_48": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_49": {
-        "Name": "lshw",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_50": {
-        "Name": "pciutils",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_51": {
-        "Name": "vim-enhanced",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_52": {
-        "Name": "emacs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_53": {
-        "Name": "zsh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_54": {
-        "Name": "openssh",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_55": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_56": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_57": {
-        "Name": "rsync",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_58": {
-        "Name": "file",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_59": {
-        "Name": "libcurl",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_60": {
-        "Name": "tar",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_61": {
-        "Name": "bzip2",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_62": {
-        "Name": "man-db",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_63": {
-        "Name": "man-pages",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_64": {
-        "Name": "strace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_65": {
-        "Name": "kexec-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_66": {
-        "Name": "openssl-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_67": {
-        "Name": "ipmitool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_68": {
-        "Name": "gdb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_69": {
-        "Name": "gdb-gdbserver",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_70": {
-        "Name": "lldb",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_71": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_72": {
-        "Name": "valgrind",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_73": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_74": {
-        "Name": "ltrace",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_75": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_76": {
-        "Name": "perf",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_77": {
-        "Name": "papi",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_78": {
-        "Name": "papi-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_79": {
-        "Name": "papi-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_80": {
-        "Name": "cmake",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_81": {
-        "Name": "make",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "os_package_id_82": {
+      "autoconf_latest_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2297,7 +800,7 @@
           }
         ]
       },
-      "os_package_id_83": {
+      "automake_latest_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2316,84 +819,8 @@
           }
         ]
       },
-      "os_package_id_84": {
-        "Name": "libtool",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_85": {
-        "Name": "gcc",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_86": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_87": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "os_package_id_88": {
-        "Name": "binutils",
+      "bash-completion_latest_rpm": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2411,7 +838,26 @@
           }
         ]
       },
-      "os_package_id_89": {
+      "bash_latest_rpm": {
+        "Name": "bash",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "binutils-devel_latest_rpm": {
         "Name": "binutils-devel",
         "SupportedOS": [
           {
@@ -2430,7 +876,83 @@
           }
         ]
       },
-      "os_package_id_90": {
+      "binutils_latest_rpm": {
+        "Name": "binutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "bzip2_latest_rpm": {
+        "Name": "bzip2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "chrony_latest_rpm": {
+        "Name": "chrony",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cloud-init_latest_rpm": {
+        "Name": "cloud-init",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "clustershell_latest_rpm": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2449,8 +971,1486 @@
           }
         ]
       },
-      "os_package_id_91": {
-        "Name": "bash-completion",
+      "cmake_latest_rpm": {
+        "Name": "cmake",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "coreutils_latest_rpm": {
+        "Name": "coreutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "cryptsetup_latest_rpm": {
+        "Name": "cryptsetup",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "curl_latest_rpm": {
+        "Name": "curl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "device-mapper_latest_rpm": {
+        "Name": "device-mapper",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dmidecode_latest_rpm": {
+        "Name": "dmidecode",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+        "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "1.1",
+        "Version": "1.1"
+      },
+      "dracut-live_latest_rpm": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network_latest_rpm": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "dracut_latest_rpm": {
+        "Name": "dracut",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs_latest_rpm": {
+        "Name": "emacs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "file_latest_rpm": {
+        "Name": "file",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "findutils_latest_rpm": {
+        "Name": "findutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "fping_latest_rpm": {
+        "Name": "fping",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "gawk_latest_rpm": {
+        "Name": "gawk",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gcc-c++_latest_rpm": {
+        "Name": "gcc-c++",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc-gfortran_latest_rpm": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gcc_latest_rpm": {
+        "Name": "gcc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb-gdbserver_latest_rpm": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb_latest_rpm": {
+        "Name": "gdb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit_latest_rpm": {
+        "Name": "gedit",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "glibc-langpack-en_latest_rpm": {
+        "Name": "glibc-langpack-en",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "grep_latest_rpm": {
+        "Name": "grep",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "gzip_latest_rpm": {
+        "Name": "gzip",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc-libs_latest_rpm": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "hwloc_latest_rpm": {
+        "Name": "hwloc",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3_latest_rpm": {
+        "Name": "iperf3",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "ipmitool_latest_rpm": {
+        "Name": "ipmitool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "iproute_latest_rpm": {
+        "Name": "iproute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iputils_latest_rpm": {
+        "Name": "iputils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kbd_latest_rpm": {
+        "Name": "kbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel-tools_latest_rpm": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kernel_latest_rpm": {
+        "Name": "kernel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools_latest_rpm": {
+        "Name": "kexec-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libcurl_latest_rpm": {
+        "Name": "libcurl",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "libtool_latest_rpm": {
+        "Name": "libtool",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb-devel_latest_rpm": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lldb_latest_rpm": {
+        "Name": "lldb",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw_latest_rpm": {
+        "Name": "lshw",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "lsof_latest_rpm": {
+        "Name": "lsof",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "ltrace_latest_rpm": {
+        "Name": "ltrace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lvm2_latest_rpm": {
+        "Name": "lvm2",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "make_latest_rpm": {
+        "Name": "make",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-db_latest_rpm": {
+        "Name": "man-db",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "man-pages_latest_rpm": {
+        "Name": "man-pages",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs-utils_latest_rpm": {
+        "Name": "nfs-utils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nfs4-acl-tools_latest_rpm": {
+        "Name": "nfs4-acl-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "nm-connection-editor_latest_rpm": {
+        "Name": "nm-connection-editor",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "nss-pam-ldapd_latest_rpm": {
+        "Name": "nss-pam-ldapd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "epel"
+          }
+        ]
+      },
+      "oddjob-mkhomedir_latest_rpm": {
+        "Name": "oddjob-mkhomedir",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "openldap-clients_latest_rpm": {
+        "Name": "openldap-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-clients_latest_rpm": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server_latest_rpm": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh_latest_rpm": {
+        "Name": "openssh",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel_latest_rpm": {
+        "Name": "openssl-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-devel_latest_rpm": {
+        "Name": "papi-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi-libs_latest_rpm": {
+        "Name": "papi-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "papi_latest_rpm": {
+        "Name": "papi",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "pciutils_latest_rpm": {
+        "Name": "pciutils",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "perf_latest_rpm": {
+        "Name": "perf",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "rsync_latest_rpm": {
+        "Name": "rsync",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "rsyslog_latest_rpm": {
+        "Name": "rsyslog",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "sed_latest_rpm": {
+        "Name": "sed",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "squashfs-tools_latest_rpm": {
+        "Name": "squashfs-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sssd_latest_rpm": {
+        "Name": "sssd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "strace_latest_rpm": {
+        "Name": "strace",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "sudo_latest_rpm": {
+        "Name": "sudo",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd-udev_latest_rpm": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "systemd_latest_rpm": {
+        "Name": "systemd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar_latest_rpm": {
+        "Name": "tar",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tcpdump_latest_rpm": {
+        "Name": "tcpdump",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "traceroute_latest_rpm": {
+        "Name": "traceroute",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "util-linux_latest_rpm": {
+        "Name": "util-linux",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "valgrind-devel_latest_rpm": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "valgrind_latest_rpm": {
+        "Name": "valgrind",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced_latest_rpm": {
+        "Name": "vim-enhanced",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "wget_latest_rpm": {
+        "Name": "wget",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "which_latest_rpm": {
+        "Name": "which",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "zsh_latest_rpm": {
+        "Name": "zsh",
         "SupportedOS": [
           {
             "Name": "RHEL",

--- a/examples/catalog/catalog_rhel_x86_64_with_slurm_only.json
+++ b/examples/catalog/catalog_rhel_x86_64_with_slurm_only.json
@@ -7,106 +7,106 @@
       {
         "Name": "login_compiler_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmd_latest_rpm",
-          "slurm_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmd_na_rpm",
+          "slurm_na_rpm"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "mariadb-server_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "mariadb-server_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-PyMySQL_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-slurmctld_latest_rpm",
-          "slurm-slurmdbd_latest_rpm"
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-PyMySQL_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-slurmctld_na_rpm",
+          "slurm-slurmdbd_na_rpm"
         ]
       },
       {
         "Name": "slurm_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_latest_rpm",
-          "device-mapper-multipath_latest_rpm",
-          "doca-ofed_latest_rpm_repo",
-          "firewalld_latest_rpm",
-          "geopm_latest_tarball",
-          "imb_latest_tarball",
-          "iscsi-initiator-utils_latest_rpm",
-          "kernel-devel_latest_rpm",
-          "kernel-headers_latest_rpm",
-          "likwid_latest_tarball",
-          "lsscsi_latest_rpm",
-          "msr-safe_latest_tarball",
-          "munge_latest_rpm",
+          "apptainer_na_rpm",
+          "device-mapper-multipath_na_rpm",
+          "doca-ofed_na_rpm_repo",
+          "firewalld_na_rpm",
+          "geopm_na_tarball",
+          "imb_na_tarball",
+          "iscsi-initiator-utils_na_rpm",
+          "kernel-devel_na_rpm",
+          "kernel-headers_na_rpm",
+          "likwid_na_tarball",
+          "lsscsi_na_rpm",
+          "msr-safe_na_tarball",
+          "munge_na_rpm",
           "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball",
-          "osu-micro-benchmarks_latest_tarball",
-          "papi_latest_tarball",
-          "pmix_latest_rpm",
-          "python3-firewall_latest_rpm",
-          "sg3_utils_latest_rpm",
-          "sionlib_latest_tarball",
-          "slurm-pam_slurm_latest_rpm",
-          "slurm-slurmd_latest_rpm"
+          "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball",
+          "osu-micro-benchmarks_na_tarball",
+          "papi_na_tarball",
+          "pmix_na_rpm",
+          "python3-firewall_na_rpm",
+          "sg3_utils_na_rpm",
+          "sionlib_na_tarball",
+          "slurm-pam_slurm_na_rpm",
+          "slurm-slurmd_na_rpm"
         ]
       }
     ],
@@ -115,97 +115,97 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_latest_rpm",
-          "authselect_latest_rpm",
-          "autoconf_latest_rpm",
-          "automake_latest_rpm",
-          "bash-completion_latest_rpm",
-          "bash_latest_rpm",
-          "binutils-devel_latest_rpm",
-          "binutils_latest_rpm",
-          "bzip2_latest_rpm",
-          "chrony_latest_rpm",
-          "cloud-init_latest_rpm",
-          "clustershell_latest_rpm",
-          "cmake_latest_rpm",
-          "coreutils_latest_rpm",
-          "cryptsetup_latest_rpm",
-          "curl_latest_rpm",
-          "device-mapper_latest_rpm",
-          "dmidecode_latest_rpm",
+          "NetworkManager_na_rpm",
+          "authselect_na_rpm",
+          "autoconf_na_rpm",
+          "automake_na_rpm",
+          "bash-completion_na_rpm",
+          "bash_na_rpm",
+          "binutils-devel_na_rpm",
+          "binutils_na_rpm",
+          "bzip2_na_rpm",
+          "chrony_na_rpm",
+          "cloud-init_na_rpm",
+          "clustershell_na_rpm",
+          "cmake_na_rpm",
+          "coreutils_na_rpm",
+          "cryptsetup_na_rpm",
+          "curl_na_rpm",
+          "device-mapper_na_rpm",
+          "dmidecode_na_rpm",
           "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_latest_rpm",
-          "dracut-network_latest_rpm",
-          "dracut_latest_rpm",
-          "emacs_latest_rpm",
-          "file_latest_rpm",
-          "findutils_latest_rpm",
-          "fping_latest_rpm",
-          "gawk_latest_rpm",
-          "gcc-c++_latest_rpm",
-          "gcc-gfortran_latest_rpm",
-          "gcc_latest_rpm",
-          "gdb-gdbserver_latest_rpm",
-          "gdb_latest_rpm",
-          "gedit_latest_rpm",
-          "glibc-langpack-en_latest_rpm",
-          "grep_latest_rpm",
-          "gzip_latest_rpm",
-          "hwloc-libs_latest_rpm",
-          "hwloc_latest_rpm",
-          "iperf3_latest_rpm",
-          "ipmitool_latest_rpm",
-          "iproute_latest_rpm",
-          "iputils_latest_rpm",
-          "kbd_latest_rpm",
-          "kernel-tools_latest_rpm",
-          "kernel_latest_rpm",
-          "kexec-tools_latest_rpm",
-          "libcurl_latest_rpm",
-          "libtool_latest_rpm",
-          "lldb-devel_latest_rpm",
-          "lldb_latest_rpm",
-          "lshw_latest_rpm",
-          "lsof_latest_rpm",
-          "ltrace_latest_rpm",
-          "lvm2_latest_rpm",
-          "make_latest_rpm",
-          "man-db_latest_rpm",
-          "man-pages_latest_rpm",
-          "nfs-utils_latest_rpm",
-          "nfs4-acl-tools_latest_rpm",
-          "nm-connection-editor_latest_rpm",
-          "nss-pam-ldapd_latest_rpm",
-          "oddjob-mkhomedir_latest_rpm",
-          "openldap-clients_latest_rpm",
-          "openssh-clients_latest_rpm",
-          "openssh-server_latest_rpm",
-          "openssh_latest_rpm",
-          "openssl-devel_latest_rpm",
-          "papi-devel_latest_rpm",
-          "papi-libs_latest_rpm",
-          "papi_latest_rpm",
-          "pciutils_latest_rpm",
-          "perf_latest_rpm",
-          "rsync_latest_rpm",
-          "rsyslog_latest_rpm",
-          "sed_latest_rpm",
-          "squashfs-tools_latest_rpm",
-          "sssd_latest_rpm",
-          "strace_latest_rpm",
-          "sudo_latest_rpm",
-          "systemd-udev_latest_rpm",
-          "systemd_latest_rpm",
-          "tar_latest_rpm",
-          "tcpdump_latest_rpm",
-          "traceroute_latest_rpm",
-          "util-linux_latest_rpm",
-          "valgrind-devel_latest_rpm",
-          "valgrind_latest_rpm",
-          "vim-enhanced_latest_rpm",
-          "wget_latest_rpm",
-          "which_latest_rpm",
-          "zsh_latest_rpm"
+          "dracut-live_na_rpm",
+          "dracut-network_na_rpm",
+          "dracut_na_rpm",
+          "emacs_na_rpm",
+          "file_na_rpm",
+          "findutils_na_rpm",
+          "fping_na_rpm",
+          "gawk_na_rpm",
+          "gcc-c++_na_rpm",
+          "gcc-gfortran_na_rpm",
+          "gcc_na_rpm",
+          "gdb-gdbserver_na_rpm",
+          "gdb_na_rpm",
+          "gedit_na_rpm",
+          "glibc-langpack-en_na_rpm",
+          "grep_na_rpm",
+          "gzip_na_rpm",
+          "hwloc-libs_na_rpm",
+          "hwloc_na_rpm",
+          "iperf3_na_rpm",
+          "ipmitool_na_rpm",
+          "iproute_na_rpm",
+          "iputils_na_rpm",
+          "kbd_na_rpm",
+          "kernel-tools_na_rpm",
+          "kernel_na_rpm",
+          "kexec-tools_na_rpm",
+          "libcurl_na_rpm",
+          "libtool_na_rpm",
+          "lldb-devel_na_rpm",
+          "lldb_na_rpm",
+          "lshw_na_rpm",
+          "lsof_na_rpm",
+          "ltrace_na_rpm",
+          "lvm2_na_rpm",
+          "make_na_rpm",
+          "man-db_na_rpm",
+          "man-pages_na_rpm",
+          "nfs-utils_na_rpm",
+          "nfs4-acl-tools_na_rpm",
+          "nm-connection-editor_na_rpm",
+          "nss-pam-ldapd_na_rpm",
+          "oddjob-mkhomedir_na_rpm",
+          "openldap-clients_na_rpm",
+          "openssh-clients_na_rpm",
+          "openssh-server_na_rpm",
+          "openssh_na_rpm",
+          "openssl-devel_na_rpm",
+          "papi-devel_na_rpm",
+          "papi-libs_na_rpm",
+          "papi_na_rpm",
+          "pciutils_na_rpm",
+          "perf_na_rpm",
+          "rsync_na_rpm",
+          "rsyslog_na_rpm",
+          "sed_na_rpm",
+          "squashfs-tools_na_rpm",
+          "sssd_na_rpm",
+          "strace_na_rpm",
+          "sudo_na_rpm",
+          "systemd-udev_na_rpm",
+          "systemd_na_rpm",
+          "tar_na_rpm",
+          "tcpdump_na_rpm",
+          "traceroute_na_rpm",
+          "util-linux_na_rpm",
+          "valgrind-devel_na_rpm",
+          "valgrind_na_rpm",
+          "vim-enhanced_na_rpm",
+          "wget_na_rpm",
+          "which_na_rpm",
+          "zsh_na_rpm"
         ]
       }
     ],
@@ -213,7 +213,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "apptainer_latest_rpm": {
+      "apptainer_na_rpm": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -232,7 +232,7 @@
           }
         ]
       },
-      "device-mapper-multipath_latest_rpm": {
+      "device-mapper-multipath_na_rpm": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -251,7 +251,7 @@
           }
         ]
       },
-      "doca-ofed_latest_rpm_repo": {
+      "doca-ofed_na_rpm_repo": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -270,7 +270,7 @@
           }
         ]
       },
-      "firewalld_latest_rpm": {
+      "firewalld_na_rpm": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -289,7 +289,7 @@
           }
         ]
       },
-      "geopm_latest_tarball": {
+      "geopm_na_tarball": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "imb_latest_tarball": {
+      "imb_na_tarball": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -327,7 +327,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_latest_rpm": {
+      "iscsi-initiator-utils_na_rpm": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -346,7 +346,7 @@
           }
         ]
       },
-      "kernel-devel_latest_rpm": {
+      "kernel-devel_na_rpm": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -365,7 +365,7 @@
           }
         ]
       },
-      "kernel-headers_latest_rpm": {
+      "kernel-headers_na_rpm": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -384,7 +384,7 @@
           }
         ]
       },
-      "likwid_latest_tarball": {
+      "likwid_na_tarball": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -403,7 +403,7 @@
           }
         ]
       },
-      "lsscsi_latest_rpm": {
+      "lsscsi_na_rpm": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -422,7 +422,7 @@
           }
         ]
       },
-      "mariadb-server_latest_rpm": {
+      "mariadb-server_na_rpm": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -441,7 +441,7 @@
           }
         ]
       },
-      "msr-safe_latest_tarball": {
+      "msr-safe_na_tarball": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -460,7 +460,7 @@
           }
         ]
       },
-      "munge_latest_rpm": {
+      "munge_na_rpm": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -494,7 +494,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_latest_tarball": {
+      "nvhpc_2025_2511_Linux_x86_64_cuda_13-0_na_tarball": {
         "Name": "nvhpc_2025_2511_Linux_x86_64_cuda_13.0",
         "SupportedOS": [
           {
@@ -513,7 +513,7 @@
           }
         ]
       },
-      "osu-micro-benchmarks_latest_tarball": {
+      "osu-micro-benchmarks_na_tarball": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -532,7 +532,7 @@
           }
         ]
       },
-      "papi_latest_tarball": {
+      "papi_na_tarball": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -551,7 +551,7 @@
           }
         ]
       },
-      "pmix_latest_rpm": {
+      "pmix_na_rpm": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -570,7 +570,7 @@
           }
         ]
       },
-      "python3-PyMySQL_latest_rpm": {
+      "python3-PyMySQL_na_rpm": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -589,7 +589,7 @@
           }
         ]
       },
-      "python3-firewall_latest_rpm": {
+      "python3-firewall_na_rpm": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -608,7 +608,7 @@
           }
         ]
       },
-      "sg3_utils_latest_rpm": {
+      "sg3_utils_na_rpm": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -627,7 +627,7 @@
           }
         ]
       },
-      "sionlib_latest_tarball": {
+      "sionlib_na_tarball": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -646,7 +646,7 @@
           }
         ]
       },
-      "slurm-pam_slurm_latest_rpm": {
+      "slurm-pam_slurm_na_rpm": {
         "Name": "slurm-pam_slurm",
         "SupportedOS": [
           {
@@ -665,7 +665,7 @@
           }
         ]
       },
-      "slurm-slurmctld_latest_rpm": {
+      "slurm-slurmctld_na_rpm": {
         "Name": "slurm-slurmctld",
         "SupportedOS": [
           {
@@ -684,7 +684,7 @@
           }
         ]
       },
-      "slurm-slurmd_latest_rpm": {
+      "slurm-slurmd_na_rpm": {
         "Name": "slurm-slurmd",
         "SupportedOS": [
           {
@@ -703,7 +703,7 @@
           }
         ]
       },
-      "slurm-slurmdbd_latest_rpm": {
+      "slurm-slurmdbd_na_rpm": {
         "Name": "slurm-slurmdbd",
         "SupportedOS": [
           {
@@ -722,7 +722,7 @@
           }
         ]
       },
-      "slurm_latest_rpm": {
+      "slurm_na_rpm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -743,7 +743,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_latest_rpm": {
+      "NetworkManager_na_rpm": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -762,7 +762,7 @@
           }
         ]
       },
-      "authselect_latest_rpm": {
+      "authselect_na_rpm": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -781,7 +781,7 @@
           }
         ]
       },
-      "autoconf_latest_rpm": {
+      "autoconf_na_rpm": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -800,7 +800,7 @@
           }
         ]
       },
-      "automake_latest_rpm": {
+      "automake_na_rpm": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -819,7 +819,7 @@
           }
         ]
       },
-      "bash-completion_latest_rpm": {
+      "bash-completion_na_rpm": {
         "Name": "bash-completion",
         "SupportedOS": [
           {
@@ -838,7 +838,7 @@
           }
         ]
       },
-      "bash_latest_rpm": {
+      "bash_na_rpm": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -857,7 +857,7 @@
           }
         ]
       },
-      "binutils-devel_latest_rpm": {
+      "binutils-devel_na_rpm": {
         "Name": "binutils-devel",
         "SupportedOS": [
           {
@@ -876,7 +876,7 @@
           }
         ]
       },
-      "binutils_latest_rpm": {
+      "binutils_na_rpm": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -895,7 +895,7 @@
           }
         ]
       },
-      "bzip2_latest_rpm": {
+      "bzip2_na_rpm": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -914,7 +914,7 @@
           }
         ]
       },
-      "chrony_latest_rpm": {
+      "chrony_na_rpm": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -933,7 +933,7 @@
           }
         ]
       },
-      "cloud-init_latest_rpm": {
+      "cloud-init_na_rpm": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -952,7 +952,7 @@
           }
         ]
       },
-      "clustershell_latest_rpm": {
+      "clustershell_na_rpm": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -971,7 +971,7 @@
           }
         ]
       },
-      "cmake_latest_rpm": {
+      "cmake_na_rpm": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -990,7 +990,7 @@
           }
         ]
       },
-      "coreutils_latest_rpm": {
+      "coreutils_na_rpm": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -1009,7 +1009,7 @@
           }
         ]
       },
-      "cryptsetup_latest_rpm": {
+      "cryptsetup_na_rpm": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -1028,7 +1028,7 @@
           }
         ]
       },
-      "curl_latest_rpm": {
+      "curl_na_rpm": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -1047,7 +1047,7 @@
           }
         ]
       },
-      "device-mapper_latest_rpm": {
+      "device-mapper_na_rpm": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -1066,7 +1066,7 @@
           }
         ]
       },
-      "dmidecode_latest_rpm": {
+      "dmidecode_na_rpm": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -1100,7 +1100,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_latest_rpm": {
+      "dracut-live_na_rpm": {
         "Name": "dracut-live",
         "SupportedOS": [
           {
@@ -1119,7 +1119,7 @@
           }
         ]
       },
-      "dracut-network_latest_rpm": {
+      "dracut-network_na_rpm": {
         "Name": "dracut-network",
         "SupportedOS": [
           {
@@ -1138,7 +1138,7 @@
           }
         ]
       },
-      "dracut_latest_rpm": {
+      "dracut_na_rpm": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -1157,7 +1157,7 @@
           }
         ]
       },
-      "emacs_latest_rpm": {
+      "emacs_na_rpm": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -1176,7 +1176,7 @@
           }
         ]
       },
-      "file_latest_rpm": {
+      "file_na_rpm": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -1195,7 +1195,7 @@
           }
         ]
       },
-      "findutils_latest_rpm": {
+      "findutils_na_rpm": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -1214,7 +1214,7 @@
           }
         ]
       },
-      "fping_latest_rpm": {
+      "fping_na_rpm": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -1233,7 +1233,7 @@
           }
         ]
       },
-      "gawk_latest_rpm": {
+      "gawk_na_rpm": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -1252,7 +1252,7 @@
           }
         ]
       },
-      "gcc-c++_latest_rpm": {
+      "gcc-c++_na_rpm": {
         "Name": "gcc-c++",
         "SupportedOS": [
           {
@@ -1271,7 +1271,7 @@
           }
         ]
       },
-      "gcc-gfortran_latest_rpm": {
+      "gcc-gfortran_na_rpm": {
         "Name": "gcc-gfortran",
         "SupportedOS": [
           {
@@ -1290,7 +1290,7 @@
           }
         ]
       },
-      "gcc_latest_rpm": {
+      "gcc_na_rpm": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -1309,7 +1309,7 @@
           }
         ]
       },
-      "gdb-gdbserver_latest_rpm": {
+      "gdb-gdbserver_na_rpm": {
         "Name": "gdb-gdbserver",
         "SupportedOS": [
           {
@@ -1328,7 +1328,7 @@
           }
         ]
       },
-      "gdb_latest_rpm": {
+      "gdb_na_rpm": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -1347,7 +1347,7 @@
           }
         ]
       },
-      "gedit_latest_rpm": {
+      "gedit_na_rpm": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -1366,7 +1366,7 @@
           }
         ]
       },
-      "glibc-langpack-en_latest_rpm": {
+      "glibc-langpack-en_na_rpm": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -1385,7 +1385,7 @@
           }
         ]
       },
-      "grep_latest_rpm": {
+      "grep_na_rpm": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -1404,7 +1404,7 @@
           }
         ]
       },
-      "gzip_latest_rpm": {
+      "gzip_na_rpm": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -1423,7 +1423,7 @@
           }
         ]
       },
-      "hwloc-libs_latest_rpm": {
+      "hwloc-libs_na_rpm": {
         "Name": "hwloc-libs",
         "SupportedOS": [
           {
@@ -1442,7 +1442,7 @@
           }
         ]
       },
-      "hwloc_latest_rpm": {
+      "hwloc_na_rpm": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -1461,7 +1461,7 @@
           }
         ]
       },
-      "iperf3_latest_rpm": {
+      "iperf3_na_rpm": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -1480,7 +1480,7 @@
           }
         ]
       },
-      "ipmitool_latest_rpm": {
+      "ipmitool_na_rpm": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -1499,7 +1499,7 @@
           }
         ]
       },
-      "iproute_latest_rpm": {
+      "iproute_na_rpm": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -1518,7 +1518,7 @@
           }
         ]
       },
-      "iputils_latest_rpm": {
+      "iputils_na_rpm": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -1537,7 +1537,7 @@
           }
         ]
       },
-      "kbd_latest_rpm": {
+      "kbd_na_rpm": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -1556,7 +1556,7 @@
           }
         ]
       },
-      "kernel-tools_latest_rpm": {
+      "kernel-tools_na_rpm": {
         "Name": "kernel-tools",
         "SupportedOS": [
           {
@@ -1575,7 +1575,7 @@
           }
         ]
       },
-      "kernel_latest_rpm": {
+      "kernel_na_rpm": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -1594,7 +1594,7 @@
           }
         ]
       },
-      "kexec-tools_latest_rpm": {
+      "kexec-tools_na_rpm": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -1613,7 +1613,7 @@
           }
         ]
       },
-      "libcurl_latest_rpm": {
+      "libcurl_na_rpm": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -1632,7 +1632,7 @@
           }
         ]
       },
-      "libtool_latest_rpm": {
+      "libtool_na_rpm": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -1651,7 +1651,7 @@
           }
         ]
       },
-      "lldb-devel_latest_rpm": {
+      "lldb-devel_na_rpm": {
         "Name": "lldb-devel",
         "SupportedOS": [
           {
@@ -1670,7 +1670,7 @@
           }
         ]
       },
-      "lldb_latest_rpm": {
+      "lldb_na_rpm": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -1689,7 +1689,7 @@
           }
         ]
       },
-      "lshw_latest_rpm": {
+      "lshw_na_rpm": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -1708,7 +1708,7 @@
           }
         ]
       },
-      "lsof_latest_rpm": {
+      "lsof_na_rpm": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -1727,7 +1727,7 @@
           }
         ]
       },
-      "ltrace_latest_rpm": {
+      "ltrace_na_rpm": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -1746,7 +1746,7 @@
           }
         ]
       },
-      "lvm2_latest_rpm": {
+      "lvm2_na_rpm": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -1765,7 +1765,7 @@
           }
         ]
       },
-      "make_latest_rpm": {
+      "make_na_rpm": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -1784,7 +1784,7 @@
           }
         ]
       },
-      "man-db_latest_rpm": {
+      "man-db_na_rpm": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -1803,7 +1803,7 @@
           }
         ]
       },
-      "man-pages_latest_rpm": {
+      "man-pages_na_rpm": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -1822,7 +1822,7 @@
           }
         ]
       },
-      "nfs-utils_latest_rpm": {
+      "nfs-utils_na_rpm": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -1841,7 +1841,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_latest_rpm": {
+      "nfs4-acl-tools_na_rpm": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -1860,7 +1860,7 @@
           }
         ]
       },
-      "nm-connection-editor_latest_rpm": {
+      "nm-connection-editor_na_rpm": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -1879,7 +1879,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_latest_rpm": {
+      "nss-pam-ldapd_na_rpm": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -1898,7 +1898,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_latest_rpm": {
+      "oddjob-mkhomedir_na_rpm": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -1917,7 +1917,7 @@
           }
         ]
       },
-      "openldap-clients_latest_rpm": {
+      "openldap-clients_na_rpm": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -1936,7 +1936,7 @@
           }
         ]
       },
-      "openssh-clients_latest_rpm": {
+      "openssh-clients_na_rpm": {
         "Name": "openssh-clients",
         "SupportedOS": [
           {
@@ -1955,7 +1955,7 @@
           }
         ]
       },
-      "openssh-server_latest_rpm": {
+      "openssh-server_na_rpm": {
         "Name": "openssh-server",
         "SupportedOS": [
           {
@@ -1974,7 +1974,7 @@
           }
         ]
       },
-      "openssh_latest_rpm": {
+      "openssh_na_rpm": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -1993,7 +1993,7 @@
           }
         ]
       },
-      "openssl-devel_latest_rpm": {
+      "openssl-devel_na_rpm": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -2012,7 +2012,7 @@
           }
         ]
       },
-      "papi-devel_latest_rpm": {
+      "papi-devel_na_rpm": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -2031,7 +2031,7 @@
           }
         ]
       },
-      "papi-libs_latest_rpm": {
+      "papi-libs_na_rpm": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -2050,7 +2050,7 @@
           }
         ]
       },
-      "papi_latest_rpm": {
+      "papi_na_rpm": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -2069,7 +2069,7 @@
           }
         ]
       },
-      "pciutils_latest_rpm": {
+      "pciutils_na_rpm": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -2088,7 +2088,7 @@
           }
         ]
       },
-      "perf_latest_rpm": {
+      "perf_na_rpm": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -2107,7 +2107,7 @@
           }
         ]
       },
-      "rsync_latest_rpm": {
+      "rsync_na_rpm": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -2126,7 +2126,7 @@
           }
         ]
       },
-      "rsyslog_latest_rpm": {
+      "rsyslog_na_rpm": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -2145,7 +2145,7 @@
           }
         ]
       },
-      "sed_latest_rpm": {
+      "sed_na_rpm": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -2164,7 +2164,7 @@
           }
         ]
       },
-      "squashfs-tools_latest_rpm": {
+      "squashfs-tools_na_rpm": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -2183,7 +2183,7 @@
           }
         ]
       },
-      "sssd_latest_rpm": {
+      "sssd_na_rpm": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -2202,7 +2202,7 @@
           }
         ]
       },
-      "strace_latest_rpm": {
+      "strace_na_rpm": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -2221,7 +2221,7 @@
           }
         ]
       },
-      "sudo_latest_rpm": {
+      "sudo_na_rpm": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -2240,7 +2240,7 @@
           }
         ]
       },
-      "systemd-udev_latest_rpm": {
+      "systemd-udev_na_rpm": {
         "Name": "systemd-udev",
         "SupportedOS": [
           {
@@ -2259,7 +2259,7 @@
           }
         ]
       },
-      "systemd_latest_rpm": {
+      "systemd_na_rpm": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -2278,7 +2278,7 @@
           }
         ]
       },
-      "tar_latest_rpm": {
+      "tar_na_rpm": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -2297,7 +2297,7 @@
           }
         ]
       },
-      "tcpdump_latest_rpm": {
+      "tcpdump_na_rpm": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -2316,7 +2316,7 @@
           }
         ]
       },
-      "traceroute_latest_rpm": {
+      "traceroute_na_rpm": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -2335,7 +2335,7 @@
           }
         ]
       },
-      "util-linux_latest_rpm": {
+      "util-linux_na_rpm": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -2354,7 +2354,7 @@
           }
         ]
       },
-      "valgrind-devel_latest_rpm": {
+      "valgrind-devel_na_rpm": {
         "Name": "valgrind-devel",
         "SupportedOS": [
           {
@@ -2373,7 +2373,7 @@
           }
         ]
       },
-      "valgrind_latest_rpm": {
+      "valgrind_na_rpm": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -2392,7 +2392,7 @@
           }
         ]
       },
-      "vim-enhanced_latest_rpm": {
+      "vim-enhanced_na_rpm": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2411,7 +2411,7 @@
           }
         ]
       },
-      "wget_latest_rpm": {
+      "wget_na_rpm": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -2430,7 +2430,7 @@
           }
         ]
       },
-      "which_latest_rpm": {
+      "which_na_rpm": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -2449,7 +2449,7 @@
           }
         ]
       },
-      "zsh_latest_rpm": {
+      "zsh_na_rpm": {
         "Name": "zsh",
         "SupportedOS": [
           {


### PR DESCRIPTION
Replace sequential package IDs with human-readable identifiers in catalog generation
    using format: {sanitized_name}_{version}_{type} or {sanitized_name}_{version}_{type}_{counter}
    
    - Implement collision detection and handling with counter suffix when duplicate IDs occur
    - Extract version information from package names for pip modules (name==version format) and RPMs