### PR TITLE
fix(prepare_oim): resolve ansible_run_tags type error

### DIFF
--- a/prepare_oim/prepare_oim.yml
+++ b/prepare_oim/prepare_oim.yml
@@ -30,10 +30,8 @@
       ansible.builtin.set_fact:
         omnia_run_tags: >-
           {{
-            (
-              ansible_run_tags | default([]) +
-              ['prepare_oim', 'local_repo', 'discovery', 'provision']
-            ) | unique
+            (ansible_run_tags | default([]) | list)
+            | union(['prepare_oim', 'local_repo', 'discovery', 'provision'])
           }}
         cacheable: true
 


### PR DESCRIPTION
## Summary

Fix template rendering error in prepare_oim.yml caused by ansible_run_tags being a tuple in newer Ansible versions.

## Issue

When running prepare_oim.yml:


## Root Cause

The original code used  concatenation between  (tuple) and a list literal. In newer Ansible versions,  is consistently a tuple, making  invalid.

## Fix

Replace concatenation () with the  filter which:
- Handles type conversion automatically  
- Performs concatenation + deduplication
- Works across old and new Ansible versions

### Before


### After  


## Files Changed

- : 2 insertions, 4 deletions