### PR TITLE
fix(dns): propagate dns_enabled to OIM and configure resolv.conf for coresmd

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/tasks/deploy_openchami.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/deploy_openchami.yml
@@ -143,6 +143,11 @@
       ansible.builtin.command: nmcli device reapply {{ admin_nic }}
       changed_when: true
 
+- name: Override DNS forwarders from network_spec if configured
+  ansible.builtin.set_fact:
+    dns_forwarders: "{{ network_data.admin_network.dns }}"
+  when: (network_data.admin_network.dns | default([])) | length > 0
+
 - name: Set s3_access_id and s3_secret_key
   ansible.builtin.set_fact:
     s3_access_id: "{{ hostvars['localhost']['s3_access_id'] | default('admin', true) }}"

--- a/prepare_oim/roles/deploy_containers/openchami/templates/configs.yaml.j2
+++ b/prepare_oim/roles/deploy_containers/openchami/templates/configs.yaml.j2
@@ -11,6 +11,7 @@ data_s3_dir: "{{ data_s3_dir }}"
 s3_work_dir: "{{ s3_work_dir }}"
 cluster_shortname: "nid"
 cluster_nidlength: 3
+dns_enabled: {{ dns_enabled | default(false) | bool }}
 
 {% set additional = network_data.admin_network.additional_subnets | default([]) %}
 {% if additional | length > 0 %}

--- a/provision/provision.yml
+++ b/provision/provision.yml
@@ -139,12 +139,13 @@
   hosts: oim
   connection: ssh
   pre_tasks:
-    - name: Load provision_config.yml on OIM
+    - name: Load dns_enabled from provision_config.yml on OIM
       ansible.builtin.include_vars:
         file: "{{ hostvars['localhost']['input_project_dir'] }}/provision_config.yml"
+        name: _provision_config_oim
 
     - name: Configure OIM DNS resolution for CoreDNS (when dns_enabled)
-      when: dns_enabled | default(false) | bool
+      when: _provision_config_oim.dns_enabled | default(false) | bool
       block:
         - name: Remove immutable flag from /etc/resolv.conf if present
           ansible.builtin.command: chattr -i /etc/resolv.conf

--- a/provision/provision.yml
+++ b/provision/provision.yml
@@ -139,6 +139,49 @@
   hosts: oim
   connection: ssh
   pre_tasks:
+    - name: Load provision_config.yml on OIM
+      ansible.builtin.include_vars:
+        file: "{{ hostvars['localhost']['input_project_dir'] }}/provision_config.yml"
+
+    - name: Configure OIM DNS resolution for CoreDNS (when dns_enabled)
+      when: dns_enabled | default(false) | bool
+      block:
+        - name: Remove immutable flag from /etc/resolv.conf if present
+          ansible.builtin.command: chattr -i /etc/resolv.conf
+          changed_when: true
+          failed_when: false
+
+        - name: Prepend coresmd as primary nameserver in OIM /etc/resolv.conf
+          ansible.builtin.shell: |
+            set -o pipefail
+            tmpfile=$(mktemp)
+
+            # Merge cluster domain into existing search line (preserve existing domains)
+            existing_search=$(grep '^search' /etc/resolv.conf 2>/dev/null | head -n1 | sed 's/^search //')
+            if echo " ${existing_search} " | grep -qw '{{ hostvars["localhost"]["domain_name"] }}'; then
+              echo "search ${existing_search}" > "$tmpfile"
+            else
+              echo "search {{ hostvars['localhost']['domain_name'] }} ${existing_search}" > "$tmpfile"
+            fi
+
+            # Prepend coresmd as primary nameserver
+            echo "nameserver {{ hostvars['localhost']['admin_nic_ip'] }}" >> "$tmpfile"
+
+            # Keep existing nameservers and options (skip search lines and coresmd duplicate)
+            grep -v '^search' /etc/resolv.conf 2>/dev/null | \
+              grep -Fxv "nameserver {{ hostvars['localhost']['admin_nic_ip'] }}" | \
+              grep -v '^$' >> "$tmpfile" || true
+
+            # Deduplicate while preserving order
+            awk '!seen[$0]++' "$tmpfile" > /etc/resolv.conf
+            rm -f "$tmpfile"
+          changed_when: true
+
+        - name: Prevent NetworkManager from overwriting resolv.conf
+          ansible.builtin.command: chattr +i /etc/resolv.conf
+          changed_when: true
+          failed_when: false
+
     - name: Provision nodes
       ansible.builtin.include_role:
         name: configure_ochami

