### PR TITLE
fix(discovery): exclude IB NIC from ADMIN_MAC and default empty LinkStatus to Unknown

### DIFF
--- a/common/library/modules/ome_server_inventory.py
+++ b/common/library/modules/ome_server_inventory.py
@@ -444,7 +444,7 @@ def extract_server_info(client, device, device_group_map=None):
     fallback_nic_link_status = ""
     for nic in nic_info_list:
         nic_id = nic.get("NicId", "")
-        if "iDRAC" not in nic_id.upper():
+        if "iDRAC" not in nic_id.upper() and "INFINIBAND" not in nic_id.upper():
             ports = nic.get("Ports", [])
             for port in ports:
                 partitions = port.get("Partitions", [])
@@ -457,9 +457,9 @@ def extract_server_info(client, device, device_group_map=None):
                 if not fallback_nic_mac:
                     fallback_nic_name = nic_id
                     fallback_nic_mac = mac
-                    fallback_nic_link_status = (port.get("LinkStatus") or "").strip()
+                    fallback_nic_link_status = (port.get("LinkStatus") or "Unknown").strip()
                 # Prefer port with LinkStatus "Up"
-                link_status = (port.get("LinkStatus") or "").strip()
+                link_status = (port.get("LinkStatus") or "Unknown").strip()
                 if link_status.upper() == "UP":
                     info["first_nic_name"] = nic_id
                     info["first_nic_mac"] = mac
@@ -478,7 +478,7 @@ def extract_server_info(client, device, device_group_map=None):
         device_nics = client.get_device_inventory(device_id, "deviceNics")
         for nic in device_nics.get("InventoryInfo", []):
             nic_id = nic.get("NicId", "")
-            if "iDRAC" not in str(nic_id).upper():
+            if "iDRAC" not in str(nic_id).upper() and "INFINIBAND" not in str(nic_id).upper():
                 info["first_nic_name"] = nic_id
                 info["first_nic_mac"] = nic.get("MacAddress", "")
                 break
@@ -497,7 +497,7 @@ def extract_server_info(client, device, device_group_map=None):
         for port in nic.get("Ports", []):
             port_id = port.get("PortId", "")
             candidate = port_id if port_id else nic_id
-            link_status = (port.get("LinkStatus") or "").strip().upper()
+            link_status = (port.get("LinkStatus") or "Unknown").strip().upper()
             if link_status == "UP":
                 info["ib_nic_name"] = candidate
                 info["ib_nic_link_status"] = "Up"
@@ -505,11 +505,11 @@ def extract_server_info(client, device, device_group_map=None):
             port_priority = _IB_STATUS_PRIORITY.get(link_status, 2)
             if port_priority < fallback_ib_priority:
                 fallback_ib_nic_name = candidate
-                fallback_ib_link_status = (port.get("LinkStatus") or "").strip()
+                fallback_ib_link_status = (port.get("LinkStatus") or "Unknown").strip()
                 fallback_ib_priority = port_priority
             elif port_priority == fallback_ib_priority and not fallback_ib_nic_name:
                 fallback_ib_nic_name = candidate
-                fallback_ib_link_status = (port.get("LinkStatus") or "").strip()
+                fallback_ib_link_status = (port.get("LinkStatus") or "Unknown").strip()
         if info["ib_nic_name"]:
             break
     if not info["ib_nic_name"] and fallback_ib_nic_name:


### PR DESCRIPTION
## Summary

Fix two discovery bugs in ome_server_inventory.py:

### Bug 1: ADMIN_MAC picking InfiniBand MAC
**Issue:** When all Ethernet NICs have UNKNOWN link status, the ADMIN_MAC field incorrectly picks an InfiniBand NIC MAC instead of an Ethernet NIC MAC.

**Root cause:** The Ethernet NIC search loop only excluded iDRAC NICs ("iDRAC" not in nic_id.upper()), not InfiniBand NICs. The fallback logic would pick the first non-iDRAC NIC, which could be an IB NIC.

**Fix:** Add "INFINIBAND" not in nic_id.upper() filter at lines 447 and 481 to exclude IB NICs from both the primary serverNetworkInterfaces search and the deviceNics fallback search.

### Bug 2: Missing LINK STATUS for UNKNOWN NICs in discovery report
**Issue:** When OME returns LinkStatus as null or empty for NICs in UNKNOWN state, the discovery report shows blank link status instead of "Unknown".

**Root cause:** (port.get("LinkStatus") or "").strip() converts null/empty values to empty string "", resulting in blank status in the report.

**Fix:** Change default from "" to "Unknown" in all 5 LinkStatus fallback expressions:
- Line 460: Ethernet NIC fallback link status
- Line 462: Ethernet NIC link status check
- Line 500: IB NIC link status check
- Lines 508, 512: IB NIC fallback link status

## Files Changed

- `common/library/modules/ome_server_inventory.py`: 7 insertions, 7 deletions

## Testing

All 19 existing unit tests pass:
- 12 IB NIC fallback tests (test_ib_nic_fallback.py)
- 7 discovery report tests (test_generate_discovery_report.py)