### PR TITLE
Fix: Move SELinux preflight task after SSH setup in build_aarch64 playbook

### DIFF
--- a/build_image_aarch64/build_image_aarch64.yml
+++ b/build_image_aarch64/build_image_aarch64.yml
@@ -107,16 +107,6 @@
     oim_group: true
   tags: always
 
-- name: Pre-flight SELinux policy fix on aarch64 node
-  hosts: admin_aarch64
-  connection: ssh
-  gather_facts: false
-  tasks:
-    - name: Install SELinux policy module for container runtime
-      ansible.builtin.include_role:
-        name: image_creation
-        tasks_from: preflight_selinux_check.yml
-
 - name: Configure auth for OpenCHAMI
   hosts: oim
   connection: ssh
@@ -146,6 +136,16 @@
   gather_facts: false
   roles:
     - prepare_arm_node
+
+- name: Pre-flight SELinux policy fix on aarch64 node
+  hosts: admin_aarch64
+  connection: ssh
+  gather_facts: false
+  tasks:
+    - name: Install SELinux policy module for container runtime
+      ansible.builtin.include_role:
+        name: image_creation
+        tasks_from: preflight_selinux_check.yml
 
 - name: Fetch packages for aarch64
   hosts: localhost


### PR DESCRIPTION
**Description:**

Fixes SSH authentication failure in build_image_aarch64.yml playbook by reordering task execution.

**Problem:** 
The "Pre-flight SELinux policy fix on aarch64 node" task was running before passwordless SSH was established, causing:

fatal: UNREACHABLE! => Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password)
Solution: Moved the SELinux preflight play to execute after the "Prepare aarch64 nodes" play, which configures passwordless SSH via the prepare_arm_node role.

**Changes:**
Moved "Pre-flight SELinux policy fix on aarch64 node" play (lines 111-119) to run after "Prepare aarch64 nodes" (line 145)
Ensures SSH authentication is available before remote tasks execute

@abhishek-sa1 Please Review