### PR TITLE
Local repo update for subscription fix with python 3.13 update

### DIFF
--- a/common/library/module_utils/local_repo/software_utils.py
+++ b/common/library/module_utils/local_repo/software_utils.py
@@ -17,14 +17,18 @@
 This module util contains all custom software utilities used across custom modules
 """
 from collections import defaultdict
+import logging
 import os
 import json
 import csv
 import re
 import shlex
+import ssl
 import yaml
 from jinja2 import Template
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
 from ansible.module_utils.local_repo.standard_logger import setup_standard_logger
 from ansible.module_utils.local_repo.common_functions import is_encrypted, process_file, get_arch_from_sw_config
 from ansible.module_utils.local_repo.parse_and_download import execute_command
@@ -170,6 +174,35 @@ def get_csv_file_path(software_name, user_csv_dir, arch):
     return status_csv_file_path
 
 
+class _RelaxedCAAdapter(HTTPAdapter):
+    """HTTPAdapter that loads a custom CA but clears VERIFY_X509_STRICT.
+
+    Python 3.13+ enforces strict RFC 5280 Basic Constraints validation,
+    rejecting CA certs where the extension is not marked critical. Some
+    vendor CAs (e.g. Red Hat redhat-uep.pem) have non-critical Basic
+    Constraints which OpenSSL/curl accept. This adapter restores the
+    Python 3.12 behavior while keeping full chain and hostname validation.
+
+    Remove this workaround once the upstream CA is reissued with the
+    Basic Constraints extension marked critical.
+    """
+
+    def __init__(self, ca_cert, client_cert, client_key, *args, **kwargs):
+        self._ca_cert = ca_cert
+        self._client_cert = client_cert
+        self._client_key = client_key
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        ctx = ssl.create_default_context(cafile=self._ca_cert)
+        ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        if self._client_cert and self._client_key:
+            ctx.load_cert_chain(self._client_cert, self._client_key)
+        self.poolmanager = PoolManager(
+            num_pools=connections, maxsize=maxsize,
+            block=block, ssl_context=ctx, **pool_kwargs)
+
+
 def is_remote_url_reachable(remote_url, timeout=10,
                             client_cert=None, client_key=None, ca_cert=None):
     """
@@ -186,20 +219,41 @@ def is_remote_url_reachable(remote_url, timeout=10,
     Returns:
         bool: True if the URL is reachable (HTTP status 200), False otherwise.
     """
+    logger = logging.getLogger(__name__)
     try:
         # Check if SSL certs are provided and handle accordingly
         if client_cert and client_key and ca_cert:
-            response = requests.get(
-                remote_url,
-                cert=(client_cert, client_key),
-                verify=ca_cert,
-                timeout=timeout
-            )
+            try:
+                response = requests.get(
+                    remote_url,
+                    cert=(client_cert, client_key),
+                    verify=ca_cert,
+                    timeout=timeout
+                )
+            except requests.exceptions.SSLError as ssl_exc:
+                # Python 3.13+ rejects CA certs with non-critical Basic
+                # Constraints (RFC 5280 strict mode). Retry against the
+                # SAME CA with VERIFY_X509_STRICT cleared — still validates
+                # the full chain and hostname, just relaxes the one check.
+                logger.warning(
+                    f"Strict SSL verification failed for {remote_url}: "
+                    f"{ssl_exc}. Retrying with VERIFY_X509_STRICT cleared.")
+                session = requests.Session()
+                adapter = _RelaxedCAAdapter(
+                    ca_cert, client_cert, client_key)
+                session.mount("https://", adapter)
+                response = session.get(remote_url, timeout=timeout)
         else:
             # Proceed with a regular HTTP request if no SSL certs are provided
             response = requests.get(remote_url, timeout=timeout)
+        if response.status_code != 200:
+            logger.error(
+                f"URL {remote_url} returned HTTP {response.status_code}")
         return response.status_code == 200
-    except Exception:
+    except Exception as exc:
+        logger.error(
+            f"URL reachability exception for {remote_url}: "
+            f"{type(exc).__name__}: {exc}")
         return False
 
 def transform_package_dict(data, arch_val,logger):
@@ -396,6 +450,10 @@ def parse_repo_urls(repo_config, local_repo_config_path,
             )
 
             logger.info(f"Processing RHEL repo '{name}' for arch '{arch}' - URL: {url}")
+            logger.info(f"RHEL SSL paths: ca_cert={ca_cert}, client_key={client_key}, client_cert={client_cert}")
+            logger.info(f"RHEL SSL files exist: ca_cert={os.path.exists(ca_cert) if ca_cert else 'N/A'}, "
+                         f"client_key={os.path.exists(client_key) if client_key else 'N/A'}, "
+                         f"client_cert={os.path.exists(client_cert) if client_cert else 'N/A'}")
 
             for path in [ca_cert, client_key, client_cert]:
                 mode = "decrypt"


### PR DESCRIPTION

## Title
Fix SSL reachability check failure for RHEL repos on Python 3.13 (strict RFC 5280 validation)

## Description

### Problem
On systems using Python 3.13 (e.g., Fedora 42 containers), the RHEL repository URL reachability check in `is_remote_url_reachable()` fails with:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
Basic Constraints of CA cert not marked critical
```

### Root Cause
Python 3.13 enables `VERIFY_X509_STRICT` by default, enforcing RFC 5280 strictly. Red Hat's entitlement CA cert (`redhat-uep.pem`) has its Basic Constraints extension marked **non-critical**, which OpenSSL/curl tolerate but Python 3.13's `ssl` module rejects. This caused reachable RHEL repos to be incorrectly reported as unreachable, failing the local repo / Pulp pre-flight checks.

### Fix
Updated `is_remote_url_reachable()` in `software_utils.py` to catch the `SSLError` raised by strict validation and retry against the **same `ca_cert`** with the `VERIFY_X509_STRICT` flag cleared (restoring Python 3.12 behavior). This preserves full chain and hostname verification while tolerating the non-critical Basic Constraints. The original `ca_cert` path is still passed through unchanged for the later Pulp sync, which uses OpenSSL directly and is unaffected.

### Changes
- `common/library/module_utils/local_repo/software_utils.py`
  - Added SSL fallback handling in `is_remote_url_reachable()`
  - Added warning log when the strict-validation fallback is triggered

### Testing
- Verified `requests.get()` against `cdn.redhat.com` now succeeds on Python 3.13 with client certs + `redhat-uep.pem`
- Re-ran the local repo playbook end-to-end successfully
