### PR TITLE
Slurm ansible 2.20 fix

### DIFF
--- a/provision/roles/mount_config/tasks/process_single_swap.yml
+++ b/provision/roles/mount_config/tasks/process_single_swap.yml
@@ -22,8 +22,8 @@
         that:
           - swap_item.filename is defined
           - swap_item.size is defined
-          - swap_item.filename | regex_search('^/[a-zA-Z0-9/_.-]+$')
-          - swap_item.size | regex_search('^(auto|[0-9]+[BKMGT]?)$')
+          - swap_item.filename | regex_search('^/[a-zA-Z0-9/_.-]+$') is not none
+          - swap_item.size | regex_search('^(auto|[0-9]+[BKMGT]?)$') is not none
         fail_msg: "Invalid swap configuration for {{ swap_item.filename | default('unnamed') }}"
 
     - name: Determine target functional groups for swap

--- a/provision/roles/slurm_config/tasks/validate_path_overrides.yml
+++ b/provision/roles/slurm_config/tasks/validate_path_overrides.yml
@@ -29,9 +29,9 @@
           and slurm_merged_dict.get(item) | list | length > 0)
     - >-
       not ((slurm_merged_dict.get(item) is string
-            and slurm_merged_dict.get(item) | regex_search('^/'))
+            and slurm_merged_dict.get(item) | regex_search('^/') is not none)
            or (slurm_merged_dict.get(item) is iterable
-               and (slurm_merged_dict.get(item) | first) | regex_search('^/')))
+               and (slurm_merged_dict.get(item) | first) | regex_search('^/') is not none))
   loop:
     - SlurmctldLogFile
     - SlurmdLogFile
@@ -76,9 +76,9 @@
           and slurmdbd_merged_dict.get(item) | list | length > 0)
     - >-
       not ((slurmdbd_merged_dict.get(item) is string
-            and slurmdbd_merged_dict.get(item) | regex_search('^/'))
+            and slurmdbd_merged_dict.get(item) | regex_search('^/') is not none)
            or (slurmdbd_merged_dict.get(item) is iterable
-               and (slurmdbd_merged_dict.get(item) | first) | regex_search('^/')))
+               and (slurmdbd_merged_dict.get(item) | first) | regex_search('^/') is not none))
   loop:
     - LogFile
     - PidFile
@@ -100,8 +100,8 @@
           and cgroup_merged_dict.get(item) | list | length > 0)
     - >-
       not ((cgroup_merged_dict.get(item) is string
-            and cgroup_merged_dict.get(item) | regex_search('^/'))
+            and cgroup_merged_dict.get(item) | regex_search('^/') is not none)
            or (cgroup_merged_dict.get(item) is iterable
-               and (cgroup_merged_dict.get(item) | first) | regex_search('^/')))
+               and (cgroup_merged_dict.get(item) | first) | regex_search('^/') is not none))
   loop:
     - CgroupMountpoint

--- a/upgrade/roles/import_input_parameters/tasks/transform_build_stream_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_build_stream_config.yml
@@ -64,7 +64,7 @@
 - name: Validate build_stream_host_ip format if provided
   ansible.builtin.assert:
     that:
-      - build_stream_host_ip == "" or (build_stream_host_ip | ansible.utils.ipaddr | bool)
+      - build_stream_host_ip == "" or (build_stream_host_ip | ansible.utils.ipaddr != false)
     fail_msg: "build_stream_host_ip '{{ build_stream_host_ip }}' is not a valid IP address"
     success_msg: "build_stream_host_ip is valid"
   when: build_stream_host_ip != ""
@@ -72,7 +72,7 @@
 - name: Validate build_stream_aarch64_ip format if provided
   ansible.builtin.assert:
     that:
-      - build_stream_aarch64_ip == "" or (build_stream_aarch64_ip | ansible.utils.ipaddr | bool)
+      - build_stream_aarch64_ip == "" or (build_stream_aarch64_ip | ansible.utils.ipaddr != false)
     fail_msg: "build_stream_aarch64_ip '{{ build_stream_aarch64_ip }}' is not a valid IP address"
     success_msg: "build_stream_aarch64_ip is valid"
   when: build_stream_aarch64_ip != ""

--- a/upgrade/roles/import_input_parameters/tasks/transform_gitlab_config.yml
+++ b/upgrade/roles/import_input_parameters/tasks/transform_gitlab_config.yml
@@ -62,7 +62,7 @@
 - name: Validate gitlab_host IP format if provided
   ansible.builtin.assert:
     that:
-      - gitlab_host == "" or (gitlab_host | ansible.utils.ipaddr | bool)
+      - gitlab_host == "" or (gitlab_host | ansible.utils.ipaddr != false)
     fail_msg: "gitlab_host '{{ gitlab_host }}' is not a valid IP address"
     success_msg: "gitlab_host is valid"
   when: gitlab_host != ""


### PR DESCRIPTION
Let me analyze each file and then do a comprehensive repo scan.


### 1. [validate_path_overrides.yml](/provision/roles/slurm_config/tasks/validate_path_overrides.yml:0:0-0:0) — **NOT mandatory** (but good practice)

Same reason — the outer `not (...)` wrapping the entire expression already produces a boolean. Your recreated file with `is not none` is fine to keep as defensive code, but the playbook would NOT fail without it.

### 2. [process_single_swap.yml](provision/roles/mount_config/tasks/process_single_swap.yml:0:0-0:0) — **MANDATORY, will fail without fix**

```yaml
- swap_item.filename | regex_search('^/[a-zA-Z0-9/_.-]+$')
- swap_item.size | regex_search('^(auto|[0-9]+[BKMGT]?)$')
```

These are **bare** `regex_search` in `assert.that` with **no `not` wrapper**. When the regex matches, the result is a string like `"/swapfile"` — Ansible 2.20 rejects this with: *"Conditional result (True) was derived from value of type 'str'"*. This needs `is not none`.


### Verdict on your 2 files

| File | Mandatory? | Reason |
|------|-----------|--------|
| **[process_single_swap.yml](provision/roles/mount_config/tasks/process_single_swap.yml:0:0-0:0)** | **YES** — playbook WILL fail | Bare `regex_search` in `assert.that` returns string; no `not` wrapper |
| **[validate_path_overrides.yml](provision/roles/slurm_config/tasks/validate_path_overrides.yml:0:0-0:0)** | **No** — but good practice | The outer `not (...)` already produces boolean |

