### PR TITLE
Fix: Multiple Ansible 2.14+ compatibility issues after upgrade

### DIFF
--- a/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
@@ -50,7 +50,7 @@
       "iDRAC IPs for pod '{{ item.key }}': {{ item.value | join(', ') }}"
     verbosity: 2
   loop: "{{ idrac_podname_idracips.idrac_podname_ips | dict2items }}"
-  when: idrac_podname_idracips.idrac_podname_ips is defined and idrac_podname_idracips.idrac_podname_ips
+  when: idrac_podname_idracips.idrac_podname_ips is defined and (idrac_podname_idracips.idrac_podname_ips | length > 0)
 
 - name: Read the existing BMC IP's from mysqlDB of the idrac telemetry pods
   block:

--- a/telemetry/roles/service_k8s_telemetry/tasks/update_metadata_file.yml
+++ b/telemetry/roles/service_k8s_telemetry/tasks/update_metadata_file.yml
@@ -1,4 +1,4 @@
-#  Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#  Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -76,14 +76,10 @@
     kind: StatefulSet
     name: idrac-telemetry
     namespace: telemetry
-    patch: |
-      [
-        {
-          "op": "replace",
-          "path": "/spec/replicas",
-          "value": {{ (idrac_telemetry_replicas | int) + 1 }}
-        }
-      ]
+    patch:
+      - op: replace
+        path: /spec/replicas
+        value: "{{ (idrac_telemetry_replicas | int) + 1 }}"
 
 - name: Generating iDRAC telemetry pods names
   ansible.builtin.set_fact:


### PR DESCRIPTION
This PR fixes telemetry playbook compatibility issues caused by upgrading Ansible from 2.14 to 2.20.1. Newer Ansible versions enforce stricter type checking that breaks existing playbooks.
 
### Issues Fixed
 
**1. k8s_json_patch Parameter Type**
- File: `telemetry/roles/service_k8s_telemetry/tasks/update_metadata_file.yml`
- Issue: Module expects YAML list but received JSON string
- Fix: Converted JSON string to native YAML structure with proper quoting
 
**2. Conditional Dict Truthiness**
- File: `telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml`
- Issue: Dict evaluated as truthy instead of boolean
- Fix: Added explicit length check `| length > 0`