### PR TITLE
Remove version.yml and fix openchami backup manifest

### DIFF
--- a/rollback/roles/rollback_openchami/tasks/rollback_status.yml
+++ b/rollback/roles/rollback_openchami/tasks/rollback_status.yml
@@ -14,10 +14,10 @@
 ---
 
 # ============================================================================
-# rollback_status.yml — Report Rollback Result and Update Version Metadata
+# rollback_status.yml — Report Rollback Result
 # ============================================================================
 # Runs in the 'always' block of main.yml — executes regardless of success
-# or failure. Updates version.yml to reflect v2.1 state on success.
+# or failure.
 # ============================================================================
 
 - name: Report rollback result
@@ -26,21 +26,6 @@
       ansible.builtin.debug:
         msg: "{{ rollback_messages.status.failure }}"
       when: openchami_rollback_failed | default(false) | bool
-
-    # ── Update version.yml to reflect v2.1 state on success ─────────────
-    - name: Update version.yml with v2.1 metadata after successful rollback
-      ansible.builtin.copy:
-        content: |
-          # OpenCHAMI version metadata — updated by rollback_openchami role
-          openchami_version: "2.1.0.0"
-          omnia_version: "2.1.0.0"
-          rollback_timestamp: "{{ ansible_date_time.iso8601 }}"
-          rolled_back_from: "2.2.0.0"
-          rollback_backup_dir: "{{ rollback_backup_dir | default(rollback_backup_dir_default) }}"
-        dest: "/opt/omnia/.data/version.yml"
-        mode: "{{ file_permissions_644 }}"
-      when:
-        - not (openchami_rollback_failed | default(false) | bool)
 
     - name: Report rollback success
       ansible.builtin.debug:

--- a/upgrade/playbooks/upgrade_oim.yml
+++ b/upgrade/playbooks/upgrade_oim.yml
@@ -86,40 +86,6 @@
               upgrade_needed={{ upgrade_needed | default(true) }},
               failed={{ openchami_upgrade_failed | default(false) }}
 
-        # Only update version tracking when an upgrade actually took place.
-        # Skipped when OpenCHAMI was not deployed or was already at target.
-        - name: Read current version.yml (if exists)
-          ansible.builtin.slurp:
-            src: "/opt/omnia/.data/version.yml"
-          register: raw_version_yml
-          failed_when: false
-          when:
-            - openchami_deployed | default(false) | bool
-            - upgrade_needed | default(true) | bool
-
-        - name: Parse current version.yml
-          ansible.builtin.set_fact:
-            current_version_data: "{{ raw_version_yml.content | b64decode | from_yaml }}"
-          when:
-            - openchami_deployed | default(false) | bool
-            - upgrade_needed | default(true) | bool
-            - raw_version_yml is defined
-            - raw_version_yml.content is defined
-
-        - name: Update version.yml with OpenCHAMI target version
-          ansible.builtin.copy:
-            content: >-
-              {{ (current_version_data | default({})) | combine({
-                   'openchami_version': manifest.target_version | default('2.2.0.0'),
-                   'openchami_previous_version': manifest.source_version | default('2.1.0.0'),
-                   'openchami_upgrade_timestamp': lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ')
-                 }) | to_nice_yaml }}
-            dest: "/opt/omnia/.data/version.yml"
-            mode: '0644'
-          when:
-            - openchami_deployed | default(false) | bool
-            - upgrade_needed | default(true) | bool
-
       rescue:
         # Re-read the manifest file to capture any intermediate writes
         # (e.g., the in-progress status set earlier in this play).

--- a/upgrade/roles/upgrade_openchami/tasks/backup_openchami.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/backup_openchami.yml
@@ -297,12 +297,18 @@
     - name: Create backup inventory manifest
       ansible.builtin.copy:
         content: |
-          # OpenCHAMI Pre-Upgrade Backup Manifest
+          # OpenCHAMI Backup Manifest
           backup_timestamp: "{{ ansible_date_time.iso8601 }}"
-          source_version: "{{ backup_manifest.source_version | default('unknown') }}"
-          target_version: "{{ backup_manifest.target_version | default('unknown') }}"
           upgrade_id: "{{ backup_manifest.upgrade_id | default('unknown') }}"
           backup_dir: "{{ openchami_backup_dir }}"
