### PR TITLE
Simplify ID format to use package name only (version stripped) instead of {name}_{version}_{type}. Adding unit tests for id generation function

### DIFF
--- a/build_stream/core/catalog/tests/test_generate_catalog_id.py
+++ b/build_stream/core/catalog/tests/test_generate_catalog_id.py
@@ -1,0 +1,70 @@
+import unittest
+import sys
+from pathlib import Path
+
+# Add parent directory to path to import generate_catalog
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from generate_catalog import _generate_human_readable_id
+
+class TestGenerateHumanReadableId(unittest.TestCase):
+    def setUp(self):
+        self.used_ids = set()
+
+    def test_basic_names(self):
+        # Should remain unchanged
+        self.assertEqual(_generate_human_readable_id("apptainer", "rpm", None, self.used_ids), "apptainer")
+        self.assertEqual(_generate_human_readable_id("device-mapper-multipath", "rpm", None, self.used_ids), "device-mapper-multipath")
+
+    def test_version_in_name_exact(self):
+        # Should strip exact version suffix
+        self.assertEqual(_generate_human_readable_id("external-snapshotter-v8.4.0", "git", "v8.4.0", self.used_ids), "external-snapshotter")
+        
+    def test_version_in_name_v_prefixed(self):
+        # Should strip if 'v' prefix is in name but not in version
+        self.assertEqual(_generate_human_readable_id("app-v1.0.0", "rpm", "1.0.0", self.used_ids), "app")
+
+    def test_version_in_name_dots_replaced(self):
+        # Should strip if dots are replaced by hyphens
+        self.assertEqual(_generate_human_readable_id("helm-charts-2-16-0", "git", "2.16.0", self.used_ids), "helm-charts")
+
+    def test_pip_module_format(self):
+        # PyMySQL==1.1.2 -> PyMySQL
+        self.assertEqual(_generate_human_readable_id("PyMySQL==1.1.2", "pip_module", None, self.used_ids), "PyMySQL")
+
+    def test_regex_fallback_no_version(self):
+        # Regex should strip the version even without explicit pkg_version
+        self.assertEqual(_generate_human_readable_id("calico-v3.31.4", "manifest", None, self.used_ids), "calico")
+        self.assertEqual(_generate_human_readable_id("cert-manager-v1-10-0", "tarball", None, self.used_ids), "cert-manager")
+        self.assertEqual(_generate_human_readable_id("helm-v3-20-1-amd64", "tarball", None, self.used_ids), "helm-amd64")
+        self.assertEqual(_generate_human_readable_id("helm-v3-20-1-chart", "tarball", None, self.used_ids), "helm-chart")
+        self.assertEqual(_generate_human_readable_id("helm-v3-20-1-anything-suffixed", "tarball", None, self.used_ids), "helm-anything-suffixed")
+        self.assertEqual(_generate_human_readable_id("metallb-native-v0-15-3", "manifest", None, self.used_ids), "metallb-native")
+        self.assertEqual(_generate_human_readable_id("strimzi-kafka-operator-helm-3-chart-0-48-0", "tarball", None, self.used_ids), "strimzi-kafka-operator-helm-3-chart")
+        self.assertEqual(_generate_human_readable_id("victoria-metrics-operator-0-59-3", "tarball", None, self.used_ids), "victoria-metrics-operator")
+        self.assertEqual(_generate_human_readable_id("python3-PyMySQL-1.1.2", "rpm", None, self.used_ids), "python3-PyMySQL")
+        self.assertEqual(_generate_human_readable_id("nfs-subdir-external-provisioner-4-0-18", "tarball", None, self.used_ids), "nfs-subdir-external-provisioner")
+        
+    def test_docker_image_without_tag_in_name(self):
+        # Docker images usually don't have the tag in the name field, just the image path
+        self.assertEqual(_generate_human_readable_id("docker.io/library/python", "image", "3.12-slim", self.used_ids), "docker.io/library/python")
+
+    def test_collision_handling(self):
+        # First call gets the base name
+        id1 = _generate_human_readable_id("calico", "rpm", None, self.used_ids)
+        self.assertEqual(id1, "calico")
+        
+        # Second call with the same base name gets _1
+        id2 = _generate_human_readable_id("calico-v1.0.0", "tarball", None, self.used_ids)
+        self.assertEqual(id2, "calico_1")
+        
+        # Third call gets _2
+        id3 = _generate_human_readable_id("calico-v2.0.0", "manifest", None, self.used_ids)
+        self.assertEqual(id3, "calico_2")
+        
+        self.assertIn("calico", self.used_ids)
+        self.assertIn("calico_1", self.used_ids)
+        self.assertIn("calico_2", self.used_ids)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_stream/core/catalog/tests/test_generate_catalog_id.py
+++ b/build_stream/core/catalog/tests/test_generate_catalog_id.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 import sys
 from pathlib import Path

--- a/build_stream/generate_catalog.py
+++ b/build_stream/generate_catalog.py
@@ -177,37 +177,43 @@ def _merge_package_entries(dst, src):
 def _generate_human_readable_id(pkg_name, pkg_type, pkg_version, used_ids):
     """Generate a human-readable package ID with collision handling.
     
-    Format: {sanitized_name}_{version}_{type}
+    Format: {name} (the version is stripped from the name)
     If collision occurs, append counter: {base_id}_{counter}
     """
     # Extract version from package name if present (e.g., PyMySQL==1.1.2)
     name_for_id = pkg_name
-    if '==' in pkg_name and pkg_type == 'pip_module':
-        # For pip modules, name==version format
+    if '==' in pkg_name:
         parts = pkg_name.split('==')
-        if len(parts) == 2:
-            name_for_id = parts[0]
-            if not pkg_version:
-                pkg_version = parts[1]
-    elif '-' in pkg_name and pkg_type == 'rpm' and not pkg_version:
-        # Some RPMs have version in name (e.g., python3-PyMySQL-1.1.2)
-        # Try to extract version if it looks like a version number
-        parts = pkg_name.rsplit('-', 1)
-        if len(parts) == 2 and re.match(r'^\d', parts[1]):
-            name_for_id = parts[0]
+        name_for_id = parts[0]
+        if not pkg_version:
             pkg_version = parts[1]
+
+    # Try exact match removal if version is known
+    if pkg_version and isinstance(pkg_version, str):
+        # match at the end with 'v' prefixed
+        if name_for_id.endswith('v' + pkg_version):
+            name_for_id = name_for_id[:-(len(pkg_version) + 1)]
+        # exact match at the end
+        elif name_for_id.endswith(pkg_version):
+            name_for_id = name_for_id[:-len(pkg_version)]
+        # match with dots replaced by hyphens
+        elif name_for_id.endswith(pkg_version.replace('.', '-')):
+            name_for_id = name_for_id[:-len(pkg_version)]
+            
+    # Use regex to strip version-like suffixes for remaining cases
+    # Matches:
+    # 1. -v followed by digits/dots/hyphens (e.g. -v1.2.3, -v2)
+    # 2. - followed by multi-part digits (e.g. -2-16-0, -1.1.2)
+    # 3. - followed by single digit at the end (e.g. -3$)
+    # Preserves trailing non-version suffixes (e.g. -amd64, -chart)
+    version_regex = r'[-_](?:v\d+(?:[-.]\d+)*|\d+(?:[-.]\d+)+|\d+$)(?=[-_]|$)'
+    name_for_id = re.sub(version_regex, '', name_for_id)
     
-    # Sanitize package name: replace special chars with hyphens
-    sanitized = re.sub(r'[/@:.]', '-', name_for_id)
-    sanitized = re.sub(r'-+', '-', sanitized).strip('-')
-    
-    # Truncate very long names to reasonable length
-    if len(sanitized) > 50:
-        sanitized = sanitized[:50]
+    # Clean up trailing separators
+    name_for_id = name_for_id.rstrip('-_')
     
     # Build base ID
-    version_part = pkg_version if pkg_version else 'na'
-    base_id = f"{sanitized}_{version_part}_{pkg_type}"
+    base_id = name_for_id
     
     # Handle collisions
     if base_id not in used_ids:

--- a/examples/catalog/catalog_rhel.json
+++ b/examples/catalog/catalog_rhel.json
@@ -7,257 +7,257 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "os_x86_64",
         "FunctionalPackages": [
-          "openssl-libs_na_rpm",
-          "ovis-ldms_na_rpm",
-          "python3-cython_na_rpm",
-          "python3-devel_na_rpm"
+          "openssl-libs",
+          "ovis-ldms",
+          "python3-cython",
+          "python3-devel"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
-          "PyMySQL_1.1.2_pip_module",
-          "apptainer_na_rpm",
-          "calico-v3-31-4_na_manifest",
-          "cert-manager-v1-10-0_na_tarball",
-          "cffi_1.17.1_pip_module",
-          "container-selinux_na_rpm",
-          "cri-o_1.35.1_rpm",
-          "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "docker-io-alpine-kubectl_1.35.1_image",
-          "docker-io-calico-cni_v3.31.4_image",
-          "docker-io-calico-kube-controllers_v3.31.4_image",
-          "docker-io-calico-node_v3.31.4_image",
-          "docker-io-curlimages-curl_8.17.0_image",
-          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
-          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
-          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
-          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
-          "docker-io-library-busybox_1.36_image",
-          "docker-io-library-mysql_9.3.0_image",
-          "docker-io-library-python_3.12-slim_image",
-          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
-          "docker-io-rmohr-activemq_5.15.9_image",
-          "docker-io-timberio-vector_0.54.0-debian_image",
-          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
-          "docker-io-victoriametrics-operator_v0.68.3_image",
-          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
-          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
-          "docker-io-victoriametrics-vlagent_v1.50.0_image",
-          "docker-io-victoriametrics-vmagent_v1.128.0_image",
-          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_na_rpm",
-          "fuse-overlayfs_na_rpm",
-          "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
-          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_na_rpm",
-          "helm-charts_container-storage-modules-1.9.2_git",
-          "helm-v3-20-1-amd64_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "karavi-observability_v1.12.0_git",
-          "kubeadm_1.35.1_rpm",
-          "kubectl_1.35.1_rpm",
-          "kubelet_1.35.1_rpm",
-          "kubernetes_33.1.0_pip_module",
-          "lsscsi_na_rpm",
-          "metallb-native-v0-15-3_na_manifest",
-          "nfs-subdir-external-provisioner-4-0-18_na_tarball",
-          "omsdk_1.2.518_pip_module",
-          "podman_na_rpm",
-          "prettytable_3.14.0_pip_module",
-          "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_na_rpm",
-          "python3_3.12.9_rpm",
-          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
-          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
-          "quay-io-metallb-speaker_v0.15.3_image",
-          "quay-io-strimzi-kafka-bridge_0.33.1_image",
-          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
-          "quay-io-strimzi-operator_0.48.0_image",
-          "registry-k8s-io-coredns-coredns_v1.13.1_image",
-          "registry-k8s-io-etcd_3.6.6-0_image",
-          "registry-k8s-io-kube-apiserver_v1.35.1_image",
-          "registry-k8s-io-kube-controller-manager_v1.35.1_image",
-          "registry-k8s-io-kube-proxy_v1.35.1_image",
-          "registry-k8s-io-kube-scheduler_v1.35.1_image",
-          "registry-k8s-io-pause_3.10.1_image",
-          "sg3_utils_na_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
-          "victoria-metrics-operator-0-59-3_na_tarball",
-          "vim-enhanced_na_rpm"
+          "PyMySQL",
+          "apptainer",
+          "calico",
+          "cert-manager",
+          "cffi",
+          "container-selinux",
+          "cri-o",
+          "cryptography",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "docker.io/alpine/kubectl",
+          "docker.io/calico/cni",
+          "docker.io/calico/kube-controllers",
+          "docker.io/calico/node",
+          "docker.io/curlimages/curl",
+          "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+          "docker.io/dellhpcomniaaisolution/kafkapump",
+          "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+          "docker.io/dellhpcomniaaisolution/victoriapump",
+          "docker.io/library/busybox",
+          "docker.io/library/mysql",
+          "docker.io/library/python",
+          "docker.io/nginxinc/nginx-unprivileged",
+          "docker.io/rmohr/activemq",
+          "docker.io/timberio/vector",
+          "docker.io/victoriametrics/operator",
+          "docker.io/victoriametrics/operator_1",
+          "docker.io/victoriametrics/victoria-logs",
+          "docker.io/victoriametrics/victoria-metrics",
+          "docker.io/victoriametrics/vlagent",
+          "docker.io/victoriametrics/vmagent",
+          "docker.io/victoriametrics/vminsert",
+          "docker.io/victoriametrics/vmselect",
+          "docker.io/victoriametrics/vmstorage",
+          "firewalld",
+          "fuse-overlayfs",
+          "ghcr.io/kube-vip/kube-vip",
+          "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+          "git",
+          "helm-amd64",
+          "helm-charts",
+          "iscsi-initiator-utils",
+          "karavi-observability",
+          "kubeadm",
+          "kubectl",
+          "kubelet",
+          "kubernetes",
+          "lsscsi",
+          "metallb-native",
+          "nfs-subdir-external-provisioner",
+          "omsdk",
+          "podman",
+          "prettytable",
+          "prometheus_client",
+          "python3",
+          "python3-firewall",
+          "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+          "quay.io/jetstack/cert-manager-acmesolver",
+          "quay.io/jetstack/cert-manager-cainjector",
+          "quay.io/jetstack/cert-manager-controller",
+          "quay.io/jetstack/cert-manager-webhook",
+          "quay.io/metallb/speaker",
+          "quay.io/strimzi/kafka",
+          "quay.io/strimzi/kafka-bridge",
+          "quay.io/strimzi/operator",
+          "registry.k8s.io/coredns/coredns",
+          "registry.k8s.io/etcd",
+          "registry.k8s.io/kube-apiserver",
+          "registry.k8s.io/kube-controller-manager",
+          "registry.k8s.io/kube-proxy",
+          "registry.k8s.io/kube-scheduler",
+          "registry.k8s.io/pause",
+          "sg3_utils",
+          "strimzi-kafka-operator-helm-3-chart",
+          "victoria-metrics-operator",
+          "vim-enhanced"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "cert-manager-v1-10-0_na_tarball",
-          "cffi_1.17.1_pip_module",
-          "container-selinux_na_rpm",
-          "cri-o_1.35.1_rpm",
-          "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "docker-io-alpine-kubectl_1.35.1_image",
-          "docker-io-curlimages-curl_8.17.0_image",
-          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
-          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
-          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
-          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
-          "docker-io-library-busybox_1.36_image",
-          "docker-io-library-mysql_9.3.0_image",
-          "docker-io-library-python_3.12-slim_image",
-          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
-          "docker-io-rmohr-activemq_5.15.9_image",
-          "docker-io-timberio-vector_0.54.0-debian_image",
-          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
-          "docker-io-victoriametrics-operator_v0.68.3_image",
-          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
-          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
-          "docker-io-victoriametrics-vlagent_v1.50.0_image",
-          "docker-io-victoriametrics-vmagent_v1.128.0_image",
-          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_na_rpm",
-          "fuse-overlayfs_na_rpm",
-          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_na_rpm",
-          "helm-charts_container-storage-modules-1.9.2_git",
-          "iscsi-initiator-utils_na_rpm",
-          "karavi-observability_v1.12.0_git",
-          "kubeadm_1.35.1_rpm",
-          "kubelet_1.35.1_rpm",
-          "kubernetes_33.1.0_pip_module",
-          "lsscsi_na_rpm",
-          "omsdk_1.2.518_pip_module",
-          "podman_na_rpm",
-          "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_na_rpm",
-          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
-          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
-          "quay-io-metallb-controller_v0.15.3_image",
-          "quay-io-metallb-speaker_v0.15.3_image",
-          "quay-io-strimzi-kafka-bridge_0.33.1_image",
-          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
-          "quay-io-strimzi-operator_0.48.0_image",
-          "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
-          "sg3_utils_na_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
-          "victoria-metrics-operator-0-59-3_na_tarball",
-          "vim-enhanced_na_rpm"
+          "apptainer",
+          "cert-manager",
+          "cffi",
+          "container-selinux",
+          "cri-o",
+          "cryptography",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "docker.io/alpine/kubectl",
+          "docker.io/curlimages/curl",
+          "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+          "docker.io/dellhpcomniaaisolution/kafkapump",
+          "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+          "docker.io/dellhpcomniaaisolution/victoriapump",
+          "docker.io/library/busybox",
+          "docker.io/library/mysql",
+          "docker.io/library/python",
+          "docker.io/nginxinc/nginx-unprivileged",
+          "docker.io/rmohr/activemq",
+          "docker.io/timberio/vector",
+          "docker.io/victoriametrics/operator",
+          "docker.io/victoriametrics/operator_1",
+          "docker.io/victoriametrics/victoria-logs",
+          "docker.io/victoriametrics/victoria-metrics",
+          "docker.io/victoriametrics/vlagent",
+          "docker.io/victoriametrics/vmagent",
+          "docker.io/victoriametrics/vminsert",
+          "docker.io/victoriametrics/vmselect",
+          "docker.io/victoriametrics/vmstorage",
+          "firewalld",
+          "fuse-overlayfs",
+          "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+          "git",
+          "helm-charts",
+          "iscsi-initiator-utils",
+          "karavi-observability",
+          "kubeadm",
+          "kubelet",
+          "kubernetes",
+          "lsscsi",
+          "omsdk",
+          "podman",
+          "prometheus_client",
+          "python3-firewall",
+          "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+          "quay.io/jetstack/cert-manager-acmesolver",
+          "quay.io/jetstack/cert-manager-cainjector",
+          "quay.io/jetstack/cert-manager-controller",
+          "quay.io/jetstack/cert-manager-webhook",
+          "quay.io/metallb/controller",
+          "quay.io/metallb/speaker",
+          "quay.io/strimzi/kafka",
+          "quay.io/strimzi/kafka-bridge",
+          "quay.io/strimzi/operator",
+          "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+          "sg3_utils",
+          "strimzi-kafka-operator-helm-3-chart",
+          "victoria-metrics-operator",
+          "vim-enhanced"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "mariadb-server_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-PyMySQL_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmctld_na_rpm",
-          "slurm-slurmdbd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "mariadb-server",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-PyMySQL",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-slurmctld",
+          "slurm-slurmdbd"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "kernel-devel_na_rpm",
-          "kernel-headers_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-pam_slurm_na_rpm",
-          "slurm-slurmd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "kernel-devel",
+          "kernel-headers",
+          "likwid",
+          "lsscsi",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-pam_slurm",
+          "slurm-slurmd"
         ]
       }
     ],
@@ -266,106 +266,106 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_na_rpm",
-          "authselect_na_rpm",
-          "autoconf_na_rpm",
-          "automake_na_rpm",
-          "bash-completion_na_rpm",
-          "bash_na_rpm",
-          "binutils-devel_na_rpm",
-          "binutils_na_rpm",
-          "bzip2_na_rpm",
-          "chrony_na_rpm",
-          "cloud-init_na_rpm",
-          "clustershell_na_rpm",
-          "cmake_na_rpm",
-          "coreutils_na_rpm",
-          "cryptsetup_na_rpm",
-          "curl_na_rpm",
-          "device-mapper_na_rpm",
-          "dmidecode_na_rpm",
-          "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
-          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_na_rpm",
-          "dracut-network_na_rpm",
-          "dracut_na_rpm",
-          "emacs_na_rpm",
-          "file_na_rpm",
-          "findutils_na_rpm",
-          "fping_na_rpm",
-          "gawk_na_rpm",
-          "gcc-c++_na_rpm",
-          "gcc-gfortran_na_rpm",
-          "gcc_na_rpm",
-          "gdb-gdbserver_na_rpm",
-          "gdb_na_rpm",
-          "gedit_na_rpm",
-          "glibc-langpack-en_na_rpm",
-          "grep_na_rpm",
-          "gzip_na_rpm",
-          "hwloc-libs_na_rpm",
-          "hwloc_na_rpm",
-          "iperf3_na_rpm",
-          "ipmitool_na_rpm",
-          "iproute_na_rpm",
-          "iputils_na_rpm",
-          "kbd_na_rpm",
-          "kernel-tools_na_rpm",
-          "kernel_na_rpm",
-          "kexec-tools_na_rpm",
-          "libcurl_na_rpm",
-          "libtool_na_rpm",
-          "lldb-devel_na_rpm",
-          "lldb_na_rpm",
-          "lshw_na_rpm",
-          "lsof_na_rpm",
-          "ltrace_na_rpm",
-          "lvm2_na_rpm",
-          "make_na_rpm",
-          "man-db_na_rpm",
-          "man-pages_na_rpm",
-          "munge-devel_na_rpm",
-          "nfs-utils_na_rpm",
-          "nfs4-acl-tools_na_rpm",
-          "nm-connection-editor_na_rpm",
-          "nss-pam-ldapd_na_rpm",
-          "oddjob-mkhomedir_na_rpm",
-          "openldap-clients_na_rpm",
-          "openmpi_5.0.8_tarball",
-          "openssh-clients_na_rpm",
-          "openssh-server_na_rpm",
-          "openssh_na_rpm",
-          "openssl-devel_na_rpm",
-          "openssl-libs_na_rpm_1",
-          "ovis-ldms_na_rpm_1",
-          "papi-devel_na_rpm",
-          "papi-libs_na_rpm",
-          "papi_na_rpm",
-          "pciutils_na_rpm",
-          "perf_na_rpm",
-          "pmix-devel_na_rpm",
-          "python3-cython_na_rpm_1",
-          "python3-devel_na_rpm_1",
-          "rsync_na_rpm",
-          "rsyslog_na_rpm",
-          "sed_na_rpm",
-          "squashfs-tools_na_rpm",
-          "sssd_na_rpm",
-          "strace_na_rpm",
-          "sudo_na_rpm",
-          "systemd-udev_na_rpm",
-          "systemd_na_rpm",
-          "tar_na_rpm",
-          "tcpdump_na_rpm",
-          "traceroute_na_rpm",
-          "ucx_1.19.0_tarball",
-          "util-linux_na_rpm",
-          "valgrind-devel_na_rpm",
-          "valgrind_na_rpm",
-          "vim-enhanced_na_rpm_1",
-          "wget_na_rpm",
-          "which_na_rpm",
-          "zsh_na_rpm"
+          "NetworkManager",
+          "authselect",
+          "autoconf",
+          "automake",
+          "bash",
+          "bash-completion",
+          "binutils",
+          "binutils-devel",
+          "bzip2",
+          "chrony",
+          "cloud-init",
+          "clustershell",
+          "cmake",
+          "coreutils",
+          "cryptsetup",
+          "curl",
+          "device-mapper",
+          "dmidecode",
+          "docker.io/dellhpcomniaaisolution/image-build-aarch64",
+          "docker.io/dellhpcomniaaisolution/image-build-el10",
+          "dracut",
+          "dracut-live",
+          "dracut-network",
+          "emacs",
+          "file",
+          "findutils",
+          "fping",
+          "gawk",
+          "gcc",
+          "gcc-c++",
+          "gcc-gfortran",
+          "gdb",
+          "gdb-gdbserver",
+          "gedit",
+          "glibc-langpack-en",
+          "grep",
+          "gzip",
+          "hwloc",
+          "hwloc-libs",
+          "iperf3",
+          "ipmitool",
+          "iproute",
+          "iputils",
+          "kbd",
+          "kernel",
+          "kernel-tools",
+          "kexec-tools",
+          "libcurl",
+          "libtool",
+          "lldb",
+          "lldb-devel",
+          "lshw",
+          "lsof",
+          "ltrace",
+          "lvm2",
+          "make",
+          "man-db",
+          "man-pages",
+          "munge-devel",
+          "nfs-utils",
+          "nfs4-acl-tools",
+          "nm-connection-editor",
+          "nss-pam-ldapd",
+          "oddjob-mkhomedir",
+          "openldap-clients",
+          "openmpi",
+          "openssh",
+          "openssh-clients",
+          "openssh-server",
+          "openssl-devel",
+          "openssl-libs_1",
+          "ovis-ldms_1",
+          "papi-devel",
+          "papi-libs",
+          "papi_1",
+          "pciutils",
+          "perf",
+          "pmix-devel",
+          "python3-cython_1",
+          "python3-devel_1",
+          "rsync",
+          "rsyslog",
+          "sed",
+          "squashfs-tools",
+          "sssd",
+          "strace",
+          "sudo",
+          "systemd",
+          "systemd-udev",
+          "tar",
+          "tcpdump",
+          "traceroute",
+          "ucx",
+          "util-linux",
+          "valgrind",
+          "valgrind-devel",
+          "vim-enhanced_1",
+          "wget",
+          "which",
+          "zsh"
         ]
       }
     ],
