### PR TITLE
Fix: Cloud-Init runcmd YAML parsing errors on aarch64 templates

### DIFF
--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -135,7 +135,7 @@
           owner: root:root
           permissions: '{{ file_mode_755 }}'
           content: |
-            {{ lookup('template', 'templates/hpc_tools/setup_doca_mpi_env.sh.j2') | indent(12) }}            
+            {{ lookup('template', 'templates/hpc_tools/setup_doca_mpi_env.sh.j2') | indent(12) }}
 
 {% if dns_enabled | default(false) | bool %}
         - path: /etc/resolv.conf
@@ -181,7 +181,7 @@
           permissions: '0644'
           content: |
             {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
-        
+
         # NVIDIA HPC SDK script (run manually: /usr/local/bin/setup_nvhpc_sdk.sh --install)
         - path: /usr/local/bin/setup_nvhpc_sdk.sh
           owner: root:root
@@ -317,38 +317,38 @@
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
         - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
         - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
-        
+
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
         - |
           bash -c '
           ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
           NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
-          
+
           # Convert IP to integer and calculate network address
           ip_to_int() {
             local IFS=.
             read -r a b c d <<< "$1"
             echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
           }
-          
+
           int_to_ip() {
             local ip=$1
-            echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"  
+            echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"
           }
-          
+
           ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
           HOST_BITS=$(( 32 - NETMASK_BITS ))
           HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
           NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
           NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
           NETWORK_IP=$(int_to_ip "$NETWORK_INT")
-          
+
           PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
           echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
           firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
           '
-        
+
         - firewall-cmd --reload
         - systemctl enable sshd
         - systemctl start sshd
@@ -389,4 +389,4 @@
         # NVIDIA HPC SDK: Script deployed to /usr/local/bin/setup_nvhpc_sdk.sh
         # User must run manually after cloud-init completes
         - echo "Cloud-Init has completed successfully."
-        - echo "To install NVIDIA HPC SDK, run: /usr/local/bin/setup_nvhpc_sdk.sh --install"
+        - echo "Run /usr/local/bin/setup_nvhpc_sdk.sh --install to install NVIDIA HPC SDK"

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -291,36 +291,36 @@
             firewall-cmd --permanent --add-service=ssh
             firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
             firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
-            
+
             # Add PXE network to trusted zone for ORTE communication
             echo "[INFO] Adding PXE network to trusted zone for ORTE communication"
             # Calculate PXE subnet using admin IP and netmask bits
             ADMIN_IP="{{ hostvars['localhost']['admin_nic_ip'] }}"
             NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
-            
+
             # Convert IP to integer and calculate network address
             ip_to_int() {
               local IFS=.
               read -r a b c d <<< "$1"
               echo $(( (a << 24) + (b << 16) + (c << 8) + d ))
             }
-            
+
             int_to_ip() {
               local ip=$1
               echo "$(( (ip >> 24) & 255 )).$(( (ip >> 16) & 255 )).$(( (ip >> 8) & 255 )).$(( ip & 255 ))"
             }
-            
+
             ADMIN_IP_INT=$(ip_to_int "$ADMIN_IP")
             HOST_BITS=$(( 32 - NETMASK_BITS ))
             HOST_MASK=$(( (1 << HOST_BITS) - 1 ))
             NETWORK_MASK=$(( ~HOST_MASK & 0xFFFFFFFF ))
             NETWORK_INT=$(( ADMIN_IP_INT & NETWORK_MASK ))
             NETWORK_IP=$(int_to_ip "$NETWORK_INT")
-            
+
             PXE_SUBNET="$NETWORK_IP/$NETMASK_BITS"
             echo "[INFO] Admin IP: $ADMIN_IP, Netmask: /$NETMASK_BITS, PXE Subnet: $PXE_SUBNET"
             firewall-cmd --zone=trusted --add-source="$PXE_SUBNET" --permanent
-            
+
             firewall-cmd --reload
 
             echo "[INFO] Unmounting controller slurm.conf directory from $CTLD_SLURM_DIR_MNT"
@@ -379,19 +379,19 @@
           permissions: '0644'
           content: |
             {{ lookup('template', 'templates/nodes/apptainer_mirror.conf.j2') | indent(12) }}
-        
+
         - path: /usr/local/bin/configure_ucx_openmpi_env.sh
           owner: root:root
           permissions: '{{ file_mode_755 }}'
           content: |
             {{ lookup('template', 'templates/hpc_tools/configure_ucx_openmpi_env.sh.j2') | indent(12) }}
-            
+
         - path: /usr/local/bin/setup_doca_mpi_env.sh
           owner: root:root
           permissions: '{{ file_mode_755 }}'
           content: |
             {{ lookup('template', 'templates/hpc_tools/setup_doca_mpi_env.sh.j2') | indent(12) }}
-            
+
         # NVIDIA HPC SDK setup script (run manually: /usr/local/bin/setup_nvhpc_sdk.sh)
         - path: /usr/local/bin/setup_nvhpc_sdk.sh
           owner: root:root
@@ -419,7 +419,7 @@
 {% if hostvars['localhost']['openmpi_support'] %}
         - bash /usr/local/bin/setup_doca_mpi_env.sh || echo "DOCA MPI environment setup failed (non-critical)"
 {% endif %}
-    
+
 {# Mount-specific runcmd entries - moved after DOCA to ensure RDMA is available #}
 {%- if cloud_init_groups_dict[functional_group_name].runcmd is defined and cloud_init_groups_dict[functional_group_name].runcmd is not none %}
 {% for cmd in cloud_init_groups_dict[functional_group_name].runcmd %}
@@ -528,4 +528,4 @@
 
         - systemctl restart slurmd
         - echo "Cloud-Init has completed successfully."
-        - echo "To setup NVIDIA HPC SDK, run: /usr/local/bin/setup_nvhpc_sdk.sh"
+        - echo "Run /usr/local/bin/setup_nvhpc_sdk.sh to setup NVIDIA HPC SDK"


### PR DESCRIPTION
Fixes cloud-init runcmd failures on aarch64 nodes (slurm-node, login-compiler-node)
due to YAML parsing errors when echo strings contain colons.

### Changes Made
- Fixed YAML parsing issue in ci-group-slurm_node_aarch64.yaml.j2
- Fixed YAML parsing issue in ci-group-login_compiler_node_aarch64.yaml.j2
- Rephrased echo commands to avoid colon pattern that YAML interprets as dict

### Files Modified
- provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
- provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2

### Issue Fixed