+
+          source_rpms:
+            openchami: "{{ current_openchami_rpm | default('not installed') }}"
+            ochami_cli: "{{ current_ochami_rpm | default('not installed') }}"
+
+          target_rpms:
+            openchami: "{{ openchami_rpm_name }}"
+            ochami_cli: "{{ ochami_client_rpm_name }}"
 
           postgresql_backup:
             file: "openchami/postgresql_backup/openchami.sql"

--- a/upgrade/roles/upgrade_openchami/tasks/pre_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/pre_upgrade_health_check.yml
@@ -95,29 +95,37 @@
     # --- Pre-upgrade health verification ---
     - name: Pre-upgrade health check
       block:
-        # ── Verify current OpenCHAMI version from version.yml ─────────
-        - name: Check if version.yml exists
-          ansible.builtin.stat:
-            path: "/opt/omnia/.data/version.yml"
-          register: version_yml_stat
+        # ── Find source (2.1) OpenCHAMI and ochami CLI RPM filenames from backup ─────
+        # The live workdir already contains the 2.2 target RPMs by the time
+        # the upgrade playbook runs. The original 2.1 RPMs are preserved in the
+        # backup directory created by omnia.sh --upgrade.
+        - name: Find source openchami RPM filename from backup
+          ansible.builtin.shell: |
+            RPM=$(ls -1 {{ openchami_backup_dir | default(openchami_backup_dir_default) }}/openchami/openchami_data/workdir/openchami*.rpm 2>/dev/null | head -1)
+            if [ -n "$RPM" ]; then basename "$RPM"; else echo "not found"; fi
+          register: source_openchami_rpm_result
+          changed_when: false
+          failed_when: false
 
-        - name: Read current OpenCHAMI version from version.yml
-          ansible.builtin.slurp:
-            src: "/opt/omnia/.data/version.yml"
-          register: version_yml_raw
-          when: version_yml_stat.stat.exists | default(false)
+        - name: Find source ochami CLI RPM filename from backup
+          ansible.builtin.shell: |
+            RPM=$(ls -1 {{ openchami_backup_dir | default(openchami_backup_dir_default) }}/openchami/openchami_data/workdir/ochami*.rpm 2>/dev/null | head -1)
+            if [ -n "$RPM" ]; then basename "$RPM"; else echo "not found"; fi
+          register: source_ochami_rpm_result
+          changed_when: false
+          failed_when: false
 
-        - name: Parse version.yml and display current version
+        - name: Set current RPM filename facts
           ansible.builtin.set_fact:
-            current_openchami_version: "{{ (version_yml_raw.content | b64decode | from_yaml).openchami_version | default('unknown') }}"
-          when:
-            - version_yml_stat.stat.exists | default(false)
-            - version_yml_raw.content is defined
+            current_openchami_rpm: "{{ source_openchami_rpm_result.stdout | default('not found') | trim }}"
+            current_ochami_rpm: "{{ source_ochami_rpm_result.stdout | default('not found') | trim }}"
 
-        - name: Display current OpenCHAMI version
+        - name: Display current installed RPM filenames
           ansible.builtin.debug:
             verbosity: 1
-            msg: "Current OpenCHAMI version: {{ current_openchami_version | default('not recorded') }}"
+            msg:
+              - "Source openchami RPM: {{ current_openchami_rpm }}"
+              - "Source ochami CLI RPM: {{ current_ochami_rpm }}"
 
         # ── Verify no active provisioning jobs ────────────────────────
         - name: Check for running discovery processes
@@ -276,7 +284,8 @@
                 and 's3_unreachable' not in pre_s3_check.stdout | default('s3_unreachable'))
                 else 'not configured (non-fatal)' }}
               - "Node count: {{ pre_upgrade_node_count }}{{ ' (prepare_oim-only)' if (pre_upgrade_node_count | int) == 0 else '' }}"
