### PR TITLE
Enhance K8s upgrade/rollback with validation and cleanup improvements

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
@@ -21,6 +21,10 @@ import yaml
 from ansible.module_utils.input_validation.common_utils import validation_utils
 from ansible.module_utils.input_validation.common_utils import config
 from ansible.module_utils.input_validation.common_utils import en_us_validation_msg
+from ansible.module_utils.input_validation.validation_flows.vip_pxe_validation import (
+    validate_vip_vs_pxe_mapping_host_ips,
+    validate_all_host_ips_same_subnet_as_vip
+)
 
 file_names = config.files
 create_error_msg = validation_utils.create_error_msg
@@ -291,11 +295,12 @@ def validate_vip_address(
     admin_network,
     pod_external_ip_list,
     admin_netmaskbits,
-    oim_admin_ip
+    oim_admin_ip,
+    pxe_mapping_file_path=None
 ):
     """
         Validate a virtual IP address against a list of existing service node VIPs,
-    admin network static and dynamic ranges, and admin subnet.
+    admin network static and dynamic ranges, admin subnet, and PXE mapping file.
 
         Parameters:
         - errors (list): A list to store error messages.
@@ -305,6 +310,7 @@ def validate_vip_address(
         - admin_network (dict): A dictionary containing admin network configuration.
         - admin_netmaskbits (str): The netmask bits value of the admin network.
         - oim_admin_ip (str): The IP address of the OIM admin interface.
+        - pxe_mapping_file_path (str, optional): Path to PXE mapping file for additional validation.
 
         Returns:
         - None: The function does not return any value, it only appends
@@ -358,6 +364,14 @@ def validate_vip_address(
                     en_us_validation_msg.VIRTUAL_IP_NOT_POD_EXT,
                 )
             )
+
+    # Validate VIP against PXE mapping file (if provided)
+    if pxe_mapping_file_path:
+        # Check VIP doesn't conflict with any HOST_IP in PXE mapping
+        validate_vip_vs_pxe_mapping_host_ips(errors, config_type, vip_address, pxe_mapping_file_path)
+        
+        # Check all HOST_IPs are in same subnet as VIP
+        validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_file_path, admin_netmaskbits)
 
 def validate_service_k8s_cluster_ha(
     errors,
@@ -414,13 +428,28 @@ def validate_service_k8s_cluster_ha(
         vip_address = hdata.get("virtual_ip_address")
         # Find the intersection
         if vip_address:
-            for ip_list in (ha_node_vip_list, pxe_admin_ips, pxe_bmc_ips):
-                if vip_address in ip_list:
-                    errors.append(
-                        create_error_msg(
-                            f"{config_type} virtual_ip_duplicate",
-                            vip_address,
-                            en_us_validation_msg.DUPLICATE_VIRTUAL_IP))
+            if vip_address in ha_node_vip_list:
+                errors.append(
+                    create_error_msg(
+                        f"{config_type} virtual_ip_duplicate",
+                        vip_address,
+                        en_us_validation_msg.DUPLICATE_VIRTUAL_IP))
+            if vip_address in pxe_admin_ips:
+                errors.append(
+                    create_error_msg(
+                        f"{config_type} virtual_ip_duplicate",
+                        vip_address,
+                        f"virtual_ip_address '{vip_address}' conflicts with an ADMIN_IP "
+                        "in pxe_mapping_file.csv. The VIP must not match any node's "
+                        "ADMIN_IP. Please use a different virtual IP address."))
+            if vip_address in pxe_bmc_ips:
+                errors.append(
+                    create_error_msg(
+                        f"{config_type} virtual_ip_duplicate",
+                        vip_address,
+                        f"virtual_ip_address '{vip_address}' conflicts with a BMC_IP "
+                        "in pxe_mapping_file.csv. The VIP must not match any node's "
+                        "BMC_IP. Please use a different virtual IP address."))
             validate_vip_address(
                 errors,
                 config_type,
@@ -428,7 +457,8 @@ def validate_service_k8s_cluster_ha(
                 admin_network,
                 pod_external_ip_list,
                 admin_netmaskbits,
-                oim_admin_ip
+                oim_admin_ip,
+                prov_cfg.get('pxe_mapping_file_path')
             )
 
 

--- a/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=too-many-arguments,too-many-locals,too-many-positional-arguments,import-error
+"""
+This module contains functions for validating VIP against PXE mapping file.
+"""
+import csv
+import os
+from ansible.module_utils.input_validation.common_utils import validation_utils
+from ansible.module_utils.input_validation.common_utils import en_us_validation_msg
+
+create_error_msg = validation_utils.create_error_msg
+
+
+def extract_host_ips_from_pxe_mapping(pxe_mapping_file_path):
+    """
+    Extract all ADMIN_IP values from PXE mapping file.
+    
+    Parameters:
+        pxe_mapping_file_path (str): Path to the PXE mapping file
+        
+    Returns:
+        list: List of ADMIN_IP values (node admin IPs)
+    """
+    host_ips = []
+    
+    if not pxe_mapping_file_path or not os.path.isfile(pxe_mapping_file_path):
+        return host_ips
+    
+    try:
+        with open(pxe_mapping_file_path, "r", encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+        
+        non_comment_lines = [ln for ln in raw_lines if ln.strip() and not ln.strip().startswith('#')]
+        reader = csv.DictReader(non_comment_lines)
+        
+        fieldname_map = {fn.strip().upper(): fn for fn in reader.fieldnames}
+        admin_ip_col = fieldname_map.get("ADMIN_IP")
+        
+        if admin_ip_col:
+            for row in reader:
+                admin_ip = row.get(admin_ip_col, "").strip() if row.get(admin_ip_col) else ""
+                if admin_ip and validation_utils.is_valid_ipv4(admin_ip):
+                    host_ips.append(admin_ip)
+                    
+    except Exception:
+        # If file can't be read, return empty list
+        pass
+    
+    return host_ips
+
+
+def validate_vip_vs_pxe_mapping_host_ips(errors, config_type, vip_address, pxe_mapping_file_path):
+    """
+    Validate that VIP doesn't conflict with any ADMIN_IP in PXE mapping file.
+    
+    Parameters:
+        errors (list): List to append error messages
+        config_type (str): Configuration type for error reporting
+        vip_address (str): VIP address to validate
+        pxe_mapping_file_path (str): Path to PXE mapping file
+    """
+    host_ips = extract_host_ips_from_pxe_mapping(pxe_mapping_file_path)
+    
+    for host_ip in host_ips:
+        if vip_address == host_ip:
+            errors.append(
+                create_error_msg(
+                    f"{config_type} virtual_ip_address",
+                    vip_address,
+                    "VIP cannot be the same as any ADMIN_IP in PXE mapping file. "
+                    f"VIP {vip_address} conflicts with node ADMIN_IP {host_ip}. "
+                    "Please use a different VIP address."
+                )
+            )
+            break  # Only need to report once
+
+
+def validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_file_path, admin_netmaskbits):
+    """
+    Validate that all ADMIN_IPs in PXE mapping are in the same subnet as VIP.
+    
+    Parameters:
+        errors (list): List to append error messages
+        vip_address (str): VIP address to validate against
+        pxe_mapping_file_path (str): Path to PXE mapping file
+        admin_netmaskbits (str): Netmask bits for subnet validation
+    """
+    host_ips = extract_host_ips_from_pxe_mapping(pxe_mapping_file_path)
+    
+    for host_ip in host_ips:
+        if not validation_utils.is_ip_in_subnet(vip_address, admin_netmaskbits, host_ip):
+            errors.append(
+                create_error_msg(
+                    "ADMIN_IP subnet consistency",
+                    host_ip,
+                    f"Node ADMIN_IP {host_ip} must be in the same subnet as VIP {vip_address}. "
+                    f"Please ensure all ADMIN_IPs in PXE mapping file are in the same subnet as the VIP."
+                )
+            )

--- a/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
@@ -56,7 +56,7 @@ def extract_host_ips_from_pxe_mapping(pxe_mapping_file_path):
                 admin_ip_value = row.get(admin_ip_col, "").strip() \
                     if row.get(admin_ip_col) else ""
                 if admin_ip_value and \
-                        validation_utils.is_valid_ipv4(admin_ip_value):
+                        validation_utils.validate_ipv4(admin_ip_value):
                     host_ips.append(admin_ip_value)
 
     except (OSError, csv.Error):

--- a/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# pylint: disable=too-many-arguments,too-many-locals,too-many-positional-arguments,import-error
+# pylint: disable=too-many-arguments,import-error,no-name-in-module
+# pylint: disable=too-many-locals,too-many-positional-arguments
 """
 This module contains functions for validating VIP against PXE mapping file.
 """
 import csv
 import os
 from ansible.module_utils.input_validation.common_utils import validation_utils
-from ansible.module_utils.input_validation.common_utils import en_us_validation_msg
 
 create_error_msg = validation_utils.create_error_msg
 
@@ -26,45 +26,51 @@ create_error_msg = validation_utils.create_error_msg
 def extract_host_ips_from_pxe_mapping(pxe_mapping_file_path):
     """
     Extract all ADMIN_IP values from PXE mapping file.
-    
+
     Parameters:
         pxe_mapping_file_path (str): Path to the PXE mapping file
-        
+
     Returns:
         list: List of ADMIN_IP values (node admin IPs)
     """
     host_ips = []
-    
+
     if not pxe_mapping_file_path or not os.path.isfile(pxe_mapping_file_path):
         return host_ips
-    
+
     try:
         with open(pxe_mapping_file_path, "r", encoding="utf-8") as fh:
             raw_lines = fh.readlines()
-        
-        non_comment_lines = [ln for ln in raw_lines if ln.strip() and not ln.strip().startswith('#')]
+
+        non_comment_lines = [
+            ln for ln in raw_lines
+            if ln.strip() and not ln.strip().startswith('#')
+        ]
         reader = csv.DictReader(non_comment_lines)
-        
+
         fieldname_map = {fn.strip().upper(): fn for fn in reader.fieldnames}
         admin_ip_col = fieldname_map.get("ADMIN_IP")
-        
+
         if admin_ip_col:
             for row in reader:
-                admin_ip = row.get(admin_ip_col, "").strip() if row.get(admin_ip_col) else ""
-                if admin_ip and validation_utils.is_valid_ipv4(admin_ip):
-                    host_ips.append(admin_ip)
-                    
-    except Exception:
+                admin_ip_value = row.get(admin_ip_col, "").strip() \
+                    if row.get(admin_ip_col) else ""
+                if admin_ip_value and \
+                        validation_utils.is_valid_ipv4(admin_ip_value):
+                    host_ips.append(admin_ip_value)
+
+    except (OSError, csv.Error):
         # If file can't be read, return empty list
         pass
-    
+
     return host_ips
 
 
-def validate_vip_vs_pxe_mapping_host_ips(errors, config_type, vip_address, pxe_mapping_file_path):
+def validate_vip_vs_pxe_mapping_host_ips(
+        errors, config_type, vip_address, pxe_mapping_file_path):
     """
     Validate that VIP doesn't conflict with any ADMIN_IP in PXE mapping file.
-    
+
     Parameters:
         errors (list): List to append error messages
         config_type (str): Configuration type for error reporting
