### PR TITLE
Backup permission issue fix and recheck logic addition for rollback openchami

### DIFF
--- a/omnia.sh
+++ b/omnia.sh
@@ -1858,6 +1858,14 @@ backup_openchami_data() {
         echo "[INFO] [ORCHESTRATOR] Quadlet .network files backed up"
     fi
 
+    # Normalize permissions on the openchami backup tree so rollback can
+    # read it even under NFS root_squash.  cp -a preserves the source
+    # permissions which may be restrictive (container-created files).
+    podman exec -u root omnia_core bash -c "
+        find '${backup_base%/}/openchami' -type d -exec chmod 0755 {} + 2>/dev/null || true
+        find '${backup_base%/}/openchami' -type f -exec chmod 0644 {} + 2>/dev/null || true
+    " 2>/dev/null || true
+
     echo "[INFO] [ORCHESTRATOR] OpenCHAMI data backup completed: ${backup_base}/openchami/"
     return 0
 }
@@ -1881,17 +1889,18 @@ phase3_backup_creation() {
         set -e
         rm -rf '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'
         mkdir -p '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'
-        chmod 0700 '${backup_base%/}' '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'
+        chmod 0755 '${backup_base%/}'
+        chmod 0755 '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'
 
         if [ -f '$CONTAINER_INPUT_DIR/default.yml' ]; then
             cp -a '$CONTAINER_INPUT_DIR/default.yml' '${backup_base%/}/input/'
-            chmod 0600 '${backup_base%/}/input/default.yml'
+            chmod 0644 '${backup_base%/}/input/default.yml'
         fi
 
         if [ -d '$CONTAINER_INPUT_DIR/project_default' ]; then
             cp -a '$CONTAINER_INPUT_DIR/project_default' '${backup_base%/}/input/'
-            chmod -R 0600 '${backup_base%/}/input/project_default'/*
-            find '${backup_base%/}/input/project_default' -type d -exec chmod 0700 {} \;
+            chmod -R 0644 '${backup_base%/}/input/project_default'/*
+            find '${backup_base%/}/input/project_default' -type d -exec chmod 0755 {} \;
         fi
 
         if [ ! -f '$CONTAINER_METADATA_FILE' ]; then
@@ -1899,7 +1908,7 @@ phase3_backup_creation() {
             exit 1
         fi
         cp -a '$CONTAINER_METADATA_FILE' '${backup_base%/}/metadata/oim_metadata.yml'
-        chmod 0600 '${backup_base%/}/metadata/oim_metadata.yml'
+        chmod 0644 '${backup_base%/}/metadata/oim_metadata.yml'
     "; then
         echo "[ERROR] [ORCHESTRATOR] Backup failed; cleaning up partial backup"
         podman exec -u root omnia_core bash -c "rm -rf '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'" >/dev/null 2>&1 || true
@@ -1912,7 +1921,7 @@ phase3_backup_creation() {
             podman exec -u root omnia_core bash -c "rm -rf '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'" >/dev/null 2>&1 || true
             return 1
         fi
-        podman exec -u root omnia_core chmod 0600 "${backup_base%/}/configs/omnia_core.container" 2>/dev/null || true
+        podman exec -u root omnia_core chmod 0644 "${backup_base%/}/configs/omnia_core.container" 2>/dev/null || true
     fi
 
     echo "[INFO] [ORCHESTRATOR] Backup created at: $backup_base"

--- a/rollback/roles/rollback_openchami/tasks/main.yml
+++ b/rollback/roles/rollback_openchami/tasks/main.yml
@@ -40,6 +40,13 @@
 
 - name: OpenCHAMI rollback workflow
   block:
+    # Normalize backup + /etc/openchami permissions BEFORE any checks or
+    # restores. The backup is created with `cp -a` which preserves restrictive
+    # source modes; on the shared NFS path those bits cause permission-denied
+    # when the rollback reads/restores configs, pg-init, and the pg_dump.
+    - name: Normalize backup and config permissions
+      ansible.builtin.include_tasks: normalize_permissions.yml
+
     - name: Pre-rollback validation checks
       ansible.builtin.include_tasks: pre_rollback_checks.yml
 

--- a/rollback/roles/rollback_openchami/tasks/normalize_permissions.yml
+++ b/rollback/roles/rollback_openchami/tasks/normalize_permissions.yml
@@ -1,0 +1,139 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# normalize_permissions.yml — Normalize Backup & Config Permissions
+# ============================================================================
+# The pre-upgrade backup is created with `cp -a`, which PRESERVES the source
+# permissions of /etc/openchami and its contents. Several of those files are
+# created by containers running as non-root UIDs (e.g. configs/, pg-init/,
+# postgresql_backup/openchami.sql) and may carry restrictive modes. On the
+# shared NFS backup path (root_squash), those restrictive bits cause
+# "permission denied" when the rollback later reads the backup or restores
+# /etc/openchami — which makes the final OpenCHAMI rollback step fail.
+#
+# This task normalizes permissions BEFORE the restore runs:
+#   - Directories  -> 0755
+#   - Files        -> 0644
+# for two roots:
+#   1. Backup root on the core container : {{ rollback_backup_dir }}/openchami
+#   2. /etc/openchami on the OIM host     : {{ openchami_etc_dir }}
+#
+# Behaviour:
+#   - If permissions are simply wrong, they are corrected automatically and
+#     the rollback proceeds with no user action.
+#   - If any directory/file CANNOT be made readable (chmod denied / immutable
+#     / read-only mount), a clear error is shown asking the operator to fix
+#     the permissions manually and re-run the OpenCHAMI/OIM rollback with
+#     `--tags oim`.
+# ============================================================================
+
+- name: Normalize backup and /etc/openchami permissions
+  block:
+    # ── Resolve the two roots to normalize ──────────────────────────────
+    - name: Set permission normalization targets
+      ansible.builtin.set_fact:
+        normalize_backup_root: "{{ rollback_backup_dir }}/openchami"
+        normalize_etc_root: "{{ openchami_etc_dir }}"
+
+    # ── 1. Backup root (core container — local, on shared NFS path) ──────
+    - name: Check backup root exists (core container)
+      ansible.builtin.stat:
+        path: "{{ normalize_backup_root }}"
+      register: normalize_backup_root_stat
+
+    - name: Normalize permissions on backup root (core container)
+      ansible.builtin.shell: |
+        set -o pipefail
+        find "{{ normalize_backup_root }}" -type d -exec chmod {{ dir_permissions_755 }} {} + 2>/dev/null || true
+        find "{{ normalize_backup_root }}" -type f -exec chmod {{ file_permissions_644 }} {} + 2>/dev/null || true
+      register: normalize_backup_chmod
+      changed_when: true
+      failed_when: false
+      when: normalize_backup_root_stat.stat.exists | default(false)
+
+    - name: Detect unreadable items under backup root (core container)
+      ansible.builtin.shell: |
+        set -o pipefail
+        {
+          find "{{ normalize_backup_root }}" -type d \( ! -readable -o ! -executable \) -print
+          find "{{ normalize_backup_root }}" -type f ! -readable -print
+        } 2>/dev/null
+      register: normalize_backup_bad
+      changed_when: false
+      failed_when: false
+      when: normalize_backup_root_stat.stat.exists | default(false)
+
+    # ── 2. /etc/openchami (OIM host — delegated) ────────────────────────
+    - name: Check /etc/openchami exists (OIM host)
+      ansible.builtin.stat:
+        path: "{{ normalize_etc_root }}"
+      register: normalize_etc_root_stat
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Normalize permissions on /etc/openchami (OIM host)
+      ansible.builtin.shell: |
+        set -o pipefail
+        find "{{ normalize_etc_root }}" -type d -exec chmod {{ dir_permissions_755 }} {} + 2>/dev/null || true
+        find "{{ normalize_etc_root }}" -type f -exec chmod {{ file_permissions_644 }} {} + 2>/dev/null || true
+      register: normalize_etc_chmod
+      changed_when: true
+      failed_when: false
+      when: normalize_etc_root_stat.stat.exists | default(false)
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Detect unreadable items under /etc/openchami (OIM host)
+      ansible.builtin.shell: |
+        set -o pipefail
+        {
+          find "{{ normalize_etc_root }}" -type d \( ! -readable -o ! -executable \) -print
+          find "{{ normalize_etc_root }}" -type f ! -readable -print
+        } 2>/dev/null
+      register: normalize_etc_bad
+      changed_when: false
+      failed_when: false
+      when: normalize_etc_root_stat.stat.exists | default(false)
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    # ── 3. Aggregate results and fail with guidance if unfixable ────────
+    - name: Build list of items that could not be normalized
+      ansible.builtin.set_fact:
+        normalize_unfixable_backup: "{{ (normalize_backup_bad.stdout_lines | default([])) | select('string') | reject('equalto', '') | list }}"
+        normalize_unfixable_etc: "{{ (normalize_etc_bad.stdout_lines | default([])) | select('string') | reject('equalto', '') | list }}"
+
+    - name: Display permission normalization summary
+      ansible.builtin.debug:
+        verbosity: 1
+        msg:
+          - "Backup root: {{ normalize_backup_root }} ({{ 'present' if normalize_backup_root_stat.stat.exists | default(false) else 'absent' }})"
+          - "/etc/openchami: {{ normalize_etc_root }} ({{ 'present' if normalize_etc_root_stat.stat.exists | default(false) else 'absent' }})"
+          - "Directories normalized to {{ dir_permissions_755 }}, files normalized to {{ file_permissions_644 }}."
+          - "Unreadable items remaining (backup): {{ normalize_unfixable_backup | length }}"
+          - "Unreadable items remaining (/etc/openchami): {{ normalize_unfixable_etc | length }}"
+
+    - name: Fail if permissions could not be corrected
+      ansible.builtin.fail:
+        msg: "{{ rollback_messages.permissions.unfixable }}"
+      when: (normalize_unfixable_backup | length > 0) or (normalize_unfixable_etc | length > 0)
+
+    - name: Display permission normalization success
+      ansible.builtin.debug:
+        msg: "{{ rollback_messages.permissions.normalized }}"

--- a/rollback/roles/rollback_openchami/vars/main.yml
+++ b/rollback/roles/rollback_openchami/vars/main.yml
@@ -32,6 +32,7 @@ rollback_backup_dir_default: "/opt/omnia/backups/upgrade/version_2.1.0.0"
 
 # OpenCHAMI configuration paths
 openchami_config_dir: "/etc/openchami/configs"
+openchami_etc_dir: "/etc/openchami"
 openchami_config_vars_path: "/opt/omnia/openchami/configs_vars.yaml"
 openchami_work_dir: "/opt/omnia/openchami/workdir"
 ochami_dir: "/etc/ochami"
@@ -127,6 +128,35 @@ rollback_messages:
       OpenCHAMI containers are already running v2.1 images.
       Rollback is not needed. Skipping.
     backup_found: "Backup directory found. Proceeding with rollback."
+  permissions:
+    normalized: "Backup and /etc/openchami permissions verified (directories 0755, files 0644)."
+    unfixable: |
+      ════════════════════════════════════════════
+        OPENCHAMI ROLLBACK BLOCKED — PERMISSION ISSUE
+      ════════════════════════════════════════════
+      One or more files/directories in the backup or /etc/openchami could not
+      be made readable. The rollback cannot read these to restore them.
+
+      This usually happens on the shared NFS backup path (root_squash) when
+      container-created files carry restrictive ownership/permissions.
+
+      Fix the permissions MANUALLY, then re-run ONLY the OpenCHAMI/OIM rollback:
+
+        On the OIM host (as a user that owns the files, e.g. the NFS owner):
+          chmod -R u+rwX,go+rX /etc/openchami
+          chmod -R u+rwX,go+rX {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami
+
+        Ensure all directories are 0755 and all files are 0644, and that none
+        are in a permission-denied / immutable state. Then retry:
+
+          cd /opt/omnia/... && ansible-playbook rollback/rollback.yml --tags oim
+
+      Relevant directories that must be readable:
+        /etc/openchami, /etc/openchami/configs, /etc/openchami/pg-init
+        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/etc_openchami
+        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/etc_openchami/configs
+        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/etc_openchami/pg-init
+        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/postgresql_backup
   restore:
     quadlets_success: "Restored v2.1 quadlet files from backup."
     quadlets_failure: "Failed to restore v2.1 quadlet files."

--- a/upgrade/roles/upgrade_openchami/tasks/backup_openchami.yml
+++ b/upgrade/roles/upgrade_openchami/tasks/backup_openchami.yml
@@ -256,6 +256,18 @@
       delegate_facts: true
       connection: ssh
 
+    - name: Normalize permissions on /etc/openchami backup (dirs 0755, files 0644)
+      ansible.builtin.shell: |
+        set -o pipefail
+        find "{{ oim_host_backup_dir }}/{{ backup_etc_openchami_subpath }}" -type d -exec chmod {{ dir_permissions_755 }} {} + 2>/dev/null || true
+        find "{{ oim_host_backup_dir }}/{{ backup_etc_openchami_subpath }}" -type f -exec chmod {{ file_permissions_644 }} {} + 2>/dev/null || true
+      changed_when: true
+      failed_when: false
+      when: etc_openchami_backup_result is defined and etc_openchami_backup_result.rc | default(1) == 0
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
     - name: Verify /etc/openchami backup was created
       ansible.builtin.stat:
         path: "{{ oim_host_backup_dir }}/{{ backup_etc_openchami_subpath }}"


### PR DESCRIPTION
If the backup files, especially if etc/openchami backup templates or postgres data backup are not set with read write permissions, openchami rollback failes since services like haproxy/smd require this data, so added a check to normalize the permissions to set to rw and also fixed omnia.sh backup creation logic to set correct permissions for all backup files and folders