-              - "Version: {{ current_openchami_version | default('not recorded') }}"
+              - "OpenCHAMI RPM: {{ current_openchami_rpm | default('not installed') }}"
+              - "ochami CLI RPM: {{ current_ochami_rpm | default('not installed') }}"
               - "════════════════════════════════════════════"
 
       rescue:

--- a/upgrade/roles/upgrade_openchami/tasks/pre_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/pre_upgrade_health_check.yml
@@ -101,7 +101,9 @@
         # backup directory created by omnia.sh --upgrade.
         - name: Find source openchami RPM filename from backup
           ansible.builtin.shell: |
-            RPM=$(ls -1 {{ openchami_backup_dir | default(openchami_backup_dir_default) }}/openchami/openchami_data/workdir/openchami*.rpm 2>/dev/null | head -1)
+            set -o pipefail
+            backup_dir="{{ openchami_backup_dir | default(openchami_backup_dir_default) }}"
+            RPM=$(ls -1 "${backup_dir}/openchami/openchami_data/workdir/openchami"*.rpm 2>/dev/null | head -1)
             if [ -n "$RPM" ]; then basename "$RPM"; else echo "not found"; fi
           register: source_openchami_rpm_result
           changed_when: false
@@ -109,7 +111,9 @@
 
         - name: Find source ochami CLI RPM filename from backup
           ansible.builtin.shell: |
-            RPM=$(ls -1 {{ openchami_backup_dir | default(openchami_backup_dir_default) }}/openchami/openchami_data/workdir/ochami*.rpm 2>/dev/null | head -1)
+            set -o pipefail
+            backup_dir="{{ openchami_backup_dir | default(openchami_backup_dir_default) }}"
+            RPM=$(ls -1 "${backup_dir}/openchami/openchami_data/workdir/ochami"*.rpm 2>/dev/null | head -1)
             if [ -n "$RPM" ]; then basename "$RPM"; else echo "not found"; fi
           register: source_ochami_rpm_result
           changed_when: false

--- a/upgrade/roles/upgrade_openchami/tasks/upgrade_status.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/upgrade_status.yml
@@ -23,36 +23,9 @@
           {{ upgrade_messages.troubleshooting.container_upgrade_diagnosis }}
       when: openchami_upgrade_failed | default(false) | bool
 
-    # ── Update version.yml with new metadata on success ──────────────
-    - name: Update version.yml with new OpenCHAMI version metadata
-      ansible.builtin.copy:
-        content: |
-          # OpenCHAMI version metadata — updated by upgrade_openchami role
-          openchami_version: "{{ backup_manifest.target_version | default('2.2.0.0') }}"
-          omnia_version: "{{ backup_manifest.target_version | default('2.2.0.0') }}"
-          upgrade_timestamp: "{{ ansible_date_time.iso8601 }}"
-          upgraded_from: "{{ backup_manifest.source_version | default('2.1.0.0') }}"
-          component_versions:
-            smd: "{{ openchami_smd_tag }}"
-            bss: "{{ openchami_bss_tag }}"
-            cloud_init: "{{ openchami_cloud_init_tag }}"
-            local_ca: "{{ openchami_local_ca_tag }}"
-            opaal: "{{ openchami_opaal_tag }}"
-            coresmd: "{{ openchami_coresmd_tag }}"
-            postgres: "{{ postgres_tag }}"
-            hydra: "{{ hydra_tag }}"
-            haproxy: "{{ haproxy_tag }}"
-            registry: "{{ registry_tag }}"
-            minio: "{{ minio_release_tag }}"
-        dest: "/opt/omnia/.data/version.yml"
-        mode: "{{ file_permissions_644 }}"
-      when:
-        - not (openchami_upgrade_failed | default(false) | bool)
-        - openchami_deployed | default(false) | bool
-
     - name: Report upgrade success
       ansible.builtin.debug:
-        msg: "OpenCHAMI upgrade completed successfully. version.yml updated."
+        msg: "OpenCHAMI upgrade completed successfully."
       when:
         - not (openchami_upgrade_failed | default(false) | bool)
         - openchami_deployed | default(false) | bool


### PR DESCRIPTION
Removing version.yml as it s not being utilized by any component and updating openchami metadata related to version and backups in openchami backup manifest created at the time of openchami upgrade