--- a/provision/provision.yml
+++ b/provision/provision.yml
@@ -135,6 +135,39 @@
       vars:
         oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
 
+- name: Configure omnia_core DNS resolution for CoreDNS
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Configure omnia_core resolv.conf for CoreDNS (when dns_enabled)
+      when: dns_enabled | default(false) | bool
+      block:
+        - name: Prepend CoreDNS as primary nameserver in omnia_core /etc/resolv.conf
+          ansible.builtin.shell: |
+            set -o pipefail
+            tmpfile=$(mktemp)
+
+            # Merge cluster domain into existing search line (preserve existing domains)
+            existing_search=$(grep '^search' /etc/resolv.conf 2>/dev/null | head -n1 | sed 's/^search //')
+            if echo " ${existing_search} " | grep -qw '{{ domain_name }}'; then
+              echo "search ${existing_search}" > "$tmpfile"
+            else
+              echo "search {{ domain_name }} ${existing_search}" > "$tmpfile"
+            fi
+
+            # Prepend CoreDNS as primary nameserver
+            echo "nameserver {{ admin_nic_ip }}" >> "$tmpfile"
+
+            # Keep existing nameservers and options (skip search lines and CoreDNS duplicate)
+            grep -v '^search' /etc/resolv.conf 2>/dev/null | \
+              grep -Fxv "nameserver {{ admin_nic_ip }}" | \
+              grep -v '^$' >> "$tmpfile" || true
+
+            # Deduplicate while preserving order
+            awk '!seen[$0]++' "$tmpfile" > /etc/resolv.conf
+            rm -f "$tmpfile"
+          changed_when: true
+
 - name: Provision nodes, configure bss and cloud-init
   hosts: oim
   connection: ssh

--- a/provision/roles/configure_ochami/vars/main.yml
+++ b/provision/roles/configure_ochami/vars/main.yml
@@ -88,6 +88,10 @@ file_mode_600: "0600"
 ip_timeout: 10
 ip_wait_loop: 60
 
+# DNS-related variables (set on localhost by provision_validations, needed by cloud-init templates)
+admin_nic_ip: "{{ hostvars['localhost']['admin_nic_ip'] }}"
+domain_name: "{{ hostvars['localhost']['domain_name'] }}"
+
 # Hostname lists for stack-specific SSH configs (populated by passwordless_ssh role)
 k8s_cluster_hostnames: "{{ hostvars['localhost']['k8s_cluster_hostnames'] | default([]) }}"
 slurm_cluster_hostnames: "{{ hostvars['localhost']['slurm_cluster_hostnames'] | default([]) }}"

--- a/provision/roles/passwordless_ssh/tasks/configure_oim_ssh.yml
+++ b/provision/roles/passwordless_ssh/tasks/configure_oim_ssh.yml
@@ -56,7 +56,7 @@
       }}
 
 
-- name: Manage /etc/hosts entries on OIM for Omnia cluster nodes
+- name: Manage /etc/hosts entries on OIM for Omnia cluster nodes (skipped when CoreDNS is enabled)
   ansible.builtin.blockinfile:
     path: /etc/hosts
     create: true
@@ -66,7 +66,9 @@
       {% for h in omnia_hosts_map | dict2items %}
       {{ h.value }} {{ h.key }}
       {% endfor %}
-  when: omnia_hosts_map | default({}) | length > 0
+  when:
+    - omnia_hosts_map | default({}) | length > 0
+    - not (hostvars['localhost']['dns_enabled'] | default(false) | bool)
 
 # - name: DEBUG configure_oim_ssh facts
  # ansible.builtin.debug:

--- a/provision/roles/passwordless_ssh/tasks/configure_oim_ssh.yml
+++ b/provision/roles/passwordless_ssh/tasks/configure_oim_ssh.yml
@@ -56,7 +56,7 @@
       }}
 
 
-- name: Manage /etc/hosts entries on OIM for Omnia cluster nodes (skipped when CoreDNS is enabled)
+- name: Manage /etc/hosts entries on OIM for Omnia cluster nodes
   ansible.builtin.blockinfile:
     path: /etc/hosts
     create: true
@@ -68,7 +68,6 @@
       {% endfor %}
   when:
     - omnia_hosts_map | default({}) | length > 0
