### PR TITLE
Fix: Add boolean type conversion for Ansible conditional in telemetry task

### DIFF
--- a/provision/roles/telemetry/tasks/get_powerscale_telemetry_dependencies.yml
+++ b/provision/roles/telemetry/tasks/get_powerscale_telemetry_dependencies.yml
@@ -89,13 +89,13 @@
     - name: Check if cert-manager is disabled in values file
       ansible.builtin.set_fact:
         cert_manager_disabled: >-
-          {%- if csm_observability_values_file_path | default('') != '' -%}
-          {%- set values_content = lookup('file', csm_observability_values_file_path, errors='ignore') -%}
-          {%- if values_content is not none and 'cert-manager:' in values_content and 'enabled: false' in values_content -%}
-          true{%- else -%}
-          false{%- endif -%}
-          {%- else -%}
-          false{%- endif -%}
+          {{-
+            (csm_observability_values_file_path | default('') != '') and
+            (lookup('file', csm_observability_values_file_path, errors='ignore') is not none) and
+            ('cert-manager:' in lookup('file', csm_observability_values_file_path, errors='ignore')) and
+            ('enabled: false' in lookup('file', csm_observability_values_file_path, errors='ignore'))
+            | bool
+          -}}
 
     - name: Display cert-manager dependency status
       ansible.builtin.debug:


### PR DESCRIPTION
## PR Summary
Fixes conditional type error in telemetry role caused by Ansible upgrade. The `cert_manager_disabled` fact was returning string values instead of boolean types, causing playbook execution to fail with newer Ansible versions that enforce strict type checking.

### Changes Made
- Modified Jinja2 template in `get_powerscale_telemetry_dependencies.yml` to use `| bool` filter
- Ensures `cert_manager_disabled` fact returns actual boolean type instead of string
- Maintains identical functional behavior while fixing type compliance

### Issue Fixed
```
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'str' at '/omnia/provision/roles/telemetry/tasks/get_powerscale_telemetry_dependencies.yml:91:32'. Conditionals must have a boolean result.