@@ -373,29 +373,29 @@
       {
         "Name": "csi",
         "InfrastructurePackages": [
-          "csi-powerscale-v2-16-0_v2.16.0_git",
-          "docker-io-dellemc-csm-encryption_v0.6.0_image",
-          "external-snapshotter-v8-4-0_v8.4.0_git",
-          "helm-charts-2-16-0_csi-isilon-2.16.0_git",
-          "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image",
-          "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image",
-          "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image",
-          "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image",
-          "quay-io-dell-container-storage-modules-podmon_v1.15.0_image",
-          "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image",
-          "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image",
-          "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image",
-          "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image",
-          "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image",
-          "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image",
-          "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image"
+          "csi-powerscale",
+          "docker.io/dellemc/csm-encryption",
+          "external-snapshotter",
+          "helm-charts_1",
+          "quay.io/dell/container-storage-modules/csi-isilon",
+          "quay.io/dell/container-storage-modules/csi-metadata-retriever",
+          "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
+          "quay.io/dell/container-storage-modules/dell-csi-replicator",
+          "quay.io/dell/container-storage-modules/podmon",
+          "registry.k8s.io/sig-storage/csi-attacher",
+          "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
+          "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+          "registry.k8s.io/sig-storage/csi-provisioner",
+          "registry.k8s.io/sig-storage/csi-resizer",
+          "registry.k8s.io/sig-storage/csi-snapshotter",
+          "registry.k8s.io/sig-storage/snapshot-controller"
         ]
       }
     ],
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "PyMySQL_1.1.2_pip_module": {
+      "PyMySQL": {
         "Name": "PyMySQL==1.1.2",
         "SupportedOS": [
           {
@@ -408,7 +408,7 @@
         ],
         "Type": "pip_module"
       },
-      "apptainer_na_rpm": {
+      "apptainer": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -423,16 +423,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "calico-v3-31-4_na_manifest": {
+      "calico": {
         "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
@@ -451,7 +451,7 @@
           }
         ]
       },
-      "cert-manager-v1-10-0_na_tarball": {
+      "cert-manager": {
         "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
@@ -470,7 +470,7 @@
           }
         ]
       },
-      "cffi_1.17.1_pip_module": {
+      "cffi": {
         "Name": "cffi==1.17.1",
         "SupportedOS": [
           {
@@ -483,7 +483,7 @@
         ],
         "Type": "pip_module"
       },
-      "container-selinux_na_rpm": {
+      "container-selinux": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -502,7 +502,7 @@
           }
         ]
       },
-      "cri-o_1.35.1_rpm": {
+      "cri-o": {
         "Name": "cri-o-1.35.1",
         "SupportedOS": [
           {
@@ -521,7 +521,7 @@
           }
         ]
       },
-      "cryptography_45.0.7_pip_module": {
+      "cryptography": {
         "Name": "cryptography==45.0.7",
         "SupportedOS": [
           {
@@ -534,7 +534,7 @@
         ],
         "Type": "pip_module"
       },
-      "device-mapper-multipath_na_rpm": {
+      "device-mapper-multipath": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -549,16 +549,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "doca-ofed_na_rpm_repo": {
+      "doca-ofed": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -573,16 +573,16 @@
         "Type": "rpm_repo",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "doca"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "doca"
           }
         ]
       },
-      "docker-io-alpine-kubectl_1.35.1_image": {
+      "docker.io/alpine/kubectl": {
         "Name": "docker.io/alpine/kubectl",
         "SupportedOS": [
           {
@@ -597,7 +597,7 @@
         "Tag": "1.35.1",
         "Version": "1.35.1"
       },
-      "docker-io-calico-cni_v3.31.4_image": {
+      "docker.io/calico/cni": {
         "Name": "docker.io/calico/cni",
         "SupportedOS": [
           {
@@ -612,7 +612,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-calico-kube-controllers_v3.31.4_image": {
+      "docker.io/calico/kube-controllers": {
         "Name": "docker.io/calico/kube-controllers",
         "SupportedOS": [
           {
@@ -627,7 +627,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-calico-node_v3.31.4_image": {
+      "docker.io/calico/node": {
         "Name": "docker.io/calico/node",
         "SupportedOS": [
           {
@@ -642,7 +642,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-curlimages-curl_8.17.0_image": {
+      "docker.io/curlimages/curl": {
         "Name": "docker.io/curlimages/curl",
         "SupportedOS": [
           {
@@ -657,7 +657,7 @@
         "Tag": "8.17.0",
         "Version": "8.17.0"
       },
-      "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver": {
         "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
         "SupportedOS": [
           {
@@ -672,7 +672,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/kafkapump": {
         "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
         "SupportedOS": [
           {
@@ -687,7 +687,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/ubuntu-ldms": {
         "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
         "SupportedOS": [
           {
@@ -702,7 +702,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/victoriapump": {
         "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
         "SupportedOS": [
           {
@@ -717,7 +717,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-library-busybox_1.36_image": {
+      "docker.io/library/busybox": {
         "Name": "docker.io/library/busybox",
         "SupportedOS": [
           {
@@ -732,7 +732,7 @@
         "Tag": "1.36",
         "Version": "1.36"
       },
-      "docker-io-library-mysql_9.3.0_image": {
+      "docker.io/library/mysql": {
         "Name": "docker.io/library/mysql",
         "SupportedOS": [
           {
@@ -747,7 +747,7 @@
         "Tag": "9.3.0",
         "Version": "9.3.0"
       },
-      "docker-io-library-python_3.12-slim_image": {
+      "docker.io/library/python": {
         "Name": "docker.io/library/python",
         "SupportedOS": [
           {
@@ -762,7 +762,7 @@
         "Tag": "3.12-slim",
         "Version": "3.12-slim"
       },
-      "docker-io-nginxinc-nginx-unprivileged_1.29_image": {
+      "docker.io/nginxinc/nginx-unprivileged": {
         "Name": "docker.io/nginxinc/nginx-unprivileged",
         "SupportedOS": [
           {
@@ -777,7 +777,7 @@
         "Tag": "1.29",
         "Version": "1.29"
       },
-      "docker-io-rmohr-activemq_5.15.9_image": {
+      "docker.io/rmohr/activemq": {
         "Name": "docker.io/rmohr/activemq",
         "SupportedOS": [
           {
@@ -792,7 +792,7 @@
         "Tag": "5.15.9",
         "Version": "5.15.9"
       },
-      "docker-io-timberio-vector_0.54.0-debian_image": {
+      "docker.io/timberio/vector": {
         "Name": "docker.io/timberio/vector",
         "SupportedOS": [
           {
@@ -807,22 +807,7 @@
         "Tag": "0.54.0-debian",
         "Version": "0.54.0-debian"
       },
-      "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "config-reloader-v0.68.3",
-        "Version": "config-reloader-v0.68.3"
-      },
-      "docker-io-victoriametrics-operator_v0.68.3_image": {
+      "docker.io/victoriametrics/operator": {
         "Name": "docker.io/victoriametrics/operator",
         "SupportedOS": [
           {
@@ -837,7 +822,22 @@
         "Tag": "v0.68.3",
         "Version": "v0.68.3"
       },
-      "docker-io-victoriametrics-victoria-logs_v1.50.0_image": {
+      "docker.io/victoriametrics/operator_1": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "config-reloader-v0.68.3",
+        "Version": "config-reloader-v0.68.3"
+      },
+      "docker.io/victoriametrics/victoria-logs": {
         "Name": "docker.io/victoriametrics/victoria-logs",
         "SupportedOS": [
           {
@@ -852,7 +852,7 @@
         "Tag": "v1.50.0",
         "Version": "v1.50.0"
       },
-      "docker-io-victoriametrics-victoria-metrics_v1.128.0_image": {
+      "docker.io/victoriametrics/victoria-metrics": {
         "Name": "docker.io/victoriametrics/victoria-metrics",
         "SupportedOS": [
           {
@@ -867,7 +867,7 @@
         "Tag": "v1.128.0",
         "Version": "v1.128.0"
       },
-      "docker-io-victoriametrics-vlagent_v1.50.0_image": {
+      "docker.io/victoriametrics/vlagent": {
         "Name": "docker.io/victoriametrics/vlagent",
         "SupportedOS": [
           {
@@ -882,7 +882,7 @@
         "Tag": "v1.50.0",
         "Version": "v1.50.0"
       },
-      "docker-io-victoriametrics-vmagent_v1.128.0_image": {
+      "docker.io/victoriametrics/vmagent": {
         "Name": "docker.io/victoriametrics/vmagent",
         "SupportedOS": [
           {
@@ -897,7 +897,7 @@
         "Tag": "v1.128.0",
         "Version": "v1.128.0"
       },
-      "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vminsert": {
         "Name": "docker.io/victoriametrics/vminsert",
         "SupportedOS": [
           {
@@ -912,7 +912,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vmselect": {
         "Name": "docker.io/victoriametrics/vmselect",
         "SupportedOS": [
           {
@@ -927,7 +927,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vmstorage": {
         "Name": "docker.io/victoriametrics/vmstorage",
         "SupportedOS": [
           {
@@ -942,7 +942,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "firewalld_na_rpm": {
+      "firewalld": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -957,16 +957,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "fuse-overlayfs_na_rpm": {
+      "fuse-overlayfs": {
         "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
@@ -985,7 +985,7 @@
           }
         ]
       },
-      "geopm_na_tarball": {
+      "geopm": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -1000,16 +1000,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
           }
         ]
       },
-      "ghcr-io-kube-vip-kube-vip_v0.8.9_image": {
+      "ghcr.io/kube-vip/kube-vip": {
         "Name": "ghcr.io/kube-vip/kube-vip",
         "SupportedOS": [
           {
@@ -1024,7 +1024,7 @@
         "Tag": "v0.8.9",
         "Version": "v0.8.9"
       },
-      "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image": {
+      "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector": {
         "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
         "SupportedOS": [
           {
@@ -1039,7 +1039,7 @@
         "Tag": "0.143.1",
         "Version": "0.143.1"
       },
-      "git_na_rpm": {
+      "git": {
         "Name": "git",
         "SupportedOS": [
           {
@@ -1058,7 +1058,26 @@
           }
         ]
       },
-      "helm-charts_container-storage-modules-1.9.2_git": {
+      "helm-amd64": {
+        "Name": "helm-v3.20.1-amd64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
+          }
+        ]
+      },
+      "helm-charts": {
         "Name": "helm-charts",
         "SupportedOS": [
           {
@@ -1078,26 +1097,7 @@
           }
         ]
       },
-      "helm-v3-20-1-amd64_na_tarball": {
-        "Name": "helm-v3.20.1-amd64",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
-          }
-        ]
-      },
-      "imb_na_tarball": {
+      "imb": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -1112,16 +1112,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "iscsi-initiator-utils_na_rpm": {
+      "iscsi-initiator-utils": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -1136,16 +1136,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "karavi-observability_v1.12.0_git": {
+      "karavi-observability": {
         "Name": "karavi-observability",
         "SupportedOS": [
           {
@@ -1165,7 +1165,7 @@
           }
         ]
       },
-      "kernel-devel_na_rpm": {
+      "kernel-devel": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1180,16 +1180,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "kernel-headers_na_rpm": {
+      "kernel-headers": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1204,16 +1204,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "kubeadm_1.35.1_rpm": {
+      "kubeadm": {
         "Name": "kubeadm-1.35.1",
         "SupportedOS": [
           {
@@ -1232,7 +1232,7 @@
           }
         ]
       },
-      "kubectl_1.35.1_rpm": {
+      "kubectl": {
         "Name": "kubectl-1.35.1",
         "SupportedOS": [
           {
@@ -1251,7 +1251,7 @@
           }
         ]
       },
-      "kubelet_1.35.1_rpm": {
+      "kubelet": {
         "Name": "kubelet-1.35.1",
         "SupportedOS": [
           {
@@ -1270,7 +1270,7 @@
           }
         ]
       },
-      "kubernetes_33.1.0_pip_module": {
+      "kubernetes": {
         "Name": "kubernetes==33.1.0",
         "SupportedOS": [
           {
@@ -1283,7 +1283,7 @@
         ],
         "Type": "pip_module"
       },
-      "likwid_na_tarball": {
+      "likwid": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -1298,16 +1298,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           }
         ]
       },
-      "lsscsi_na_rpm": {
+      "lsscsi": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -1322,16 +1322,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "mariadb-server_na_rpm": {
+      "mariadb-server": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -1346,16 +1346,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "metallb-native-v0-15-3_na_manifest": {
+      "metallb-native": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -1374,7 +1374,7 @@
           }
         ]
       },
-      "msr-safe_na_tarball": {
+      "msr-safe": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -1393,7 +1393,7 @@
           }
         ]
       },
-      "munge_na_rpm": {
+      "munge": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -1408,16 +1408,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "nfs-subdir-external-provisioner-4-0-18_na_tarball": {
+      "nfs-subdir-external-provisioner": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -1436,7 +1436,7 @@
           }
         ]
       },
-      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+      "nvcr.io/nvidia/hpc-benchmarks": {
         "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
@@ -1452,7 +1452,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "omsdk_1.2.518_pip_module": {
+      "omsdk": {
         "Name": "omsdk==1.2.518",
         "SupportedOS": [
           {
@@ -1465,7 +1465,7 @@
         ],
         "Type": "pip_module"
       },
-      "openssl-libs_na_rpm": {
+      "openssl-libs": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -1480,16 +1480,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "osu-micro-benchmarks_na_tarball": {
+      "osu-micro-benchmarks": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -1504,16 +1504,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
           }
         ]
       },
-      "ovis-ldms_na_rpm": {
+      "ovis-ldms": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -1528,16 +1528,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "ldms"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "ldms"
           }
         ]
       },
-      "papi_na_tarball": {
+      "papi": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -1552,16 +1552,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
           }
         ]
       },
-      "pmix_na_rpm": {
+      "pmix": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -1576,16 +1576,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "podman_na_rpm": {
+      "podman": {
         "Name": "podman",
         "SupportedOS": [
           {
@@ -1604,7 +1604,7 @@
           }
         ]
       },
-      "prettytable_3.14.0_pip_module": {
+      "prettytable": {
         "Name": "prettytable==3.14.0",
         "SupportedOS": [
           {
@@ -1617,7 +1617,7 @@
         ],
         "Type": "pip_module"
       },
-      "prometheus_client_0.20.0_pip_module": {
+      "prometheus_client": {
         "Name": "prometheus_client==0.20.0",
         "SupportedOS": [
           {
@@ -1630,103 +1630,7 @@
         ],
         "Type": "pip_module"
       },
-      "python3-PyMySQL_na_rpm": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "python3-cython_na_rpm": {
-        "Name": "python3-cython",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "codeready-builder"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          }
-        ]
-      },
-      "python3-devel_na_rpm": {
-        "Name": "python3-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "python3-firewall_na_rpm": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "python3_3.12.9_rpm": {
+      "python3": {
         "Name": "python3-3.12.9",
         "SupportedOS": [
           {
@@ -1745,7 +1649,103 @@
           }
         ]
       },
-      "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image": {
+      "python3-PyMySQL": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-cython": {
+        "Name": "python3-cython",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "python3-devel": {
+        "Name": "python3-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "quay.io/dell/container-storage-modules/csm-metrics-powerscale": {
         "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
         "SupportedOS": [
           {
@@ -1760,7 +1760,7 @@
         "Tag": "v1.11.0",
         "Version": "v1.11.0"
       },
-      "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-acmesolver": {
         "Name": "quay.io/jetstack/cert-manager-acmesolver",
         "SupportedOS": [
           {
@@ -1775,7 +1775,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-cainjector": {
         "Name": "quay.io/jetstack/cert-manager-cainjector",
         "SupportedOS": [
           {
@@ -1790,7 +1790,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-controller_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-controller": {
         "Name": "quay.io/jetstack/cert-manager-controller",
         "SupportedOS": [
           {
@@ -1805,7 +1805,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-webhook_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-webhook": {
         "Name": "quay.io/jetstack/cert-manager-webhook",
         "SupportedOS": [
           {
@@ -1820,7 +1820,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-metallb-controller_v0.15.3_image": {
+      "quay.io/metallb/controller": {
         "Name": "quay.io/metallb/controller",
         "SupportedOS": [
           {
@@ -1835,7 +1835,7 @@
         "Tag": "v0.15.3",
         "Version": "v0.15.3"
       },
-      "quay-io-metallb-speaker_v0.15.3_image": {
+      "quay.io/metallb/speaker": {
         "Name": "quay.io/metallb/speaker",
         "SupportedOS": [
           {
@@ -1850,22 +1850,7 @@
         "Tag": "v0.15.3",
         "Version": "v0.15.3"
       },
-      "quay-io-strimzi-kafka-bridge_0.33.1_image": {
-        "Name": "quay.io/strimzi/kafka-bridge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.33.1",
-        "Version": "0.33.1"
-      },
-      "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image": {
+      "quay.io/strimzi/kafka": {
         "Name": "quay.io/strimzi/kafka",
         "SupportedOS": [
           {
@@ -1880,7 +1865,22 @@
         "Tag": "0.48.0-kafka-4.1.0",
         "Version": "0.48.0-kafka-4.1.0"
       },
-      "quay-io-strimzi-operator_0.48.0_image": {
+      "quay.io/strimzi/kafka-bridge": {
+        "Name": "quay.io/strimzi/kafka-bridge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.33.1",
+        "Version": "0.33.1"
+      },
+      "quay.io/strimzi/operator": {
         "Name": "quay.io/strimzi/operator",
         "SupportedOS": [
           {
@@ -1895,7 +1895,7 @@
         "Tag": "0.48.0",
         "Version": "0.48.0"
       },
-      "registry-k8s-io-coredns-coredns_v1.13.1_image": {
+      "registry.k8s.io/coredns/coredns": {
         "Name": "registry.k8s.io/coredns/coredns",
         "SupportedOS": [
           {
@@ -1910,7 +1910,7 @@
         "Tag": "v1.13.1",
         "Version": "v1.13.1"
       },
-      "registry-k8s-io-etcd_3.6.6-0_image": {
+      "registry.k8s.io/etcd": {
         "Name": "registry.k8s.io/etcd",
         "SupportedOS": [
           {
@@ -1925,7 +1925,7 @@
         "Tag": "3.6.6-0",
         "Version": "3.6.6-0"
       },
-      "registry-k8s-io-kube-apiserver_v1.35.1_image": {
+      "registry.k8s.io/kube-apiserver": {
         "Name": "registry.k8s.io/kube-apiserver",
         "SupportedOS": [
           {
@@ -1940,7 +1940,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-controller-manager_v1.35.1_image": {
+      "registry.k8s.io/kube-controller-manager": {
         "Name": "registry.k8s.io/kube-controller-manager",
         "SupportedOS": [
           {
@@ -1955,7 +1955,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-proxy_v1.35.1_image": {
+      "registry.k8s.io/kube-proxy": {
         "Name": "registry.k8s.io/kube-proxy",
         "SupportedOS": [
           {
@@ -1970,7 +1970,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-scheduler_v1.35.1_image": {
+      "registry.k8s.io/kube-scheduler": {
         "Name": "registry.k8s.io/kube-scheduler",
         "SupportedOS": [
           {
@@ -1985,7 +1985,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-pause_3.10.1_image": {
+      "registry.k8s.io/pause": {
         "Name": "registry.k8s.io/pause",
         "SupportedOS": [
           {
@@ -2000,7 +2000,7 @@
         "Tag": "3.10.1",
         "Version": "3.10.1"
       },
-      "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image": {
+      "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner": {
         "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
         "SupportedOS": [
           {
@@ -2015,7 +2015,7 @@
         "Tag": "v4.0.2",
         "Version": "v4.0.2"
       },
-      "sg3_utils_na_rpm": {
+      "sg3_utils": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -2030,16 +2030,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sionlib_na_tarball": {
+      "sionlib": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -2054,112 +2054,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          },
-          {
             "Architecture": "x86_64",
             "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "slurm-pam_slurm_na_rpm": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmctld_na_rpm": {
-        "Name": "slurm-slurmctld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
           }
         ]
       },
-      "slurm-slurmd_na_rpm": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmdbd_na_rpm": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm_na_rpm": {
+      "slurm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -2174,16 +2078,112 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "slurm_custom"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "slurm_custom"
           }
         ]
       },
-      "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball": {
+      "slurm-pam_slurm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "strimzi-kafka-operator-helm-3-chart": {
         "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
         "SupportedOS": [
           {
@@ -2202,7 +2202,7 @@
           }
         ]
       },
-      "victoria-metrics-operator-0-59-3_na_tarball": {
+      "victoria-metrics-operator": {
         "Name": "victoria-metrics-operator-0.59.3",
         "SupportedOS": [
           {
@@ -2221,7 +2221,7 @@
           }
         ]
       },
-      "vim-enhanced_na_rpm": {
+      "vim-enhanced": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2236,18 +2236,18 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       }
     },
     "OSPackages": {
-      "NetworkManager_na_rpm": {
+      "NetworkManager": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -2262,16 +2262,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "authselect_na_rpm": {
+      "authselect": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -2286,16 +2286,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "autoconf_na_rpm": {
+      "autoconf": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2310,16 +2310,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "automake_na_rpm": {
+      "automake": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2334,40 +2334,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "bash-completion_na_rpm": {
-        "Name": "bash-completion",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "bash_na_rpm": {
+      "bash": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -2382,17 +2358,17 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "binutils-devel_na_rpm": {
-        "Name": "binutils-devel",
+      "bash-completion": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2406,16 +2382,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
           }
         ]
       },
-      "binutils_na_rpm": {
+      "binutils": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -2430,16 +2406,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "bzip2_na_rpm": {
+      "binutils-devel": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bzip2": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -2454,16 +2454,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "chrony_na_rpm": {
+      "chrony": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -2478,16 +2478,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "cloud-init_na_rpm": {
+      "cloud-init": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -2502,16 +2502,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "clustershell_na_rpm": {
+      "clustershell": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2526,16 +2526,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "cmake_na_rpm": {
+      "cmake": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -2550,16 +2550,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "coreutils_na_rpm": {
+      "coreutils": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -2574,16 +2574,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "cryptsetup_na_rpm": {
+      "cryptsetup": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -2598,16 +2598,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "curl_na_rpm": {
+      "curl": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -2622,16 +2622,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "device-mapper_na_rpm": {
+      "device-mapper": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -2646,16 +2646,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "dmidecode_na_rpm": {
+      "dmidecode": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -2670,16 +2670,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-aarch64": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
         "SupportedOS": [
           {
@@ -2694,7 +2694,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-el10": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
         "SupportedOS": [
           {
@@ -2709,55 +2709,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_na_rpm": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "dracut-network_na_rpm": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "dracut_na_rpm": {
+      "dracut": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -2772,16 +2724,64 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "emacs_na_rpm": {
+      "dracut-live": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -2796,16 +2796,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "file_na_rpm": {
+      "file": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -2820,16 +2820,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "findutils_na_rpm": {
+      "findutils": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -2844,16 +2844,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "fping_na_rpm": {
+      "fping": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -2868,16 +2868,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "gawk_na_rpm": {
+      "gawk": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -2892,64 +2892,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
             "Architecture": "x86_64",
             "RepoName": "baseos"
-          }
-        ]
-      },
-      "gcc-c++_na_rpm": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc-gfortran_na_rpm": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "RepoName": "baseos"
           }
         ]
       },
-      "gcc_na_rpm": {
+      "gcc": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -2964,17 +2916,17 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gdb-gdbserver_na_rpm": {
-        "Name": "gdb-gdbserver",
+      "gcc-c++": {
+        "Name": "gcc-c++",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2988,16 +2940,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gdb_na_rpm": {
+      "gcc-gfortran": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -3012,16 +2988,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gedit_na_rpm": {
+      "gdb-gdbserver": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -3036,16 +3036,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "glibc-langpack-en_na_rpm": {
+      "glibc-langpack-en": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -3060,16 +3060,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "grep_na_rpm": {
+      "grep": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -3084,16 +3084,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "gzip_na_rpm": {
+      "gzip": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -3108,40 +3108,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "hwloc-libs_na_rpm": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "hwloc_na_rpm": {
+      "hwloc": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -3156,16 +3132,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "iperf3_na_rpm": {
+      "hwloc-libs": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -3180,16 +3180,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "ipmitool_na_rpm": {
+      "ipmitool": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -3204,16 +3204,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "iproute_na_rpm": {
+      "iproute": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -3228,16 +3228,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "iputils_na_rpm": {
+      "iputils": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -3252,16 +3252,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kbd_na_rpm": {
+      "kbd": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -3276,40 +3276,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kernel-tools_na_rpm": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "kernel_na_rpm": {
+      "kernel": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -3324,16 +3300,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kexec-tools_na_rpm": {
+      "kernel-tools": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -3348,16 +3348,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "libcurl_na_rpm": {
+      "libcurl": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -3372,16 +3372,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "libtool_na_rpm": {
+      "libtool": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -3396,40 +3396,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lldb-devel_na_rpm": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "lldb_na_rpm": {
+      "lldb": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -3444,16 +3420,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lshw_na_rpm": {
+      "lldb-devel": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -3468,16 +3468,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "lsof_na_rpm": {
+      "lsof": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -3492,16 +3492,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ltrace_na_rpm": {
+      "ltrace": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -3516,16 +3516,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lvm2_na_rpm": {
+      "lvm2": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -3540,16 +3540,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "make_na_rpm": {
+      "make": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -3564,16 +3564,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "man-db_na_rpm": {
+      "man-db": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -3588,16 +3588,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "man-pages_na_rpm": {
+      "man-pages": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -3612,16 +3612,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "munge-devel_na_rpm": {
+      "munge-devel": {
         "Name": "munge-devel",
         "SupportedOS": [
           {
@@ -3636,16 +3636,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "codeready-builder"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "codeready-builder"
           }
         ]
       },
-      "nfs-utils_na_rpm": {
+      "nfs-utils": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -3660,16 +3660,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nfs4-acl-tools_na_rpm": {
+      "nfs4-acl-tools": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -3684,16 +3684,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nm-connection-editor_na_rpm": {
+      "nm-connection-editor": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -3708,16 +3708,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "nss-pam-ldapd_na_rpm": {
+      "nss-pam-ldapd": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -3732,16 +3732,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "oddjob-mkhomedir_na_rpm": {
+      "oddjob-mkhomedir": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -3756,16 +3756,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "openldap-clients_na_rpm": {
+      "openldap-clients": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -3780,16 +3780,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "openmpi_5.0.8_tarball": {
+      "openmpi": {
         "Name": "openmpi",
         "SupportedOS": [
           {
@@ -3805,64 +3805,16 @@
         "Version": "5.0.8",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "Uri": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
-          },
-          {
             "Architecture": "x86_64",
             "Uri": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
-          }
-        ]
-      },
-      "openssh-clients_na_rpm": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh-server_na_rpm": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
+            "Uri": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
           }
         ]
       },
-      "openssh_na_rpm": {
+      "openssh": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -3877,16 +3829,64 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "openssl-devel_na_rpm": {
+      "openssh-clients": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -3901,16 +3901,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "openssl-libs_na_rpm_1": {
+      "openssl-libs_1": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -3925,16 +3925,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ovis-ldms_na_rpm_1": {
+      "ovis-ldms_1": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -3949,16 +3949,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "ldms"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "ldms"
           }
         ]
       },
-      "papi-devel_na_rpm": {
+      "papi-devel": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -3973,16 +3973,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi-libs_na_rpm": {
+      "papi-libs": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -3997,16 +3997,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi_na_rpm": {
+      "papi_1": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -4021,16 +4021,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "pciutils_na_rpm": {
+      "pciutils": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -4045,16 +4045,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "perf_na_rpm": {
+      "perf": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -4069,16 +4069,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "pmix-devel_na_rpm": {
+      "pmix-devel": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -4093,16 +4093,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "python3-cython_na_rpm_1": {
+      "python3-cython_1": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -4117,16 +4117,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "codeready-builder"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "codeready-builder"
           }
         ]
       },
-      "python3-devel_na_rpm_1": {
+      "python3-devel_1": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -4141,16 +4141,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "rsync_na_rpm": {
+      "rsync": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -4165,16 +4165,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "rsyslog_na_rpm": {
+      "rsyslog": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -4189,16 +4189,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "sed_na_rpm": {
+      "sed": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -4213,16 +4213,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "squashfs-tools_na_rpm": {
+      "squashfs-tools": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -4237,16 +4237,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sssd_na_rpm": {
+      "sssd": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -4261,16 +4261,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "strace_na_rpm": {
+      "strace": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -4285,16 +4285,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sudo_na_rpm": {
+      "sudo": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -4309,40 +4309,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "systemd-udev_na_rpm": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "systemd_na_rpm": {
+      "systemd": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -4357,16 +4333,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "tar_na_rpm": {
+      "systemd-udev": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -4381,16 +4381,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "tcpdump_na_rpm": {
+      "tcpdump": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -4405,16 +4405,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "traceroute_na_rpm": {
+      "traceroute": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -4429,16 +4429,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ucx_1.19.0_tarball": {
+      "ucx": {
         "Name": "ucx",
         "SupportedOS": [
           {
@@ -4454,16 +4454,16 @@
         "Version": "1.19.0",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/openucx/ucx/releases/download/v1.19.0/ucx-1.19.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/openucx/ucx/releases/download/v1.19.0/ucx-1.19.0.tar.gz"
           }
         ]
       },
-      "util-linux_na_rpm": {
+      "util-linux": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -4478,40 +4478,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "valgrind-devel_na_rpm": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "valgrind_na_rpm": {
+      "valgrind": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -4526,16 +4502,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "vim-enhanced_na_rpm_1": {
+      "valgrind-devel": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced_1": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -4550,16 +4550,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "wget_na_rpm": {
+      "wget": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -4574,16 +4574,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "which_na_rpm": {
+      "which": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -4598,16 +4598,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "zsh_na_rpm": {
+      "zsh": {
         "Name": "zsh",
         "SupportedOS": [
           {
@@ -4622,11 +4622,11 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
@@ -4634,7 +4634,7 @@
     },
     "Miscellaneous": [],
     "InfrastructurePackages": {
-      "csi-powerscale-v2-16-0_v2.16.0_git": {
+      "csi-powerscale": {
         "Name": "csi-powerscale-v2.16.0",
         "Type": "git",
         "Version": "v2.16.0",
@@ -4653,7 +4653,7 @@
           }
         ]
       },
-      "docker-io-dellemc-csm-encryption_v0.6.0_image": {
+      "docker.io/dellemc/csm-encryption": {
         "Name": "docker.io/dellemc/csm-encryption",
         "Type": "image",
         "Version": "v0.6.0",
@@ -4667,7 +4667,7 @@
         ],
         "Tag": "v0.6.0"
       },
-      "external-snapshotter-v8-4-0_v8.4.0_git": {
+      "external-snapshotter": {
         "Name": "external-snapshotter-v8.4.0",
         "Type": "git",
         "Version": "v8.4.0",
@@ -4686,7 +4686,7 @@
           }
         ]
       },
-      "helm-charts-2-16-0_csi-isilon-2.16.0_git": {
+      "helm-charts_1": {
         "Name": "helm-charts-2.16.0",
         "Type": "git",
         "Version": "csi-isilon-2.16.0",
@@ -4705,7 +4705,7 @@
           }
         ]
       },
-      "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image": {
+      "quay.io/dell/container-storage-modules/csi-isilon": {
         "Name": "quay.io/dell/container-storage-modules/csi-isilon",
         "Type": "image",
         "Version": "v2.16.0",
@@ -4719,7 +4719,7 @@
         ],
         "Tag": "v2.16.0"
       },
-      "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image": {
+      "quay.io/dell/container-storage-modules/csi-metadata-retriever": {
         "Name": "quay.io/dell/container-storage-modules/csi-metadata-retriever",
         "Type": "image",
         "Version": "v1.13.0",
@@ -4733,7 +4733,7 @@
         ],
         "Tag": "v1.13.0"
       },
-      "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image": {
+      "quay.io/dell/container-storage-modules/csm-authorization-sidecar": {
         "Name": "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
         "Type": "image",
         "Version": "v2.4.0",
@@ -4747,7 +4747,7 @@
         ],
         "Tag": "v2.4.0"
       },
-      "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image": {
+      "quay.io/dell/container-storage-modules/dell-csi-replicator": {
         "Name": "quay.io/dell/container-storage-modules/dell-csi-replicator",
         "Type": "image",
         "Version": "v1.14.0",
@@ -4761,7 +4761,7 @@
         ],
         "Tag": "v1.14.0"
       },
-      "quay-io-dell-container-storage-modules-podmon_v1.15.0_image": {
+      "quay.io/dell/container-storage-modules/podmon": {
         "Name": "quay.io/dell/container-storage-modules/podmon",
         "Type": "image",
         "Version": "v1.15.0",
@@ -4775,7 +4775,7 @@
         ],
         "Tag": "v1.15.0"
       },
-      "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image": {
+      "registry.k8s.io/sig-storage/csi-attacher": {
         "Name": "registry.k8s.io/sig-storage/csi-attacher",
         "Type": "image",
         "Version": "v4.10.0",
@@ -4789,7 +4789,7 @@
         ],
         "Tag": "v4.10.0"
       },
-      "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image": {
+      "registry.k8s.io/sig-storage/csi-external-health-monitor-controller": {
         "Name": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
         "Type": "image",
         "Version": "v0.16.0",
@@ -4803,7 +4803,7 @@
         ],
         "Tag": "v0.16.0"
       },
-      "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image": {
+      "registry.k8s.io/sig-storage/csi-node-driver-registrar": {
         "Name": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
         "Type": "image",
         "Version": "v2.15.0",
@@ -4817,7 +4817,7 @@
         ],
         "Tag": "v2.15.0"
       },
-      "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image": {
+      "registry.k8s.io/sig-storage/csi-provisioner": {
         "Name": "registry.k8s.io/sig-storage/csi-provisioner",
         "Type": "image",
         "Version": "v6.1.0",
@@ -4831,7 +4831,7 @@
         ],
         "Tag": "v6.1.0"
       },
-      "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image": {
+      "registry.k8s.io/sig-storage/csi-resizer": {
         "Name": "registry.k8s.io/sig-storage/csi-resizer",
         "Type": "image",
         "Version": "v2.0.0",
@@ -4845,7 +4845,7 @@
         ],
         "Tag": "v2.0.0"
       },
-      "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image": {
+      "registry.k8s.io/sig-storage/csi-snapshotter": {
         "Name": "registry.k8s.io/sig-storage/csi-snapshotter",
         "Type": "image",
         "Version": "v8.4.0",
@@ -4859,7 +4859,7 @@
         ],
         "Tag": "v8.4.0"
       },
-      "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image": {
+      "registry.k8s.io/sig-storage/snapshot-controller": {
         "Name": "registry.k8s.io/sig-storage/snapshot-controller",
         "Type": "image",
         "Version": "v8.4.0",

--- a/examples/catalog/catalog_rhel_aarch64_with_slurm_only.json
+++ b/examples/catalog/catalog_rhel_aarch64_with_slurm_only.json
@@ -7,103 +7,103 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "mariadb-server_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-PyMySQL_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmctld_na_rpm",
-          "slurm-slurmdbd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "mariadb-server",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-PyMySQL",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-slurmctld",
+          "slurm-slurmdbd"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "kernel-devel_na_rpm",
-          "kernel-headers_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-pam_slurm_na_rpm",
-          "slurm-slurmd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "kernel-devel",
+          "kernel-headers",
+          "likwid",
+          "lsscsi",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-pam_slurm",
+          "slurm-slurmd"
         ]
       }
     ],
@@ -112,98 +112,98 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_na_rpm",
-          "authselect_na_rpm",
-          "autoconf_na_rpm",
-          "automake_na_rpm",
-          "bash-completion_na_rpm",
-          "bash_na_rpm",
-          "binutils-devel_na_rpm",
-          "binutils_na_rpm",
-          "bzip2_na_rpm",
-          "chrony_na_rpm",
-          "cloud-init_na_rpm",
-          "clustershell_na_rpm",
-          "cmake_na_rpm",
-          "coreutils_na_rpm",
-          "cryptsetup_na_rpm",
-          "curl_na_rpm",
-          "device-mapper_na_rpm",
-          "dmidecode_na_rpm",
-          "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
-          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_na_rpm",
-          "dracut-network_na_rpm",
-          "dracut_na_rpm",
-          "emacs_na_rpm",
-          "file_na_rpm",
-          "findutils_na_rpm",
-          "fping_na_rpm",
-          "gawk_na_rpm",
-          "gcc-c++_na_rpm",
-          "gcc-gfortran_na_rpm",
-          "gcc_na_rpm",
-          "gdb-gdbserver_na_rpm",
-          "gdb_na_rpm",
-          "gedit_na_rpm",
-          "glibc-langpack-en_na_rpm",
-          "grep_na_rpm",
-          "gzip_na_rpm",
-          "hwloc-libs_na_rpm",
-          "hwloc_na_rpm",
-          "iperf3_na_rpm",
-          "ipmitool_na_rpm",
-          "iproute_na_rpm",
-          "iputils_na_rpm",
-          "kbd_na_rpm",
-          "kernel-tools_na_rpm",
-          "kernel_na_rpm",
-          "kexec-tools_na_rpm",
-          "libcurl_na_rpm",
-          "libtool_na_rpm",
-          "lldb-devel_na_rpm",
-          "lldb_na_rpm",
-          "lshw_na_rpm",
-          "lsof_na_rpm",
-          "ltrace_na_rpm",
-          "lvm2_na_rpm",
-          "make_na_rpm",
-          "man-db_na_rpm",
-          "man-pages_na_rpm",
-          "nfs-utils_na_rpm",
-          "nfs4-acl-tools_na_rpm",
-          "nm-connection-editor_na_rpm",
-          "nss-pam-ldapd_na_rpm",
-          "oddjob-mkhomedir_na_rpm",
-          "openldap-clients_na_rpm",
-          "openssh-clients_na_rpm",
-          "openssh-server_na_rpm",
-          "openssh_na_rpm",
-          "openssl-devel_na_rpm",
-          "papi-devel_na_rpm",
-          "papi-libs_na_rpm",
-          "papi_na_rpm",
-          "pciutils_na_rpm",
-          "perf_na_rpm",
-          "rsync_na_rpm",
-          "rsyslog_na_rpm",
-          "sed_na_rpm",
-          "squashfs-tools_na_rpm",
-          "sssd_na_rpm",
-          "strace_na_rpm",
-          "sudo_na_rpm",
-          "systemd-udev_na_rpm",
-          "systemd_na_rpm",
-          "tar_na_rpm",
-          "tcpdump_na_rpm",
-          "traceroute_na_rpm",
-          "util-linux_na_rpm",
-          "valgrind-devel_na_rpm",
-          "valgrind_na_rpm",
-          "vim-enhanced_na_rpm",
-          "wget_na_rpm",
-          "which_na_rpm",
-          "zsh_na_rpm"
+          "NetworkManager",
+          "authselect",
+          "autoconf",
+          "automake",
+          "bash",
+          "bash-completion",
+          "binutils",
+          "binutils-devel",
+          "bzip2",
+          "chrony",
+          "cloud-init",
+          "clustershell",
+          "cmake",
+          "coreutils",
+          "cryptsetup",
+          "curl",
+          "device-mapper",
+          "dmidecode",
+          "docker.io/dellhpcomniaaisolution/image-build-aarch64",
+          "docker.io/dellhpcomniaaisolution/image-build-el10",
+          "dracut",
+          "dracut-live",
+          "dracut-network",
+          "emacs",
+          "file",
+          "findutils",
+          "fping",
+          "gawk",
+          "gcc",
+          "gcc-c++",
+          "gcc-gfortran",
+          "gdb",
+          "gdb-gdbserver",
+          "gedit",
+          "glibc-langpack-en",
+          "grep",
+          "gzip",
+          "hwloc",
+          "hwloc-libs",
+          "iperf3",
+          "ipmitool",
+          "iproute",
+          "iputils",
+          "kbd",
+          "kernel",
+          "kernel-tools",
+          "kexec-tools",
+          "libcurl",
+          "libtool",
+          "lldb",
+          "lldb-devel",
+          "lshw",
+          "lsof",
+          "ltrace",
+          "lvm2",
+          "make",
+          "man-db",
+          "man-pages",
+          "nfs-utils",
+          "nfs4-acl-tools",
+          "nm-connection-editor",
+          "nss-pam-ldapd",
+          "oddjob-mkhomedir",
+          "openldap-clients",
+          "openssh",
+          "openssh-clients",
+          "openssh-server",
+          "openssl-devel",
+          "papi-devel",
+          "papi-libs",
+          "papi_1",
+          "pciutils",
+          "perf",
+          "rsync",
+          "rsyslog",
+          "sed",
+          "squashfs-tools",
+          "sssd",
+          "strace",
+          "sudo",
+          "systemd",
+          "systemd-udev",
+          "tar",
+          "tcpdump",
+          "traceroute",
+          "util-linux",
+          "valgrind",
+          "valgrind-devel",
+          "vim-enhanced",
+          "wget",
+          "which",
+          "zsh"
         ]
       }
     ],
@@ -211,7 +211,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "apptainer_na_rpm": {
+      "apptainer": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -226,16 +226,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "device-mapper-multipath_na_rpm": {
+      "device-mapper-multipath": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -250,16 +250,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "doca-ofed_na_rpm_repo": {
+      "doca-ofed": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -274,16 +274,16 @@
         "Type": "rpm_repo",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "doca"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "doca"
           }
         ]
       },
-      "firewalld_na_rpm": {
+      "firewalld": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -298,16 +298,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "geopm_na_tarball": {
+      "geopm": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -322,16 +322,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
           }
         ]
       },
-      "imb_na_tarball": {
+      "imb": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -346,16 +346,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "iscsi-initiator-utils_na_rpm": {
+      "iscsi-initiator-utils": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -370,16 +370,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kernel-devel_na_rpm": {
+      "kernel-devel": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -394,16 +394,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "kernel-headers_na_rpm": {
+      "kernel-headers": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -418,16 +418,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "likwid_na_tarball": {
+      "likwid": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -442,16 +442,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           }
         ]
       },
-      "lsscsi_na_rpm": {
+      "lsscsi": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -466,16 +466,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "mariadb-server_na_rpm": {
+      "mariadb-server": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -490,16 +490,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "msr-safe_na_tarball": {
+      "msr-safe": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -518,7 +518,7 @@
           }
         ]
       },
-      "munge_na_rpm": {
+      "munge": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -533,16 +533,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+      "nvcr.io/nvidia/hpc-benchmarks": {
         "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
@@ -558,7 +558,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "osu-micro-benchmarks_na_tarball": {
+      "osu-micro-benchmarks": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -573,16 +573,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
           }
         ]
       },
-      "papi_na_tarball": {
+      "papi": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -597,16 +597,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
           }
         ]
       },
-      "pmix_na_rpm": {
+      "pmix": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -621,16 +621,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "python3-PyMySQL_na_rpm": {
+      "python3-PyMySQL": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -645,16 +645,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "python3-firewall_na_rpm": {
+      "python3-firewall": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -669,16 +669,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sg3_utils_na_rpm": {
+      "sg3_utils": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -693,16 +693,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sionlib_na_tarball": {
+      "sionlib": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -717,112 +717,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          },
-          {
             "Architecture": "x86_64",
             "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "slurm-pam_slurm_na_rpm": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmctld_na_rpm": {
-        "Name": "slurm-slurmctld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
           }
         ]
       },
-      "slurm-slurmd_na_rpm": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmdbd_na_rpm": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm_na_rpm": {
+      "slurm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -837,18 +741,114 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "slurm_custom"
           },
           {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-pam_slurm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
             "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
             "RepoName": "slurm_custom"
           }
         ]
       }
     },
     "OSPackages": {
-      "NetworkManager_na_rpm": {
+      "NetworkManager": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -863,16 +863,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "authselect_na_rpm": {
+      "authselect": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -887,16 +887,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "autoconf_na_rpm": {
+      "autoconf": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -911,16 +911,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "automake_na_rpm": {
+      "automake": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -935,40 +935,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "bash-completion_na_rpm": {
-        "Name": "bash-completion",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "bash_na_rpm": {
+      "bash": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -983,17 +959,17 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "binutils-devel_na_rpm": {
-        "Name": "binutils-devel",
+      "bash-completion": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1007,16 +983,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
           }
         ]
       },
-      "binutils_na_rpm": {
+      "binutils": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -1031,16 +1007,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "bzip2_na_rpm": {
+      "binutils-devel": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bzip2": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -1055,16 +1055,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "chrony_na_rpm": {
+      "chrony": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -1079,16 +1079,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "cloud-init_na_rpm": {
+      "cloud-init": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -1103,16 +1103,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "clustershell_na_rpm": {
+      "clustershell": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -1127,16 +1127,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "cmake_na_rpm": {
+      "cmake": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -1151,16 +1151,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "coreutils_na_rpm": {
+      "coreutils": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -1175,16 +1175,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "cryptsetup_na_rpm": {
+      "cryptsetup": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -1199,16 +1199,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "curl_na_rpm": {
+      "curl": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -1223,16 +1223,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "device-mapper_na_rpm": {
+      "device-mapper": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -1247,16 +1247,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "dmidecode_na_rpm": {
+      "dmidecode": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -1271,16 +1271,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-aarch64": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
         "SupportedOS": [
           {
@@ -1295,7 +1295,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-el10": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
         "SupportedOS": [
           {
@@ -1310,55 +1310,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_na_rpm": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "dracut-network_na_rpm": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "dracut_na_rpm": {
+      "dracut": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -1373,16 +1325,64 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "emacs_na_rpm": {
+      "dracut-live": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -1397,16 +1397,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "file_na_rpm": {
+      "file": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -1421,16 +1421,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "findutils_na_rpm": {
+      "findutils": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -1445,16 +1445,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "fping_na_rpm": {
+      "fping": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -1469,16 +1469,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "gawk_na_rpm": {
+      "gawk": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -1493,64 +1493,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
             "Architecture": "x86_64",
             "RepoName": "baseos"
-          }
-        ]
-      },
-      "gcc-c++_na_rpm": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc-gfortran_na_rpm": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "RepoName": "baseos"
           }
         ]
       },
-      "gcc_na_rpm": {
+      "gcc": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -1565,17 +1517,17 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gdb-gdbserver_na_rpm": {
-        "Name": "gdb-gdbserver",
+      "gcc-c++": {
+        "Name": "gcc-c++",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1589,16 +1541,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gdb_na_rpm": {
+      "gcc-gfortran": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -1613,16 +1589,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gedit_na_rpm": {
+      "gdb-gdbserver": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -1637,16 +1637,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "glibc-langpack-en_na_rpm": {
+      "glibc-langpack-en": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -1661,16 +1661,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "grep_na_rpm": {
+      "grep": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -1685,16 +1685,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "gzip_na_rpm": {
+      "gzip": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -1709,40 +1709,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "hwloc-libs_na_rpm": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "hwloc_na_rpm": {
+      "hwloc": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -1757,16 +1733,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "iperf3_na_rpm": {
+      "hwloc-libs": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -1781,16 +1781,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "ipmitool_na_rpm": {
+      "ipmitool": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -1805,16 +1805,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "iproute_na_rpm": {
+      "iproute": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -1829,16 +1829,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "iputils_na_rpm": {
+      "iputils": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -1853,16 +1853,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kbd_na_rpm": {
+      "kbd": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -1877,40 +1877,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kernel-tools_na_rpm": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "kernel_na_rpm": {
+      "kernel": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -1925,16 +1901,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kexec-tools_na_rpm": {
+      "kernel-tools": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -1949,16 +1949,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "libcurl_na_rpm": {
+      "libcurl": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -1973,16 +1973,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "libtool_na_rpm": {
+      "libtool": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -1997,40 +1997,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lldb-devel_na_rpm": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "lldb_na_rpm": {
+      "lldb": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -2045,16 +2021,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lshw_na_rpm": {
+      "lldb-devel": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -2069,16 +2069,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "lsof_na_rpm": {
+      "lsof": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -2093,16 +2093,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ltrace_na_rpm": {
+      "ltrace": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -2117,16 +2117,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lvm2_na_rpm": {
+      "lvm2": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -2141,16 +2141,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "make_na_rpm": {
+      "make": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -2165,16 +2165,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "man-db_na_rpm": {
+      "man-db": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -2189,16 +2189,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "man-pages_na_rpm": {
+      "man-pages": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -2213,16 +2213,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nfs-utils_na_rpm": {
+      "nfs-utils": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -2237,16 +2237,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nfs4-acl-tools_na_rpm": {
+      "nfs4-acl-tools": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -2261,16 +2261,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nm-connection-editor_na_rpm": {
+      "nm-connection-editor": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -2285,16 +2285,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "nss-pam-ldapd_na_rpm": {
+      "nss-pam-ldapd": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -2309,16 +2309,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "oddjob-mkhomedir_na_rpm": {
+      "oddjob-mkhomedir": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -2333,16 +2333,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "openldap-clients_na_rpm": {
+      "openldap-clients": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -2357,64 +2357,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "openssh-clients_na_rpm": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh-server_na_rpm": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh_na_rpm": {
+      "openssh": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -2429,16 +2381,64 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "openssl-devel_na_rpm": {
+      "openssh-clients": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -2453,16 +2453,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi-devel_na_rpm": {
+      "papi-devel": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -2477,16 +2477,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi-libs_na_rpm": {
+      "papi-libs": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -2501,16 +2501,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi_na_rpm": {
+      "papi_1": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -2525,16 +2525,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "pciutils_na_rpm": {
+      "pciutils": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -2549,16 +2549,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "perf_na_rpm": {
+      "perf": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -2573,16 +2573,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "rsync_na_rpm": {
+      "rsync": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -2597,16 +2597,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "rsyslog_na_rpm": {
+      "rsyslog": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -2621,16 +2621,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "sed_na_rpm": {
+      "sed": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -2645,16 +2645,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "squashfs-tools_na_rpm": {
+      "squashfs-tools": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -2669,16 +2669,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sssd_na_rpm": {
+      "sssd": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -2693,16 +2693,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "strace_na_rpm": {
+      "strace": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -2717,16 +2717,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sudo_na_rpm": {
+      "sudo": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -2741,40 +2741,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "systemd-udev_na_rpm": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "systemd_na_rpm": {
+      "systemd": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -2789,16 +2765,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "tar_na_rpm": {
+      "systemd-udev": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -2813,16 +2813,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "tcpdump_na_rpm": {
+      "tcpdump": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -2837,16 +2837,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "traceroute_na_rpm": {
+      "traceroute": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -2861,16 +2861,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "util-linux_na_rpm": {
+      "util-linux": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -2885,40 +2885,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "valgrind-devel_na_rpm": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "valgrind_na_rpm": {
+      "valgrind": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -2933,16 +2909,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "vim-enhanced_na_rpm": {
+      "valgrind-devel": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2957,16 +2957,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "wget_na_rpm": {
+      "wget": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -2981,16 +2981,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "which_na_rpm": {
+      "which": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -3005,16 +3005,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "zsh_na_rpm": {
+      "zsh": {
         "Name": "zsh",
         "SupportedOS": [
           {
@@ -3029,11 +3029,11 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]

--- a/examples/catalog/catalog_rhel_with_nfs_provisioner.json
+++ b/examples/catalog/catalog_rhel_with_nfs_provisioner.json
@@ -7,248 +7,248 @@
       {
         "Name": "login_compiler_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
-          "PyMySQL_1.1.2_pip_module",
-          "apptainer_na_rpm",
-          "calico-v3-31-4_na_manifest",
-          "cert-manager-v1-10-0_na_tarball",
-          "cffi_1.17.1_pip_module",
-          "container-selinux_na_rpm",
-          "cri-o_1.35.1_rpm",
-          "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "docker-io-alpine-kubectl_1.35.1_image",
-          "docker-io-calico-cni_v3.31.4_image",
-          "docker-io-calico-kube-controllers_v3.31.4_image",
-          "docker-io-calico-node_v3.31.4_image",
-          "docker-io-curlimages-curl_8.17.0_image",
-          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
-          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
-          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
-          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
-          "docker-io-library-busybox_1.36_image",
-          "docker-io-library-mysql_9.3.0_image",
-          "docker-io-library-python_3.12-slim_image",
-          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
-          "docker-io-rmohr-activemq_5.15.9_image",
-          "docker-io-timberio-vector_0.54.0-debian_image",
-          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
-          "docker-io-victoriametrics-operator_v0.68.3_image",
-          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
-          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
-          "docker-io-victoriametrics-vlagent_v1.50.0_image",
-          "docker-io-victoriametrics-vmagent_v1.128.0_image",
-          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_na_rpm",
-          "fuse-overlayfs_na_rpm",
-          "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
-          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_na_rpm",
-          "helm-charts_container-storage-modules-1.9.2_git",
-          "helm-v3-20-1-amd64_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "karavi-observability_v1.12.0_git",
-          "kubeadm_1.35.1_rpm",
-          "kubectl_1.35.1_rpm",
-          "kubelet_1.35.1_rpm",
-          "kubernetes_33.1.0_pip_module",
-          "lsscsi_na_rpm",
-          "metallb-native-v0-15-3_na_manifest",
-          "nfs-subdir-external-provisioner-4-0-18_na_tarball",
-          "omsdk_1.2.518_pip_module",
-          "podman_na_rpm",
-          "prettytable_3.14.0_pip_module",
-          "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_na_rpm",
-          "python3_3.12.9_rpm",
-          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
-          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
-          "quay-io-metallb-speaker_v0.15.3_image",
-          "quay-io-strimzi-kafka-bridge_0.33.1_image",
-          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
-          "quay-io-strimzi-operator_0.48.0_image",
-          "registry-k8s-io-coredns-coredns_v1.13.1_image",
-          "registry-k8s-io-etcd_3.6.6-0_image",
-          "registry-k8s-io-kube-apiserver_v1.35.1_image",
-          "registry-k8s-io-kube-controller-manager_v1.35.1_image",
-          "registry-k8s-io-kube-proxy_v1.35.1_image",
-          "registry-k8s-io-kube-scheduler_v1.35.1_image",
-          "registry-k8s-io-pause_3.10.1_image",
-          "sg3_utils_na_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
-          "victoria-metrics-operator-0-59-3_na_tarball",
-          "vim-enhanced_na_rpm"
+          "PyMySQL",
+          "apptainer",
+          "calico",
+          "cert-manager",
+          "cffi",
+          "container-selinux",
+          "cri-o",
+          "cryptography",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "docker.io/alpine/kubectl",
+          "docker.io/calico/cni",
+          "docker.io/calico/kube-controllers",
+          "docker.io/calico/node",
+          "docker.io/curlimages/curl",
+          "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+          "docker.io/dellhpcomniaaisolution/kafkapump",
+          "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+          "docker.io/dellhpcomniaaisolution/victoriapump",
+          "docker.io/library/busybox",
+          "docker.io/library/mysql",
+          "docker.io/library/python",
+          "docker.io/nginxinc/nginx-unprivileged",
+          "docker.io/rmohr/activemq",
+          "docker.io/timberio/vector",
+          "docker.io/victoriametrics/operator",
+          "docker.io/victoriametrics/operator_1",
+          "docker.io/victoriametrics/victoria-logs",
+          "docker.io/victoriametrics/victoria-metrics",
+          "docker.io/victoriametrics/vlagent",
+          "docker.io/victoriametrics/vmagent",
+          "docker.io/victoriametrics/vminsert",
+          "docker.io/victoriametrics/vmselect",
+          "docker.io/victoriametrics/vmstorage",
+          "firewalld",
+          "fuse-overlayfs",
+          "ghcr.io/kube-vip/kube-vip",
+          "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+          "git",
+          "helm-amd64",
+          "helm-charts",
+          "iscsi-initiator-utils",
+          "karavi-observability",
+          "kubeadm",
+          "kubectl",
+          "kubelet",
+          "kubernetes",
+          "lsscsi",
+          "metallb-native",
+          "nfs-subdir-external-provisioner",
+          "omsdk",
+          "podman",
+          "prettytable",
+          "prometheus_client",
+          "python3",
+          "python3-firewall",
+          "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+          "quay.io/jetstack/cert-manager-acmesolver",
+          "quay.io/jetstack/cert-manager-cainjector",
+          "quay.io/jetstack/cert-manager-controller",
+          "quay.io/jetstack/cert-manager-webhook",
+          "quay.io/metallb/speaker",
+          "quay.io/strimzi/kafka",
+          "quay.io/strimzi/kafka-bridge",
+          "quay.io/strimzi/operator",
+          "registry.k8s.io/coredns/coredns",
+          "registry.k8s.io/etcd",
+          "registry.k8s.io/kube-apiserver",
+          "registry.k8s.io/kube-controller-manager",
+          "registry.k8s.io/kube-proxy",
+          "registry.k8s.io/kube-scheduler",
+          "registry.k8s.io/pause",
+          "sg3_utils",
+          "strimzi-kafka-operator-helm-3-chart",
+          "victoria-metrics-operator",
+          "vim-enhanced"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "cert-manager-v1-10-0_na_tarball",
-          "cffi_1.17.1_pip_module",
-          "container-selinux_na_rpm",
-          "cri-o_1.35.1_rpm",
-          "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "docker-io-alpine-kubectl_1.35.1_image",
-          "docker-io-curlimages-curl_8.17.0_image",
-          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
-          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
-          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
-          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
-          "docker-io-library-busybox_1.36_image",
-          "docker-io-library-mysql_9.3.0_image",
-          "docker-io-library-python_3.12-slim_image",
-          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
-          "docker-io-rmohr-activemq_5.15.9_image",
-          "docker-io-timberio-vector_0.54.0-debian_image",
-          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
-          "docker-io-victoriametrics-operator_v0.68.3_image",
-          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
-          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
-          "docker-io-victoriametrics-vlagent_v1.50.0_image",
-          "docker-io-victoriametrics-vmagent_v1.128.0_image",
-          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_na_rpm",
-          "fuse-overlayfs_na_rpm",
-          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_na_rpm",
-          "helm-charts_container-storage-modules-1.9.2_git",
-          "iscsi-initiator-utils_na_rpm",
-          "karavi-observability_v1.12.0_git",
-          "kubeadm_1.35.1_rpm",
-          "kubelet_1.35.1_rpm",
-          "kubernetes_33.1.0_pip_module",
-          "lsscsi_na_rpm",
-          "omsdk_1.2.518_pip_module",
-          "podman_na_rpm",
-          "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_na_rpm",
-          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
-          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
-          "quay-io-metallb-controller_v0.15.3_image",
-          "quay-io-metallb-speaker_v0.15.3_image",
-          "quay-io-strimzi-kafka-bridge_0.33.1_image",
-          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
-          "quay-io-strimzi-operator_0.48.0_image",
-          "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
-          "sg3_utils_na_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
-          "victoria-metrics-operator-0-59-3_na_tarball",
-          "vim-enhanced_na_rpm"
+          "apptainer",
+          "cert-manager",
+          "cffi",
+          "container-selinux",
+          "cri-o",
+          "cryptography",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "docker.io/alpine/kubectl",
+          "docker.io/curlimages/curl",
+          "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+          "docker.io/dellhpcomniaaisolution/kafkapump",
+          "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+          "docker.io/dellhpcomniaaisolution/victoriapump",
+          "docker.io/library/busybox",
+          "docker.io/library/mysql",
+          "docker.io/library/python",
+          "docker.io/nginxinc/nginx-unprivileged",
+          "docker.io/rmohr/activemq",
+          "docker.io/timberio/vector",
+          "docker.io/victoriametrics/operator",
+          "docker.io/victoriametrics/operator_1",
+          "docker.io/victoriametrics/victoria-logs",
+          "docker.io/victoriametrics/victoria-metrics",
+          "docker.io/victoriametrics/vlagent",
+          "docker.io/victoriametrics/vmagent",
+          "docker.io/victoriametrics/vminsert",
+          "docker.io/victoriametrics/vmselect",
+          "docker.io/victoriametrics/vmstorage",
+          "firewalld",
+          "fuse-overlayfs",
+          "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+          "git",
+          "helm-charts",
+          "iscsi-initiator-utils",
+          "karavi-observability",
+          "kubeadm",
+          "kubelet",
+          "kubernetes",
+          "lsscsi",
+          "omsdk",
+          "podman",
+          "prometheus_client",
+          "python3-firewall",
+          "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+          "quay.io/jetstack/cert-manager-acmesolver",
+          "quay.io/jetstack/cert-manager-cainjector",
+          "quay.io/jetstack/cert-manager-controller",
+          "quay.io/jetstack/cert-manager-webhook",
+          "quay.io/metallb/controller",
+          "quay.io/metallb/speaker",
+          "quay.io/strimzi/kafka",
+          "quay.io/strimzi/kafka-bridge",
+          "quay.io/strimzi/operator",
+          "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+          "sg3_utils",
+          "strimzi-kafka-operator-helm-3-chart",
+          "victoria-metrics-operator",
+          "vim-enhanced"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "mariadb-server_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-PyMySQL_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmctld_na_rpm",
-          "slurm-slurmdbd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "mariadb-server",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-PyMySQL",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-slurmctld",
+          "slurm-slurmdbd"
         ]
       },
       {
         "Name": "slurm_node_aarch64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "kernel-devel_na_rpm",
-          "kernel-headers_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-pam_slurm_na_rpm",
-          "slurm-slurmd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "kernel-devel",
+          "kernel-headers",
+          "likwid",
+          "lsscsi",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-pam_slurm",
+          "slurm-slurmd"
         ]
       }
     ],
@@ -257,106 +257,106 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_na_rpm",
-          "authselect_na_rpm",
-          "autoconf_na_rpm",
-          "automake_na_rpm",
-          "bash-completion_na_rpm",
-          "bash_na_rpm",
-          "binutils-devel_na_rpm",
-          "binutils_na_rpm",
-          "bzip2_na_rpm",
-          "chrony_na_rpm",
-          "cloud-init_na_rpm",
-          "clustershell_na_rpm",
-          "cmake_na_rpm",
-          "coreutils_na_rpm",
-          "cryptsetup_na_rpm",
-          "curl_na_rpm",
-          "device-mapper_na_rpm",
-          "dmidecode_na_rpm",
-          "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image",
-          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_na_rpm",
-          "dracut-network_na_rpm",
-          "dracut_na_rpm",
-          "emacs_na_rpm",
-          "file_na_rpm",
-          "findutils_na_rpm",
-          "fping_na_rpm",
-          "gawk_na_rpm",
-          "gcc-c++_na_rpm",
-          "gcc-gfortran_na_rpm",
-          "gcc_na_rpm",
-          "gdb-gdbserver_na_rpm",
-          "gdb_na_rpm",
-          "gedit_na_rpm",
-          "glibc-langpack-en_na_rpm",
-          "grep_na_rpm",
-          "gzip_na_rpm",
-          "hwloc-libs_na_rpm",
-          "hwloc_na_rpm",
-          "iperf3_na_rpm",
-          "ipmitool_na_rpm",
-          "iproute_na_rpm",
-          "iputils_na_rpm",
-          "kbd_na_rpm",
-          "kernel-tools_na_rpm",
-          "kernel_na_rpm",
-          "kexec-tools_na_rpm",
-          "libcurl_na_rpm",
-          "libtool_na_rpm",
-          "lldb-devel_na_rpm",
-          "lldb_na_rpm",
-          "lshw_na_rpm",
-          "lsof_na_rpm",
-          "ltrace_na_rpm",
-          "lvm2_na_rpm",
-          "make_na_rpm",
-          "man-db_na_rpm",
-          "man-pages_na_rpm",
-          "munge-devel_na_rpm",
-          "nfs-utils_na_rpm",
-          "nfs4-acl-tools_na_rpm",
-          "nm-connection-editor_na_rpm",
-          "nss-pam-ldapd_na_rpm",
-          "oddjob-mkhomedir_na_rpm",
-          "openldap-clients_na_rpm",
-          "openmpi_5.0.8_tarball",
-          "openssh-clients_na_rpm",
-          "openssh-server_na_rpm",
-          "openssh_na_rpm",
-          "openssl-devel_na_rpm",
-          "openssl-libs_na_rpm",
-          "ovis-ldms_na_rpm",
-          "papi-devel_na_rpm",
-          "papi-libs_na_rpm",
-          "papi_na_rpm",
-          "pciutils_na_rpm",
-          "perf_na_rpm",
-          "pmix-devel_na_rpm",
-          "python3-cython_na_rpm",
-          "python3-devel_na_rpm",
-          "rsync_na_rpm",
-          "rsyslog_na_rpm",
-          "sed_na_rpm",
-          "squashfs-tools_na_rpm",
-          "sssd_na_rpm",
-          "strace_na_rpm",
-          "sudo_na_rpm",
-          "systemd-udev_na_rpm",
-          "systemd_na_rpm",
-          "tar_na_rpm",
-          "tcpdump_na_rpm",
-          "traceroute_na_rpm",
-          "ucx_1.19.0_tarball",
-          "util-linux_na_rpm",
-          "valgrind-devel_na_rpm",
-          "valgrind_na_rpm",
-          "vim-enhanced_na_rpm_1",
-          "wget_na_rpm",
-          "which_na_rpm",
-          "zsh_na_rpm"
+          "NetworkManager",
+          "authselect",
+          "autoconf",
+          "automake",
+          "bash",
+          "bash-completion",
+          "binutils",
+          "binutils-devel",
+          "bzip2",
+          "chrony",
+          "cloud-init",
+          "clustershell",
+          "cmake",
+          "coreutils",
+          "cryptsetup",
+          "curl",
+          "device-mapper",
+          "dmidecode",
+          "docker.io/dellhpcomniaaisolution/image-build-aarch64",
+          "docker.io/dellhpcomniaaisolution/image-build-el10",
+          "dracut",
+          "dracut-live",
+          "dracut-network",
+          "emacs",
+          "file",
+          "findutils",
+          "fping",
+          "gawk",
+          "gcc",
+          "gcc-c++",
+          "gcc-gfortran",
+          "gdb",
+          "gdb-gdbserver",
+          "gedit",
+          "glibc-langpack-en",
+          "grep",
+          "gzip",
+          "hwloc",
+          "hwloc-libs",
+          "iperf3",
+          "ipmitool",
+          "iproute",
+          "iputils",
+          "kbd",
+          "kernel",
+          "kernel-tools",
+          "kexec-tools",
+          "libcurl",
+          "libtool",
+          "lldb",
+          "lldb-devel",
+          "lshw",
+          "lsof",
+          "ltrace",
+          "lvm2",
+          "make",
+          "man-db",
+          "man-pages",
+          "munge-devel",
+          "nfs-utils",
+          "nfs4-acl-tools",
+          "nm-connection-editor",
+          "nss-pam-ldapd",
+          "oddjob-mkhomedir",
+          "openldap-clients",
+          "openmpi",
+          "openssh",
+          "openssh-clients",
+          "openssh-server",
+          "openssl-devel",
+          "openssl-libs",
+          "ovis-ldms",
+          "papi-devel",
+          "papi-libs",
+          "papi_1",
+          "pciutils",
+          "perf",
+          "pmix-devel",
+          "python3-cython",
+          "python3-devel",
+          "rsync",
+          "rsyslog",
+          "sed",
+          "squashfs-tools",
+          "sssd",
+          "strace",
+          "sudo",
+          "systemd",
+          "systemd-udev",
+          "tar",
+          "tcpdump",
+          "traceroute",
+          "ucx",
+          "util-linux",
+          "valgrind",
+          "valgrind-devel",
+          "vim-enhanced_1",
+          "wget",
+          "which",
+          "zsh"
         ]
       }
     ],
@@ -364,7 +364,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "PyMySQL_1.1.2_pip_module": {
+      "PyMySQL": {
         "Name": "PyMySQL==1.1.2",
         "SupportedOS": [
           {
@@ -377,7 +377,7 @@
         ],
         "Type": "pip_module"
       },
-      "apptainer_na_rpm": {
+      "apptainer": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -392,16 +392,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "calico-v3-31-4_na_manifest": {
+      "calico": {
         "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
@@ -420,7 +420,7 @@
           }
         ]
       },
-      "cert-manager-v1-10-0_na_tarball": {
+      "cert-manager": {
         "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
@@ -439,7 +439,7 @@
           }
         ]
       },
-      "cffi_1.17.1_pip_module": {
+      "cffi": {
         "Name": "cffi==1.17.1",
         "SupportedOS": [
           {
@@ -452,7 +452,7 @@
         ],
         "Type": "pip_module"
       },
-      "container-selinux_na_rpm": {
+      "container-selinux": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -471,7 +471,7 @@
           }
         ]
       },
-      "cri-o_1.35.1_rpm": {
+      "cri-o": {
         "Name": "cri-o-1.35.1",
         "SupportedOS": [
           {
@@ -490,7 +490,7 @@
           }
         ]
       },
-      "cryptography_45.0.7_pip_module": {
+      "cryptography": {
         "Name": "cryptography==45.0.7",
         "SupportedOS": [
           {
@@ -503,7 +503,7 @@
         ],
         "Type": "pip_module"
       },
-      "device-mapper-multipath_na_rpm": {
+      "device-mapper-multipath": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -518,16 +518,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "doca-ofed_na_rpm_repo": {
+      "doca-ofed": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -542,16 +542,16 @@
         "Type": "rpm_repo",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "doca"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "doca"
           }
         ]
       },
-      "docker-io-alpine-kubectl_1.35.1_image": {
+      "docker.io/alpine/kubectl": {
         "Name": "docker.io/alpine/kubectl",
         "SupportedOS": [
           {
@@ -566,7 +566,7 @@
         "Tag": "1.35.1",
         "Version": "1.35.1"
       },
-      "docker-io-calico-cni_v3.31.4_image": {
+      "docker.io/calico/cni": {
         "Name": "docker.io/calico/cni",
         "SupportedOS": [
           {
@@ -581,7 +581,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-calico-kube-controllers_v3.31.4_image": {
+      "docker.io/calico/kube-controllers": {
         "Name": "docker.io/calico/kube-controllers",
         "SupportedOS": [
           {
@@ -596,7 +596,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-calico-node_v3.31.4_image": {
+      "docker.io/calico/node": {
         "Name": "docker.io/calico/node",
         "SupportedOS": [
           {
@@ -611,7 +611,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-curlimages-curl_8.17.0_image": {
+      "docker.io/curlimages/curl": {
         "Name": "docker.io/curlimages/curl",
         "SupportedOS": [
           {
@@ -626,7 +626,7 @@
         "Tag": "8.17.0",
         "Version": "8.17.0"
       },
-      "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver": {
         "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
         "SupportedOS": [
           {
@@ -641,7 +641,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/kafkapump": {
         "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
         "SupportedOS": [
           {
@@ -656,7 +656,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/ubuntu-ldms": {
         "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
         "SupportedOS": [
           {
@@ -671,7 +671,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/victoriapump": {
         "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
         "SupportedOS": [
           {
@@ -686,7 +686,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-library-busybox_1.36_image": {
+      "docker.io/library/busybox": {
         "Name": "docker.io/library/busybox",
         "SupportedOS": [
           {
@@ -701,7 +701,7 @@
         "Tag": "1.36",
         "Version": "1.36"
       },
-      "docker-io-library-mysql_9.3.0_image": {
+      "docker.io/library/mysql": {
         "Name": "docker.io/library/mysql",
         "SupportedOS": [
           {
@@ -716,7 +716,7 @@
         "Tag": "9.3.0",
         "Version": "9.3.0"
       },
-      "docker-io-library-python_3.12-slim_image": {
+      "docker.io/library/python": {
         "Name": "docker.io/library/python",
         "SupportedOS": [
           {
@@ -731,7 +731,7 @@
         "Tag": "3.12-slim",
         "Version": "3.12-slim"
       },
-      "docker-io-nginxinc-nginx-unprivileged_1.29_image": {
+      "docker.io/nginxinc/nginx-unprivileged": {
         "Name": "docker.io/nginxinc/nginx-unprivileged",
         "SupportedOS": [
           {
@@ -746,7 +746,7 @@
         "Tag": "1.29",
         "Version": "1.29"
       },
-      "docker-io-rmohr-activemq_5.15.9_image": {
+      "docker.io/rmohr/activemq": {
         "Name": "docker.io/rmohr/activemq",
         "SupportedOS": [
           {
@@ -761,7 +761,7 @@
         "Tag": "5.15.9",
         "Version": "5.15.9"
       },
-      "docker-io-timberio-vector_0.54.0-debian_image": {
+      "docker.io/timberio/vector": {
         "Name": "docker.io/timberio/vector",
         "SupportedOS": [
           {
@@ -776,22 +776,7 @@
         "Tag": "0.54.0-debian",
         "Version": "0.54.0-debian"
       },
-      "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "config-reloader-v0.68.3",
-        "Version": "config-reloader-v0.68.3"
-      },
-      "docker-io-victoriametrics-operator_v0.68.3_image": {
+      "docker.io/victoriametrics/operator": {
         "Name": "docker.io/victoriametrics/operator",
         "SupportedOS": [
           {
@@ -806,7 +791,22 @@
         "Tag": "v0.68.3",
         "Version": "v0.68.3"
       },
-      "docker-io-victoriametrics-victoria-logs_v1.50.0_image": {
+      "docker.io/victoriametrics/operator_1": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "config-reloader-v0.68.3",
+        "Version": "config-reloader-v0.68.3"
+      },
+      "docker.io/victoriametrics/victoria-logs": {
         "Name": "docker.io/victoriametrics/victoria-logs",
         "SupportedOS": [
           {
@@ -821,7 +821,7 @@
         "Tag": "v1.50.0",
         "Version": "v1.50.0"
       },
-      "docker-io-victoriametrics-victoria-metrics_v1.128.0_image": {
+      "docker.io/victoriametrics/victoria-metrics": {
         "Name": "docker.io/victoriametrics/victoria-metrics",
         "SupportedOS": [
           {
@@ -836,7 +836,7 @@
         "Tag": "v1.128.0",
         "Version": "v1.128.0"
       },
-      "docker-io-victoriametrics-vlagent_v1.50.0_image": {
+      "docker.io/victoriametrics/vlagent": {
         "Name": "docker.io/victoriametrics/vlagent",
         "SupportedOS": [
           {
@@ -851,7 +851,7 @@
         "Tag": "v1.50.0",
         "Version": "v1.50.0"
       },
-      "docker-io-victoriametrics-vmagent_v1.128.0_image": {
+      "docker.io/victoriametrics/vmagent": {
         "Name": "docker.io/victoriametrics/vmagent",
         "SupportedOS": [
           {
@@ -866,7 +866,7 @@
         "Tag": "v1.128.0",
         "Version": "v1.128.0"
       },
-      "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vminsert": {
         "Name": "docker.io/victoriametrics/vminsert",
         "SupportedOS": [
           {
@@ -881,7 +881,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vmselect": {
         "Name": "docker.io/victoriametrics/vmselect",
         "SupportedOS": [
           {
@@ -896,7 +896,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vmstorage": {
         "Name": "docker.io/victoriametrics/vmstorage",
         "SupportedOS": [
           {
@@ -911,7 +911,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "firewalld_na_rpm": {
+      "firewalld": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -926,16 +926,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "fuse-overlayfs_na_rpm": {
+      "fuse-overlayfs": {
         "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
@@ -954,7 +954,7 @@
           }
         ]
       },
-      "geopm_na_tarball": {
+      "geopm": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -969,16 +969,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/geopm/geopm/archive/refs/tags/v3.1.0.tar.gz"
           }
         ]
       },
-      "ghcr-io-kube-vip-kube-vip_v0.8.9_image": {
+      "ghcr.io/kube-vip/kube-vip": {
         "Name": "ghcr.io/kube-vip/kube-vip",
         "SupportedOS": [
           {
@@ -993,7 +993,7 @@
         "Tag": "v0.8.9",
         "Version": "v0.8.9"
       },
-      "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image": {
+      "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector": {
         "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
         "SupportedOS": [
           {
@@ -1008,7 +1008,7 @@
         "Tag": "0.143.1",
         "Version": "0.143.1"
       },
-      "git_na_rpm": {
+      "git": {
         "Name": "git",
         "SupportedOS": [
           {
@@ -1027,7 +1027,26 @@
           }
         ]
       },
-      "helm-charts_container-storage-modules-1.9.2_git": {
+      "helm-amd64": {
+        "Name": "helm-v3.20.1-amd64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
+          }
+        ]
+      },
+      "helm-charts": {
         "Name": "helm-charts",
         "SupportedOS": [
           {
@@ -1047,26 +1066,7 @@
           }
         ]
       },
-      "helm-v3-20-1-amd64_na_tarball": {
-        "Name": "helm-v3.20.1-amd64",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
-          }
-        ]
-      },
-      "imb_na_tarball": {
+      "imb": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -1081,16 +1081,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v2021.8.tar.gz"
           }
         ]
       },
-      "iscsi-initiator-utils_na_rpm": {
+      "iscsi-initiator-utils": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -1105,16 +1105,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "karavi-observability_v1.12.0_git": {
+      "karavi-observability": {
         "Name": "karavi-observability",
         "SupportedOS": [
           {
@@ -1134,7 +1134,7 @@
           }
         ]
       },
-      "kernel-devel_na_rpm": {
+      "kernel-devel": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1149,16 +1149,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "kernel-headers_na_rpm": {
+      "kernel-headers": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1173,16 +1173,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "kubeadm_1.35.1_rpm": {
+      "kubeadm": {
         "Name": "kubeadm-1.35.1",
         "SupportedOS": [
           {
@@ -1201,7 +1201,7 @@
           }
         ]
       },
-      "kubectl_1.35.1_rpm": {
+      "kubectl": {
         "Name": "kubectl-1.35.1",
         "SupportedOS": [
           {
@@ -1220,7 +1220,7 @@
           }
         ]
       },
-      "kubelet_1.35.1_rpm": {
+      "kubelet": {
         "Name": "kubelet-1.35.1",
         "SupportedOS": [
           {
@@ -1239,7 +1239,7 @@
           }
         ]
       },
-      "kubernetes_33.1.0_pip_module": {
+      "kubernetes": {
         "Name": "kubernetes==33.1.0",
         "SupportedOS": [
           {
@@ -1252,7 +1252,7 @@
         ],
         "Type": "pip_module"
       },
-      "likwid_na_tarball": {
+      "likwid": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -1267,16 +1267,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/RRZE-HPC/likwid/archive/refs/tags/v5.4.1.tar.gz"
           }
         ]
       },
-      "lsscsi_na_rpm": {
+      "lsscsi": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -1291,16 +1291,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "mariadb-server_na_rpm": {
+      "mariadb-server": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -1315,16 +1315,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "metallb-native-v0-15-3_na_manifest": {
+      "metallb-native": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -1343,7 +1343,7 @@
           }
         ]
       },
-      "msr-safe_na_tarball": {
+      "msr-safe": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -1362,7 +1362,7 @@
           }
         ]
       },
-      "munge_na_rpm": {
+      "munge": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -1377,16 +1377,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "nfs-subdir-external-provisioner-4-0-18_na_tarball": {
+      "nfs-subdir-external-provisioner": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -1405,7 +1405,7 @@
           }
         ]
       },
-      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+      "nvcr.io/nvidia/hpc-benchmarks": {
         "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
@@ -1421,7 +1421,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "omsdk_1.2.518_pip_module": {
+      "omsdk": {
         "Name": "omsdk==1.2.518",
         "SupportedOS": [
           {
@@ -1434,7 +1434,7 @@
         ],
         "Type": "pip_module"
       },
-      "osu-micro-benchmarks_na_tarball": {
+      "osu-micro-benchmarks": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -1449,16 +1449,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz"
           }
         ]
       },
-      "papi_na_tarball": {
+      "papi": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -1473,16 +1473,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/icl-utk-edu/papi/releases/download/papi-7-2-0-t/papi-7.2.0.tar.gz"
           }
         ]
       },
-      "pmix_na_rpm": {
+      "pmix": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -1497,16 +1497,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "podman_na_rpm": {
+      "podman": {
         "Name": "podman",
         "SupportedOS": [
           {
@@ -1525,7 +1525,7 @@
           }
         ]
       },
-      "prettytable_3.14.0_pip_module": {
+      "prettytable": {
         "Name": "prettytable==3.14.0",
         "SupportedOS": [
           {
@@ -1538,7 +1538,7 @@
         ],
         "Type": "pip_module"
       },
-      "prometheus_client_0.20.0_pip_module": {
+      "prometheus_client": {
         "Name": "prometheus_client==0.20.0",
         "SupportedOS": [
           {
@@ -1551,55 +1551,7 @@
         ],
         "Type": "pip_module"
       },
-      "python3-PyMySQL_na_rpm": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "python3-firewall_na_rpm": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "python3_3.12.9_rpm": {
+      "python3": {
         "Name": "python3-3.12.9",
         "SupportedOS": [
           {
@@ -1618,7 +1570,55 @@
           }
         ]
       },
-      "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image": {
+      "python3-PyMySQL": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "quay.io/dell/container-storage-modules/csm-metrics-powerscale": {
         "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
         "SupportedOS": [
           {
@@ -1633,7 +1633,7 @@
         "Tag": "v1.11.0",
         "Version": "v1.11.0"
       },
-      "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-acmesolver": {
         "Name": "quay.io/jetstack/cert-manager-acmesolver",
         "SupportedOS": [
           {
@@ -1648,7 +1648,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-cainjector": {
         "Name": "quay.io/jetstack/cert-manager-cainjector",
         "SupportedOS": [
           {
@@ -1663,7 +1663,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-controller_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-controller": {
         "Name": "quay.io/jetstack/cert-manager-controller",
         "SupportedOS": [
           {
@@ -1678,7 +1678,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-webhook_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-webhook": {
         "Name": "quay.io/jetstack/cert-manager-webhook",
         "SupportedOS": [
           {
@@ -1693,7 +1693,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-metallb-controller_v0.15.3_image": {
+      "quay.io/metallb/controller": {
         "Name": "quay.io/metallb/controller",
         "SupportedOS": [
           {
@@ -1708,7 +1708,7 @@
         "Tag": "v0.15.3",
         "Version": "v0.15.3"
       },
-      "quay-io-metallb-speaker_v0.15.3_image": {
+      "quay.io/metallb/speaker": {
         "Name": "quay.io/metallb/speaker",
         "SupportedOS": [
           {
@@ -1723,22 +1723,7 @@
         "Tag": "v0.15.3",
         "Version": "v0.15.3"
       },
-      "quay-io-strimzi-kafka-bridge_0.33.1_image": {
-        "Name": "quay.io/strimzi/kafka-bridge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.33.1",
-        "Version": "0.33.1"
-      },
-      "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image": {
+      "quay.io/strimzi/kafka": {
         "Name": "quay.io/strimzi/kafka",
         "SupportedOS": [
           {
@@ -1753,7 +1738,22 @@
         "Tag": "0.48.0-kafka-4.1.0",
         "Version": "0.48.0-kafka-4.1.0"
       },
-      "quay-io-strimzi-operator_0.48.0_image": {
+      "quay.io/strimzi/kafka-bridge": {
+        "Name": "quay.io/strimzi/kafka-bridge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.33.1",
+        "Version": "0.33.1"
+      },
+      "quay.io/strimzi/operator": {
         "Name": "quay.io/strimzi/operator",
         "SupportedOS": [
           {
@@ -1768,7 +1768,7 @@
         "Tag": "0.48.0",
         "Version": "0.48.0"
       },
-      "registry-k8s-io-coredns-coredns_v1.13.1_image": {
+      "registry.k8s.io/coredns/coredns": {
         "Name": "registry.k8s.io/coredns/coredns",
         "SupportedOS": [
           {
@@ -1783,7 +1783,7 @@
         "Tag": "v1.13.1",
         "Version": "v1.13.1"
       },
-      "registry-k8s-io-etcd_3.6.6-0_image": {
+      "registry.k8s.io/etcd": {
         "Name": "registry.k8s.io/etcd",
         "SupportedOS": [
           {
@@ -1798,7 +1798,7 @@
         "Tag": "3.6.6-0",
         "Version": "3.6.6-0"
       },
-      "registry-k8s-io-kube-apiserver_v1.35.1_image": {
+      "registry.k8s.io/kube-apiserver": {
         "Name": "registry.k8s.io/kube-apiserver",
         "SupportedOS": [
           {
@@ -1813,7 +1813,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-controller-manager_v1.35.1_image": {
+      "registry.k8s.io/kube-controller-manager": {
         "Name": "registry.k8s.io/kube-controller-manager",
         "SupportedOS": [
           {
@@ -1828,7 +1828,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-proxy_v1.35.1_image": {
+      "registry.k8s.io/kube-proxy": {
         "Name": "registry.k8s.io/kube-proxy",
         "SupportedOS": [
           {
@@ -1843,7 +1843,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-scheduler_v1.35.1_image": {
+      "registry.k8s.io/kube-scheduler": {
         "Name": "registry.k8s.io/kube-scheduler",
         "SupportedOS": [
           {
@@ -1858,7 +1858,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-pause_3.10.1_image": {
+      "registry.k8s.io/pause": {
         "Name": "registry.k8s.io/pause",
         "SupportedOS": [
           {
@@ -1873,7 +1873,7 @@
         "Tag": "3.10.1",
         "Version": "3.10.1"
       },
-      "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image": {
+      "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner": {
         "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
         "SupportedOS": [
           {
@@ -1888,7 +1888,7 @@
         "Tag": "v4.0.2",
         "Version": "v4.0.2"
       },
-      "sg3_utils_na_rpm": {
+      "sg3_utils": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -1903,16 +1903,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sionlib_na_tarball": {
+      "sionlib": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -1927,112 +1927,16 @@
         "Type": "tarball",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          },
-          {
             "Architecture": "x86_64",
             "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
-          }
-        ]
-      },
-      "slurm-pam_slurm_na_rpm": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmctld_na_rpm": {
-        "Name": "slurm-slurmctld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
+            "Uri": "https://apps.fz-juelich.de/jsc/sionlib/download.php?version=1.7.7"
           }
         ]
       },
-      "slurm-slurmd_na_rpm": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmdbd_na_rpm": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "slurm_custom"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm_na_rpm": {
+      "slurm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -2047,16 +1951,112 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "slurm_custom"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "slurm_custom"
           }
         ]
       },
-      "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball": {
+      "slurm-pam_slurm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "strimzi-kafka-operator-helm-3-chart": {
         "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
         "SupportedOS": [
           {
@@ -2075,7 +2075,7 @@
           }
         ]
       },
-      "victoria-metrics-operator-0-59-3_na_tarball": {
+      "victoria-metrics-operator": {
         "Name": "victoria-metrics-operator-0.59.3",
         "SupportedOS": [
           {
@@ -2094,7 +2094,7 @@
           }
         ]
       },
-      "vim-enhanced_na_rpm": {
+      "vim-enhanced": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2109,18 +2109,18 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       }
     },
     "OSPackages": {
-      "NetworkManager_na_rpm": {
+      "NetworkManager": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -2135,16 +2135,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "authselect_na_rpm": {
+      "authselect": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -2159,16 +2159,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "autoconf_na_rpm": {
+      "autoconf": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2183,16 +2183,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "automake_na_rpm": {
+      "automake": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2207,40 +2207,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "bash-completion_na_rpm": {
-        "Name": "bash-completion",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "bash_na_rpm": {
+      "bash": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -2255,17 +2231,17 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "binutils-devel_na_rpm": {
-        "Name": "binutils-devel",
+      "bash-completion": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2279,16 +2255,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
           }
         ]
       },
-      "binutils_na_rpm": {
+      "binutils": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -2303,16 +2279,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "bzip2_na_rpm": {
+      "binutils-devel": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bzip2": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -2327,16 +2327,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "chrony_na_rpm": {
+      "chrony": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -2351,16 +2351,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "cloud-init_na_rpm": {
+      "cloud-init": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -2375,16 +2375,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "clustershell_na_rpm": {
+      "clustershell": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2399,16 +2399,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "cmake_na_rpm": {
+      "cmake": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -2423,16 +2423,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "coreutils_na_rpm": {
+      "coreutils": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -2447,16 +2447,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "cryptsetup_na_rpm": {
+      "cryptsetup": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -2471,16 +2471,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "curl_na_rpm": {
+      "curl": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -2495,16 +2495,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "device-mapper_na_rpm": {
+      "device-mapper": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -2519,16 +2519,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "dmidecode_na_rpm": {
+      "dmidecode": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -2543,16 +2543,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "docker-io-dellhpcomniaaisolution-image-build-aarch_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-aarch64": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-aarch64",
         "SupportedOS": [
           {
@@ -2567,7 +2567,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-el10": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
         "SupportedOS": [
           {
@@ -2582,55 +2582,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_na_rpm": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "dracut-network_na_rpm": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "dracut_na_rpm": {
+      "dracut": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -2645,16 +2597,64 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "emacs_na_rpm": {
+      "dracut-live": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -2669,16 +2669,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "file_na_rpm": {
+      "file": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -2693,16 +2693,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "findutils_na_rpm": {
+      "findutils": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -2717,16 +2717,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "fping_na_rpm": {
+      "fping": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -2741,16 +2741,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "gawk_na_rpm": {
+      "gawk": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -2765,64 +2765,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
             "Architecture": "x86_64",
             "RepoName": "baseos"
-          }
-        ]
-      },
-      "gcc-c++_na_rpm": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc-gfortran_na_rpm": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "RepoName": "baseos"
           }
         ]
       },
-      "gcc_na_rpm": {
+      "gcc": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -2837,17 +2789,17 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gdb-gdbserver_na_rpm": {
-        "Name": "gdb-gdbserver",
+      "gcc-c++": {
+        "Name": "gcc-c++",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2861,16 +2813,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gdb_na_rpm": {
+      "gcc-gfortran": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -2885,16 +2861,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "gedit_na_rpm": {
+      "gdb-gdbserver": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -2909,16 +2909,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "glibc-langpack-en_na_rpm": {
+      "glibc-langpack-en": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -2933,16 +2933,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "grep_na_rpm": {
+      "grep": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -2957,16 +2957,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "gzip_na_rpm": {
+      "gzip": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -2981,40 +2981,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "hwloc-libs_na_rpm": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "hwloc_na_rpm": {
+      "hwloc": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -3029,16 +3005,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "iperf3_na_rpm": {
+      "hwloc-libs": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -3053,16 +3053,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "ipmitool_na_rpm": {
+      "ipmitool": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -3077,16 +3077,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "iproute_na_rpm": {
+      "iproute": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -3101,16 +3101,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "iputils_na_rpm": {
+      "iputils": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -3125,16 +3125,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kbd_na_rpm": {
+      "kbd": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -3149,40 +3149,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kernel-tools_na_rpm": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "kernel_na_rpm": {
+      "kernel": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -3197,16 +3173,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "kexec-tools_na_rpm": {
+      "kernel-tools": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -3221,16 +3221,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "libcurl_na_rpm": {
+      "libcurl": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -3245,16 +3245,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "libtool_na_rpm": {
+      "libtool": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -3269,40 +3269,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lldb-devel_na_rpm": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "lldb_na_rpm": {
+      "lldb": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -3317,16 +3293,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lshw_na_rpm": {
+      "lldb-devel": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -3341,16 +3341,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "lsof_na_rpm": {
+      "lsof": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -3365,16 +3365,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ltrace_na_rpm": {
+      "ltrace": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -3389,16 +3389,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "lvm2_na_rpm": {
+      "lvm2": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -3413,16 +3413,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "make_na_rpm": {
+      "make": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -3437,16 +3437,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "man-db_na_rpm": {
+      "man-db": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -3461,16 +3461,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "man-pages_na_rpm": {
+      "man-pages": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -3485,16 +3485,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "munge-devel_na_rpm": {
+      "munge-devel": {
         "Name": "munge-devel",
         "SupportedOS": [
           {
@@ -3509,16 +3509,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "codeready-builder"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "codeready-builder"
           }
         ]
       },
-      "nfs-utils_na_rpm": {
+      "nfs-utils": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -3533,16 +3533,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nfs4-acl-tools_na_rpm": {
+      "nfs4-acl-tools": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -3557,16 +3557,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "nm-connection-editor_na_rpm": {
+      "nm-connection-editor": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -3581,16 +3581,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "nss-pam-ldapd_na_rpm": {
+      "nss-pam-ldapd": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -3605,16 +3605,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "epel"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "epel"
           }
         ]
       },
-      "oddjob-mkhomedir_na_rpm": {
+      "oddjob-mkhomedir": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -3629,16 +3629,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "openldap-clients_na_rpm": {
+      "openldap-clients": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -3653,16 +3653,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "openmpi_5.0.8_tarball": {
+      "openmpi": {
         "Name": "openmpi",
         "SupportedOS": [
           {
@@ -3678,64 +3678,16 @@
         "Version": "5.0.8",
         "Sources": [
           {
-            "Architecture": "aarch64",
-            "Uri": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
-          },
-          {
             "Architecture": "x86_64",
             "Uri": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
-          }
-        ]
-      },
-      "openssh-clients_na_rpm": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh-server_na_rpm": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
             "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
+            "Uri": "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.gz"
           }
         ]
       },
-      "openssh_na_rpm": {
+      "openssh": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -3750,16 +3702,64 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "openssl-devel_na_rpm": {
+      "openssh-clients": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -3774,16 +3774,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "openssl-libs_na_rpm": {
+      "openssl-libs": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -3798,16 +3798,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ovis-ldms_na_rpm": {
+      "ovis-ldms": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -3822,16 +3822,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "ldms"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "ldms"
           }
         ]
       },
-      "papi-devel_na_rpm": {
+      "papi-devel": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -3846,16 +3846,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi-libs_na_rpm": {
+      "papi-libs": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -3870,16 +3870,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "papi_na_rpm": {
+      "papi_1": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -3894,16 +3894,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "pciutils_na_rpm": {
+      "pciutils": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -3918,16 +3918,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "perf_na_rpm": {
+      "perf": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -3942,16 +3942,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "pmix-devel_na_rpm": {
+      "pmix-devel": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -3966,16 +3966,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "python3-cython_na_rpm": {
+      "python3-cython": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -3990,16 +3990,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "codeready-builder"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "codeready-builder"
           }
         ]
       },
-      "python3-devel_na_rpm": {
+      "python3-devel": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -4014,16 +4014,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "rsync_na_rpm": {
+      "rsync": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -4038,16 +4038,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "rsyslog_na_rpm": {
+      "rsyslog": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -4062,16 +4062,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "sed_na_rpm": {
+      "sed": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -4086,16 +4086,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "squashfs-tools_na_rpm": {
+      "squashfs-tools": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -4110,16 +4110,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sssd_na_rpm": {
+      "sssd": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -4134,16 +4134,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "strace_na_rpm": {
+      "strace": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -4158,16 +4158,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "sudo_na_rpm": {
+      "sudo": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -4182,40 +4182,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "systemd-udev_na_rpm": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "baseos"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "systemd_na_rpm": {
+      "systemd": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -4230,16 +4206,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "tar_na_rpm": {
+      "systemd-udev": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -4254,16 +4254,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "tcpdump_na_rpm": {
+      "tcpdump": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -4278,16 +4278,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "traceroute_na_rpm": {
+      "traceroute": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -4302,16 +4302,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "ucx_1.19.0_tarball": {
+      "ucx": {
         "Name": "ucx",
         "SupportedOS": [
           {
@@ -4327,16 +4327,16 @@
         "Version": "1.19.0",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "Uri": "https://github.com/openucx/ucx/releases/download/v1.19.0/ucx-1.19.0.tar.gz"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "Uri": "https://github.com/openucx/ucx/releases/download/v1.19.0/ucx-1.19.0.tar.gz"
           }
         ]
       },
-      "util-linux_na_rpm": {
+      "util-linux": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -4351,40 +4351,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "valgrind-devel_na_rpm": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "aarch64",
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "aarch64",
-            "RepoName": "appstream"
-          },
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "valgrind_na_rpm": {
+      "valgrind": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -4399,16 +4375,40 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "vim-enhanced_na_rpm_1": {
+      "valgrind-devel": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "aarch64",
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          },
+          {
+            "Architecture": "aarch64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced_1": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -4423,16 +4423,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "wget_na_rpm": {
+      "wget": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -4447,16 +4447,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "appstream"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "appstream"
           }
         ]
       },
-      "which_na_rpm": {
+      "which": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -4471,16 +4471,16 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]
       },
-      "zsh_na_rpm": {
+      "zsh": {
         "Name": "zsh",
         "SupportedOS": [
           {
@@ -4495,11 +4495,11 @@
         "Type": "rpm",
         "Sources": [
           {
-            "Architecture": "aarch64",
+            "Architecture": "x86_64",
             "RepoName": "baseos"
           },
           {
-            "Architecture": "x86_64",
+            "Architecture": "aarch64",
             "RepoName": "baseos"
           }
         ]

--- a/examples/catalog/catalog_rhel_x86_64.json
+++ b/examples/catalog/catalog_rhel_x86_64.json
@@ -7,259 +7,259 @@
       {
         "Name": "login_compiler_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "os_x86_64",
         "FunctionalPackages": [
-          "openssl-libs_na_rpm",
-          "ovis-ldms_na_rpm",
-          "python3-cython_na_rpm",
-          "python3-devel_na_rpm"
+          "openssl-libs",
+          "ovis-ldms",
+          "python3-cython",
+          "python3-devel"
         ]
       },
       {
         "Name": "service_kube_control_plane_x86_64",
         "FunctionalPackages": [
-          "PyMySQL_1.1.2_pip_module",
-          "apptainer_na_rpm",
-          "calico-v3-31-4_na_manifest",
-          "cert-manager-v1-10-0_na_tarball",
-          "cffi_1.17.1_pip_module",
-          "container-selinux_na_rpm",
-          "cri-o_1.35.1_rpm",
-          "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "docker-io-alpine-kubectl_1.35.1_image",
-          "docker-io-calico-cni_v3.31.4_image",
-          "docker-io-calico-kube-controllers_v3.31.4_image",
-          "docker-io-calico-node_v3.31.4_image",
-          "docker-io-curlimages-curl_8.17.0_image",
-          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
-          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
-          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
-          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
-          "docker-io-library-busybox_1.36_image",
-          "docker-io-library-mysql_9.3.0_image",
-          "docker-io-library-python_3.12-slim_image",
-          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
-          "docker-io-rmohr-activemq_5.15.9_image",
-          "docker-io-timberio-vector_0.54.0-debian_image",
-          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
-          "docker-io-victoriametrics-operator_v0.68.3_image",
-          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
-          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
-          "docker-io-victoriametrics-vlagent_v1.50.0_image",
-          "docker-io-victoriametrics-vmagent_v1.128.0_image",
-          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_na_rpm",
-          "fuse-overlayfs_na_rpm",
-          "ghcr-io-kube-vip-kube-vip_v0.8.9_image",
-          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_na_rpm",
-          "helm-charts_container-storage-modules-1.9.2_git",
-          "helm-v3-20-1-amd64_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "karavi-observability_v1.12.0_git",
-          "kubeadm_1.35.1_rpm",
-          "kubectl_1.35.1_rpm",
-          "kubelet_1.35.1_rpm",
-          "kubernetes_33.1.0_pip_module",
-          "lsscsi_na_rpm",
-          "metallb-native-v0-15-3_na_manifest",
-          "nfs-subdir-external-provisioner-4-0-18_na_tarball",
-          "omsdk_1.2.518_pip_module",
-          "podman_na_rpm",
-          "prettytable_3.14.0_pip_module",
-          "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_na_rpm",
-          "python3_3.12.9_rpm",
-          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
-          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
-          "quay-io-metallb-speaker_v0.15.3_image",
-          "quay-io-strimzi-kafka-bridge_0.33.1_image",
-          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
-          "quay-io-strimzi-operator_0.48.0_image",
-          "registry-k8s-io-coredns-coredns_v1.13.1_image",
-          "registry-k8s-io-etcd_3.6.6-0_image",
-          "registry-k8s-io-kube-apiserver_v1.35.1_image",
-          "registry-k8s-io-kube-controller-manager_v1.35.1_image",
-          "registry-k8s-io-kube-proxy_v1.35.1_image",
-          "registry-k8s-io-kube-scheduler_v1.35.1_image",
-          "registry-k8s-io-pause_3.10.1_image",
-          "sg3_utils_na_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
-          "victoria-metrics-operator-0-59-3_na_tarball",
-          "vim-enhanced_na_rpm"
+          "PyMySQL",
+          "apptainer",
+          "calico",
+          "cert-manager",
+          "cffi",
+          "container-selinux",
+          "cri-o",
+          "cryptography",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "docker.io/alpine/kubectl",
+          "docker.io/calico/cni",
+          "docker.io/calico/kube-controllers",
+          "docker.io/calico/node",
+          "docker.io/curlimages/curl",
+          "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+          "docker.io/dellhpcomniaaisolution/kafkapump",
+          "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+          "docker.io/dellhpcomniaaisolution/victoriapump",
+          "docker.io/library/busybox",
+          "docker.io/library/mysql",
+          "docker.io/library/python",
+          "docker.io/nginxinc/nginx-unprivileged",
+          "docker.io/rmohr/activemq",
+          "docker.io/timberio/vector",
+          "docker.io/victoriametrics/operator",
+          "docker.io/victoriametrics/operator_1",
+          "docker.io/victoriametrics/victoria-logs",
+          "docker.io/victoriametrics/victoria-metrics",
+          "docker.io/victoriametrics/vlagent",
+          "docker.io/victoriametrics/vmagent",
+          "docker.io/victoriametrics/vminsert",
+          "docker.io/victoriametrics/vmselect",
+          "docker.io/victoriametrics/vmstorage",
+          "firewalld",
+          "fuse-overlayfs",
+          "ghcr.io/kube-vip/kube-vip",
+          "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+          "git",
+          "helm-amd64",
+          "helm-charts",
+          "iscsi-initiator-utils",
+          "karavi-observability",
+          "kubeadm",
+          "kubectl",
+          "kubelet",
+          "kubernetes",
+          "lsscsi",
+          "metallb-native",
+          "nfs-subdir-external-provisioner",
+          "omsdk",
+          "podman",
+          "prettytable",
+          "prometheus_client",
+          "python3",
+          "python3-firewall",
+          "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+          "quay.io/jetstack/cert-manager-acmesolver",
+          "quay.io/jetstack/cert-manager-cainjector",
+          "quay.io/jetstack/cert-manager-controller",
+          "quay.io/jetstack/cert-manager-webhook",
+          "quay.io/metallb/speaker",
+          "quay.io/strimzi/kafka",
+          "quay.io/strimzi/kafka-bridge",
+          "quay.io/strimzi/operator",
+          "registry.k8s.io/coredns/coredns",
+          "registry.k8s.io/etcd",
+          "registry.k8s.io/kube-apiserver",
+          "registry.k8s.io/kube-controller-manager",
+          "registry.k8s.io/kube-proxy",
+          "registry.k8s.io/kube-scheduler",
+          "registry.k8s.io/pause",
+          "sg3_utils",
+          "strimzi-kafka-operator-helm-3-chart",
+          "victoria-metrics-operator",
+          "vim-enhanced"
         ]
       },
       {
         "Name": "service_kube_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "cert-manager-v1-10-0_na_tarball",
-          "cffi_1.17.1_pip_module",
-          "container-selinux_na_rpm",
-          "cri-o_1.35.1_rpm",
-          "cryptography_45.0.7_pip_module",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "docker-io-alpine-kubectl_1.35.1_image",
-          "docker-io-curlimages-curl_8.17.0_image",
-          "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image",
-          "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image",
-          "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image",
-          "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image",
-          "docker-io-library-busybox_1.36_image",
-          "docker-io-library-mysql_9.3.0_image",
-          "docker-io-library-python_3.12-slim_image",
-          "docker-io-nginxinc-nginx-unprivileged_1.29_image",
-          "docker-io-rmohr-activemq_5.15.9_image",
-          "docker-io-timberio-vector_0.54.0-debian_image",
-          "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image",
-          "docker-io-victoriametrics-operator_v0.68.3_image",
-          "docker-io-victoriametrics-victoria-logs_v1.50.0_image",
-          "docker-io-victoriametrics-victoria-metrics_v1.128.0_image",
-          "docker-io-victoriametrics-vlagent_v1.50.0_image",
-          "docker-io-victoriametrics-vmagent_v1.128.0_image",
-          "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image",
-          "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image",
-          "firewalld_na_rpm",
-          "fuse-overlayfs_na_rpm",
-          "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image",
-          "git_na_rpm",
-          "helm-charts_container-storage-modules-1.9.2_git",
-          "iscsi-initiator-utils_na_rpm",
-          "karavi-observability_v1.12.0_git",
-          "kubeadm_1.35.1_rpm",
-          "kubelet_1.35.1_rpm",
-          "kubernetes_33.1.0_pip_module",
-          "lsscsi_na_rpm",
-          "omsdk_1.2.518_pip_module",
-          "podman_na_rpm",
-          "prometheus_client_0.20.0_pip_module",
-          "python3-firewall_na_rpm",
-          "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image",
-          "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-controller_v1.10.0_image",
-          "quay-io-jetstack-cert-manager-webhook_v1.10.0_image",
-          "quay-io-metallb-controller_v0.15.3_image",
-          "quay-io-metallb-speaker_v0.15.3_image",
-          "quay-io-strimzi-kafka-bridge_0.33.1_image",
-          "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image",
-          "quay-io-strimzi-operator_0.48.0_image",
-          "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image",
-          "sg3_utils_na_rpm",
-          "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball",
-          "victoria-metrics-operator-0-59-3_na_tarball",
-          "vim-enhanced_na_rpm"
+          "apptainer",
+          "cert-manager",
+          "cffi",
+          "container-selinux",
+          "cri-o",
+          "cryptography",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "docker.io/alpine/kubectl",
+          "docker.io/curlimages/curl",
+          "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
+          "docker.io/dellhpcomniaaisolution/kafkapump",
+          "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
+          "docker.io/dellhpcomniaaisolution/victoriapump",
+          "docker.io/library/busybox",
+          "docker.io/library/mysql",
+          "docker.io/library/python",
+          "docker.io/nginxinc/nginx-unprivileged",
+          "docker.io/rmohr/activemq",
+          "docker.io/timberio/vector",
+          "docker.io/victoriametrics/operator",
+          "docker.io/victoriametrics/operator_1",
+          "docker.io/victoriametrics/victoria-logs",
+          "docker.io/victoriametrics/victoria-metrics",
+          "docker.io/victoriametrics/vlagent",
+          "docker.io/victoriametrics/vmagent",
+          "docker.io/victoriametrics/vminsert",
+          "docker.io/victoriametrics/vmselect",
+          "docker.io/victoriametrics/vmstorage",
+          "firewalld",
+          "fuse-overlayfs",
+          "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+          "git",
+          "helm-charts",
+          "iscsi-initiator-utils",
+          "karavi-observability",
+          "kubeadm",
+          "kubelet",
+          "kubernetes",
+          "lsscsi",
+          "omsdk",
+          "podman",
+          "prometheus_client",
+          "python3-firewall",
+          "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
+          "quay.io/jetstack/cert-manager-acmesolver",
+          "quay.io/jetstack/cert-manager-cainjector",
+          "quay.io/jetstack/cert-manager-controller",
+          "quay.io/jetstack/cert-manager-webhook",
+          "quay.io/metallb/controller",
+          "quay.io/metallb/speaker",
+          "quay.io/strimzi/kafka",
+          "quay.io/strimzi/kafka-bridge",
+          "quay.io/strimzi/operator",
+          "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
+          "sg3_utils",
+          "strimzi-kafka-operator-helm-3-chart",
+          "victoria-metrics-operator",
+          "vim-enhanced"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "mariadb-server_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-PyMySQL_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmctld_na_rpm",
-          "slurm-slurmdbd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "mariadb-server",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-PyMySQL",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-slurmctld",
+          "slurm-slurmdbd"
         ]
       },
       {
         "Name": "slurm_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "kernel-devel_na_rpm",
-          "kernel-headers_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-pam_slurm_na_rpm",
-          "slurm-slurmd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "kernel-devel",
+          "kernel-headers",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-pam_slurm",
+          "slurm-slurmd"
         ]
       }
     ],
@@ -268,105 +268,105 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_na_rpm",
-          "authselect_na_rpm",
-          "autoconf_na_rpm",
-          "automake_na_rpm",
-          "bash-completion_na_rpm",
-          "bash_na_rpm",
-          "binutils-devel_na_rpm",
-          "binutils_na_rpm",
-          "bzip2_na_rpm",
-          "chrony_na_rpm",
-          "cloud-init_na_rpm",
-          "clustershell_na_rpm",
-          "cmake_na_rpm",
-          "coreutils_na_rpm",
-          "cryptsetup_na_rpm",
-          "curl_na_rpm",
-          "device-mapper_na_rpm",
-          "dmidecode_na_rpm",
-          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_na_rpm",
-          "dracut-network_na_rpm",
-          "dracut_na_rpm",
-          "emacs_na_rpm",
-          "file_na_rpm",
-          "findutils_na_rpm",
-          "fping_na_rpm",
-          "gawk_na_rpm",
-          "gcc-c++_na_rpm",
-          "gcc-gfortran_na_rpm",
-          "gcc_na_rpm",
-          "gdb-gdbserver_na_rpm",
-          "gdb_na_rpm",
-          "gedit_na_rpm",
-          "glibc-langpack-en_na_rpm",
-          "grep_na_rpm",
-          "gzip_na_rpm",
-          "hwloc-libs_na_rpm",
-          "hwloc_na_rpm",
-          "iperf3_na_rpm",
-          "ipmitool_na_rpm",
-          "iproute_na_rpm",
-          "iputils_na_rpm",
-          "kbd_na_rpm",
-          "kernel-tools_na_rpm",
-          "kernel_na_rpm",
-          "kexec-tools_na_rpm",
-          "libcurl_na_rpm",
-          "libtool_na_rpm",
-          "lldb-devel_na_rpm",
-          "lldb_na_rpm",
-          "lshw_na_rpm",
-          "lsof_na_rpm",
-          "ltrace_na_rpm",
-          "lvm2_na_rpm",
-          "make_na_rpm",
-          "man-db_na_rpm",
-          "man-pages_na_rpm",
-          "munge-devel_na_rpm",
-          "nfs-utils_na_rpm",
-          "nfs4-acl-tools_na_rpm",
-          "nm-connection-editor_na_rpm",
-          "nss-pam-ldapd_na_rpm",
-          "oddjob-mkhomedir_na_rpm",
-          "openldap-clients_na_rpm",
-          "openmpi_5.0.8_tarball",
-          "openssh-clients_na_rpm",
-          "openssh-server_na_rpm",
-          "openssh_na_rpm",
-          "openssl-devel_na_rpm",
-          "openssl-libs_na_rpm_1",
-          "ovis-ldms_na_rpm_1",
-          "papi-devel_na_rpm",
-          "papi-libs_na_rpm",
-          "papi_na_rpm",
-          "pciutils_na_rpm",
-          "perf_na_rpm",
-          "pmix-devel_na_rpm",
-          "python3-cython_na_rpm_1",
-          "python3-devel_na_rpm_1",
-          "rsync_na_rpm",
-          "rsyslog_na_rpm",
-          "sed_na_rpm",
-          "squashfs-tools_na_rpm",
-          "sssd_na_rpm",
-          "strace_na_rpm",
-          "sudo_na_rpm",
-          "systemd-udev_na_rpm",
-          "systemd_na_rpm",
-          "tar_na_rpm",
-          "tcpdump_na_rpm",
-          "traceroute_na_rpm",
-          "ucx_1.19.0_tarball",
-          "util-linux_na_rpm",
-          "valgrind-devel_na_rpm",
-          "valgrind_na_rpm",
-          "vim-enhanced_na_rpm_1",
-          "wget_na_rpm",
-          "which_na_rpm",
-          "zsh_na_rpm"
+          "NetworkManager",
+          "authselect",
+          "autoconf",
+          "automake",
+          "bash",
+          "bash-completion",
+          "binutils",
+          "binutils-devel",
+          "bzip2",
+          "chrony",
+          "cloud-init",
+          "clustershell",
+          "cmake",
+          "coreutils",
+          "cryptsetup",
+          "curl",
+          "device-mapper",
+          "dmidecode",
+          "docker.io/dellhpcomniaaisolution/image-build-el10",
+          "dracut",
+          "dracut-live",
+          "dracut-network",
+          "emacs",
+          "file",
+          "findutils",
+          "fping",
+          "gawk",
+          "gcc",
+          "gcc-c++",
+          "gcc-gfortran",
+          "gdb",
+          "gdb-gdbserver",
+          "gedit",
+          "glibc-langpack-en",
+          "grep",
+          "gzip",
+          "hwloc",
+          "hwloc-libs",
+          "iperf3",
+          "ipmitool",
+          "iproute",
+          "iputils",
+          "kbd",
+          "kernel",
+          "kernel-tools",
+          "kexec-tools",
+          "libcurl",
+          "libtool",
+          "lldb",
+          "lldb-devel",
+          "lshw",
+          "lsof",
+          "ltrace",
+          "lvm2",
+          "make",
+          "man-db",
+          "man-pages",
+          "munge-devel",
+          "nfs-utils",
+          "nfs4-acl-tools",
+          "nm-connection-editor",
+          "nss-pam-ldapd",
+          "oddjob-mkhomedir",
+          "openldap-clients",
+          "openmpi",
+          "openssh",
+          "openssh-clients",
+          "openssh-server",
+          "openssl-devel",
+          "openssl-libs_1",
+          "ovis-ldms_1",
+          "papi-devel",
+          "papi-libs",
+          "papi_1",
+          "pciutils",
+          "perf",
+          "pmix-devel",
+          "python3-cython_1",
+          "python3-devel_1",
+          "rsync",
+          "rsyslog",
+          "sed",
+          "squashfs-tools",
+          "sssd",
+          "strace",
+          "sudo",
+          "systemd",
+          "systemd-udev",
+          "tar",
+          "tcpdump",
+          "traceroute",
+          "ucx",
+          "util-linux",
+          "valgrind",
+          "valgrind-devel",
+          "vim-enhanced_1",
+          "wget",
+          "which",
+          "zsh"
         ]
       }
     ],
@@ -374,29 +374,29 @@
       {
         "Name": "csi",
         "InfrastructurePackages": [
-          "csi-powerscale-v2-16-0_v2.16.0_git",
-          "docker-io-dellemc-csm-encryption_v0.6.0_image",
-          "external-snapshotter-v8-4-0_v8.4.0_git",
-          "helm-charts-2-16-0_csi-isilon-2.16.0_git",
-          "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image",
-          "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image",
-          "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image",
-          "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image",
-          "quay-io-dell-container-storage-modules-podmon_v1.15.0_image",
-          "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image",
-          "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image",
-          "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image",
-          "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image",
-          "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image",
-          "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image",
-          "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image"
+          "csi-powerscale",
+          "docker.io/dellemc/csm-encryption",
+          "external-snapshotter",
+          "helm-charts_1",
+          "quay.io/dell/container-storage-modules/csi-isilon",
+          "quay.io/dell/container-storage-modules/csi-metadata-retriever",
+          "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
+          "quay.io/dell/container-storage-modules/dell-csi-replicator",
+          "quay.io/dell/container-storage-modules/podmon",
+          "registry.k8s.io/sig-storage/csi-attacher",
+          "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
+          "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+          "registry.k8s.io/sig-storage/csi-provisioner",
+          "registry.k8s.io/sig-storage/csi-resizer",
+          "registry.k8s.io/sig-storage/csi-snapshotter",
+          "registry.k8s.io/sig-storage/snapshot-controller"
         ]
       }
     ],
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "PyMySQL_1.1.2_pip_module": {
+      "PyMySQL": {
         "Name": "PyMySQL==1.1.2",
         "SupportedOS": [
           {
@@ -409,7 +409,7 @@
         ],
         "Type": "pip_module"
       },
-      "apptainer_na_rpm": {
+      "apptainer": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -428,7 +428,7 @@
           }
         ]
       },
-      "calico-v3-31-4_na_manifest": {
+      "calico": {
         "Name": "calico-v3.31.4",
         "SupportedOS": [
           {
@@ -447,7 +447,7 @@
           }
         ]
       },
-      "cert-manager-v1-10-0_na_tarball": {
+      "cert-manager": {
         "Name": "cert-manager-v1.10.0",
         "SupportedOS": [
           {
@@ -466,7 +466,7 @@
           }
         ]
       },
-      "cffi_1.17.1_pip_module": {
+      "cffi": {
         "Name": "cffi==1.17.1",
         "SupportedOS": [
           {
@@ -479,7 +479,7 @@
         ],
         "Type": "pip_module"
       },
-      "container-selinux_na_rpm": {
+      "container-selinux": {
         "Name": "container-selinux",
         "SupportedOS": [
           {
@@ -498,7 +498,7 @@
           }
         ]
       },
-      "cri-o_1.35.1_rpm": {
+      "cri-o": {
         "Name": "cri-o-1.35.1",
         "SupportedOS": [
           {
@@ -517,7 +517,7 @@
           }
         ]
       },
-      "cryptography_45.0.7_pip_module": {
+      "cryptography": {
         "Name": "cryptography==45.0.7",
         "SupportedOS": [
           {
@@ -530,7 +530,7 @@
         ],
         "Type": "pip_module"
       },
-      "device-mapper-multipath_na_rpm": {
+      "device-mapper-multipath": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -549,7 +549,7 @@
           }
         ]
       },
-      "doca-ofed_na_rpm_repo": {
+      "doca-ofed": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -568,7 +568,7 @@
           }
         ]
       },
-      "docker-io-alpine-kubectl_1.35.1_image": {
+      "docker.io/alpine/kubectl": {
         "Name": "docker.io/alpine/kubectl",
         "SupportedOS": [
           {
@@ -583,7 +583,7 @@
         "Tag": "1.35.1",
         "Version": "1.35.1"
       },
-      "docker-io-calico-cni_v3.31.4_image": {
+      "docker.io/calico/cni": {
         "Name": "docker.io/calico/cni",
         "SupportedOS": [
           {
@@ -598,7 +598,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-calico-kube-controllers_v3.31.4_image": {
+      "docker.io/calico/kube-controllers": {
         "Name": "docker.io/calico/kube-controllers",
         "SupportedOS": [
           {
@@ -613,7 +613,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-calico-node_v3.31.4_image": {
+      "docker.io/calico/node": {
         "Name": "docker.io/calico/node",
         "SupportedOS": [
           {
@@ -628,7 +628,7 @@
         "Tag": "v3.31.4",
         "Version": "v3.31.4"
       },
-      "docker-io-curlimages-curl_8.17.0_image": {
+      "docker.io/curlimages/curl": {
         "Name": "docker.io/curlimages/curl",
         "SupportedOS": [
           {
@@ -643,7 +643,7 @@
         "Tag": "8.17.0",
         "Version": "8.17.0"
       },
-      "docker-io-dellhpcomniaaisolution-idrac_telemetry_r_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver": {
         "Name": "docker.io/dellhpcomniaaisolution/idrac_telemetry_receiver",
         "SupportedOS": [
           {
@@ -658,7 +658,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-dellhpcomniaaisolution-kafkapump_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/kafkapump": {
         "Name": "docker.io/dellhpcomniaaisolution/kafkapump",
         "SupportedOS": [
           {
@@ -673,7 +673,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-dellhpcomniaaisolution-ubuntu-ldms_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/ubuntu-ldms": {
         "Name": "docker.io/dellhpcomniaaisolution/ubuntu-ldms",
         "SupportedOS": [
           {
@@ -688,7 +688,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "docker-io-dellhpcomniaaisolution-victoriapump_1.3_image": {
+      "docker.io/dellhpcomniaaisolution/victoriapump": {
         "Name": "docker.io/dellhpcomniaaisolution/victoriapump",
         "SupportedOS": [
           {
@@ -703,7 +703,7 @@
         "Tag": "1.3",
         "Version": "1.3"
       },
-      "docker-io-library-busybox_1.36_image": {
+      "docker.io/library/busybox": {
         "Name": "docker.io/library/busybox",
         "SupportedOS": [
           {
@@ -718,7 +718,7 @@
         "Tag": "1.36",
         "Version": "1.36"
       },
-      "docker-io-library-mysql_9.3.0_image": {
+      "docker.io/library/mysql": {
         "Name": "docker.io/library/mysql",
         "SupportedOS": [
           {
@@ -733,7 +733,7 @@
         "Tag": "9.3.0",
         "Version": "9.3.0"
       },
-      "docker-io-library-python_3.12-slim_image": {
+      "docker.io/library/python": {
         "Name": "docker.io/library/python",
         "SupportedOS": [
           {
@@ -748,7 +748,7 @@
         "Tag": "3.12-slim",
         "Version": "3.12-slim"
       },
-      "docker-io-nginxinc-nginx-unprivileged_1.29_image": {
+      "docker.io/nginxinc/nginx-unprivileged": {
         "Name": "docker.io/nginxinc/nginx-unprivileged",
         "SupportedOS": [
           {
@@ -763,7 +763,7 @@
         "Tag": "1.29",
         "Version": "1.29"
       },
-      "docker-io-rmohr-activemq_5.15.9_image": {
+      "docker.io/rmohr/activemq": {
         "Name": "docker.io/rmohr/activemq",
         "SupportedOS": [
           {
@@ -778,7 +778,7 @@
         "Tag": "5.15.9",
         "Version": "5.15.9"
       },
-      "docker-io-timberio-vector_0.54.0-debian_image": {
+      "docker.io/timberio/vector": {
         "Name": "docker.io/timberio/vector",
         "SupportedOS": [
           {
@@ -793,22 +793,7 @@
         "Tag": "0.54.0-debian",
         "Version": "0.54.0-debian"
       },
-      "docker-io-victoriametrics-operator_config-reloader-v0.68.3_image": {
-        "Name": "docker.io/victoriametrics/operator",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "config-reloader-v0.68.3",
-        "Version": "config-reloader-v0.68.3"
-      },
-      "docker-io-victoriametrics-operator_v0.68.3_image": {
+      "docker.io/victoriametrics/operator": {
         "Name": "docker.io/victoriametrics/operator",
         "SupportedOS": [
           {
@@ -823,7 +808,22 @@
         "Tag": "v0.68.3",
         "Version": "v0.68.3"
       },
-      "docker-io-victoriametrics-victoria-logs_v1.50.0_image": {
+      "docker.io/victoriametrics/operator_1": {
+        "Name": "docker.io/victoriametrics/operator",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "config-reloader-v0.68.3",
+        "Version": "config-reloader-v0.68.3"
+      },
+      "docker.io/victoriametrics/victoria-logs": {
         "Name": "docker.io/victoriametrics/victoria-logs",
         "SupportedOS": [
           {
@@ -838,7 +838,7 @@
         "Tag": "v1.50.0",
         "Version": "v1.50.0"
       },
-      "docker-io-victoriametrics-victoria-metrics_v1.128.0_image": {
+      "docker.io/victoriametrics/victoria-metrics": {
         "Name": "docker.io/victoriametrics/victoria-metrics",
         "SupportedOS": [
           {
@@ -853,7 +853,7 @@
         "Tag": "v1.128.0",
         "Version": "v1.128.0"
       },
-      "docker-io-victoriametrics-vlagent_v1.50.0_image": {
+      "docker.io/victoriametrics/vlagent": {
         "Name": "docker.io/victoriametrics/vlagent",
         "SupportedOS": [
           {
@@ -868,7 +868,7 @@
         "Tag": "v1.50.0",
         "Version": "v1.50.0"
       },
-      "docker-io-victoriametrics-vmagent_v1.128.0_image": {
+      "docker.io/victoriametrics/vmagent": {
         "Name": "docker.io/victoriametrics/vmagent",
         "SupportedOS": [
           {
@@ -883,7 +883,7 @@
         "Tag": "v1.128.0",
         "Version": "v1.128.0"
       },
-      "docker-io-victoriametrics-vminsert_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vminsert": {
         "Name": "docker.io/victoriametrics/vminsert",
         "SupportedOS": [
           {
@@ -898,7 +898,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "docker-io-victoriametrics-vmselect_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vmselect": {
         "Name": "docker.io/victoriametrics/vmselect",
         "SupportedOS": [
           {
@@ -913,7 +913,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "docker-io-victoriametrics-vmstorage_v1.128.0-cluster_image": {
+      "docker.io/victoriametrics/vmstorage": {
         "Name": "docker.io/victoriametrics/vmstorage",
         "SupportedOS": [
           {
@@ -928,7 +928,7 @@
         "Tag": "v1.128.0-cluster",
         "Version": "v1.128.0-cluster"
       },
-      "firewalld_na_rpm": {
+      "firewalld": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -947,7 +947,7 @@
           }
         ]
       },
-      "fuse-overlayfs_na_rpm": {
+      "fuse-overlayfs": {
         "Name": "fuse-overlayfs",
         "SupportedOS": [
           {
@@ -966,7 +966,7 @@
           }
         ]
       },
-      "geopm_na_tarball": {
+      "geopm": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -985,7 +985,7 @@
           }
         ]
       },
-      "ghcr-io-kube-vip-kube-vip_v0.8.9_image": {
+      "ghcr.io/kube-vip/kube-vip": {
         "Name": "ghcr.io/kube-vip/kube-vip",
         "SupportedOS": [
           {
@@ -1000,7 +1000,7 @@
         "Tag": "v0.8.9",
         "Version": "v0.8.9"
       },
-      "ghcr-io-open-telemetry-opentelemetry-collector-rel_0.143.1_image": {
+      "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector": {
         "Name": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
         "SupportedOS": [
           {
@@ -1015,7 +1015,7 @@
         "Tag": "0.143.1",
         "Version": "0.143.1"
       },
-      "git_na_rpm": {
+      "git": {
         "Name": "git",
         "SupportedOS": [
           {
@@ -1034,7 +1034,26 @@
           }
         ]
       },
-      "helm-charts_container-storage-modules-1.9.2_git": {
+      "helm-amd64": {
+        "Name": "helm-v3.20.1-amd64",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "tarball",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
+          }
+        ]
+      },
+      "helm-charts": {
         "Name": "helm-charts",
         "SupportedOS": [
           {
@@ -1054,26 +1073,7 @@
           }
         ]
       },
-      "helm-v3-20-1-amd64_na_tarball": {
-        "Name": "helm-v3.20.1-amd64",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "tarball",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "Uri": "https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz"
-          }
-        ]
-      },
-      "imb_na_tarball": {
+      "imb": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -1092,7 +1092,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_na_rpm": {
+      "iscsi-initiator-utils": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -1111,7 +1111,7 @@
           }
         ]
       },
-      "karavi-observability_v1.12.0_git": {
+      "karavi-observability": {
         "Name": "karavi-observability",
         "SupportedOS": [
           {
@@ -1131,7 +1131,7 @@
           }
         ]
       },
-      "kernel-devel_na_rpm": {
+      "kernel-devel": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -1150,7 +1150,7 @@
           }
         ]
       },
-      "kernel-headers_na_rpm": {
+      "kernel-headers": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -1169,7 +1169,7 @@
           }
         ]
       },
-      "kubeadm_1.35.1_rpm": {
+      "kubeadm": {
         "Name": "kubeadm-1.35.1",
         "SupportedOS": [
           {
@@ -1188,7 +1188,7 @@
           }
         ]
       },
-      "kubectl_1.35.1_rpm": {
+      "kubectl": {
         "Name": "kubectl-1.35.1",
         "SupportedOS": [
           {
@@ -1207,7 +1207,7 @@
           }
         ]
       },
-      "kubelet_1.35.1_rpm": {
+      "kubelet": {
         "Name": "kubelet-1.35.1",
         "SupportedOS": [
           {
@@ -1226,7 +1226,7 @@
           }
         ]
       },
-      "kubernetes_33.1.0_pip_module": {
+      "kubernetes": {
         "Name": "kubernetes==33.1.0",
         "SupportedOS": [
           {
@@ -1239,7 +1239,7 @@
         ],
         "Type": "pip_module"
       },
-      "likwid_na_tarball": {
+      "likwid": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -1258,7 +1258,7 @@
           }
         ]
       },
-      "lsscsi_na_rpm": {
+      "lsscsi": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -1277,7 +1277,7 @@
           }
         ]
       },
-      "mariadb-server_na_rpm": {
+      "mariadb-server": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -1296,7 +1296,7 @@
           }
         ]
       },
-      "metallb-native-v0-15-3_na_manifest": {
+      "metallb-native": {
         "Name": "metallb-native-v0.15.3",
         "SupportedOS": [
           {
@@ -1315,7 +1315,7 @@
           }
         ]
       },
-      "msr-safe_na_tarball": {
+      "msr-safe": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -1334,7 +1334,7 @@
           }
         ]
       },
-      "munge_na_rpm": {
+      "munge": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -1353,7 +1353,7 @@
           }
         ]
       },
-      "nfs-subdir-external-provisioner-4-0-18_na_tarball": {
+      "nfs-subdir-external-provisioner": {
         "Name": "nfs-subdir-external-provisioner-4.0.18",
         "SupportedOS": [
           {
@@ -1372,7 +1372,7 @@
           }
         ]
       },
-      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+      "nvcr.io/nvidia/hpc-benchmarks": {
         "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
@@ -1387,7 +1387,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "omsdk_1.2.518_pip_module": {
+      "omsdk": {
         "Name": "omsdk==1.2.518",
         "SupportedOS": [
           {
@@ -1400,7 +1400,7 @@
         ],
         "Type": "pip_module"
       },
-      "openssl-libs_na_rpm": {
+      "openssl-libs": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -1419,7 +1419,7 @@
           }
         ]
       },
-      "osu-micro-benchmarks_na_tarball": {
+      "osu-micro-benchmarks": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -1438,7 +1438,7 @@
           }
         ]
       },
-      "ovis-ldms_na_rpm": {
+      "ovis-ldms": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -1457,7 +1457,7 @@
           }
         ]
       },
-      "papi_na_tarball": {
+      "papi": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -1476,7 +1476,7 @@
           }
         ]
       },
-      "pmix_na_rpm": {
+      "pmix": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -1495,7 +1495,7 @@
           }
         ]
       },
-      "podman_na_rpm": {
+      "podman": {
         "Name": "podman",
         "SupportedOS": [
           {
@@ -1514,7 +1514,7 @@
           }
         ]
       },
-      "prettytable_3.14.0_pip_module": {
+      "prettytable": {
         "Name": "prettytable==3.14.0",
         "SupportedOS": [
           {
@@ -1527,7 +1527,7 @@
         ],
         "Type": "pip_module"
       },
-      "prometheus_client_0.20.0_pip_module": {
+      "prometheus_client": {
         "Name": "prometheus_client==0.20.0",
         "SupportedOS": [
           {
@@ -1540,83 +1540,7 @@
         ],
         "Type": "pip_module"
       },
-      "python3-PyMySQL_na_rpm": {
-        "Name": "python3-PyMySQL",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "python3-cython_na_rpm": {
-        "Name": "python3-cython",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "codeready-builder"
-          }
-        ]
-      },
-      "python3-devel_na_rpm": {
-        "Name": "python3-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "python3-firewall_na_rpm": {
-        "Name": "python3-firewall",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "python3_3.12.9_rpm": {
+      "python3": {
         "Name": "python3-3.12.9",
         "SupportedOS": [
           {
@@ -1635,7 +1559,83 @@
           }
         ]
       },
-      "quay-io-dell-container-storage-modules-csm-metrics_v1.11.0_image": {
+      "python3-PyMySQL": {
+        "Name": "python3-PyMySQL",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-cython": {
+        "Name": "python3-cython",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "codeready-builder"
+          }
+        ]
+      },
+      "python3-devel": {
+        "Name": "python3-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "python3-firewall": {
+        "Name": "python3-firewall",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "quay.io/dell/container-storage-modules/csm-metrics-powerscale": {
         "Name": "quay.io/dell/container-storage-modules/csm-metrics-powerscale",
         "SupportedOS": [
           {
@@ -1650,7 +1650,7 @@
         "Tag": "v1.11.0",
         "Version": "v1.11.0"
       },
-      "quay-io-jetstack-cert-manager-acmesolver_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-acmesolver": {
         "Name": "quay.io/jetstack/cert-manager-acmesolver",
         "SupportedOS": [
           {
@@ -1665,7 +1665,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-cainjector_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-cainjector": {
         "Name": "quay.io/jetstack/cert-manager-cainjector",
         "SupportedOS": [
           {
@@ -1680,7 +1680,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-controller_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-controller": {
         "Name": "quay.io/jetstack/cert-manager-controller",
         "SupportedOS": [
           {
@@ -1695,7 +1695,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-jetstack-cert-manager-webhook_v1.10.0_image": {
+      "quay.io/jetstack/cert-manager-webhook": {
         "Name": "quay.io/jetstack/cert-manager-webhook",
         "SupportedOS": [
           {
@@ -1710,7 +1710,7 @@
         "Tag": "v1.10.0",
         "Version": "v1.10.0"
       },
-      "quay-io-metallb-controller_v0.15.3_image": {
+      "quay.io/metallb/controller": {
         "Name": "quay.io/metallb/controller",
         "SupportedOS": [
           {
@@ -1725,7 +1725,7 @@
         "Tag": "v0.15.3",
         "Version": "v0.15.3"
       },
-      "quay-io-metallb-speaker_v0.15.3_image": {
+      "quay.io/metallb/speaker": {
         "Name": "quay.io/metallb/speaker",
         "SupportedOS": [
           {
@@ -1740,22 +1740,7 @@
         "Tag": "v0.15.3",
         "Version": "v0.15.3"
       },
-      "quay-io-strimzi-kafka-bridge_0.33.1_image": {
-        "Name": "quay.io/strimzi/kafka-bridge",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "image",
-        "Tag": "0.33.1",
-        "Version": "0.33.1"
-      },
-      "quay-io-strimzi-kafka_0.48.0-kafka-4.1.0_image": {
+      "quay.io/strimzi/kafka": {
         "Name": "quay.io/strimzi/kafka",
         "SupportedOS": [
           {
@@ -1770,7 +1755,22 @@
         "Tag": "0.48.0-kafka-4.1.0",
         "Version": "0.48.0-kafka-4.1.0"
       },
-      "quay-io-strimzi-operator_0.48.0_image": {
+      "quay.io/strimzi/kafka-bridge": {
+        "Name": "quay.io/strimzi/kafka-bridge",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "image",
+        "Tag": "0.33.1",
+        "Version": "0.33.1"
+      },
+      "quay.io/strimzi/operator": {
         "Name": "quay.io/strimzi/operator",
         "SupportedOS": [
           {
@@ -1785,7 +1785,7 @@
         "Tag": "0.48.0",
         "Version": "0.48.0"
       },
-      "registry-k8s-io-coredns-coredns_v1.13.1_image": {
+      "registry.k8s.io/coredns/coredns": {
         "Name": "registry.k8s.io/coredns/coredns",
         "SupportedOS": [
           {
@@ -1800,7 +1800,7 @@
         "Tag": "v1.13.1",
         "Version": "v1.13.1"
       },
-      "registry-k8s-io-etcd_3.6.6-0_image": {
+      "registry.k8s.io/etcd": {
         "Name": "registry.k8s.io/etcd",
         "SupportedOS": [
           {
@@ -1815,7 +1815,7 @@
         "Tag": "3.6.6-0",
         "Version": "3.6.6-0"
       },
-      "registry-k8s-io-kube-apiserver_v1.35.1_image": {
+      "registry.k8s.io/kube-apiserver": {
         "Name": "registry.k8s.io/kube-apiserver",
         "SupportedOS": [
           {
@@ -1830,7 +1830,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-controller-manager_v1.35.1_image": {
+      "registry.k8s.io/kube-controller-manager": {
         "Name": "registry.k8s.io/kube-controller-manager",
         "SupportedOS": [
           {
@@ -1845,7 +1845,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-proxy_v1.35.1_image": {
+      "registry.k8s.io/kube-proxy": {
         "Name": "registry.k8s.io/kube-proxy",
         "SupportedOS": [
           {
@@ -1860,7 +1860,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-kube-scheduler_v1.35.1_image": {
+      "registry.k8s.io/kube-scheduler": {
         "Name": "registry.k8s.io/kube-scheduler",
         "SupportedOS": [
           {
@@ -1875,7 +1875,7 @@
         "Tag": "v1.35.1",
         "Version": "v1.35.1"
       },
-      "registry-k8s-io-pause_3.10.1_image": {
+      "registry.k8s.io/pause": {
         "Name": "registry.k8s.io/pause",
         "SupportedOS": [
           {
@@ -1890,7 +1890,7 @@
         "Tag": "3.10.1",
         "Version": "3.10.1"
       },
-      "registry-k8s-io-sig-storage-nfs-subdir-external-pr_v4.0.2_image": {
+      "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner": {
         "Name": "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner",
         "SupportedOS": [
           {
@@ -1905,7 +1905,7 @@
         "Tag": "v4.0.2",
         "Version": "v4.0.2"
       },
-      "sg3_utils_na_rpm": {
+      "sg3_utils": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -1924,7 +1924,7 @@
           }
         ]
       },
-      "sionlib_na_tarball": {
+      "sionlib": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -1943,83 +1943,7 @@
           }
         ]
       },
-      "slurm-pam_slurm_na_rpm": {
-        "Name": "slurm-pam_slurm",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmctld_na_rpm": {
-        "Name": "slurm-slurmctld",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmd_na_rpm": {
-        "Name": "slurm-slurmd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm-slurmdbd_na_rpm": {
-        "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm_na_rpm": {
+      "slurm": {
         "Name": "slurm",
         "SupportedOS": [
           {
@@ -2038,7 +1962,83 @@
           }
         ]
       },
-      "strimzi-kafka-operator-helm-3-chart-0-48-0_na_tarball": {
+      "slurm-pam_slurm": {
+        "Name": "slurm-pam_slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmctld": {
+        "Name": "slurm-slurmctld",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmd": {
+        "Name": "slurm-slurmd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-slurmdbd": {
+        "Name": "slurm-slurmdbd",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "strimzi-kafka-operator-helm-3-chart": {
         "Name": "strimzi-kafka-operator-helm-3-chart-0.48.0",
         "SupportedOS": [
           {
@@ -2057,7 +2057,7 @@
           }
         ]
       },
-      "victoria-metrics-operator-0-59-3_na_tarball": {
+      "victoria-metrics-operator": {
         "Name": "victoria-metrics-operator-0.59.3",
         "SupportedOS": [
           {
@@ -2076,7 +2076,7 @@
           }
         ]
       },
-      "vim-enhanced_na_rpm": {
+      "vim-enhanced": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2097,7 +2097,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_na_rpm": {
+      "NetworkManager": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -2116,7 +2116,7 @@
           }
         ]
       },
-      "authselect_na_rpm": {
+      "authselect": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -2135,7 +2135,7 @@
           }
         ]
       },
-      "autoconf_na_rpm": {
+      "autoconf": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -2154,7 +2154,7 @@
           }
         ]
       },
-      "automake_na_rpm": {
+      "automake": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -2173,26 +2173,7 @@
           }
         ]
       },
-      "bash-completion_na_rpm": {
-        "Name": "bash-completion",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "bash_na_rpm": {
+      "bash": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -2211,8 +2192,8 @@
           }
         ]
       },
-      "binutils-devel_na_rpm": {
-        "Name": "binutils-devel",
+      "bash-completion": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2226,11 +2207,11 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "RepoName": "baseos"
           }
         ]
       },
-      "binutils_na_rpm": {
+      "binutils": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -2249,7 +2230,26 @@
           }
         ]
       },
-      "bzip2_na_rpm": {
+      "binutils-devel": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bzip2": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -2268,7 +2268,7 @@
           }
         ]
       },
-      "chrony_na_rpm": {
+      "chrony": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -2287,7 +2287,7 @@
           }
         ]
       },
-      "cloud-init_na_rpm": {
+      "cloud-init": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -2306,7 +2306,7 @@
           }
         ]
       },
-      "clustershell_na_rpm": {
+      "clustershell": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -2325,7 +2325,7 @@
           }
         ]
       },
-      "cmake_na_rpm": {
+      "cmake": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -2344,7 +2344,7 @@
           }
         ]
       },
-      "coreutils_na_rpm": {
+      "coreutils": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -2363,7 +2363,7 @@
           }
         ]
       },
-      "cryptsetup_na_rpm": {
+      "cryptsetup": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -2382,7 +2382,7 @@
           }
         ]
       },
-      "curl_na_rpm": {
+      "curl": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -2401,7 +2401,7 @@
           }
         ]
       },
-      "device-mapper_na_rpm": {
+      "device-mapper": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -2420,7 +2420,7 @@
           }
         ]
       },
-      "dmidecode_na_rpm": {
+      "dmidecode": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -2439,7 +2439,7 @@
           }
         ]
       },
-      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-el10": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
         "SupportedOS": [
           {
@@ -2454,45 +2454,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_na_rpm": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "dracut-network_na_rpm": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "dracut_na_rpm": {
+      "dracut": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -2511,7 +2473,45 @@
           }
         ]
       },
-      "emacs_na_rpm": {
+      "dracut-live": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -2530,7 +2530,7 @@
           }
         ]
       },
-      "file_na_rpm": {
+      "file": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -2549,7 +2549,7 @@
           }
         ]
       },
-      "findutils_na_rpm": {
+      "findutils": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -2568,7 +2568,7 @@
           }
         ]
       },
-      "fping_na_rpm": {
+      "fping": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -2587,7 +2587,7 @@
           }
         ]
       },
-      "gawk_na_rpm": {
+      "gawk": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -2606,45 +2606,7 @@
           }
         ]
       },
-      "gcc-c++_na_rpm": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc-gfortran_na_rpm": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc_na_rpm": {
+      "gcc": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -2663,8 +2625,8 @@
           }
         ]
       },
-      "gdb-gdbserver_na_rpm": {
-        "Name": "gdb-gdbserver",
+      "gcc-c++": {
+        "Name": "gcc-c++",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -2682,7 +2644,26 @@
           }
         ]
       },
-      "gdb_na_rpm": {
+      "gcc-gfortran": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -2701,7 +2682,26 @@
           }
         ]
       },
-      "gedit_na_rpm": {
+      "gdb-gdbserver": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -2720,7 +2720,7 @@
           }
         ]
       },
-      "glibc-langpack-en_na_rpm": {
+      "glibc-langpack-en": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -2739,7 +2739,7 @@
           }
         ]
       },
-      "grep_na_rpm": {
+      "grep": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -2758,7 +2758,7 @@
           }
         ]
       },
-      "gzip_na_rpm": {
+      "gzip": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -2777,26 +2777,7 @@
           }
         ]
       },
-      "hwloc-libs_na_rpm": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "hwloc_na_rpm": {
+      "hwloc": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -2815,7 +2796,26 @@
           }
         ]
       },
-      "iperf3_na_rpm": {
+      "hwloc-libs": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -2834,7 +2834,7 @@
           }
         ]
       },
-      "ipmitool_na_rpm": {
+      "ipmitool": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -2853,7 +2853,7 @@
           }
         ]
       },
-      "iproute_na_rpm": {
+      "iproute": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -2872,7 +2872,7 @@
           }
         ]
       },
-      "iputils_na_rpm": {
+      "iputils": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -2891,7 +2891,7 @@
           }
         ]
       },
-      "kbd_na_rpm": {
+      "kbd": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -2910,26 +2910,7 @@
           }
         ]
       },
-      "kernel-tools_na_rpm": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "kernel_na_rpm": {
+      "kernel": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -2948,7 +2929,26 @@
           }
         ]
       },
-      "kexec-tools_na_rpm": {
+      "kernel-tools": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -2967,7 +2967,7 @@
           }
         ]
       },
-      "libcurl_na_rpm": {
+      "libcurl": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -2986,7 +2986,7 @@
           }
         ]
       },
-      "libtool_na_rpm": {
+      "libtool": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -3005,26 +3005,7 @@
           }
         ]
       },
-      "lldb-devel_na_rpm": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "lldb_na_rpm": {
+      "lldb": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -3043,7 +3024,26 @@
           }
         ]
       },
-      "lshw_na_rpm": {
+      "lldb-devel": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -3062,7 +3062,7 @@
           }
         ]
       },
-      "lsof_na_rpm": {
+      "lsof": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -3081,7 +3081,7 @@
           }
         ]
       },
-      "ltrace_na_rpm": {
+      "ltrace": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -3100,7 +3100,7 @@
           }
         ]
       },
-      "lvm2_na_rpm": {
+      "lvm2": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -3119,7 +3119,7 @@
           }
         ]
       },
-      "make_na_rpm": {
+      "make": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -3138,7 +3138,7 @@
           }
         ]
       },
-      "man-db_na_rpm": {
+      "man-db": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -3157,7 +3157,7 @@
           }
         ]
       },
-      "man-pages_na_rpm": {
+      "man-pages": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -3176,7 +3176,7 @@
           }
         ]
       },
-      "munge-devel_na_rpm": {
+      "munge-devel": {
         "Name": "munge-devel",
         "SupportedOS": [
           {
@@ -3195,7 +3195,7 @@
           }
         ]
       },
-      "nfs-utils_na_rpm": {
+      "nfs-utils": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -3214,7 +3214,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_na_rpm": {
+      "nfs4-acl-tools": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -3233,7 +3233,7 @@
           }
         ]
       },
-      "nm-connection-editor_na_rpm": {
+      "nm-connection-editor": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -3252,7 +3252,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_na_rpm": {
+      "nss-pam-ldapd": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -3271,7 +3271,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_na_rpm": {
+      "oddjob-mkhomedir": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -3290,7 +3290,7 @@
           }
         ]
       },
-      "openldap-clients_na_rpm": {
+      "openldap-clients": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -3309,7 +3309,7 @@
           }
         ]
       },
-      "openmpi_5.0.8_tarball": {
+      "openmpi": {
         "Name": "openmpi",
         "SupportedOS": [
           {
@@ -3329,45 +3329,7 @@
           }
         ]
       },
-      "openssh-clients_na_rpm": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh-server_na_rpm": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh_na_rpm": {
+      "openssh": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -3386,7 +3348,45 @@
           }
         ]
       },
-      "openssl-devel_na_rpm": {
+      "openssh-clients": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -3405,7 +3405,7 @@
           }
         ]
       },
-      "openssl-libs_na_rpm_1": {
+      "openssl-libs_1": {
         "Name": "openssl-libs",
         "SupportedOS": [
           {
@@ -3424,7 +3424,7 @@
           }
         ]
       },
-      "ovis-ldms_na_rpm_1": {
+      "ovis-ldms_1": {
         "Name": "ovis-ldms",
         "SupportedOS": [
           {
@@ -3443,7 +3443,7 @@
           }
         ]
       },
-      "papi-devel_na_rpm": {
+      "papi-devel": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -3462,7 +3462,7 @@
           }
         ]
       },
-      "papi-libs_na_rpm": {
+      "papi-libs": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -3481,7 +3481,7 @@
           }
         ]
       },
-      "papi_na_rpm": {
+      "papi_1": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -3500,7 +3500,7 @@
           }
         ]
       },
-      "pciutils_na_rpm": {
+      "pciutils": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -3519,7 +3519,7 @@
           }
         ]
       },
-      "perf_na_rpm": {
+      "perf": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -3538,7 +3538,7 @@
           }
         ]
       },
-      "pmix-devel_na_rpm": {
+      "pmix-devel": {
         "Name": "pmix-devel",
         "SupportedOS": [
           {
@@ -3557,7 +3557,7 @@
           }
         ]
       },
-      "python3-cython_na_rpm_1": {
+      "python3-cython_1": {
         "Name": "python3-cython",
         "SupportedOS": [
           {
@@ -3576,7 +3576,7 @@
           }
         ]
       },
-      "python3-devel_na_rpm_1": {
+      "python3-devel_1": {
         "Name": "python3-devel",
         "SupportedOS": [
           {
@@ -3595,7 +3595,7 @@
           }
         ]
       },
-      "rsync_na_rpm": {
+      "rsync": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -3614,7 +3614,7 @@
           }
         ]
       },
-      "rsyslog_na_rpm": {
+      "rsyslog": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -3633,7 +3633,7 @@
           }
         ]
       },
-      "sed_na_rpm": {
+      "sed": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -3652,7 +3652,7 @@
           }
         ]
       },
-      "squashfs-tools_na_rpm": {
+      "squashfs-tools": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -3671,7 +3671,7 @@
           }
         ]
       },
-      "sssd_na_rpm": {
+      "sssd": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -3690,7 +3690,7 @@
           }
         ]
       },
-      "strace_na_rpm": {
+      "strace": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -3709,7 +3709,7 @@
           }
         ]
       },
-      "sudo_na_rpm": {
+      "sudo": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -3728,26 +3728,7 @@
           }
         ]
       },
-      "systemd-udev_na_rpm": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "systemd_na_rpm": {
+      "systemd": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -3766,7 +3747,26 @@
           }
         ]
       },
-      "tar_na_rpm": {
+      "systemd-udev": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -3785,7 +3785,7 @@
           }
         ]
       },
-      "tcpdump_na_rpm": {
+      "tcpdump": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -3804,7 +3804,7 @@
           }
         ]
       },
-      "traceroute_na_rpm": {
+      "traceroute": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -3823,7 +3823,7 @@
           }
         ]
       },
-      "ucx_1.19.0_tarball": {
+      "ucx": {
         "Name": "ucx",
         "SupportedOS": [
           {
@@ -3843,7 +3843,7 @@
           }
         ]
       },
-      "util-linux_na_rpm": {
+      "util-linux": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -3862,26 +3862,7 @@
           }
         ]
       },
-      "valgrind-devel_na_rpm": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "valgrind_na_rpm": {
+      "valgrind": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -3900,7 +3881,26 @@
           }
         ]
       },
-      "vim-enhanced_na_rpm_1": {
+      "valgrind-devel": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced_1": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -3919,7 +3919,7 @@
           }
         ]
       },
-      "wget_na_rpm": {
+      "wget": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -3938,7 +3938,7 @@
           }
         ]
       },
-      "which_na_rpm": {
+      "which": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -3957,7 +3957,7 @@
           }
         ]
       },
-      "zsh_na_rpm": {
+      "zsh": {
         "Name": "zsh",
         "SupportedOS": [
           {
@@ -3979,7 +3979,7 @@
     },
     "Miscellaneous": [],
     "InfrastructurePackages": {
-      "csi-powerscale-v2-16-0_v2.16.0_git": {
+      "csi-powerscale": {
         "Name": "csi-powerscale-v2.16.0",
         "Type": "git",
         "Version": "v2.16.0",
@@ -3998,7 +3998,7 @@
           }
         ]
       },
-      "docker-io-dellemc-csm-encryption_v0.6.0_image": {
+      "docker.io/dellemc/csm-encryption": {
         "Name": "docker.io/dellemc/csm-encryption",
         "Type": "image",
         "Version": "v0.6.0",
@@ -4012,7 +4012,7 @@
         ],
         "Tag": "v0.6.0"
       },
-      "external-snapshotter-v8-4-0_v8.4.0_git": {
+      "external-snapshotter": {
         "Name": "external-snapshotter-v8.4.0",
         "Type": "git",
         "Version": "v8.4.0",
@@ -4031,7 +4031,7 @@
           }
         ]
       },
-      "helm-charts-2-16-0_csi-isilon-2.16.0_git": {
+      "helm-charts_1": {
         "Name": "helm-charts-2.16.0",
         "Type": "git",
         "Version": "csi-isilon-2.16.0",
@@ -4050,7 +4050,7 @@
           }
         ]
       },
-      "quay-io-dell-container-storage-modules-csi-isilon_v2.16.0_image": {
+      "quay.io/dell/container-storage-modules/csi-isilon": {
         "Name": "quay.io/dell/container-storage-modules/csi-isilon",
         "Type": "image",
         "Version": "v2.16.0",
@@ -4064,7 +4064,7 @@
         ],
         "Tag": "v2.16.0"
       },
-      "quay-io-dell-container-storage-modules-csi-metadat_v1.13.0_image": {
+      "quay.io/dell/container-storage-modules/csi-metadata-retriever": {
         "Name": "quay.io/dell/container-storage-modules/csi-metadata-retriever",
         "Type": "image",
         "Version": "v1.13.0",
@@ -4078,7 +4078,7 @@
         ],
         "Tag": "v1.13.0"
       },
-      "quay-io-dell-container-storage-modules-csm-authori_v2.4.0_image": {
+      "quay.io/dell/container-storage-modules/csm-authorization-sidecar": {
         "Name": "quay.io/dell/container-storage-modules/csm-authorization-sidecar",
         "Type": "image",
         "Version": "v2.4.0",
@@ -4092,7 +4092,7 @@
         ],
         "Tag": "v2.4.0"
       },
-      "quay-io-dell-container-storage-modules-dell-csi-re_v1.14.0_image": {
+      "quay.io/dell/container-storage-modules/dell-csi-replicator": {
         "Name": "quay.io/dell/container-storage-modules/dell-csi-replicator",
         "Type": "image",
         "Version": "v1.14.0",
@@ -4106,7 +4106,7 @@
         ],
         "Tag": "v1.14.0"
       },
-      "quay-io-dell-container-storage-modules-podmon_v1.15.0_image": {
+      "quay.io/dell/container-storage-modules/podmon": {
         "Name": "quay.io/dell/container-storage-modules/podmon",
         "Type": "image",
         "Version": "v1.15.0",
@@ -4120,7 +4120,7 @@
         ],
         "Tag": "v1.15.0"
       },
-      "registry-k8s-io-sig-storage-csi-attacher_v4.10.0_image": {
+      "registry.k8s.io/sig-storage/csi-attacher": {
         "Name": "registry.k8s.io/sig-storage/csi-attacher",
         "Type": "image",
         "Version": "v4.10.0",
@@ -4134,7 +4134,7 @@
         ],
         "Tag": "v4.10.0"
       },
-      "registry-k8s-io-sig-storage-csi-external-health-mo_v0.16.0_image": {
+      "registry.k8s.io/sig-storage/csi-external-health-monitor-controller": {
         "Name": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
         "Type": "image",
         "Version": "v0.16.0",
@@ -4148,7 +4148,7 @@
         ],
         "Tag": "v0.16.0"
       },
-      "registry-k8s-io-sig-storage-csi-node-driver-regist_v2.15.0_image": {
+      "registry.k8s.io/sig-storage/csi-node-driver-registrar": {
         "Name": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
         "Type": "image",
         "Version": "v2.15.0",
@@ -4162,7 +4162,7 @@
         ],
         "Tag": "v2.15.0"
       },
-      "registry-k8s-io-sig-storage-csi-provisioner_v6.1.0_image": {
+      "registry.k8s.io/sig-storage/csi-provisioner": {
         "Name": "registry.k8s.io/sig-storage/csi-provisioner",
         "Type": "image",
         "Version": "v6.1.0",
@@ -4176,7 +4176,7 @@
         ],
         "Tag": "v6.1.0"
       },
-      "registry-k8s-io-sig-storage-csi-resizer_v2.0.0_image": {
+      "registry.k8s.io/sig-storage/csi-resizer": {
         "Name": "registry.k8s.io/sig-storage/csi-resizer",
         "Type": "image",
         "Version": "v2.0.0",
@@ -4190,7 +4190,7 @@
         ],
         "Tag": "v2.0.0"
       },
-      "registry-k8s-io-sig-storage-csi-snapshotter_v8.4.0_image": {
+      "registry.k8s.io/sig-storage/csi-snapshotter": {
         "Name": "registry.k8s.io/sig-storage/csi-snapshotter",
         "Type": "image",
         "Version": "v8.4.0",
@@ -4204,7 +4204,7 @@
         ],
         "Tag": "v8.4.0"
       },
-      "registry-k8s-io-sig-storage-snapshot-controller_v8.4.0_image": {
+      "registry.k8s.io/sig-storage/snapshot-controller": {
         "Name": "registry.k8s.io/sig-storage/snapshot-controller",
         "Type": "image",
         "Version": "v8.4.0",

--- a/examples/catalog/catalog_rhel_x86_64_with_slurm_only.json
+++ b/examples/catalog/catalog_rhel_x86_64_with_slurm_only.json
@@ -7,105 +7,105 @@
       {
         "Name": "login_compiler_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "login_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmd_na_rpm",
-          "slurm_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm",
+          "slurm-slurmd"
         ]
       },
       {
         "Name": "slurm_control_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "mariadb-server_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-PyMySQL_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-slurmctld_na_rpm",
-          "slurm-slurmdbd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "likwid",
+          "lsscsi",
+          "mariadb-server",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-PyMySQL",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-slurmctld",
+          "slurm-slurmdbd"
         ]
       },
       {
         "Name": "slurm_node_x86_64",
         "FunctionalPackages": [
-          "apptainer_na_rpm",
-          "device-mapper-multipath_na_rpm",
-          "doca-ofed_na_rpm_repo",
-          "firewalld_na_rpm",
-          "geopm_na_tarball",
-          "imb_na_tarball",
-          "iscsi-initiator-utils_na_rpm",
-          "kernel-devel_na_rpm",
-          "kernel-headers_na_rpm",
-          "likwid_na_tarball",
-          "lsscsi_na_rpm",
-          "msr-safe_na_tarball",
-          "munge_na_rpm",
-          "nvcr-io-nvidia-hpc-benchmarks_25.09_image",
-          "osu-micro-benchmarks_na_tarball",
-          "papi_na_tarball",
-          "pmix_na_rpm",
-          "python3-firewall_na_rpm",
-          "sg3_utils_na_rpm",
-          "sionlib_na_tarball",
-          "slurm-pam_slurm_na_rpm",
-          "slurm-slurmd_na_rpm"
+          "apptainer",
+          "device-mapper-multipath",
+          "doca-ofed",
+          "firewalld",
+          "geopm",
+          "imb",
+          "iscsi-initiator-utils",
+          "kernel-devel",
+          "kernel-headers",
+          "likwid",
+          "lsscsi",
+          "msr-safe",
+          "munge",
+          "nvcr.io/nvidia/hpc-benchmarks",
+          "osu-micro-benchmarks",
+          "papi",
+          "pmix",
+          "python3-firewall",
+          "sg3_utils",
+          "sionlib",
+          "slurm-pam_slurm",
+          "slurm-slurmd"
         ]
       }
     ],
@@ -114,97 +114,97 @@
         "Name": "RHEL",
         "Version": "10.0",
         "osPackages": [
-          "NetworkManager_na_rpm",
-          "authselect_na_rpm",
-          "autoconf_na_rpm",
-          "automake_na_rpm",
-          "bash-completion_na_rpm",
-          "bash_na_rpm",
-          "binutils-devel_na_rpm",
-          "binutils_na_rpm",
-          "bzip2_na_rpm",
-          "chrony_na_rpm",
-          "cloud-init_na_rpm",
-          "clustershell_na_rpm",
-          "cmake_na_rpm",
-          "coreutils_na_rpm",
-          "cryptsetup_na_rpm",
-          "curl_na_rpm",
-          "device-mapper_na_rpm",
-          "dmidecode_na_rpm",
-          "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image",
-          "dracut-live_na_rpm",
-          "dracut-network_na_rpm",
-          "dracut_na_rpm",
-          "emacs_na_rpm",
-          "file_na_rpm",
-          "findutils_na_rpm",
-          "fping_na_rpm",
-          "gawk_na_rpm",
-          "gcc-c++_na_rpm",
-          "gcc-gfortran_na_rpm",
-          "gcc_na_rpm",
-          "gdb-gdbserver_na_rpm",
-          "gdb_na_rpm",
-          "gedit_na_rpm",
-          "glibc-langpack-en_na_rpm",
-          "grep_na_rpm",
-          "gzip_na_rpm",
-          "hwloc-libs_na_rpm",
-          "hwloc_na_rpm",
-          "iperf3_na_rpm",
-          "ipmitool_na_rpm",
-          "iproute_na_rpm",
-          "iputils_na_rpm",
-          "kbd_na_rpm",
-          "kernel-tools_na_rpm",
-          "kernel_na_rpm",
-          "kexec-tools_na_rpm",
-          "libcurl_na_rpm",
-          "libtool_na_rpm",
-          "lldb-devel_na_rpm",
-          "lldb_na_rpm",
-          "lshw_na_rpm",
-          "lsof_na_rpm",
-          "ltrace_na_rpm",
-          "lvm2_na_rpm",
-          "make_na_rpm",
-          "man-db_na_rpm",
-          "man-pages_na_rpm",
-          "nfs-utils_na_rpm",
-          "nfs4-acl-tools_na_rpm",
-          "nm-connection-editor_na_rpm",
-          "nss-pam-ldapd_na_rpm",
-          "oddjob-mkhomedir_na_rpm",
-          "openldap-clients_na_rpm",
-          "openssh-clients_na_rpm",
-          "openssh-server_na_rpm",
-          "openssh_na_rpm",
-          "openssl-devel_na_rpm",
-          "papi-devel_na_rpm",
-          "papi-libs_na_rpm",
-          "papi_na_rpm",
-          "pciutils_na_rpm",
-          "perf_na_rpm",
-          "rsync_na_rpm",
-          "rsyslog_na_rpm",
-          "sed_na_rpm",
-          "squashfs-tools_na_rpm",
-          "sssd_na_rpm",
-          "strace_na_rpm",
-          "sudo_na_rpm",
-          "systemd-udev_na_rpm",
-          "systemd_na_rpm",
-          "tar_na_rpm",
-          "tcpdump_na_rpm",
-          "traceroute_na_rpm",
-          "util-linux_na_rpm",
-          "valgrind-devel_na_rpm",
-          "valgrind_na_rpm",
-          "vim-enhanced_na_rpm",
-          "wget_na_rpm",
-          "which_na_rpm",
-          "zsh_na_rpm"
+          "NetworkManager",
+          "authselect",
+          "autoconf",
+          "automake",
+          "bash",
+          "bash-completion",
+          "binutils",
+          "binutils-devel",
+          "bzip2",
+          "chrony",
+          "cloud-init",
+          "clustershell",
+          "cmake",
+          "coreutils",
+          "cryptsetup",
+          "curl",
+          "device-mapper",
+          "dmidecode",
+          "docker.io/dellhpcomniaaisolution/image-build-el10",
+          "dracut",
+          "dracut-live",
+          "dracut-network",
+          "emacs",
+          "file",
+          "findutils",
+          "fping",
+          "gawk",
+          "gcc",
+          "gcc-c++",
+          "gcc-gfortran",
+          "gdb",
+          "gdb-gdbserver",
+          "gedit",
+          "glibc-langpack-en",
+          "grep",
+          "gzip",
+          "hwloc",
+          "hwloc-libs",
+          "iperf3",
+          "ipmitool",
+          "iproute",
+          "iputils",
+          "kbd",
+          "kernel",
+          "kernel-tools",
+          "kexec-tools",
+          "libcurl",
+          "libtool",
+          "lldb",
+          "lldb-devel",
+          "lshw",
+          "lsof",
+          "ltrace",
+          "lvm2",
+          "make",
+          "man-db",
+          "man-pages",
+          "nfs-utils",
+          "nfs4-acl-tools",
+          "nm-connection-editor",
+          "nss-pam-ldapd",
+          "oddjob-mkhomedir",
+          "openldap-clients",
+          "openssh",
+          "openssh-clients",
+          "openssh-server",
+          "openssl-devel",
+          "papi-devel",
+          "papi-libs",
+          "papi_1",
+          "pciutils",
+          "perf",
+          "rsync",
+          "rsyslog",
+          "sed",
+          "squashfs-tools",
+          "sssd",
+          "strace",
+          "sudo",
+          "systemd",
+          "systemd-udev",
+          "tar",
+          "tcpdump",
+          "traceroute",
+          "util-linux",
+          "valgrind",
+          "valgrind-devel",
+          "vim-enhanced",
+          "wget",
+          "which",
+          "zsh"
         ]
       }
     ],
@@ -212,7 +212,7 @@
     "Drivers": [],
     "DriverPackages": {},
     "FunctionalPackages": {
-      "apptainer_na_rpm": {
+      "apptainer": {
         "Name": "apptainer",
         "SupportedOS": [
           {
@@ -231,7 +231,7 @@
           }
         ]
       },
-      "device-mapper-multipath_na_rpm": {
+      "device-mapper-multipath": {
         "Name": "device-mapper-multipath",
         "SupportedOS": [
           {
@@ -250,7 +250,7 @@
           }
         ]
       },
-      "doca-ofed_na_rpm_repo": {
+      "doca-ofed": {
         "Name": "doca-ofed",
         "SupportedOS": [
           {
@@ -269,7 +269,7 @@
           }
         ]
       },
-      "firewalld_na_rpm": {
+      "firewalld": {
         "Name": "firewalld",
         "SupportedOS": [
           {
@@ -288,7 +288,7 @@
           }
         ]
       },
-      "geopm_na_tarball": {
+      "geopm": {
         "Name": "geopm",
         "SupportedOS": [
           {
@@ -307,7 +307,7 @@
           }
         ]
       },
-      "imb_na_tarball": {
+      "imb": {
         "Name": "imb",
         "SupportedOS": [
           {
@@ -326,7 +326,7 @@
           }
         ]
       },
-      "iscsi-initiator-utils_na_rpm": {
+      "iscsi-initiator-utils": {
         "Name": "iscsi-initiator-utils",
         "SupportedOS": [
           {
@@ -345,7 +345,7 @@
           }
         ]
       },
-      "kernel-devel_na_rpm": {
+      "kernel-devel": {
         "Name": "kernel-devel",
         "SupportedOS": [
           {
@@ -364,7 +364,7 @@
           }
         ]
       },
-      "kernel-headers_na_rpm": {
+      "kernel-headers": {
         "Name": "kernel-headers",
         "SupportedOS": [
           {
@@ -383,7 +383,7 @@
           }
         ]
       },
-      "likwid_na_tarball": {
+      "likwid": {
         "Name": "likwid",
         "SupportedOS": [
           {
@@ -402,7 +402,7 @@
           }
         ]
       },
-      "lsscsi_na_rpm": {
+      "lsscsi": {
         "Name": "lsscsi",
         "SupportedOS": [
           {
@@ -421,7 +421,7 @@
           }
         ]
       },
-      "mariadb-server_na_rpm": {
+      "mariadb-server": {
         "Name": "mariadb-server",
         "SupportedOS": [
           {
@@ -440,7 +440,7 @@
           }
         ]
       },
-      "msr-safe_na_tarball": {
+      "msr-safe": {
         "Name": "msr-safe",
         "SupportedOS": [
           {
@@ -459,7 +459,7 @@
           }
         ]
       },
-      "munge_na_rpm": {
+      "munge": {
         "Name": "munge",
         "SupportedOS": [
           {
@@ -478,7 +478,7 @@
           }
         ]
       },
-      "nvcr-io-nvidia-hpc-benchmarks_25.09_image": {
+      "nvcr.io/nvidia/hpc-benchmarks": {
         "Name": "nvcr.io/nvidia/hpc-benchmarks",
         "SupportedOS": [
           {
@@ -493,7 +493,7 @@
         "Tag": "25.09",
         "Version": "25.09"
       },
-      "osu-micro-benchmarks_na_tarball": {
+      "osu-micro-benchmarks": {
         "Name": "osu-micro-benchmarks",
         "SupportedOS": [
           {
@@ -512,7 +512,7 @@
           }
         ]
       },
-      "papi_na_tarball": {
+      "papi": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -531,7 +531,7 @@
           }
         ]
       },
-      "pmix_na_rpm": {
+      "pmix": {
         "Name": "pmix",
         "SupportedOS": [
           {
@@ -550,7 +550,7 @@
           }
         ]
       },
-      "python3-PyMySQL_na_rpm": {
+      "python3-PyMySQL": {
         "Name": "python3-PyMySQL",
         "SupportedOS": [
           {
@@ -569,7 +569,7 @@
           }
         ]
       },
-      "python3-firewall_na_rpm": {
+      "python3-firewall": {
         "Name": "python3-firewall",
         "SupportedOS": [
           {
@@ -588,7 +588,7 @@
           }
         ]
       },
-      "sg3_utils_na_rpm": {
+      "sg3_utils": {
         "Name": "sg3_utils",
         "SupportedOS": [
           {
@@ -607,7 +607,7 @@
           }
         ]
       },
-      "sionlib_na_tarball": {
+      "sionlib": {
         "Name": "sionlib",
         "SupportedOS": [
           {
@@ -626,7 +626,26 @@
           }
         ]
       },
-      "slurm-pam_slurm_na_rpm": {
+      "slurm": {
+        "Name": "slurm",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "slurm_custom"
+          }
+        ]
+      },
+      "slurm-pam_slurm": {
         "Name": "slurm-pam_slurm",
         "SupportedOS": [
           {
@@ -645,7 +664,7 @@
           }
         ]
       },
-      "slurm-slurmctld_na_rpm": {
+      "slurm-slurmctld": {
         "Name": "slurm-slurmctld",
         "SupportedOS": [
           {
@@ -664,7 +683,7 @@
           }
         ]
       },
-      "slurm-slurmd_na_rpm": {
+      "slurm-slurmd": {
         "Name": "slurm-slurmd",
         "SupportedOS": [
           {
@@ -683,27 +702,8 @@
           }
         ]
       },
-      "slurm-slurmdbd_na_rpm": {
+      "slurm-slurmdbd": {
         "Name": "slurm-slurmdbd",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "slurm_custom"
-          }
-        ]
-      },
-      "slurm_na_rpm": {
-        "Name": "slurm",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -723,7 +723,7 @@
       }
     },
     "OSPackages": {
-      "NetworkManager_na_rpm": {
+      "NetworkManager": {
         "Name": "NetworkManager",
         "SupportedOS": [
           {
@@ -742,7 +742,7 @@
           }
         ]
       },
-      "authselect_na_rpm": {
+      "authselect": {
         "Name": "authselect",
         "SupportedOS": [
           {
@@ -761,7 +761,7 @@
           }
         ]
       },
-      "autoconf_na_rpm": {
+      "autoconf": {
         "Name": "autoconf",
         "SupportedOS": [
           {
@@ -780,7 +780,7 @@
           }
         ]
       },
-      "automake_na_rpm": {
+      "automake": {
         "Name": "automake",
         "SupportedOS": [
           {
@@ -799,26 +799,7 @@
           }
         ]
       },
-      "bash-completion_na_rpm": {
-        "Name": "bash-completion",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "bash_na_rpm": {
+      "bash": {
         "Name": "bash",
         "SupportedOS": [
           {
@@ -837,8 +818,8 @@
           }
         ]
       },
-      "binutils-devel_na_rpm": {
-        "Name": "binutils-devel",
+      "bash-completion": {
+        "Name": "bash-completion",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -852,11 +833,11 @@
         "Sources": [
           {
             "Architecture": "x86_64",
-            "RepoName": "appstream"
+            "RepoName": "baseos"
           }
         ]
       },
-      "binutils_na_rpm": {
+      "binutils": {
         "Name": "binutils",
         "SupportedOS": [
           {
@@ -875,7 +856,26 @@
           }
         ]
       },
-      "bzip2_na_rpm": {
+      "binutils-devel": {
+        "Name": "binutils-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "bzip2": {
         "Name": "bzip2",
         "SupportedOS": [
           {
@@ -894,7 +894,7 @@
           }
         ]
       },
-      "chrony_na_rpm": {
+      "chrony": {
         "Name": "chrony",
         "SupportedOS": [
           {
@@ -913,7 +913,7 @@
           }
         ]
       },
-      "cloud-init_na_rpm": {
+      "cloud-init": {
         "Name": "cloud-init",
         "SupportedOS": [
           {
@@ -932,7 +932,7 @@
           }
         ]
       },
-      "clustershell_na_rpm": {
+      "clustershell": {
         "Name": "clustershell",
         "SupportedOS": [
           {
@@ -951,7 +951,7 @@
           }
         ]
       },
-      "cmake_na_rpm": {
+      "cmake": {
         "Name": "cmake",
         "SupportedOS": [
           {
@@ -970,7 +970,7 @@
           }
         ]
       },
-      "coreutils_na_rpm": {
+      "coreutils": {
         "Name": "coreutils",
         "SupportedOS": [
           {
@@ -989,7 +989,7 @@
           }
         ]
       },
-      "cryptsetup_na_rpm": {
+      "cryptsetup": {
         "Name": "cryptsetup",
         "SupportedOS": [
           {
@@ -1008,7 +1008,7 @@
           }
         ]
       },
-      "curl_na_rpm": {
+      "curl": {
         "Name": "curl",
         "SupportedOS": [
           {
@@ -1027,7 +1027,7 @@
           }
         ]
       },
-      "device-mapper_na_rpm": {
+      "device-mapper": {
         "Name": "device-mapper",
         "SupportedOS": [
           {
@@ -1046,7 +1046,7 @@
           }
         ]
       },
-      "dmidecode_na_rpm": {
+      "dmidecode": {
         "Name": "dmidecode",
         "SupportedOS": [
           {
@@ -1065,7 +1065,7 @@
           }
         ]
       },
-      "docker-io-dellhpcomniaaisolution-image-build-el10_1.1_image": {
+      "docker.io/dellhpcomniaaisolution/image-build-el10": {
         "Name": "docker.io/dellhpcomniaaisolution/image-build-el10",
         "SupportedOS": [
           {
@@ -1080,45 +1080,7 @@
         "Tag": "1.1",
         "Version": "1.1"
       },
-      "dracut-live_na_rpm": {
-        "Name": "dracut-live",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "dracut-network_na_rpm": {
-        "Name": "dracut-network",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "dracut_na_rpm": {
+      "dracut": {
         "Name": "dracut",
         "SupportedOS": [
           {
@@ -1137,7 +1099,45 @@
           }
         ]
       },
-      "emacs_na_rpm": {
+      "dracut-live": {
+        "Name": "dracut-live",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "dracut-network": {
+        "Name": "dracut-network",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "emacs": {
         "Name": "emacs",
         "SupportedOS": [
           {
@@ -1156,7 +1156,7 @@
           }
         ]
       },
-      "file_na_rpm": {
+      "file": {
         "Name": "file",
         "SupportedOS": [
           {
@@ -1175,7 +1175,7 @@
           }
         ]
       },
-      "findutils_na_rpm": {
+      "findutils": {
         "Name": "findutils",
         "SupportedOS": [
           {
@@ -1194,7 +1194,7 @@
           }
         ]
       },
-      "fping_na_rpm": {
+      "fping": {
         "Name": "fping",
         "SupportedOS": [
           {
@@ -1213,7 +1213,7 @@
           }
         ]
       },
-      "gawk_na_rpm": {
+      "gawk": {
         "Name": "gawk",
         "SupportedOS": [
           {
@@ -1232,45 +1232,7 @@
           }
         ]
       },
-      "gcc-c++_na_rpm": {
-        "Name": "gcc-c++",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc-gfortran_na_rpm": {
-        "Name": "gcc-gfortran",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "gcc_na_rpm": {
+      "gcc": {
         "Name": "gcc",
         "SupportedOS": [
           {
@@ -1289,8 +1251,8 @@
           }
         ]
       },
-      "gdb-gdbserver_na_rpm": {
-        "Name": "gdb-gdbserver",
+      "gcc-c++": {
+        "Name": "gcc-c++",
         "SupportedOS": [
           {
             "Name": "RHEL",
@@ -1308,7 +1270,26 @@
           }
         ]
       },
-      "gdb_na_rpm": {
+      "gcc-gfortran": {
+        "Name": "gcc-gfortran",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gdb": {
         "Name": "gdb",
         "SupportedOS": [
           {
@@ -1327,7 +1308,26 @@
           }
         ]
       },
-      "gedit_na_rpm": {
+      "gdb-gdbserver": {
+        "Name": "gdb-gdbserver",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "gedit": {
         "Name": "gedit",
         "SupportedOS": [
           {
@@ -1346,7 +1346,7 @@
           }
         ]
       },
-      "glibc-langpack-en_na_rpm": {
+      "glibc-langpack-en": {
         "Name": "glibc-langpack-en",
         "SupportedOS": [
           {
@@ -1365,7 +1365,7 @@
           }
         ]
       },
-      "grep_na_rpm": {
+      "grep": {
         "Name": "grep",
         "SupportedOS": [
           {
@@ -1384,7 +1384,7 @@
           }
         ]
       },
-      "gzip_na_rpm": {
+      "gzip": {
         "Name": "gzip",
         "SupportedOS": [
           {
@@ -1403,26 +1403,7 @@
           }
         ]
       },
-      "hwloc-libs_na_rpm": {
-        "Name": "hwloc-libs",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "hwloc_na_rpm": {
+      "hwloc": {
         "Name": "hwloc",
         "SupportedOS": [
           {
@@ -1441,7 +1422,26 @@
           }
         ]
       },
-      "iperf3_na_rpm": {
+      "hwloc-libs": {
+        "Name": "hwloc-libs",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "iperf3": {
         "Name": "iperf3",
         "SupportedOS": [
           {
@@ -1460,7 +1460,7 @@
           }
         ]
       },
-      "ipmitool_na_rpm": {
+      "ipmitool": {
         "Name": "ipmitool",
         "SupportedOS": [
           {
@@ -1479,7 +1479,7 @@
           }
         ]
       },
-      "iproute_na_rpm": {
+      "iproute": {
         "Name": "iproute",
         "SupportedOS": [
           {
@@ -1498,7 +1498,7 @@
           }
         ]
       },
-      "iputils_na_rpm": {
+      "iputils": {
         "Name": "iputils",
         "SupportedOS": [
           {
@@ -1517,7 +1517,7 @@
           }
         ]
       },
-      "kbd_na_rpm": {
+      "kbd": {
         "Name": "kbd",
         "SupportedOS": [
           {
@@ -1536,26 +1536,7 @@
           }
         ]
       },
-      "kernel-tools_na_rpm": {
-        "Name": "kernel-tools",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "kernel_na_rpm": {
+      "kernel": {
         "Name": "kernel",
         "SupportedOS": [
           {
@@ -1574,7 +1555,26 @@
           }
         ]
       },
-      "kexec-tools_na_rpm": {
+      "kernel-tools": {
+        "Name": "kernel-tools",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "kexec-tools": {
         "Name": "kexec-tools",
         "SupportedOS": [
           {
@@ -1593,7 +1593,7 @@
           }
         ]
       },
-      "libcurl_na_rpm": {
+      "libcurl": {
         "Name": "libcurl",
         "SupportedOS": [
           {
@@ -1612,7 +1612,7 @@
           }
         ]
       },
-      "libtool_na_rpm": {
+      "libtool": {
         "Name": "libtool",
         "SupportedOS": [
           {
@@ -1631,26 +1631,7 @@
           }
         ]
       },
-      "lldb-devel_na_rpm": {
-        "Name": "lldb-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "lldb_na_rpm": {
+      "lldb": {
         "Name": "lldb",
         "SupportedOS": [
           {
@@ -1669,7 +1650,26 @@
           }
         ]
       },
-      "lshw_na_rpm": {
+      "lldb-devel": {
+        "Name": "lldb-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "lshw": {
         "Name": "lshw",
         "SupportedOS": [
           {
@@ -1688,7 +1688,7 @@
           }
         ]
       },
-      "lsof_na_rpm": {
+      "lsof": {
         "Name": "lsof",
         "SupportedOS": [
           {
@@ -1707,7 +1707,7 @@
           }
         ]
       },
-      "ltrace_na_rpm": {
+      "ltrace": {
         "Name": "ltrace",
         "SupportedOS": [
           {
@@ -1726,7 +1726,7 @@
           }
         ]
       },
-      "lvm2_na_rpm": {
+      "lvm2": {
         "Name": "lvm2",
         "SupportedOS": [
           {
@@ -1745,7 +1745,7 @@
           }
         ]
       },
-      "make_na_rpm": {
+      "make": {
         "Name": "make",
         "SupportedOS": [
           {
@@ -1764,7 +1764,7 @@
           }
         ]
       },
-      "man-db_na_rpm": {
+      "man-db": {
         "Name": "man-db",
         "SupportedOS": [
           {
@@ -1783,7 +1783,7 @@
           }
         ]
       },
-      "man-pages_na_rpm": {
+      "man-pages": {
         "Name": "man-pages",
         "SupportedOS": [
           {
@@ -1802,7 +1802,7 @@
           }
         ]
       },
-      "nfs-utils_na_rpm": {
+      "nfs-utils": {
         "Name": "nfs-utils",
         "SupportedOS": [
           {
@@ -1821,7 +1821,7 @@
           }
         ]
       },
-      "nfs4-acl-tools_na_rpm": {
+      "nfs4-acl-tools": {
         "Name": "nfs4-acl-tools",
         "SupportedOS": [
           {
@@ -1840,7 +1840,7 @@
           }
         ]
       },
-      "nm-connection-editor_na_rpm": {
+      "nm-connection-editor": {
         "Name": "nm-connection-editor",
         "SupportedOS": [
           {
@@ -1859,7 +1859,7 @@
           }
         ]
       },
-      "nss-pam-ldapd_na_rpm": {
+      "nss-pam-ldapd": {
         "Name": "nss-pam-ldapd",
         "SupportedOS": [
           {
@@ -1878,7 +1878,7 @@
           }
         ]
       },
-      "oddjob-mkhomedir_na_rpm": {
+      "oddjob-mkhomedir": {
         "Name": "oddjob-mkhomedir",
         "SupportedOS": [
           {
@@ -1897,7 +1897,7 @@
           }
         ]
       },
-      "openldap-clients_na_rpm": {
+      "openldap-clients": {
         "Name": "openldap-clients",
         "SupportedOS": [
           {
@@ -1916,45 +1916,7 @@
           }
         ]
       },
-      "openssh-clients_na_rpm": {
-        "Name": "openssh-clients",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh-server_na_rpm": {
-        "Name": "openssh-server",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "openssh_na_rpm": {
+      "openssh": {
         "Name": "openssh",
         "SupportedOS": [
           {
@@ -1973,7 +1935,45 @@
           }
         ]
       },
-      "openssl-devel_na_rpm": {
+      "openssh-clients": {
+        "Name": "openssh-clients",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssh-server": {
+        "Name": "openssh-server",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "openssl-devel": {
         "Name": "openssl-devel",
         "SupportedOS": [
           {
@@ -1992,7 +1992,7 @@
           }
         ]
       },
-      "papi-devel_na_rpm": {
+      "papi-devel": {
         "Name": "papi-devel",
         "SupportedOS": [
           {
@@ -2011,7 +2011,7 @@
           }
         ]
       },
-      "papi-libs_na_rpm": {
+      "papi-libs": {
         "Name": "papi-libs",
         "SupportedOS": [
           {
@@ -2030,7 +2030,7 @@
           }
         ]
       },
-      "papi_na_rpm": {
+      "papi_1": {
         "Name": "papi",
         "SupportedOS": [
           {
@@ -2049,7 +2049,7 @@
           }
         ]
       },
-      "pciutils_na_rpm": {
+      "pciutils": {
         "Name": "pciutils",
         "SupportedOS": [
           {
@@ -2068,7 +2068,7 @@
           }
         ]
       },
-      "perf_na_rpm": {
+      "perf": {
         "Name": "perf",
         "SupportedOS": [
           {
@@ -2087,7 +2087,7 @@
           }
         ]
       },
-      "rsync_na_rpm": {
+      "rsync": {
         "Name": "rsync",
         "SupportedOS": [
           {
@@ -2106,7 +2106,7 @@
           }
         ]
       },
-      "rsyslog_na_rpm": {
+      "rsyslog": {
         "Name": "rsyslog",
         "SupportedOS": [
           {
@@ -2125,7 +2125,7 @@
           }
         ]
       },
-      "sed_na_rpm": {
+      "sed": {
         "Name": "sed",
         "SupportedOS": [
           {
@@ -2144,7 +2144,7 @@
           }
         ]
       },
-      "squashfs-tools_na_rpm": {
+      "squashfs-tools": {
         "Name": "squashfs-tools",
         "SupportedOS": [
           {
@@ -2163,7 +2163,7 @@
           }
         ]
       },
-      "sssd_na_rpm": {
+      "sssd": {
         "Name": "sssd",
         "SupportedOS": [
           {
@@ -2182,7 +2182,7 @@
           }
         ]
       },
-      "strace_na_rpm": {
+      "strace": {
         "Name": "strace",
         "SupportedOS": [
           {
@@ -2201,7 +2201,7 @@
           }
         ]
       },
-      "sudo_na_rpm": {
+      "sudo": {
         "Name": "sudo",
         "SupportedOS": [
           {
@@ -2220,26 +2220,7 @@
           }
         ]
       },
-      "systemd-udev_na_rpm": {
-        "Name": "systemd-udev",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "baseos"
-          }
-        ]
-      },
-      "systemd_na_rpm": {
+      "systemd": {
         "Name": "systemd",
         "SupportedOS": [
           {
@@ -2258,7 +2239,26 @@
           }
         ]
       },
-      "tar_na_rpm": {
+      "systemd-udev": {
+        "Name": "systemd-udev",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "baseos"
+          }
+        ]
+      },
+      "tar": {
         "Name": "tar",
         "SupportedOS": [
           {
@@ -2277,7 +2277,7 @@
           }
         ]
       },
-      "tcpdump_na_rpm": {
+      "tcpdump": {
         "Name": "tcpdump",
         "SupportedOS": [
           {
@@ -2296,7 +2296,7 @@
           }
         ]
       },
-      "traceroute_na_rpm": {
+      "traceroute": {
         "Name": "traceroute",
         "SupportedOS": [
           {
@@ -2315,7 +2315,7 @@
           }
         ]
       },
-      "util-linux_na_rpm": {
+      "util-linux": {
         "Name": "util-linux",
         "SupportedOS": [
           {
@@ -2334,26 +2334,7 @@
           }
         ]
       },
-      "valgrind-devel_na_rpm": {
-        "Name": "valgrind-devel",
-        "SupportedOS": [
-          {
-            "Name": "RHEL",
-            "Version": "10.0"
-          }
-        ],
-        "Architecture": [
-          "x86_64"
-        ],
-        "Type": "rpm",
-        "Sources": [
-          {
-            "Architecture": "x86_64",
-            "RepoName": "appstream"
-          }
-        ]
-      },
-      "valgrind_na_rpm": {
+      "valgrind": {
         "Name": "valgrind",
         "SupportedOS": [
           {
@@ -2372,7 +2353,26 @@
           }
         ]
       },
-      "vim-enhanced_na_rpm": {
+      "valgrind-devel": {
+        "Name": "valgrind-devel",
+        "SupportedOS": [
+          {
+            "Name": "RHEL",
+            "Version": "10.0"
+          }
+        ],
+        "Architecture": [
+          "x86_64"
+        ],
+        "Type": "rpm",
+        "Sources": [
+          {
+            "Architecture": "x86_64",
+            "RepoName": "appstream"
+          }
+        ]
+      },
+      "vim-enhanced": {
         "Name": "vim-enhanced",
         "SupportedOS": [
           {
@@ -2391,7 +2391,7 @@
           }
         ]
       },
-      "wget_na_rpm": {
+      "wget": {
         "Name": "wget",
         "SupportedOS": [
           {
@@ -2410,7 +2410,7 @@
           }
         ]
       },
-      "which_na_rpm": {
+      "which": {
         "Name": "which",
         "SupportedOS": [
           {
@@ -2429,7 +2429,7 @@
           }
         ]
       },
-      "zsh_na_rpm": {
+      "zsh": {
         "Name": "zsh",
         "SupportedOS": [
           {


### PR DESCRIPTION
- Add comprehensive unit tests for _generate_human_readable_id function
- Improve version stripping to handle exact matches, v-prefixed versions, and dot-to-hyphen replacements
- Add regex-based fallback for version-like suffixes in package names
- Simplify ID format to use package name only (version stripped) instead of {name}_{version}_{type}
- Update catalog examples to reflect new simplified ID format
- Preserve trailing non-version suffixes like -amd64, -chart