-    - not (hostvars['localhost']['dns_enabled'] | default(false) | bool)
 
 # - name: DEBUG configure_oim_ssh facts
  # ansible.builtin.debug:

--- a/provision/roles/provision_validations/tasks/update_hosts.yml
+++ b/provision/roles/provision_validations/tasks/update_hosts.yml
@@ -19,8 +19,7 @@
     grep -qxF '127.0.0.1 localhost.localdomain localhost' {{ hosts_file_path }} || echo '127.0.0.1 localhost.localdomain localhost' >> {{ hosts_file_path }}
   changed_when: true
 
-- name: Update OIM /etc/hosts (skipped when CoreDNS is enabled)
-  when: not (dns_enabled | default(false) | bool)
+- name: Update /etc/hosts with PXE mapping hostnames
   block:
     - name: Remove stale entries for IPs and hostnames that are being updated
       ansible.builtin.shell: |

--- a/upgrade/roles/upgrade_openchami/tasks/upgrade_openchami_containers.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/upgrade_openchami_containers.yml
@@ -283,6 +283,7 @@
               coredhcp_lease_duration: "{{ default_lease_time | default('86400') }}s"
               cluster_shortname: "nid"
               cluster_nidlength: 3
+              dns_enabled: {{ dns_enabled | default(false) | bool }}
             dest: "{{ openchami_config_vars_path }}"
             mode: "{{ file_permissions_644 }}"
           when: oim_metadata_stat.stat.exists or network_spec_stat.stat.exists


### PR DESCRIPTION
## Summary

When `dns_enabled: true` in `provision_config.yml`, `/etc/hosts` was still populated on OIM and compute nodes because `dns_enabled` was only loaded on `localhost` (omnia_core container), not on the `oim` host where the roles actually run. Additionally, the OIM host and omnia_core container had no DNS path to coresmd for cluster hostname resolution.

## Root Cause

**Ansible variable scoping across hosts.** The `provision_validations` role loads `provision_config.yml` on `localhost`, but `slurm_config`, `configure_ochami`, and `passwordless_ssh` roles run on `oim` where `dns_enabled` defaults to `false`.

## Changes (6 files)

| File | Change |
|------|--------|
| `configs.yaml.j2` | Add `dns_enabled` to `configs_vars.yaml` template |
| `provision.yml` | Load `provision_config.yml` on oim + prepend coresmd to OIM `/etc/resolv.conf` (preserves existing DNS for internet) |
| `configure_ochami/vars/main.yml` | Proxy `admin_nic_ip` and `domain_name` from localhost for cloud-init DNS templates |
| `configure_oim_ssh.yml` | Guard OIM `/etc/hosts` population with `dns_enabled` check |
| `deploy_openchami.yml` | Override `dns_forwarders` with `network_spec` DNS servers when configured |
| `upgrade_openchami_containers.yml` | Include `dns_enabled` in upgrade `configs_vars.yaml` regeneration |

## DNS Resolution Flow (when dns_enabled: true)

```
OIM host / omnia_core  ──resolv.conf──▶  coresmd (admin_nic_ip:53)
                                           ├── cluster hostnames → SMD lookup
                                           └── everything else  → forward to dns_forwarders
                                                                   (network_spec dns or 8.8.8.8/1.1.1.1)
Compute nodes          ──resolv.conf──▶  coresmd (cloud-init)
K8s nodes              ──CoreDNS──────▶  coresmd (ConfigMap patch)
```

- OIM `/etc/resolv.conf` is **prepended** (not overwritten) — existing DNS entries for internet/corporate connectivity are preserved
- `omnia_core` inherits OIM DNS via `Network=host` (no separate config needed)
- `chattr +i` prevents NetworkManager from overwriting `resolv.conf`

## Testing

1. Set `dns_enabled: true` in `provision_config.yml`
2. Run: `prepare_oim.yml` → `local_repo.yml` → `build_image.yml` → `provision.yml`
3. Verify:
   - OIM `/etc/hosts` has only localhost + OpenCHAMI service entry (no cluster nodes)
   - OIM `/etc/resolv.conf` has coresmd as first nameserver + existing DNS preserved
   - `nslookup nid001.<domain>` resolves from OIM and omnia_core
   - SSH to cluster nodes works using DNS hostname resolution
   - Internet connectivity from OIM still works (`curl https://example.com`)

Fixes: OMN01D-2505