@@ -72,25 +78,27 @@ def validate_vip_vs_pxe_mapping_host_ips(errors, config_type, vip_address, pxe_m
         pxe_mapping_file_path (str): Path to PXE mapping file
     """
     host_ips = extract_host_ips_from_pxe_mapping(pxe_mapping_file_path)
-    
+
     for host_ip in host_ips:
         if vip_address == host_ip:
             errors.append(
                 create_error_msg(
                     f"{config_type} virtual_ip_address",
                     vip_address,
-                    "VIP cannot be the same as any ADMIN_IP in PXE mapping file. "
-                    f"VIP {vip_address} conflicts with node ADMIN_IP {host_ip}. "
+                    "VIP cannot be the same as any ADMIN_IP in PXE "
+                    f"mapping file. VIP {vip_address} conflicts with "
+                    f"node ADMIN_IP {host_ip}. "
                     "Please use a different VIP address."
                 )
             )
             break  # Only need to report once
 
 
-def validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_file_path, admin_netmaskbits):
+def validate_all_host_ips_same_subnet_as_vip(
+        errors, vip_address, pxe_mapping_file_path, admin_netmaskbits):
     """
-    Validate that all ADMIN_IPs in PXE mapping are in the same subnet as VIP.
-    
+    Validate that all ADMIN_IPs in PXE mapping are in same subnet as VIP.
+
     Parameters:
         errors (list): List to append error messages
         vip_address (str): VIP address to validate against
@@ -98,14 +106,17 @@ def validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_fi
         admin_netmaskbits (str): Netmask bits for subnet validation
     """
     host_ips = extract_host_ips_from_pxe_mapping(pxe_mapping_file_path)
-    
+
     for host_ip in host_ips:
-        if not validation_utils.is_ip_in_subnet(vip_address, admin_netmaskbits, host_ip):
+        if not validation_utils.is_ip_in_subnet(
+                vip_address, admin_netmaskbits, host_ip):
             errors.append(
                 create_error_msg(
                     "ADMIN_IP subnet consistency",
                     host_ip,
-                    f"Node ADMIN_IP {host_ip} must be in the same subnet as VIP {vip_address}. "
-                    f"Please ensure all ADMIN_IPs in PXE mapping file are in the same subnet as the VIP."
+                    f"Node ADMIN_IP {host_ip} must be in the same "
+                    f"subnet as VIP {vip_address}. "
+                    "Please ensure all ADMIN_IPs in PXE mapping file "
+                    "are in the same subnet as the VIP."
                 )
             )

--- a/rollback/playbooks/rollback_k8s.yml
+++ b/rollback/playbooks/rollback_k8s.yml
@@ -143,7 +143,7 @@
       block:
         - name: Rollback Kubernetes cluster
           ansible.builtin.include_role:
-            name: rollback_k8s
+            name: "{{ playbook_dir }}/../roles/rollback_k8s"
 
         - name: Display K8s rollback outcome
           ansible.builtin.debug:

--- a/rollback/playbooks/rollback_oim.yml
+++ b/rollback/playbooks/rollback_oim.yml
@@ -71,7 +71,7 @@
       block:
         - name: Rollback OpenCHAMI containers and services
           ansible.builtin.include_role:
-            name: ../roles/rollback_openchami
+            name: "{{ playbook_dir }}/../roles/rollback_openchami"
 
         - name: Display OpenCHAMI rollback outcome
           ansible.builtin.debug:

--- a/rollback/playbooks/rollback_slurm.yml
+++ b/rollback/playbooks/rollback_slurm.yml
@@ -262,7 +262,7 @@
 
     - name: Include slurm rollback role
       ansible.builtin.include_role:
-        name: ../roles/rollback_slurm
+        name: "{{ playbook_dir }}/../roles/rollback_slurm"
       tags: slurm
 
 - name: Reboot Slurm nodes and validate services

--- a/rollback/roles/rollback_k8s/tasks/cleanup_stale_volume_attachments.yml
+++ b/rollback/roles/rollback_k8s/tasks/cleanup_stale_volume_attachments.yml
@@ -235,23 +235,7 @@
       until: _csi_pods_check.stdout | trim | length == 0
       when: "'csi-isilon.dellemc.com' in (_csi_drivers.stdout | default(''))"
 
-    # ── Clean up old terminated NFS provisioner pods ───────────────
-    - name: Delete old terminated NFS provisioner pods
-      ansible.builtin.shell:
-        cmd: >-
-          kubectl --server=https://{{ first_cp_ip }}:6443
-          delete pods -A
-          -l app=nfs-subdir-external-provisioner
-          --field-selector=status.phase=Failed
-          --ignore-not-found=true;
-          kubectl --server=https://{{ first_cp_ip }}:6443
-          delete pods -A
-          -l app=nfs-subdir-external-provisioner
-          --field-selector=status.phase=Succeeded
-          --ignore-not-found=true
-      delegate_to: "{{ groups_cp_first | first }}"
-      changed_when: true
-      failed_when: false
+    
 
     # ── Verify NFS client provisioner pod is Running ──────────────
     - name: Check if NFS client provisioner exists

--- a/rollback/roles/rollback_k8s/tasks/cleanup_stale_volume_attachments.yml
+++ b/rollback/roles/rollback_k8s/tasks/cleanup_stale_volume_attachments.yml
@@ -235,6 +235,24 @@
       until: _csi_pods_check.stdout | trim | length == 0
       when: "'csi-isilon.dellemc.com' in (_csi_drivers.stdout | default(''))"
 
+    # ── Clean up old terminated NFS provisioner pods ───────────────
+    - name: Delete old terminated NFS provisioner pods
+      ansible.builtin.shell:
+        cmd: >-
+          kubectl --server=https://{{ first_cp_ip }}:6443
+          delete pods -A
+          -l app=nfs-subdir-external-provisioner
+          --field-selector=status.phase=Failed
+          --ignore-not-found=true;
+          kubectl --server=https://{{ first_cp_ip }}:6443
+          delete pods -A
+          -l app=nfs-subdir-external-provisioner
+          --field-selector=status.phase=Succeeded
+          --ignore-not-found=true
+      delegate_to: "{{ groups_cp_first | first }}"
+      changed_when: true
+      failed_when: false
+
     # ── Verify NFS client provisioner pod is Running ──────────────
     - name: Check if NFS client provisioner exists
       ansible.builtin.command:

--- a/rollback/roles/rollback_k8s/tasks/cleanup_stale_volume_attachments.yml
+++ b/rollback/roles/rollback_k8s/tasks/cleanup_stale_volume_attachments.yml
@@ -235,7 +235,6 @@
       until: _csi_pods_check.stdout | trim | length == 0
       when: "'csi-isilon.dellemc.com' in (_csi_drivers.stdout | default(''))"
 
-    
 
     # ── Verify NFS client provisioner pod is Running ──────────────
     - name: Check if NFS client provisioner exists

--- a/rollback/roles/rollback_k8s/tasks/load_rollback_status.yml
+++ b/rollback/roles/rollback_k8s/tasks/load_rollback_status.yml
@@ -22,38 +22,46 @@
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     groups: kube_vip_group
 
-# ── Read nodes.yaml for inventory ──────────────────────────────────
-- name: Read nodes.yaml
-  ansible.builtin.slurp:
-    src: "{{ nodes_yaml_path }}"
-  register: nodes_slurp
-  changed_when: false
+# ══════════════════════════════════════════════════════════════════════════════
+# Build node inventory from upgrade_status.nodes (nodes that were actually upgraded)
+# This ensures rollback targets the same nodes that were part of the upgrade
+# ══════════════════════════════════════════════════════════════════════════════
 
-- name: Parse nodes.yaml
-  ansible.builtin.set_fact:
-    parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+- name: Display upgrade status nodes info
+  ansible.builtin.debug:
+    msg: "{{ nodes_info_banner }}"
+  vars:
+    nodes_info_banner:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[ROLLBACK] BUILDING NODE INVENTORY FROM UPGRADE STATUS"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Using nodes from upgrade_status.yml (nodes that were part of the upgrade)"
+      - "Total nodes in upgrade status: {{ upgrade_status.nodes | length }}"
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
 
-# ── Build node lists by role ────────────────────────────────────────
-- name: Build first control plane list
+# ── Build node lists from upgrade_status.nodes ───────────────────────
+- name: Build first control plane list from upgrade_status
   ansible.builtin.set_fact:
     groups_cp_first: >-
-      {{ parsed_nodes.nodes
-         | selectattr('group', 'equalto', group_cp_first)
-         | map(attribute='name') | list }}
+      {{ upgrade_status.nodes | dict2items
+         | selectattr('value.role', 'equalto', 'control_plane_first')
+         | map(attribute='key') | list }}
 
-- name: Build additional control plane list
+- name: Build additional control plane list from upgrade_status
   ansible.builtin.set_fact:
     groups_cp: >-
-      {{ parsed_nodes.nodes
-         | selectattr('group', 'equalto', group_cp)
-         | map(attribute='name') | list }}
+      {{ upgrade_status.nodes | dict2items
+         | selectattr('value.role', 'equalto', 'control_plane')
+         | map(attribute='key') | list }}
 
-- name: Build worker list
+- name: Build worker list from upgrade_status
   ansible.builtin.set_fact:
     groups_worker: >-
-      {{ parsed_nodes.nodes
-         | selectattr('group', 'equalto', group_worker)
-         | map(attribute='name') | list }}
+      {{ upgrade_status.nodes | dict2items
+         | selectattr('value.role', 'equalto', 'worker')
+         | map(attribute='key') | list }}
 
 - name: Build all nodes list
   ansible.builtin.set_fact:
@@ -61,18 +69,105 @@
     all_worker_nodes: "{{ groups_worker }}"
     all_rollback_nodes: "{{ groups_cp_first + groups_cp + groups_worker }}"
 
-# ── Build node IP map ───────────────────────────────────────────────
-- name: Build node name-to-IP mapping
+# ── Build node IP map from upgrade_status.nodes ──────────────────────
+- name: Build node name-to-IP mapping from upgrade_status
   ansible.builtin.set_fact:
     node_ips: >-
       {{ node_ips | default({}) | combine({
-           item.name: (item.interfaces | first).ip_addrs
-                      | selectattr('name', 'equalto', 'management')
-                      | map(attribute='ip_addr') | first
+           item.key: item.value.ip
          }) }}
-  loop: "{{ parsed_nodes.nodes }}"
+  loop: "{{ upgrade_status.nodes | dict2items }}"
   loop_control:
-    label: "{{ item.name }}"
+    label: "{{ item.key }}"
+
+# ── Display rollback node inventory ──────────────────────────────────
+- name: Display rollback node inventory
+  ansible.builtin.debug:
+    msg: "{{ inventory_banner }}"
+  vars:
+    inventory_banner:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[ROLLBACK] NODE INVENTORY"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Total nodes for rollback: {{ all_rollback_nodes | length }}"
+      - ""
+      - "Control plane (first): {{ groups_cp_first | length }} node(s)"
+      - "{% for node in groups_cp_first %}  - {{ node }} ({{ node_ips[node] }})\n{% endfor %}"
+      - ""
+      - "Control plane (additional): {{ groups_cp | length }} node(s)"
+      - "{% for node in groups_cp %}  - {{ node }} ({{ node_ips[node] }})\n{% endfor %}"
+      - ""
+      - "Workers: {{ groups_worker | length }} node(s)"
+      - "{% for node in groups_worker %}  - {{ node }} ({{ node_ips[node] }})\n{% endfor %}"
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
+
+# ── Validate SSH connectivity to all rollback nodes ──────────────────
+- name: Display SSH connectivity check message
+  ansible.builtin.debug:
+    msg: "Checking SSH connectivity to {{ all_rollback_nodes | length }} rollback nodes..."
+
+- name: Check SSH connectivity to all rollback nodes
+  ansible.builtin.wait_for:
+    host: "{{ node_ips[item] }}"
+    port: 22
+    timeout: 10
+    state: started
+  loop: "{{ all_rollback_nodes }}"
+  loop_control:
+    label: "{{ item }} ({{ node_ips[item] }})"
+  register: ssh_check_results
+  ignore_errors: true
+
+- name: Build list of nodes with SSH failures
+  ansible.builtin.set_fact:
+    ssh_failed_nodes: >-
+      {{ ssh_check_results.results
+         | selectattr('failed', 'defined')
+         | selectattr('failed', 'equalto', true)
+         | map(attribute='item')
+         | list }}
+
+- name: Display SSH check results
+  ansible.builtin.debug:
+    msg: "{{ ssh_results_banner }}"
+  vars:
+    ssh_results_banner:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[SSH] CONNECTIVITY CHECK RESULTS"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Nodes with SSH accessible: {{ all_rollback_nodes | difference(ssh_failed_nodes) | length }}"
+      - "Nodes with SSH failed: {{ ssh_failed_nodes | length }}"
+      - "{% if ssh_failed_nodes | length > 0 %}  Failed nodes: {{ ssh_failed_nodes | join(', ') }}{% endif %}"
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
+
+- name: Fail if any node has SSH connectivity failure
+  ansible.builtin.fail:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [ERROR] SSH CONNECTIVITY FAILURE
+      ════════════════════════════════════════════════════════════════════════════════
+      The following nodes failed SSH connectivity check:
+      {% for node in ssh_failed_nodes %}
+        - {{ node }} ({{ node_ips[node] }})
+      {% endfor %}
+
+      Cannot proceed with rollback. Please ensure:
+        1. All nodes are powered on and accessible
+        2. SSH service is running on all nodes
+        3. Network connectivity exists between control node and target nodes
+        4. SSH keys are properly configured
+
+      Fix the connectivity issues and re-run the rollback.
+      ════════════════════════════════════════════════════════════════════════════════
+  when: ssh_failed_nodes | length > 0
+
+- name: Display all nodes SSH accessible
+  ansible.builtin.debug:
+    msg: "[OK] SSH connectivity verified for all {{ all_rollback_nodes | length }} rollback nodes"
 
 # ── Add all nodes to Ansible inventory ──────────────────────────────
 - name: Add K8s nodes to inventory

--- a/rollback/roles/rollback_k8s/tasks/main.yml
+++ b/rollback/roles/rollback_k8s/tasks/main.yml
@@ -67,6 +67,9 @@
     k8s_config_backup_dir: "{{ k8s_client_mount_path }}/upgrade/backup/configs"
 
 # ── Resolve first CP node for delegation (avoids kube_vip dependency) ─
+# NOTE: This reads nodes.yaml ONLY to get the first CP node for initial delegation.
+# The actual rollback inventory is built from upgrade_status.nodes in load_rollback_status.yml
+# to ensure we rollback the same nodes that were part of the upgrade.
 - name: Read nodes.yaml for early CP resolution
   ansible.builtin.slurp:
     src: "{{ nodes_yaml_path }}"

--- a/rollback/roles/rollback_k8s/tasks/restore_bss_cloud_init.yml
+++ b/rollback/roles/rollback_k8s/tasks/restore_bss_cloud_init.yml
@@ -141,7 +141,7 @@
              + ([] if (groups_cp | length == 0) else [group_cp])
              + [group_worker] }}
 
-    - name: "Restore BSS and cloud-init for {{ item }}"
+    - name: Restore BSS and cloud-init for functional groups
       ansible.builtin.shell:
         cmd: >
           set -o pipefail && ansible-playbook

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -95,13 +95,14 @@
 
     - name: Abort rollback if upgrade completed successfully
       ansible.builtin.fail:
-        msg: |
-          The previous upgrade completed successfully (upgrade_status: completed).
-          Rollback after a successful upgrade is not recommended because all
-          components were upgraded consistently.
-          If you need to rollback despite successful completion:
-            cd /omnia/rollback
-            ansible-playbook rollback.yml -e force_rollback=true
+        msg:
+          - "The previous upgrade completed successfully (upgrade_status: completed)."
+          - "Rollback after a successful upgrade is not recommended because all"
+          - "components were upgraded consistently."
+          - ""
+          - "If you need to rollback despite successful completion:"
+          - "  cd /omnia/rollback"
+          - "  ansible-playbook rollback.yml -e force_rollback=true"
       when:
         - upgrade_manifest is defined
         - upgrade_manifest.upgrade_status | default('') == 'completed'

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -100,7 +100,8 @@
           Rollback after a successful upgrade is not recommended because all
           components were upgraded consistently.
           If you need to rollback despite successful completion:
-            ansible-playbook rollback/rollback.yml -e force_rollback=true
+            cd /omnia/rollback
+            ansible-playbook rollback.yml -e force_rollback=true
       when:
         - upgrade_manifest is defined
         - upgrade_manifest.upgrade_status | default('') == 'completed'
@@ -129,7 +130,8 @@
           The previous rollback already completed successfully.
           Rollback ID: {{ prior_rollback.rollback_id | default('N/A') }}
           If you need to force a new rollback:
-            ansible-playbook rollback/rollback.yml -e force_rollback=true
+            cd /omnia/rollback
+            ansible-playbook rollback.yml -e force_rollback=true
       when:
         - existing_rollback.stat.exists
         - prior_rollback.rollback_status | default('') == 'completed'

--- a/upgrade/playbooks/upgrade_k8s.yml
+++ b/upgrade/playbooks/upgrade_k8s.yml
@@ -624,6 +624,45 @@
       ansible.builtin.set_fact:
         k8s_client_mount_path_kube_vip: "{{ k8s_client_mount_path }}"
 
+# ══════════════════════════════════════════════════════════════════════════════
+# Validate cluster nodes against nodes.yaml before proceeding
+# ══════════════════════════════════════════════════════════════════════════════
+- name: "Kubernetes Upgrade - Validate cluster nodes against nodes.yaml"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    input_project_dir: "/opt/omnia/input/project_default"
+    nodes_yaml_path: "/opt/omnia/openchami/workdir/nodes/nodes.yaml"
+    group_cp_first: "service_kube_control_plane_first_x86_64"
+    group_cp: "service_kube_control_plane_x86_64"
+    group_worker: "service_kube_node_x86_64"
+    kube_vip: "{{ hostvars['localhost']['kube_vip'] }}"
+  tasks:
+    - name: "Skip all tasks — service_k8s not configured, already completed, or resuming post-validation"
+      ansible.builtin.meta: end_play
+      when: >
+        not (hostvars['localhost']['k8s_upgrade_enabled'] | default(true)) or
+        (hostvars['localhost']['k8s_upgrade_skip'] | default(false)) or
+        (hostvars['localhost']['resume_post_validation_only'] | default(false))
+
+    - name: "Load upgrade role variables"
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../roles/upgrade_k8s/vars/main.yml"
+
+    - name: "Validate cluster nodes against nodes.yaml"
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/upgrade_k8s/tasks/validate_cluster_nodes.yml"
+
+    - name: "Cache validated node groups for subsequent plays"
+      ansible.builtin.set_fact:
+        validated_groups_cp_first: "{{ groups_cp_first }}"
+        validated_groups_cp: "{{ groups_cp }}"
+        validated_groups_worker: "{{ groups_worker }}"
+        validated_all_upgrade_nodes: "{{ all_upgrade_nodes }}"
+        validated_node_ips: "{{ node_ips }}"
+        validated_parsed_nodes: "{{ parsed_nodes }}"
+        cacheable: true
+
 - name: "Kubernetes Upgrade - Initialize upgrade status file"
   hosts: localhost
   connection: local
@@ -663,52 +702,65 @@
               | selectattr('name', 'equalto', k8s_nfs_storage_name)
               | first).mount_point }}
 
-    - name: Read nodes.yaml
-      ansible.builtin.slurp:
-        src: "{{ nodes_yaml_path }}"
-      register: nodes_slurp
-      changed_when: false
-
-    - name: Parse nodes.yaml
+    - name: "Use validated node groups from cluster validation"
       ansible.builtin.set_fact:
-        parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+        groups_cp_first: "{{ hostvars['localhost']['validated_groups_cp_first'] }}"
+        groups_cp: "{{ hostvars['localhost']['validated_groups_cp'] }}"
+        groups_worker: "{{ hostvars['localhost']['validated_groups_worker'] }}"
+        all_upgrade_nodes: "{{ hostvars['localhost']['validated_all_upgrade_nodes'] }}"
+        node_ips: "{{ hostvars['localhost']['validated_node_ips'] }}"
+        parsed_nodes: "{{ hostvars['localhost']['validated_parsed_nodes'] }}"
+      when: hostvars['localhost']['cluster_validation_completed'] | default(false)
 
-    - name: Build node lists by role
-      ansible.builtin.set_fact:
-        groups_cp_first: >-
-          {{ parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_cp_first)
-             | map(attribute='name') | list }}
-        groups_cp: >-
-          {{ parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_cp)
-             | map(attribute='name') | list }}
-        groups_worker: >-
-          {{ parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_worker)
-             | map(attribute='name') | list }}
-        all_upgrade_nodes: >-
-          {{ (parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_cp_first)
-             | map(attribute='name') | list) +
-             (parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_cp)
-             | map(attribute='name') | list) +
-             (parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_worker)
-             | map(attribute='name') | list) }}
+    - name: "Fallback - Read nodes.yaml if validation was skipped"
+      when: not (hostvars['localhost']['cluster_validation_completed'] | default(false))
+      block:
+        - name: Read nodes.yaml
+          ansible.builtin.slurp:
+            src: "{{ nodes_yaml_path }}"
+          register: nodes_slurp
+          changed_when: false
 
-    - name: Build node IP map
-      ansible.builtin.set_fact:
-        node_ips: >-
-          {{ node_ips | default({}) | combine({
-               item.name: (item.interfaces | first).ip_addrs
-                          | selectattr('name', 'equalto', 'management')
-                          | map(attribute='ip_addr') | first
-             }) }}
-      loop: "{{ parsed_nodes.nodes }}"
-      loop_control:
-        label: "{{ item.name }}"
+        - name: Parse nodes.yaml
+          ansible.builtin.set_fact:
+            parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+
+        - name: Build node lists by role
+          ansible.builtin.set_fact:
+            groups_cp_first: >-
+              {{ parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_cp_first)
+                 | map(attribute='name') | list }}
+            groups_cp: >-
+              {{ parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_cp)
+                 | map(attribute='name') | list }}
+            groups_worker: >-
+              {{ parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_worker)
+                 | map(attribute='name') | list }}
+            all_upgrade_nodes: >-
+              {{ (parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_cp_first)
+                 | map(attribute='name') | list) +
+                 (parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_cp)
+                 | map(attribute='name') | list) +
+                 (parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_worker)
+                 | map(attribute='name') | list) }}
+
+        - name: Build node IP map
+          ansible.builtin.set_fact:
+            node_ips: >-
+              {{ node_ips | default({}) | combine({
+                   item.name: (item.interfaces | first).ip_addrs
+                              | selectattr('name', 'equalto', 'management')
+                              | map(attribute='ip_addr') | first
+                 }) }}
+          loop: "{{ parsed_nodes.nodes }}"
+          loop_control:
+            label: "{{ item.name }}"
 
     - name: Load variables from file
       ansible.builtin.include_vars:
@@ -917,36 +969,48 @@
       ansible.builtin.set_fact:
         k8s_nfs_storage_name: "{{ omnia_config.service_k8s_cluster[0].nfs_storage_name }}"
 
-    - name: Read nodes.yaml
-      ansible.builtin.slurp:
-        src: "{{ nodes_yaml_path }}"
-      register: nodes_slurp
-      changed_when: false
-
-    - name: Parse nodes.yaml
+    - name: "Use validated node groups from cluster validation"
       ansible.builtin.set_fact:
-        parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+        groups_cp_first: "{{ hostvars['localhost']['validated_groups_cp_first'] }}"
+        groups_cp: "{{ hostvars['localhost']['validated_groups_cp'] }}"
+        groups_worker: "{{ hostvars['localhost']['validated_groups_worker'] }}"
+        parsed_nodes: "{{ hostvars['localhost']['validated_parsed_nodes'] }}"
+        node_ips: "{{ hostvars['localhost']['validated_node_ips'] }}"
+      when: hostvars['localhost']['cluster_validation_completed'] | default(false)
 
-    - name: Build first control plane list
-      ansible.builtin.set_fact:
-        groups_cp_first: >-
-          {{ parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_cp_first)
-             | map(attribute='name') | list }}
+    - name: "Fallback - Read nodes.yaml if validation was skipped"
+      when: not (hostvars['localhost']['cluster_validation_completed'] | default(false))
+      block:
+        - name: Read nodes.yaml
+          ansible.builtin.slurp:
+            src: "{{ nodes_yaml_path }}"
+          register: nodes_slurp
+          changed_when: false
 
-    - name: Build additional control plane list
-      ansible.builtin.set_fact:
-        groups_cp: >-
-          {{ parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_cp)
-             | map(attribute='name') | list }}
+        - name: Parse nodes.yaml
+          ansible.builtin.set_fact:
+            parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
 
-    - name: Build worker list
-      ansible.builtin.set_fact:
-        groups_worker: >-
-          {{ parsed_nodes.nodes
-             | selectattr('group', 'equalto', group_worker)
-             | map(attribute='name') | list }}
+        - name: Build first control plane list
+          ansible.builtin.set_fact:
+            groups_cp_first: >-
+              {{ parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_cp_first)
+                 | map(attribute='name') | list }}
+
+        - name: Build additional control plane list
+          ansible.builtin.set_fact:
+            groups_cp: >-
+              {{ parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_cp)
+                 | map(attribute='name') | list }}
+
+        - name: Build worker list
+          ansible.builtin.set_fact:
+            groups_worker: >-
+              {{ parsed_nodes.nodes
+                 | selectattr('group', 'equalto', group_worker)
+                 | map(attribute='name') | list }}
 
     - name: Add first control plane to inventory
       ansible.builtin.add_host:
@@ -1440,7 +1504,7 @@
 
     - name: Call upgrade_k8s role
       ansible.builtin.include_role:
-        name: ../roles/upgrade_k8s
+        name: "{{ playbook_dir }}/../roles/upgrade_k8s"
 
 - name: "Kubernetes Upgrade - Post-Validation"
   hosts: localhost
@@ -1498,27 +1562,35 @@
       ansible.builtin.set_fact:
         status_file: "{{ k8s_client_mount_path }}/upgrade/upgrade_status.yml"
 
-    - name: Read nodes.yaml for all_upgrade_nodes
-      ansible.builtin.slurp:
-        src: "/opt/omnia/openchami/workdir/nodes/nodes.yaml"
-      register: nodes_slurp
-
-    - name: Parse nodes.yaml
+    - name: "Use validated node groups from cluster validation"
       ansible.builtin.set_fact:
-        parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+        all_upgrade_nodes: "{{ hostvars['localhost']['validated_all_upgrade_nodes'] }}"
+      when: hostvars['localhost']['cluster_validation_completed'] | default(false)
 
-    - name: Build all_upgrade_nodes list
-      ansible.builtin.set_fact:
-        all_upgrade_nodes: >-
-          {{ (parsed_nodes.nodes
-             | selectattr('group', 'equalto', 'service_kube_control_plane_first_x86_64')
-             | map(attribute='name') | list) +
-             (parsed_nodes.nodes
-             | selectattr('group', 'equalto', 'service_kube_control_plane_x86_64')
-             | map(attribute='name') | list) +
-             (parsed_nodes.nodes
-             | selectattr('group', 'equalto', 'service_kube_node_x86_64')
-             | map(attribute='name') | list) }}
+    - name: "Fallback - Read nodes.yaml for all_upgrade_nodes if validation was skipped"
+      when: not (hostvars['localhost']['cluster_validation_completed'] | default(false))
+      block:
+        - name: Read nodes.yaml for all_upgrade_nodes
+          ansible.builtin.slurp:
+            src: "/opt/omnia/openchami/workdir/nodes/nodes.yaml"
+          register: nodes_slurp
+
+        - name: Parse nodes.yaml
+          ansible.builtin.set_fact:
+            parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+
+        - name: Build all_upgrade_nodes list
+          ansible.builtin.set_fact:
+            all_upgrade_nodes: >-
+              {{ (parsed_nodes.nodes
+                 | selectattr('group', 'equalto', 'service_kube_control_plane_first_x86_64')
+                 | map(attribute='name') | list) +
+                 (parsed_nodes.nodes
+                 | selectattr('group', 'equalto', 'service_kube_control_plane_x86_64')
+                 | map(attribute='name') | list) +
+                 (parsed_nodes.nodes
+                 | selectattr('group', 'equalto', 'service_kube_node_x86_64')
+                 | map(attribute='name') | list) }}
 
     - name: Get k8s_from_version from status file
       ansible.builtin.slurp:

--- a/upgrade/playbooks/upgrade_k8s.yml
+++ b/upgrade/playbooks/upgrade_k8s.yml
@@ -632,7 +632,6 @@
   connection: local
   gather_facts: false
   vars:
-    input_project_dir: "/opt/omnia/input/project_default"
     nodes_yaml_path: "/opt/omnia/openchami/workdir/nodes/nodes.yaml"
     group_cp_first: "service_kube_control_plane_first_x86_64"
     group_cp: "service_kube_control_plane_x86_64"

--- a/upgrade/playbooks/upgrade_k8s.yml
+++ b/upgrade/playbooks/upgrade_k8s.yml
@@ -711,55 +711,16 @@
         parsed_nodes: "{{ hostvars['localhost']['validated_parsed_nodes'] }}"
       when: hostvars['localhost']['cluster_validation_completed'] | default(false)
 
-    - name: "Fallback - Read nodes.yaml if validation was skipped"
+    - name: "Run cluster validation if not already done"
       when: not (hostvars['localhost']['cluster_validation_completed'] | default(false))
       block:
-        - name: Read nodes.yaml
-          ansible.builtin.slurp:
-            src: "{{ nodes_yaml_path }}"
-          register: nodes_slurp
-          changed_when: false
+        - name: "Load upgrade role variables for validation"
+          ansible.builtin.include_vars:
+            file: "{{ playbook_dir }}/../roles/upgrade_k8s/vars/main.yml"
 
-        - name: Parse nodes.yaml
-          ansible.builtin.set_fact:
-            parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
-
-        - name: Build node lists by role
-          ansible.builtin.set_fact:
-            groups_cp_first: >-
-              {{ parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_cp_first)
-                 | map(attribute='name') | list }}
-            groups_cp: >-
-              {{ parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_cp)
-                 | map(attribute='name') | list }}
-            groups_worker: >-
-              {{ parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_worker)
-                 | map(attribute='name') | list }}
-            all_upgrade_nodes: >-
-              {{ (parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_cp_first)
-                 | map(attribute='name') | list) +
-                 (parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_cp)
-                 | map(attribute='name') | list) +
-                 (parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_worker)
-                 | map(attribute='name') | list) }}
-
-        - name: Build node IP map
-          ansible.builtin.set_fact:
-            node_ips: >-
-              {{ node_ips | default({}) | combine({
-                   item.name: (item.interfaces | first).ip_addrs
-                              | selectattr('name', 'equalto', 'management')
-                              | map(attribute='ip_addr') | first
-                 }) }}
-          loop: "{{ parsed_nodes.nodes }}"
-          loop_control:
-            label: "{{ item.name }}"
+        - name: "Run cluster node validation"
+          ansible.builtin.include_tasks:
+            file: "{{ playbook_dir }}/../roles/upgrade_k8s/tasks/validate_cluster_nodes.yml"
 
     - name: Load variables from file
       ansible.builtin.include_vars:
@@ -977,39 +938,16 @@
         node_ips: "{{ hostvars['localhost']['validated_node_ips'] }}"
       when: hostvars['localhost']['cluster_validation_completed'] | default(false)
 
-    - name: "Fallback - Read nodes.yaml if validation was skipped"
+    - name: "Run cluster validation if not already done"
       when: not (hostvars['localhost']['cluster_validation_completed'] | default(false))
       block:
-        - name: Read nodes.yaml
-          ansible.builtin.slurp:
-            src: "{{ nodes_yaml_path }}"
-          register: nodes_slurp
-          changed_when: false
+        - name: "Load upgrade role variables for validation"
+          ansible.builtin.include_vars:
+            file: "{{ playbook_dir }}/../roles/upgrade_k8s/vars/main.yml"
 
-        - name: Parse nodes.yaml
-          ansible.builtin.set_fact:
-            parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
-
-        - name: Build first control plane list
-          ansible.builtin.set_fact:
-            groups_cp_first: >-
-              {{ parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_cp_first)
-                 | map(attribute='name') | list }}
-
-        - name: Build additional control plane list
-          ansible.builtin.set_fact:
-            groups_cp: >-
-              {{ parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_cp)
-                 | map(attribute='name') | list }}
-
-        - name: Build worker list
-          ansible.builtin.set_fact:
-            groups_worker: >-
-              {{ parsed_nodes.nodes
-                 | selectattr('group', 'equalto', group_worker)
-                 | map(attribute='name') | list }}
+        - name: "Run cluster node validation"
+          ansible.builtin.include_tasks:
+            file: "{{ playbook_dir }}/../roles/upgrade_k8s/tasks/validate_cluster_nodes.yml"
 
     - name: Add first control plane to inventory
       ansible.builtin.add_host:
@@ -1566,30 +1504,20 @@
         all_upgrade_nodes: "{{ hostvars['localhost']['validated_all_upgrade_nodes'] }}"
       when: hostvars['localhost']['cluster_validation_completed'] | default(false)
 
-    - name: "Fallback - Read nodes.yaml for all_upgrade_nodes if validation was skipped"
+    - name: "Run cluster validation if not already done"
       when: not (hostvars['localhost']['cluster_validation_completed'] | default(false))
       block:
-        - name: Read nodes.yaml for all_upgrade_nodes
-          ansible.builtin.slurp:
-            src: "/opt/omnia/openchami/workdir/nodes/nodes.yaml"
-          register: nodes_slurp
+        - name: "Load upgrade role variables for validation"
+          ansible.builtin.include_vars:
+            file: "{{ playbook_dir }}/../roles/upgrade_k8s/vars/main.yml"
 
-        - name: Parse nodes.yaml
-          ansible.builtin.set_fact:
-            parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+        - name: "Run cluster node validation"
+          ansible.builtin.include_tasks:
+            file: "{{ playbook_dir }}/../roles/upgrade_k8s/tasks/validate_cluster_nodes.yml"
 
-        - name: Build all_upgrade_nodes list
+        - name: "Set all_upgrade_nodes from validation"
           ansible.builtin.set_fact:
-            all_upgrade_nodes: >-
-              {{ (parsed_nodes.nodes
-                 | selectattr('group', 'equalto', 'service_kube_control_plane_first_x86_64')
-                 | map(attribute='name') | list) +
-                 (parsed_nodes.nodes
-                 | selectattr('group', 'equalto', 'service_kube_control_plane_x86_64')
-                 | map(attribute='name') | list) +
-                 (parsed_nodes.nodes
-                 | selectattr('group', 'equalto', 'service_kube_node_x86_64')
-                 | map(attribute='name') | list) }}
+            all_upgrade_nodes: "{{ groups_cp_first + groups_cp + groups_worker }}"
 
     - name: Get k8s_from_version from status file
       ansible.builtin.slurp:

--- a/upgrade/playbooks/upgrade_oim.yml
+++ b/upgrade/playbooks/upgrade_oim.yml
@@ -76,7 +76,7 @@
       block:
         - name: Upgrade OpenCHAMI containers and services
           ansible.builtin.include_role:
-            name: ../roles/upgrade_openchami
+            name: "{{ playbook_dir }}/../roles/upgrade_openchami"
 
         - name: Display OpenCHAMI upgrade outcome
           ansible.builtin.debug:

--- a/upgrade/playbooks/upgrade_provision.yml
+++ b/upgrade/playbooks/upgrade_provision.yml
@@ -153,13 +153,13 @@
 
     - name: Include required input to resolve kube_vip
       ansible.builtin.include_role:
-        name: ../roles/upgrade_telemetry
+        name: "{{ playbook_dir }}/../roles/upgrade_telemetry"
         tasks_from: include_required_input.yml
       when: k8s_configured | default(false) | bool
 
     - name: Backup telemetry scripts before provisioning target version
       ansible.builtin.include_role:
-        name: ../roles/upgrade_telemetry
+        name: "{{ playbook_dir }}/../roles/upgrade_telemetry"
         tasks_from: backup_telemetry.yml
       when: k8s_configured | default(false) | bool
 

--- a/upgrade/playbooks/upgrade_slurm.yml
+++ b/upgrade/playbooks/upgrade_slurm.yml
@@ -246,7 +246,7 @@
 
     - name: Include slurm upgrade role
       ansible.builtin.include_role:
-        name: ../roles/upgrade_slurm
+        name: "{{ playbook_dir }}/../roles/upgrade_slurm"
       tags: slurm
 
     - name: Update cloud-init and BSS for slurm

--- a/upgrade/playbooks/upgrade_telemetry.yml
+++ b/upgrade/playbooks/upgrade_telemetry.yml
@@ -137,7 +137,7 @@
       block:
         - name: Invoke upgrade_telemetry role
           ansible.builtin.include_role:
-            name: ../roles/upgrade_telemetry
+            name: "{{ playbook_dir }}/../roles/upgrade_telemetry"
 
         - name: Mark telemetry upgrade as completed
           ansible.builtin.copy:

--- a/upgrade/roles/upgrade_k8s/tasks/load_status.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/load_status.yml
@@ -42,55 +42,26 @@
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     groups: kube_vip_group
 
-# ── Read nodes.yaml for inventory ──────────────────────────────────
-- name: Read nodes.yaml
-  ansible.builtin.slurp:
-    src: "{{ nodes_yaml_path }}"
-  register: nodes_slurp
-  changed_when: false
+# ══════════════════════════════════════════════════════════════════════════════
+# Validated nodes from validate_cluster_nodes.yml are used
+# The following variables should already be set:
+#   - groups_cp_first, groups_cp, groups_worker
+#   - all_upgrade_nodes
+#   - node_ips
+# ══════════════════════════════════════════════════════════════════════════════
 
-- name: Parse nodes.yaml
-  ansible.builtin.set_fact:
-    parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
-
-# ── Build node lists by role ────────────────────────────────────────
-- name: Build first control plane list
-  ansible.builtin.set_fact:
-    groups_cp_first: >-
-      {{ parsed_nodes.nodes
-         | selectattr('group', 'equalto', group_cp_first)
-         | map(attribute='name') | list }}
-
-- name: Build additional control plane list
-  ansible.builtin.set_fact:
-    groups_cp: >-
-      {{ parsed_nodes.nodes
-         | selectattr('group', 'equalto', group_cp)
-         | map(attribute='name') | list }}
-
-- name: Build worker list
-  ansible.builtin.set_fact:
-    groups_worker: >-
-      {{ parsed_nodes.nodes
-         | selectattr('group', 'equalto', group_worker)
-         | map(attribute='name') | list }}
-
-- name: Build all nodes list
-  ansible.builtin.set_fact:
-    all_upgrade_nodes: "{{ groups_cp_first + groups_cp + groups_worker }}"
-
-# ── Build node IP map ───────────────────────────────────────────────
-- name: Build node name-to-IP mapping
-  ansible.builtin.set_fact:
-    node_ips: >-
-      {{ node_ips | default({}) | combine({
-           item.name: (item.interfaces | first).ip_addrs
-                      | selectattr('name', 'equalto', 'management')
-                      | map(attribute='ip_addr') | first
-         }) }}
-  loop: "{{ parsed_nodes.nodes }}"
-  loop_control:
-    label: "{{ item.name }}"
+- name: Verify cluster validation was completed
+  ansible.builtin.assert:
+    that:
+      - cluster_validation_completed | default(false)
+      - all_upgrade_nodes is defined
+      - all_upgrade_nodes | length > 0
+      - node_ips is defined
+    fail_msg: |
+      Cluster validation was not completed or no validated nodes found.
+      Please ensure validate_cluster_nodes.yml runs before load_status.yml.
+      Variables required: cluster_validation_completed, all_upgrade_nodes, node_ips
+    success_msg: "Using {{ all_upgrade_nodes | length }} validated nodes from cluster validation"
 
 # ── Add all nodes to Ansible inventory ──────────────────────────────
 - name: Add K8s nodes to inventory

--- a/upgrade/roles/upgrade_k8s/tasks/load_status.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/load_status.yml
@@ -43,25 +43,22 @@
     groups: kube_vip_group
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Validated nodes from validate_cluster_nodes.yml are used
-# The following variables should already be set:
-#   - groups_cp_first, groups_cp, groups_worker
-#   - all_upgrade_nodes
-#   - node_ips
+# Use validated nodes if available, otherwise run validation
 # ══════════════════════════════════════════════════════════════════════════════
 
-- name: Verify cluster validation was completed
-  ansible.builtin.assert:
-    that:
-      - cluster_validation_completed | default(false)
-      - all_upgrade_nodes is defined
-      - all_upgrade_nodes | length > 0
-      - node_ips is defined
-    fail_msg: |
-      Cluster validation was not completed or no validated nodes found.
-      Please ensure validate_cluster_nodes.yml runs before load_status.yml.
-      Variables required: cluster_validation_completed, all_upgrade_nodes, node_ips
-    success_msg: "Using {{ all_upgrade_nodes | length }} validated nodes from cluster validation"
+- name: Check if validated nodes are available
+  ansible.builtin.debug:
+    msg: "Using {{ all_upgrade_nodes | length }} validated nodes"
+  when:
+    - all_upgrade_nodes is defined
+    - all_upgrade_nodes | length > 0
+    - node_ips is defined
+
+- name: Run cluster validation if nodes not available
+  when: all_upgrade_nodes is not defined or (all_upgrade_nodes | length == 0) or node_ips is not defined
+  block:
+    - name: "Run cluster node validation"
+      ansible.builtin.include_tasks: validate_cluster_nodes.yml
 
 # ── Add all nodes to Ansible inventory ──────────────────────────────
 - name: Add K8s nodes to inventory

--- a/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
@@ -260,8 +260,11 @@
 
       Nodes with SSH accessible: {{ all_validated_nodes | difference(ssh_failed_nodes) | length }}
       Nodes with SSH failed: {{ ssh_failed_nodes | length }}
-      {% if ssh_failed_nodes | length > 0 %}  Failed nodes: {{ ssh_failed_nodes | join(', ') }}{% else %}  (none){% endif %}
-
+      {% if ssh_failed_nodes | length > 0 %}
+      Failed nodes: {{ ssh_failed_nodes | join(', ') }}
+      {% else %}
+        (all nodes accessible)
+      {% endif %}
       ════════════════════════════════════════════════════════════════════════════════
 
 - name: Fail if any node has SSH connectivity failure
@@ -329,8 +332,11 @@
 
       Nodes in Ready state: {{ all_validated_nodes | difference(validated_nodes_not_ready) | length }}
       Nodes NOT Ready: {{ validated_nodes_not_ready | length }}
-      {% if validated_nodes_not_ready | length > 0 %}  Not Ready nodes: {{ validated_nodes_not_ready | join(', ') }}{% else %}  (none){% endif %}
-
+      {% if validated_nodes_not_ready | length > 0 %}
+      Not Ready nodes: {{ validated_nodes_not_ready | join(', ') }}
+      {% else %}
+        (all nodes ready)
+      {% endif %}
       ════════════════════════════════════════════════════════════════════════════════
 
 - name: Fail if any validated node is not Ready
@@ -426,10 +432,13 @@
       Total pods in cluster: {{ total_pods }}
       Healthy pods: {{ healthy_pods }}
       Unhealthy pods: {{ all_unhealthy_pods | length }}
-
-      {% if all_unhealthy_pods | length > 0 %}Problem pods (namespace/name):
+      {% if all_unhealthy_pods | length > 0 %}
+      Problem pods (namespace/name):
       {% for pod in all_unhealthy_pods %}  - {{ pod }}
-      {% endfor %}{% else %}  (none){% endif %}
+      {% endfor %}
+      {% else %}
+        (all pods healthy)
+      {% endif %}
       ════════════════════════════════════════════════════════════════════════════════
 
 - name: Fail if any pods are not healthy

--- a/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
@@ -148,31 +148,50 @@
   ansible.builtin.set_fact:
     has_discrepancies: "{{ (nodes_only_in_yaml | length > 0) or (nodes_only_in_cluster | length > 0) }}"
 
+# ── Build validation display lines ───────────────────────────────────
+- name: Build IP mapping display lines
+  ansible.builtin.set_fact:
+    ip_mapping_lines: []
+
+- name: Add IP mapping lines
+  ansible.builtin.set_fact:
+    ip_mapping_lines: "{{ ip_mapping_lines + ['  - ' + item + ': ' + nodes_yaml_ips[item]] }}"
+  loop: "{{ all_expected_nodes }}"
+
+- name: Build matched nodes display lines
+  ansible.builtin.set_fact:
+    matched_nodes_lines: []
+
+- name: Add matched nodes lines
+  ansible.builtin.set_fact:
+    matched_nodes_lines: "{{ matched_nodes_lines + ['  - ' + item + ' -> ' + nodes_yaml_ips[item]] }}"
+  loop: "{{ nodes_in_both }}"
+
 # ── Display validation results ───────────────────────────────────────
 - name: Display cluster node validation results
   ansible.builtin.debug:
     msg: "{{ validation_banner }}"
   vars:
-    validation_banner: |
-      ════════════════════════════════════════════════════════════════════════════════
-      [UPGRADE] CLUSTER NODE VALIDATION
-      ════════════════════════════════════════════════════════════════════════════════
-
-      Expected nodes from nodes.yaml: {{ all_expected_nodes | length }}
-        - Control plane (first): {{ expected_cp_first | join(', ') | default('none', true) }}
-        - Control plane (additional): {{ expected_cp | join(', ') | default('none', true) }}
-        - Workers: {{ expected_workers | join(', ') | default('none', true) }}
-
-      nodes.yaml IP mappings:
-      {% for node in all_expected_nodes %}  - {{ node }}: {{ nodes_yaml_ips[node] }}
-      {% endfor %}
-      Actual nodes in cluster (by IP): {{ cluster_all_nodes | length }}
-        - Cluster IPs: {{ cluster_all_nodes | join(', ') | default('none', true) }}
-
-      Matched nodes (nodes.yaml hostname -> cluster IP): {{ nodes_in_both | length }}
-      {% for node in nodes_in_both %}  - {{ node }} -> {{ nodes_yaml_ips[node] }}
-      {% endfor %}
-      ════════════════════════════════════════════════════════════════════════════════
+    validation_banner: >-
+      {{
+        ['════════════════════════════════════════════════════════════════════════════════',
+         '[UPGRADE] CLUSTER NODE VALIDATION',
+         '════════════════════════════════════════════════════════════════════════════════',
+         '',
+         'Expected nodes from nodes.yaml: ' ~ (all_expected_nodes | length),
+         '  - Control plane (first): ' ~ (expected_cp_first | join(', ') | default('none', true)),
+         '  - Control plane (additional): ' ~ (expected_cp | join(', ') | default('none', true)),
+         '  - Workers: ' ~ (expected_workers | join(', ') | default('none', true)),
+         '',
+         'nodes.yaml IP mappings:']
+        + ip_mapping_lines
+        + ['Actual nodes in cluster (by IP): ' ~ (cluster_all_nodes | length),
+           '  - Cluster IPs: ' ~ (cluster_all_nodes | join(', ') | default('none', true)),
+           '',
+           'Matched nodes (nodes.yaml hostname -> cluster IP): ' ~ (nodes_in_both | length)]
+        + matched_nodes_lines
+        + ['════════════════════════════════════════════════════════════════════════════════']
+      }}
 
 - name: Display discrepancy warning
   ansible.builtin.debug:
@@ -251,21 +270,15 @@
 
 - name: Display SSH check results
   ansible.builtin.debug:
-    msg: "{{ ssh_results_banner }}"
-  vars:
-    ssh_results_banner: |
-      ════════════════════════════════════════════════════════════════════════════════
-      [SSH] CONNECTIVITY CHECK RESULTS
-      ════════════════════════════════════════════════════════════════════════════════
-
-      Nodes with SSH accessible: {{ all_validated_nodes | difference(ssh_failed_nodes) | length }}
-      Nodes with SSH failed: {{ ssh_failed_nodes | length }}
-      {% if ssh_failed_nodes | length > 0 %}
-      Failed nodes: {{ ssh_failed_nodes | join(', ') }}
-      {% else %}
-        (all nodes accessible)
-      {% endif %}
-      ════════════════════════════════════════════════════════════════════════════════
+    msg:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[SSH] CONNECTIVITY CHECK RESULTS"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Nodes with SSH accessible: {{ all_validated_nodes | difference(ssh_failed_nodes) | length }}"
+      - "Nodes with SSH failed: {{ ssh_failed_nodes | length }}"
+      - "{{ 'Failed nodes: ' + (ssh_failed_nodes | join(', ')) if ssh_failed_nodes | length > 0 else '  (all nodes accessible)' }}"
+      - "════════════════════════════════════════════════════════════════════════════════"
 
 - name: Fail if any node has SSH connectivity failure
   ansible.builtin.fail:
@@ -323,21 +336,15 @@
 
 - name: Display node Ready status results
   ansible.builtin.debug:
-    msg: "{{ ready_status_banner }}"
-  vars:
-    ready_status_banner: |
-      ════════════════════════════════════════════════════════════════════════════════
-      [NODE STATUS] READY CHECK RESULTS
-      ════════════════════════════════════════════════════════════════════════════════
-
-      Nodes in Ready state: {{ all_validated_nodes | difference(validated_nodes_not_ready) | length }}
-      Nodes NOT Ready: {{ validated_nodes_not_ready | length }}
-      {% if validated_nodes_not_ready | length > 0 %}
-      Not Ready nodes: {{ validated_nodes_not_ready | join(', ') }}
-      {% else %}
-        (all nodes ready)
-      {% endif %}
-      ════════════════════════════════════════════════════════════════════════════════
+    msg:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[NODE STATUS] READY CHECK RESULTS"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Nodes in Ready state: {{ all_validated_nodes | difference(validated_nodes_not_ready) | length }}"
+      - "Nodes NOT Ready: {{ validated_nodes_not_ready | length }}"
+      - "{{ 'Not Ready nodes: ' + (validated_nodes_not_ready | join(', ')) if validated_nodes_not_ready | length > 0 else '  (all nodes ready)' }}"
+      - "════════════════════════════════════════════════════════════════════════════════"
 
 - name: Fail if any validated node is not Ready
   ansible.builtin.fail:
@@ -409,11 +416,19 @@
   register: total_pods_count
   changed_when: false
 
+- name: Parse unhealthy pods from output
+  ansible.builtin.set_fact:
+    all_unhealthy_pods: []
+
 - name: Build unhealthy pods list
   ansible.builtin.set_fact:
     all_unhealthy_pods: >-
-      {{ unhealthy_pods_check.stdout_lines | default([]) | select('match', '.+') |
-         map('regex_replace', '(.+)\\|(.+)\\|(.+)', '\\1/\\2 (\\3)') | list }}
+      {{ all_unhealthy_pods + [item.split('|')[0] + '/' + item.split('|')[1] + ' (' + item.split('|')[2] + ')'] }}
+  loop: "{{ unhealthy_pods_check.stdout_lines | default([]) | select('match', '.+') | list }}"
+  when: "'|' in item"
+
+- name: Set total pods count
+  ansible.builtin.set_fact:
     total_pods: "{{ total_pods_count.stdout | trim }}"
 
 - name: Count healthy pods
@@ -424,22 +439,20 @@
   ansible.builtin.debug:
     msg: "{{ pod_health_banner }}"
   vars:
-    pod_health_banner: |
-      ════════════════════════════════════════════════════════════════════════════════
-      [POD STATUS] CLUSTER-WIDE HEALTH CHECK
-      ════════════════════════════════════════════════════════════════════════════════
-
-      Total pods in cluster: {{ total_pods }}
-      Healthy pods: {{ healthy_pods }}
-      Unhealthy pods: {{ all_unhealthy_pods | length }}
-      {% if all_unhealthy_pods | length > 0 %}
-      Problem pods (namespace/name):
-      {% for pod in all_unhealthy_pods %}  - {{ pod }}
-      {% endfor %}
-      {% else %}
-        (all pods healthy)
-      {% endif %}
-      ════════════════════════════════════════════════════════════════════════════════
+    pod_health_banner: >-
+      {{
+        ['════════════════════════════════════════════════════════════════════════════════',
+         '[POD STATUS] CLUSTER-WIDE HEALTH CHECK',
+         '════════════════════════════════════════════════════════════════════════════════',
+         '',
+         'Total pods in cluster: ' + (total_pods | string),
+         'Healthy pods: ' + (healthy_pods | string),
+         'Unhealthy pods: ' + (all_unhealthy_pods | length | string)]
+        + (['Problem pods (namespace/name):'] + (all_unhealthy_pods | map('regex_replace', '^', '  - ') | list)
+           if all_unhealthy_pods | length > 0
+           else ['  (all pods healthy)'])
+        + ['════════════════════════════════════════════════════════════════════════════════']
+      }}
 
 - name: Fail if any pods are not healthy
   ansible.builtin.fail:
@@ -485,28 +498,52 @@
       ════════════════════════════════════════════════════════════════════════════════
   when: validated_cp_first | length == 0
 
+# ── Build inventory summary node lines ────────────────────────────────
+- name: Build inventory node display lines
+  ansible.builtin.set_fact:
+    inv_cp_first_lines: "{{ validated_cp_first | map('regex_replace', '^(.*)$', '  - \\1') | list }}"
+    inv_cp_lines: "{{ validated_cp | map('regex_replace', '^(.*)$', '  - \\1') | list }}"
+    inv_worker_lines: "{{ validated_workers | map('regex_replace', '^(.*)$', '  - \\1') | list }}"
+
+- name: Add IPs to control plane first lines
+  ansible.builtin.set_fact:
+    inv_cp_first_display: >-
+      {{ inv_cp_first_display | default([]) + ['  - ' + item + ' (' + nodes_yaml_ips[item] + ')'] }}
+  loop: "{{ validated_cp_first }}"
+
+- name: Add IPs to control plane additional lines
+  ansible.builtin.set_fact:
+    inv_cp_display: >-
+      {{ inv_cp_display | default([]) + ['  - ' + item + ' (' + nodes_yaml_ips[item] + ')'] }}
+  loop: "{{ validated_cp }}"
+
+- name: Add IPs to worker lines
+  ansible.builtin.set_fact:
+    inv_worker_display: >-
+      {{ inv_worker_display | default([]) + ['  - ' + item + ' (' + nodes_yaml_ips[item] + ')'] }}
+  loop: "{{ validated_workers }}"
+
 # ── Display upgrade inventory summary ────────────────────────────────
 - name: Display upgrade inventory summary
   ansible.builtin.debug:
-    msg: "{{ inventory_banner }}"
+    msg: "{{ inventory_summary }}"
   vars:
-    inventory_banner: |
-      ════════════════════════════════════════════════════════════════════════════════
-      [UPGRADE] PROCEEDING WITH THE FOLLOWING NODES
-      ════════════════════════════════════════════════════════════════════════════════
-
-      Total nodes for upgrade: {{ all_validated_nodes | length }}
-
-      Control plane (first): {{ validated_cp_first | length }} node(s)
-      {% for node in validated_cp_first %}  - {{ node }} ({{ nodes_yaml_ips[node] }})
-      {% endfor %}
-      Control plane (additional): {{ validated_cp | length }} node(s)
-      {% for node in validated_cp %}  - {{ node }} ({{ nodes_yaml_ips[node] }})
-      {% endfor %}
-      Workers: {{ validated_workers | length }} node(s)
-      {% for node in validated_workers %}  - {{ node }} ({{ nodes_yaml_ips[node] }})
-      {% endfor %}
-      ════════════════════════════════════════════════════════════════════════════════
+    inventory_summary: >-
+      {{
+        ['════════════════════════════════════════════════════════════════════════════════',
+         '[UPGRADE] PROCEEDING WITH THE FOLLOWING NODES',
+         '════════════════════════════════════════════════════════════════════════════════',
+         '',
+         'Total nodes for upgrade: ' ~ (all_validated_nodes | length),
+         '',
+         'Control plane (first): ' ~ (validated_cp_first | length) ~ ' node(s)']
+        + (inv_cp_first_display | default([]))
+        + ['Control plane (additional): ' ~ (validated_cp | length) ~ ' node(s)']
+        + (inv_cp_display | default(['  (none)']) if validated_cp | length > 0 else ['  (none)'])
+        + ['Workers: ' ~ (validated_workers | length) ~ ' node(s)']
+        + (inv_worker_display | default(['  (none)']) if validated_workers | length > 0 else ['  (none)'])
+        + ['════════════════════════════════════════════════════════════════════════════════']
+      }}
 
 # ── Pause to allow user to review discrepancies ──────────────────────
 - name: Display proceeding message with discrepancies

--- a/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
@@ -68,7 +68,9 @@
 - name: Get actual cluster nodes with roles
   ansible.builtin.command:
     cmd: >-
-      kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.node-role\.kubernetes\.io/control-plane}|{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}'
+      kubectl get nodes
+      -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.node-role\.kubernetes\.io/control-plane}|
+      {.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}'
   delegate_to: "{{ kube_vip }}"
   register: cluster_nodes_raw
   changed_when: false
@@ -117,7 +119,7 @@
 - name: Find nodes in nodes.yaml but NOT in cluster (by IP)
   ansible.builtin.set_fact:
     nodes_only_in_yaml: >-
-      {{ all_expected_nodes | select('in', 
+      {{ all_expected_nodes | select('in',
            (nodes_yaml_ips | dict2items | rejectattr('value', 'in', cluster_ip_list) | map(attribute='key') | list)
          ) | list }}
 
@@ -243,11 +245,11 @@
       ════════════════════════════════════════════════════════════════════════════════
       [SSH] CONNECTIVITY CHECK RESULTS
       ════════════════════════════════════════════════════════════════════════════════
-      
+
       Nodes with SSH accessible: {{ all_validated_nodes | difference(ssh_failed_nodes) | length }}
       Nodes with SSH failed: {{ ssh_failed_nodes | length }}
       {% if ssh_failed_nodes | length > 0 %}  Failed nodes: {{ ssh_failed_nodes | join(', ') }}{% else %}  (none){% endif %}
-      
+
       ════════════════════════════════════════════════════════════════════════════════
 
 - name: Fail if any node has SSH connectivity failure
@@ -312,11 +314,11 @@
       ════════════════════════════════════════════════════════════════════════════════
       [NODE STATUS] READY CHECK RESULTS
       ════════════════════════════════════════════════════════════════════════════════
-      
+
       Nodes in Ready state: {{ all_validated_nodes | difference(validated_nodes_not_ready) | length }}
       Nodes NOT Ready: {{ validated_nodes_not_ready | length }}
       {% if validated_nodes_not_ready | length > 0 %}  Not Ready nodes: {{ validated_nodes_not_ready | join(', ') }}{% else %}  (none){% endif %}
-      
+
       ════════════════════════════════════════════════════════════════════════════════
 
 - name: Fail if any validated node is not Ready
@@ -359,7 +361,10 @@
 - name: Get all pods status across all namespaces
   ansible.builtin.shell:
     cmd: |
-      kubectl get pods --all-namespaces --no-headers -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,READY:.status.containerStatuses[*].ready' 2>/dev/null | \
+      set -o pipefail
+      kubectl get pods --all-namespaces --no-headers \
+        -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,READY:.status.containerStatuses[*].ready' \
+        2>/dev/null | \
       while read ns name phase ready; do
         # Healthy: Running with all containers ready, or Succeeded (completed)
         if [[ "$phase" == "Running" && "$ready" == *"false"* ]]; then
@@ -368,13 +373,20 @@
           echo "$ns|$name|$phase"
         fi
       done
+  args:
+    executable: /bin/bash
   delegate_to: "{{ kube_vip }}"
   register: unhealthy_pods_check
   changed_when: false
+  failed_when: false
 
 - name: Get total pod count
   ansible.builtin.shell:
-    cmd: kubectl get pods --all-namespaces --no-headers | wc -l
+    cmd: |
+      set -o pipefail
+      kubectl get pods --all-namespaces --no-headers | wc -l
+  args:
+    executable: /bin/bash
   delegate_to: "{{ kube_vip }}"
   register: total_pods_count
   changed_when: false
@@ -382,7 +394,7 @@
 - name: Build unhealthy pods list
   ansible.builtin.set_fact:
     all_unhealthy_pods: >-
-      {{ unhealthy_pods_check.stdout_lines | default([]) | select('match', '.+') | 
+      {{ unhealthy_pods_check.stdout_lines | default([]) | select('match', '.+') |
          map('regex_replace', '(.+)\\|(.+)\\|(.+)', '\\1/\\2 (\\3)') | list }}
     total_pods: "{{ total_pods_count.stdout | trim }}"
 
@@ -398,11 +410,11 @@
       ════════════════════════════════════════════════════════════════════════════════
       [POD STATUS] CLUSTER-WIDE HEALTH CHECK
       ════════════════════════════════════════════════════════════════════════════════
-      
+
       Total pods in cluster: {{ total_pods }}
       Healthy pods: {{ healthy_pods }}
       Unhealthy pods: {{ all_unhealthy_pods | length }}
-      
+
       {% if all_unhealthy_pods | length > 0 %}Problem pods (namespace/name):
       {% for pod in all_unhealthy_pods %}  - {{ pod }}
       {% endfor %}{% else %}  (none){% endif %}

--- a/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
@@ -65,12 +65,12 @@
     label: "{{ item.name }}"
 
 # ── Query actual cluster nodes ───────────────────────────────────────
+# Cluster nodes are typically named by their IP addresses (e.g., 10.60.0.101)
 - name: Get actual cluster nodes with roles
   ansible.builtin.command:
     cmd: >-
       kubectl get nodes
-      -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.node-role\.kubernetes\.io/control-plane}|
-      {.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}'
+      -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.node-role\.kubernetes\.io/control-plane}{"\n"}{end}'
   delegate_to: "{{ kube_vip }}"
   register: cluster_nodes_raw
   changed_when: false
@@ -80,8 +80,7 @@
     cluster_nodes_parsed: >-
       {{ cluster_nodes_parsed | default([]) + [{
            'name': item.split('|')[0],
-           'is_control_plane': (item.split('|')[1] | default('') | length > 0),
-           'ip': item.split('|')[2] | default('')
+           'is_control_plane': (item.split('|')[1] | default('') | length > 0)
          }] }}
   loop: "{{ cluster_nodes_raw.stdout_lines | select('match', '.+') | list }}"
   loop_control:
@@ -96,46 +95,54 @@
     cluster_all_nodes: >-
       {{ cluster_nodes_parsed | map(attribute='name') | list }}
 
-- name: Build cluster node IP map
-  ansible.builtin.set_fact:
-    cluster_node_ips: >-
-      {{ cluster_node_ips | default({}) | combine({
-           item.name: item.ip
-         }) }}
-  loop: "{{ cluster_nodes_parsed }}"
-  loop_control:
-    label: "{{ item.name }}"
+# ══════════════════════════════════════════════════════════════════════════════
+# Compare nodes.yaml with cluster nodes
+# ══════════════════════════════════════════════════════════════════════════════
+# nodes.yaml has: hostname -> IP mapping (e.g., kcp1 -> 10.60.0.102)
+# Cluster has: node names which ARE the IPs (e.g., 10.60.0.102)
+# So we compare nodes_yaml IPs against cluster node names (which are IPs)
 
-# ── Compare nodes.yaml with cluster by IP address ────────────────────
-# Cluster nodes may be named by IP or hostname, so compare using IPs
 - name: Build IP list from nodes.yaml
   ansible.builtin.set_fact:
     nodes_yaml_ip_list: "{{ nodes_yaml_ips.values() | list }}"
 
-- name: Build IP list from cluster
+# cluster_all_nodes contains IPs (since nodes are named by IP)
+- name: Build IP list from cluster (node names are IPs)
   ansible.builtin.set_fact:
-    cluster_ip_list: "{{ cluster_node_ips.values() | list }}"
+    cluster_ip_list: "{{ cluster_all_nodes }}"
 
+# Find nodes.yaml entries whose IP is NOT in the cluster
 - name: Find nodes in nodes.yaml but NOT in cluster (by IP)
   ansible.builtin.set_fact:
     nodes_only_in_yaml: >-
-      {{ all_expected_nodes | select('in',
-           (nodes_yaml_ips | dict2items | rejectattr('value', 'in', cluster_ip_list) | map(attribute='key') | list)
-         ) | list }}
+      {{ nodes_yaml_ips | dict2items
+         | rejectattr('value', 'in', cluster_ip_list)
+         | map(attribute='key') | list }}
 
+# Find cluster nodes (IPs) that are NOT in nodes.yaml
 - name: Find nodes in cluster but NOT in nodes.yaml (by IP)
   ansible.builtin.set_fact:
     nodes_only_in_cluster: >-
-      {{ cluster_all_nodes | select('in',
-           (cluster_node_ips | dict2items | rejectattr('value', 'in', nodes_yaml_ip_list) | map(attribute='key') | list)
-         ) | list }}
+      {{ cluster_all_nodes | reject('in', nodes_yaml_ip_list) | list }}
 
+# Find nodes.yaml entries whose IP IS in the cluster
 - name: Find nodes present in both (by IP) - get nodes.yaml names
   ansible.builtin.set_fact:
     nodes_in_both: >-
-      {{ all_expected_nodes | select('in',
-           (nodes_yaml_ips | dict2items | selectattr('value', 'in', cluster_ip_list) | map(attribute='key') | list)
-         ) | list }}
+      {{ nodes_yaml_ips | dict2items
+         | selectattr('value', 'in', cluster_ip_list)
+         | map(attribute='key') | list }}
+
+# Build reverse mapping: cluster IP -> nodes.yaml hostname (for display)
+- name: Build IP to hostname mapping
+  ansible.builtin.set_fact:
+    ip_to_hostname: >-
+      {{ ip_to_hostname | default({}) | combine({
+           item.value: item.key
+         }) }}
+  loop: "{{ nodes_yaml_ips | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
 
 - name: Determine if there are discrepancies
   ansible.builtin.set_fact:
@@ -156,9 +163,14 @@
       - "  - Control plane (additional): {{ expected_cp | join(', ') | default('none') }}"
       - "  - Workers: {{ expected_workers | join(', ') | default('none') }}"
       - ""
-      - "Actual nodes in cluster: {{ cluster_all_nodes | length }}"
-      - "  - Control planes: {{ cluster_control_planes | join(', ') | default('none') }}"
-      - "  - Workers: {{ cluster_workers | join(', ') | default('none') }}"
+      - "nodes.yaml IP mappings:"
+      - "{% for node in all_expected_nodes %}  - {{ node }}: {{ nodes_yaml_ips[node] }}\n{% endfor %}"
+      - ""
+      - "Actual nodes in cluster (by IP): {{ cluster_all_nodes | length }}"
+      - "  - Cluster IPs: {{ cluster_all_nodes | join(', ') | default('none') }}"
+      - ""
+      - "Matched nodes (nodes.yaml hostname -> cluster IP): {{ nodes_in_both | length }}"
+      - "{% for node in nodes_in_both %}  - {{ node }} -> {{ nodes_yaml_ips[node] }}\n{% endfor %}"
       - ""
       - "════════════════════════════════════════════════════════════════════════════════"
 

--- a/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
@@ -153,26 +153,26 @@
   ansible.builtin.debug:
     msg: "{{ validation_banner }}"
   vars:
-    validation_banner:
-      - "════════════════════════════════════════════════════════════════════════════════"
-      - "[UPGRADE] CLUSTER NODE VALIDATION"
-      - "════════════════════════════════════════════════════════════════════════════════"
-      - ""
-      - "Expected nodes from nodes.yaml: {{ all_expected_nodes | length }}"
-      - "  - Control plane (first): {{ expected_cp_first | join(', ') | default('none') }}"
-      - "  - Control plane (additional): {{ expected_cp | join(', ') | default('none') }}"
-      - "  - Workers: {{ expected_workers | join(', ') | default('none') }}"
-      - ""
-      - "nodes.yaml IP mappings:"
-      - "{% for node in all_expected_nodes %}  - {{ node }}: {{ nodes_yaml_ips[node] }}\n{% endfor %}"
-      - ""
-      - "Actual nodes in cluster (by IP): {{ cluster_all_nodes | length }}"
-      - "  - Cluster IPs: {{ cluster_all_nodes | join(', ') | default('none') }}"
-      - ""
-      - "Matched nodes (nodes.yaml hostname -> cluster IP): {{ nodes_in_both | length }}"
-      - "{% for node in nodes_in_both %}  - {{ node }} -> {{ nodes_yaml_ips[node] }}\n{% endfor %}"
-      - ""
-      - "════════════════════════════════════════════════════════════════════════════════"
+    validation_banner: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [UPGRADE] CLUSTER NODE VALIDATION
+      ════════════════════════════════════════════════════════════════════════════════
+
+      Expected nodes from nodes.yaml: {{ all_expected_nodes | length }}
+        - Control plane (first): {{ expected_cp_first | join(', ') | default('none', true) }}
+        - Control plane (additional): {{ expected_cp | join(', ') | default('none', true) }}
+        - Workers: {{ expected_workers | join(', ') | default('none', true) }}
+
+      nodes.yaml IP mappings:
+      {% for node in all_expected_nodes %}  - {{ node }}: {{ nodes_yaml_ips[node] }}
+      {% endfor %}
+      Actual nodes in cluster (by IP): {{ cluster_all_nodes | length }}
+        - Cluster IPs: {{ cluster_all_nodes | join(', ') | default('none', true) }}
+
+      Matched nodes (nodes.yaml hostname -> cluster IP): {{ nodes_in_both | length }}
+      {% for node in nodes_in_both %}  - {{ node }} -> {{ nodes_yaml_ips[node] }}
+      {% endfor %}
+      ════════════════════════════════════════════════════════════════════════════════
 
 - name: Display discrepancy warning
   ansible.builtin.debug:
@@ -481,23 +481,23 @@
   ansible.builtin.debug:
     msg: "{{ inventory_banner }}"
   vars:
-    inventory_banner:
-      - "════════════════════════════════════════════════════════════════════════════════"
-      - "[UPGRADE] PROCEEDING WITH THE FOLLOWING NODES"
-      - "════════════════════════════════════════════════════════════════════════════════"
-      - ""
-      - "Total nodes for upgrade: {{ all_validated_nodes | length }}"
-      - ""
-      - "Control plane (first): {{ validated_cp_first | length }} node(s)"
-      - "{% for node in validated_cp_first %}  - {{ node }} ({{ nodes_yaml_ips[node] }})\n{% endfor %}"
-      - ""
-      - "Control plane (additional): {{ validated_cp | length }} node(s)"
-      - "{% for node in validated_cp %}  - {{ node }} ({{ nodes_yaml_ips[node] }})\n{% endfor %}"
-      - ""
-      - "Workers: {{ validated_workers | length }} node(s)"
-      - "{% for node in validated_workers %}  - {{ node }} ({{ nodes_yaml_ips[node] }})\n{% endfor %}"
-      - ""
-      - "════════════════════════════════════════════════════════════════════════════════"
+    inventory_banner: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [UPGRADE] PROCEEDING WITH THE FOLLOWING NODES
+      ════════════════════════════════════════════════════════════════════════════════
+
+      Total nodes for upgrade: {{ all_validated_nodes | length }}
+
+      Control plane (first): {{ validated_cp_first | length }} node(s)
+      {% for node in validated_cp_first %}  - {{ node }} ({{ nodes_yaml_ips[node] }})
+      {% endfor %}
+      Control plane (additional): {{ validated_cp | length }} node(s)
+      {% for node in validated_cp %}  - {{ node }} ({{ nodes_yaml_ips[node] }})
+      {% endfor %}
+      Workers: {{ validated_workers | length }} node(s)
+      {% for node in validated_workers %}  - {{ node }} ({{ nodes_yaml_ips[node] }})
+      {% endfor %}
+      ════════════════════════════════════════════════════════════════════════════════
 
 # ── Pause to allow user to review discrepancies ──────────────────────
 - name: Display proceeding message with discrepancies

--- a/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/validate_cluster_nodes.yml
@@ -1,0 +1,530 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Validate nodes.yaml against actual cluster nodes and build validated inventory
+# This task file:
+# 1. Reads nodes.yaml to get expected nodes
+# 2. Queries the cluster to get actual nodes
+# 3. Compares and shows discrepancies
+# 4. Prompts user for confirmation
+# 5. Builds inventory from actual cluster nodes only
+
+# ── Read nodes.yaml for expected nodes ──────────────────────────────
+- name: Read nodes.yaml
+  ansible.builtin.slurp:
+    src: "{{ nodes_yaml_path }}"
+  register: nodes_slurp
+  changed_when: false
+
+- name: Parse nodes.yaml
+  ansible.builtin.set_fact:
+    parsed_nodes: "{{ nodes_slurp.content | b64decode | from_yaml }}"
+
+# ── Build expected node lists from nodes.yaml ────────────────────────
+- name: Build expected node lists from nodes.yaml
+  ansible.builtin.set_fact:
+    expected_cp_first: >-
+      {{ parsed_nodes.nodes
+         | selectattr('group', 'equalto', group_cp_first)
+         | map(attribute='name') | list }}
+    expected_cp: >-
+      {{ parsed_nodes.nodes
+         | selectattr('group', 'equalto', group_cp)
+         | map(attribute='name') | list }}
+    expected_workers: >-
+      {{ parsed_nodes.nodes
+         | selectattr('group', 'equalto', group_worker)
+         | map(attribute='name') | list }}
+
+- name: Build all expected nodes list
+  ansible.builtin.set_fact:
+    all_expected_nodes: "{{ expected_cp_first + expected_cp + expected_workers }}"
+
+# ── Build node IP map from nodes.yaml ────────────────────────────────
+- name: Build node name-to-IP mapping from nodes.yaml
+  ansible.builtin.set_fact:
+    nodes_yaml_ips: >-
+      {{ nodes_yaml_ips | default({}) | combine({
+           item.name: (item.interfaces | first).ip_addrs
+                      | selectattr('name', 'equalto', 'management')
+                      | map(attribute='ip_addr') | first
+         }) }}
+  loop: "{{ parsed_nodes.nodes }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ── Query actual cluster nodes ───────────────────────────────────────
+- name: Get actual cluster nodes with roles
+  ansible.builtin.command:
+    cmd: >-
+      kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.node-role\.kubernetes\.io/control-plane}|{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}'
+  delegate_to: "{{ kube_vip }}"
+  register: cluster_nodes_raw
+  changed_when: false
+
+- name: Parse cluster nodes
+  ansible.builtin.set_fact:
+    cluster_nodes_parsed: >-
+      {{ cluster_nodes_parsed | default([]) + [{
+           'name': item.split('|')[0],
+           'is_control_plane': (item.split('|')[1] | default('') | length > 0),
+           'ip': item.split('|')[2] | default('')
+         }] }}
+  loop: "{{ cluster_nodes_raw.stdout_lines | select('match', '.+') | list }}"
+  loop_control:
+    label: "{{ item.split('|')[0] }}"
+
+- name: Build cluster node lists by role
+  ansible.builtin.set_fact:
+    cluster_control_planes: >-
+      {{ cluster_nodes_parsed | selectattr('is_control_plane', 'equalto', true) | map(attribute='name') | list }}
+    cluster_workers: >-
+      {{ cluster_nodes_parsed | selectattr('is_control_plane', 'equalto', false) | map(attribute='name') | list }}
+    cluster_all_nodes: >-
+      {{ cluster_nodes_parsed | map(attribute='name') | list }}
+
+- name: Build cluster node IP map
+  ansible.builtin.set_fact:
+    cluster_node_ips: >-
+      {{ cluster_node_ips | default({}) | combine({
+           item.name: item.ip
+         }) }}
+  loop: "{{ cluster_nodes_parsed }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ── Compare nodes.yaml with cluster by IP address ────────────────────
+# Cluster nodes may be named by IP or hostname, so compare using IPs
+- name: Build IP list from nodes.yaml
+  ansible.builtin.set_fact:
+    nodes_yaml_ip_list: "{{ nodes_yaml_ips.values() | list }}"
+
+- name: Build IP list from cluster
+  ansible.builtin.set_fact:
+    cluster_ip_list: "{{ cluster_node_ips.values() | list }}"
+
+- name: Find nodes in nodes.yaml but NOT in cluster (by IP)
+  ansible.builtin.set_fact:
+    nodes_only_in_yaml: >-
+      {{ all_expected_nodes | select('in', 
+           (nodes_yaml_ips | dict2items | rejectattr('value', 'in', cluster_ip_list) | map(attribute='key') | list)
+         ) | list }}
+
+- name: Find nodes in cluster but NOT in nodes.yaml (by IP)
+  ansible.builtin.set_fact:
+    nodes_only_in_cluster: >-
+      {{ cluster_all_nodes | select('in',
+           (cluster_node_ips | dict2items | rejectattr('value', 'in', nodes_yaml_ip_list) | map(attribute='key') | list)
+         ) | list }}
+
+- name: Find nodes present in both (by IP) - get nodes.yaml names
+  ansible.builtin.set_fact:
+    nodes_in_both: >-
+      {{ all_expected_nodes | select('in',
+           (nodes_yaml_ips | dict2items | selectattr('value', 'in', cluster_ip_list) | map(attribute='key') | list)
+         ) | list }}
+
+- name: Determine if there are discrepancies
+  ansible.builtin.set_fact:
+    has_discrepancies: "{{ (nodes_only_in_yaml | length > 0) or (nodes_only_in_cluster | length > 0) }}"
+
+# ── Display validation results ───────────────────────────────────────
+- name: Display cluster node validation results
+  ansible.builtin.debug:
+    msg: "{{ validation_banner }}"
+  vars:
+    validation_banner:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[UPGRADE] CLUSTER NODE VALIDATION"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Expected nodes from nodes.yaml: {{ all_expected_nodes | length }}"
+      - "  - Control plane (first): {{ expected_cp_first | join(', ') | default('none') }}"
+      - "  - Control plane (additional): {{ expected_cp | join(', ') | default('none') }}"
+      - "  - Workers: {{ expected_workers | join(', ') | default('none') }}"
+      - ""
+      - "Actual nodes in cluster: {{ cluster_all_nodes | length }}"
+      - "  - Control planes: {{ cluster_control_planes | join(', ') | default('none') }}"
+      - "  - Workers: {{ cluster_workers | join(', ') | default('none') }}"
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
+
+- name: Display discrepancy warning
+  ansible.builtin.debug:
+    msg: "{{ discrepancy_banner }}"
+  vars:
+    discrepancy_banner:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[WARNING] NODE DISCREPANCIES DETECTED"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Nodes in nodes.yaml but NOT in cluster (will be SKIPPED):"
+      - "  {{ nodes_only_in_yaml | join(', ') | default('none') }}"
+      - ""
+      - "Nodes in cluster but NOT in nodes.yaml (will be SKIPPED - no IP mapping):"
+      - "  {{ nodes_only_in_cluster | join(', ') | default('none') }}"
+      - ""
+      - "Nodes that will be upgraded (present in both):"
+      - "  {{ nodes_in_both | join(', ') }}"
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
+  when: has_discrepancies
+
+- name: Display no discrepancies message
+  ansible.builtin.debug:
+    msg:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[OK] All nodes in nodes.yaml are present in the cluster"
+      - "════════════════════════════════════════════════════════════════════════════════"
+  when: not has_discrepancies
+
+# ── Build validated inventory (only nodes whose IP is in cluster) ────
+- name: Build validated control plane first list
+  ansible.builtin.set_fact:
+    validated_cp_first: >-
+      {{ expected_cp_first | select('in', nodes_in_both) | list }}
+
+- name: Build validated additional control plane list
+  ansible.builtin.set_fact:
+    validated_cp: >-
+      {{ expected_cp | select('in', nodes_in_both) | list }}
+
+- name: Build validated worker list
+  ansible.builtin.set_fact:
+    validated_workers: >-
+      {{ expected_workers | select('in', nodes_in_both) | list }}
+
+- name: Build all validated nodes list
+  ansible.builtin.set_fact:
+    all_validated_nodes: "{{ validated_cp_first + validated_cp + validated_workers }}"
+
+# ── Validate SSH connectivity to all validated nodes ─────────────────
+- name: Display SSH connectivity check message
+  ansible.builtin.debug:
+    msg: "Checking SSH connectivity to {{ all_validated_nodes | length }} validated nodes..."
+
+- name: Check SSH connectivity to all validated nodes
+  ansible.builtin.wait_for:
+    host: "{{ nodes_yaml_ips[item] }}"
+    port: 22
+    timeout: 10
+    state: started
+  loop: "{{ all_validated_nodes }}"
+  loop_control:
+    label: "{{ item }} ({{ nodes_yaml_ips[item] }})"
+  register: ssh_check_results
+  ignore_errors: true
+
+- name: Build list of nodes with SSH failures
+  ansible.builtin.set_fact:
+    ssh_failed_nodes: >-
+      {{ ssh_check_results.results
+         | selectattr('failed', 'defined')
+         | selectattr('failed', 'equalto', true)
+         | map(attribute='item')
+         | list }}
+
+- name: Display SSH check results
+  ansible.builtin.debug:
+    msg: "{{ ssh_results_banner }}"
+  vars:
+    ssh_results_banner: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [SSH] CONNECTIVITY CHECK RESULTS
+      ════════════════════════════════════════════════════════════════════════════════
+      
+      Nodes with SSH accessible: {{ all_validated_nodes | difference(ssh_failed_nodes) | length }}
+      Nodes with SSH failed: {{ ssh_failed_nodes | length }}
+      {% if ssh_failed_nodes | length > 0 %}  Failed nodes: {{ ssh_failed_nodes | join(', ') }}{% else %}  (none){% endif %}
+      
+      ════════════════════════════════════════════════════════════════════════════════
+
+- name: Fail if any node has SSH connectivity failure
+  ansible.builtin.fail:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [ERROR] SSH CONNECTIVITY FAILURE
+      ════════════════════════════════════════════════════════════════════════════════
+      The following nodes failed SSH connectivity check:
+      {% for node in ssh_failed_nodes %}
+        - {{ node }} ({{ nodes_yaml_ips[node] }})
+      {% endfor %}
+
+      Cannot proceed with upgrade. Please ensure:
+        1. All nodes are powered on and accessible
+        2. SSH service is running on all nodes
+        3. Network connectivity exists between control node and target nodes
+        4. SSH keys are properly configured
+
+      Fix the connectivity issues and re-run the upgrade.
+      ════════════════════════════════════════════════════════════════════════════════
+  when: ssh_failed_nodes | length > 0
+
+- name: Display all nodes SSH accessible
+  ansible.builtin.debug:
+    msg: "[OK] SSH connectivity verified for all {{ all_validated_nodes | length }} validated nodes"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Validate all nodes are in Ready state
+# ══════════════════════════════════════════════════════════════════════════════
+- name: Display node Ready status check message
+  ansible.builtin.debug:
+    msg: "Checking all nodes are in Ready state..."
+
+- name: Get node Ready status from cluster
+  ansible.builtin.command:
+    cmd: >-
+      kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}|{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}'
+  delegate_to: "{{ kube_vip }}"
+  register: node_ready_status
+  changed_when: false
+
+- name: Parse node Ready status
+  ansible.builtin.set_fact:
+    nodes_not_ready: >-
+      {{ nodes_not_ready | default([]) + (
+           [item.split('|')[0]] if (item.split('|')[1] | default('False')) != 'True' else []
+         ) }}
+  loop: "{{ node_ready_status.stdout_lines | select('match', '.+') | list }}"
+  loop_control:
+    label: "{{ item.split('|')[0] }}"
+
+- name: Filter not-ready nodes to only validated nodes
+  ansible.builtin.set_fact:
+    validated_nodes_not_ready: "{{ nodes_not_ready | default([]) | intersect(all_validated_nodes) }}"
+
+- name: Display node Ready status results
+  ansible.builtin.debug:
+    msg: "{{ ready_status_banner }}"
+  vars:
+    ready_status_banner: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [NODE STATUS] READY CHECK RESULTS
+      ════════════════════════════════════════════════════════════════════════════════
+      
+      Nodes in Ready state: {{ all_validated_nodes | difference(validated_nodes_not_ready) | length }}
+      Nodes NOT Ready: {{ validated_nodes_not_ready | length }}
+      {% if validated_nodes_not_ready | length > 0 %}  Not Ready nodes: {{ validated_nodes_not_ready | join(', ') }}{% else %}  (none){% endif %}
+      
+      ════════════════════════════════════════════════════════════════════════════════
+
+- name: Fail if any validated node is not Ready
+  ansible.builtin.fail:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [ERROR] NODES NOT IN READY STATE
+      ════════════════════════════════════════════════════════════════════════════════
+      The following nodes are not in Ready state:
+      {% for node in validated_nodes_not_ready %}
+        - {{ node }}
+      {% endfor %}
+
+      Cannot proceed with upgrade. Please ensure:
+        1. All nodes are healthy and running
+        2. Kubelet is running on all nodes
+        3. Network connectivity between nodes is working
+        4. Check node conditions: kubectl describe node <node-name>
+
+      Fix the node issues and re-run the upgrade.
+      ════════════════════════════════════════════════════════════════════════════════
+  when: validated_nodes_not_ready | length > 0
+
+- name: Display all nodes Ready
+  ansible.builtin.debug:
+    msg: "[OK] All {{ all_validated_nodes | length }} validated nodes are in Ready state"
+  when: validated_nodes_not_ready | length == 0
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Validate all pods in the cluster are healthy
+# Healthy STATUS values: Running, Completed, Succeeded
+# Unhealthy: CrashLoopBackOff, Error, ImagePullBackOff, Pending, Failed, etc.
+# ══════════════════════════════════════════════════════════════════════════════
+- name: Display pod health check message
+  ansible.builtin.debug:
+    msg: "Checking all pods in the cluster are healthy..."
+
+# Get all pods with their STATUS (same as kubectl get pods output)
+# Healthy phases: Running, Succeeded (Completed jobs show as Succeeded)
+- name: Get all pods status across all namespaces
+  ansible.builtin.shell:
+    cmd: |
+      kubectl get pods --all-namespaces --no-headers -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,READY:.status.containerStatuses[*].ready' 2>/dev/null | \
+      while read ns name phase ready; do
+        # Healthy: Running with all containers ready, or Succeeded (completed)
+        if [[ "$phase" == "Running" && "$ready" == *"false"* ]]; then
+          echo "$ns|$name|ContainersNotReady"
+        elif [[ "$phase" != "Running" && "$phase" != "Succeeded" ]]; then
+          echo "$ns|$name|$phase"
+        fi
+      done
+  delegate_to: "{{ kube_vip }}"
+  register: unhealthy_pods_check
+  changed_when: false
+
+- name: Get total pod count
+  ansible.builtin.shell:
+    cmd: kubectl get pods --all-namespaces --no-headers | wc -l
+  delegate_to: "{{ kube_vip }}"
+  register: total_pods_count
+  changed_when: false
+
+- name: Build unhealthy pods list
+  ansible.builtin.set_fact:
+    all_unhealthy_pods: >-
+      {{ unhealthy_pods_check.stdout_lines | default([]) | select('match', '.+') | 
+         map('regex_replace', '(.+)\\|(.+)\\|(.+)', '\\1/\\2 (\\3)') | list }}
+    total_pods: "{{ total_pods_count.stdout | trim }}"
+
+- name: Count healthy pods
+  ansible.builtin.set_fact:
+    healthy_pods: "{{ (total_pods | int) - (all_unhealthy_pods | length) }}"
+
+- name: Display pod health check results
+  ansible.builtin.debug:
+    msg: "{{ pod_health_banner }}"
+  vars:
+    pod_health_banner: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [POD STATUS] CLUSTER-WIDE HEALTH CHECK
+      ════════════════════════════════════════════════════════════════════════════════
+      
+      Total pods in cluster: {{ total_pods }}
+      Healthy pods: {{ healthy_pods }}
+      Unhealthy pods: {{ all_unhealthy_pods | length }}
+      
+      {% if all_unhealthy_pods | length > 0 %}Problem pods (namespace/name):
+      {% for pod in all_unhealthy_pods %}  - {{ pod }}
+      {% endfor %}{% else %}  (none){% endif %}
+      ════════════════════════════════════════════════════════════════════════════════
+
+- name: Fail if any pods are not healthy
+  ansible.builtin.fail:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [ERROR] UNHEALTHY PODS DETECTED
+      ════════════════════════════════════════════════════════════════════════════════
+      The following pods are not healthy:
+      {% for pod in all_unhealthy_pods %}
+        - {{ pod }}
+      {% endfor %}
+
+      Healthy pods must have STATUS: Running or Succeeded
+      with all containers in Ready state.
+
+      Cannot proceed with upgrade. Please fix these issues:
+        1. Check pod status: kubectl get pods --all-namespaces
+        2. Check pod logs: kubectl logs -n <namespace> <pod-name>
+        3. Check pod events: kubectl describe pod -n <namespace> <pod-name>
+
+      Re-run the upgrade after fixing the pod issues.
+      ════════════════════════════════════════════════════════════════════════════════
+  when: all_unhealthy_pods | length > 0
+
+- name: Display all pods healthy
+  ansible.builtin.debug:
+    msg: "[OK] All {{ total_pods }} pods in the cluster are healthy"
+  when: all_unhealthy_pods | length == 0
+
+# ── Fail if no control plane first node is available ─────────────────
+- name: Fail if no first control plane node is available for upgrade
+  ansible.builtin.fail:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════════════
+      [ERROR] NO FIRST CONTROL PLANE NODE AVAILABLE
+      ════════════════════════════════════════════════════════════════════════════════
+      The first control plane node(s) from nodes.yaml are not present in the cluster:
+        Expected: {{ expected_cp_first | join(', ') }}
+        In cluster: {{ cluster_control_planes | join(', ') }}
+
+      Cannot proceed with upgrade without a first control plane node.
+      Please verify your cluster state and nodes.yaml configuration.
+      ════════════════════════════════════════════════════════════════════════════════
+  when: validated_cp_first | length == 0
+
+# ── Display upgrade inventory summary ────────────────────────────────
+- name: Display upgrade inventory summary
+  ansible.builtin.debug:
+    msg: "{{ inventory_banner }}"
+  vars:
+    inventory_banner:
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[UPGRADE] PROCEEDING WITH THE FOLLOWING NODES"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "Total nodes for upgrade: {{ all_validated_nodes | length }}"
+      - ""
+      - "Control plane (first): {{ validated_cp_first | length }} node(s)"
+      - "{% for node in validated_cp_first %}  - {{ node }} ({{ nodes_yaml_ips[node] }})\n{% endfor %}"
+      - ""
+      - "Control plane (additional): {{ validated_cp | length }} node(s)"
+      - "{% for node in validated_cp %}  - {{ node }} ({{ nodes_yaml_ips[node] }})\n{% endfor %}"
+      - ""
+      - "Workers: {{ validated_workers | length }} node(s)"
+      - "{% for node in validated_workers %}  - {{ node }} ({{ nodes_yaml_ips[node] }})\n{% endfor %}"
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
+
+# ── Pause to allow user to review discrepancies ──────────────────────
+- name: Display proceeding message with discrepancies
+  ansible.builtin.debug:
+    msg: "{{ proceed_banner }}"
+  vars:
+    proceed_banner:
+      - ""
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - "[NOTICE] PROCEEDING WITH CLUSTER NODES ONLY"
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+      - "The following nodes from nodes.yaml are NOT in the cluster (will be SKIPPED):"
+      - "  {{ nodes_only_in_yaml | join(', ') | default('none') }}"
+      - ""
+      - "The following nodes are in cluster but NOT in nodes.yaml (will be SKIPPED):"
+      - "  {{ nodes_only_in_cluster | join(', ') | default('none') }}"
+      - ""
+      - "Upgrade will proceed with {{ all_validated_nodes | length }} nodes:"
+      - "  - Control plane (first): {{ validated_cp_first | join(', ') }}"
+      - "  - Control plane (additional): {{ validated_cp | join(', ') | default('none') }}"
+      - "  - Workers: {{ validated_workers | join(', ') | default('none') }}"
+      - ""
+      - "Pausing for {{ cluster_validation_pause_seconds | default(10) }} seconds..."
+      - "Press Ctrl+C then 'A' to abort if this is not correct."
+      - "════════════════════════════════════════════════════════════════════════════════"
+      - ""
+  when:
+    - has_discrepancies
+    - not (skip_cluster_validation_pause | default(false))
+
+- name: Pause to allow review of discrepancies
+  ansible.builtin.pause:
+    seconds: "{{ cluster_validation_pause_seconds | default(10) }}"
+  when:
+    - has_discrepancies
+    - not (skip_cluster_validation_pause | default(false))
+
+- name: Log proceeding with validated nodes
+  ansible.builtin.debug:
+    msg: "[OK] Proceeding with upgrade on {{ all_validated_nodes | length }} validated cluster nodes"
+  when: has_discrepancies
+
+# ── Set validated groups for use by other tasks ──────────────────────
+- name: Set validated node groups for inventory
+  ansible.builtin.set_fact:
+    groups_cp_first: "{{ validated_cp_first }}"
+    groups_cp: "{{ validated_cp }}"
+    groups_worker: "{{ validated_workers }}"
+    all_upgrade_nodes: "{{ all_validated_nodes }}"
+    node_ips: "{{ nodes_yaml_ips }}"
+    cluster_validation_completed: true
+    nodes_only_in_yaml_final: "{{ nodes_only_in_yaml }}"
+    nodes_only_in_cluster_final: "{{ nodes_only_in_cluster }}"

--- a/upgrade/roles/upgrade_k8s/vars/main.yml
+++ b/upgrade/roles/upgrade_k8s/vars/main.yml
@@ -89,7 +89,7 @@ worker_parallel_count: 1
 # Cluster validation settings
 # ---------------------------------------------------------------------------
 # When cluster nodes don't match nodes.yaml, the playbook pauses to allow review.
-# 
+#
 # cluster_validation_pause_seconds: How long to pause (default: 10 seconds)
 #   Override via --extra-vars cluster_validation_pause_seconds=30
 #

--- a/upgrade/roles/upgrade_k8s/vars/main.yml
+++ b/upgrade/roles/upgrade_k8s/vars/main.yml
@@ -86,6 +86,20 @@ reboot_connect_timeout: 300
 worker_parallel_count: 1
 
 # ---------------------------------------------------------------------------
+# Cluster validation settings
+# ---------------------------------------------------------------------------
+# When cluster nodes don't match nodes.yaml, the playbook pauses to allow review.
+# 
+# cluster_validation_pause_seconds: How long to pause (default: 10 seconds)
+#   Override via --extra-vars cluster_validation_pause_seconds=30
+#
+# skip_cluster_validation_pause: Skip the pause entirely (default: false)
+#   Set to true for automated/CI pipelines.
+#   Override via --extra-vars skip_cluster_validation_pause=true
+cluster_validation_pause_seconds: 10
+skip_cluster_validation_pause: false
+
+# ---------------------------------------------------------------------------
 # Step definitions per role
 # ---------------------------------------------------------------------------
 cp_first_steps:

--- a/upgrade/upgrade.yml
+++ b/upgrade/upgrade.yml
@@ -19,11 +19,12 @@
 # Supports --tags for selective execution of upgrade sub-flows.
 #
 # Usage:
-#   ansible-playbook upgrade/upgrade.yml                     # Full upgrade
-#   ansible-playbook upgrade/upgrade.yml --tags oim          # OIM only
-#   ansible-playbook upgrade/upgrade.yml --tags k8s          # K8s only
-#   ansible-playbook upgrade/upgrade.yml --tags provision
-#   ansible-playbook upgrade/upgrade.yml --tags "k8s,telemetry"
+#   cd /omnia/upgrade
+#   ansible-playbook upgrade.yml                     # Full upgrade
+#   ansible-playbook upgrade.yml --tags oim          # OIM only
+#   ansible-playbook upgrade.yml --tags k8s          # K8s only
+#   ansible-playbook upgrade.yml --tags provision
+#   ansible-playbook upgrade.yml --tags "k8s,telemetry"
 #
 # IMPORTANT: Must be invoked from the parent directory containing upgrade/,
 # rollback/, and playbooks/ folders. Internal playbooks are imported via
@@ -122,7 +123,8 @@
           Source: {{ existing_manifest.source_version | default('N/A') }} → Target: {{ existing_manifest.target_version | default('N/A') }}
           Re-running upgrade after successful completion is not allowed.
           If you need to force a new upgrade cycle:
-            ansible-playbook upgrade/upgrade.yml -e force_upgrade=true
+            cd /omnia/upgrade
+            ansible-playbook upgrade.yml -e force_upgrade=true
       when:
         - manifest_stat.stat.exists
         - existing_manifest.upgrade_status | default('') == 'completed'
@@ -558,7 +560,8 @@
               Please re-run the upgrade playbook and type 'yes' at the
               confirmation prompt:
 
-                ansible-playbook upgrade/upgrade.yml
+                cd /omnia/upgrade
+                ansible-playbook upgrade.yml
 
               ══════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
  • Added cluster node validation for upgrades (SSH, readiness, pod health)
  • Improved Node Inventory: Now uses upgrade_status.nodes to target only nodes that were part of the upgrade
  • SSH Validation: Pre-flight SSH connectivity checks to all rollback nodes
  • Improved VIP validation against PXE mapping IPs and subnet consistency
  • Fixed role paths in all playbooks and resolved template errors
  • Removed duplicate cleanup tasks
