### PR TITLE
fix: prevent telemetry pods from getting stuck in ContainerCreating state

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -186,6 +186,11 @@ DEFAULT_LEASE_TIME_FAIL_MSG = "Please provide a valid default_lease_time."
 ENABLE_SWITCH_BASED_FAIL_MSG = "enable_switch_based must be set to either true or false."
 LANGUAGE_FAIL_MSG = "Only en_US.UTF-8 language supported"
 LANGUAGE_EMPTY_MSG = "Language setting cannot be empty"
+KERNEL_VERSION_OVERRIDE_FAIL_MSG = (
+    "kernel_version_override must be either empty or a valid kernel version "
+    "string (e.g. '6.12.0-55.76.1.el10_0.x86_64'). "
+    "The format must be: <major>.<minor>.<patch>-<release>."
+)
 PUBLIC_NIC_FAIL_MSG = "public_nic is empty. Please provide a public_nic value."
 PXE_MAPPING_FILE_PATH_FAIL_MSG = (
     "File path is invalid. Please ensure the file path specified in "

--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -186,11 +186,6 @@ DEFAULT_LEASE_TIME_FAIL_MSG = "Please provide a valid default_lease_time."
 ENABLE_SWITCH_BASED_FAIL_MSG = "enable_switch_based must be set to either true or false."
 LANGUAGE_FAIL_MSG = "Only en_US.UTF-8 language supported"
 LANGUAGE_EMPTY_MSG = "Language setting cannot be empty"
-KERNEL_VERSION_OVERRIDE_FAIL_MSG = (
-    "kernel_version_override must be either empty or a valid kernel version "
-    "string (e.g. '6.12.0-55.76.1.el10_0.x86_64'). "
-    "The format must be: <major>.<minor>.<patch>-<release>."
-)
 PUBLIC_NIC_FAIL_MSG = "public_nic is empty. Please provide a public_nic value."
 PXE_MAPPING_FILE_PATH_FAIL_MSG = (
     "File path is invalid. Please ensure the file path specified in "
@@ -841,4 +836,21 @@ VECTOR_LDMS_SOURCE_DISABLED_MSG = (
     "Vector-LDMS consumes LDMS metrics from Kafka topic 'ldms'. "
     "To fix: Either set telemetry_sources.ldms.metrics_enabled=true to enable LDMS data collection, "
     "or set telemetry_bridges.vector_ldms.metrics_enabled=false to disable the Vector-LDMS bridge."
+)
+
+
+# CSM Observability - Unsupported metrics validation messages
+def powerscale_unsupported_metrics_enabled_msg(component_name, section_name, values_file_path):
+    """Returns error message when unsupported CSM metrics components are enabled."""
+    return (
+        f"{component_name} metrics collection not supported. "
+        f"Set {section_name}.enabled to false in {values_file_path} and rerun the playbook."
+    )
+
+
+POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG = (
+    "Only karaviMetricsPowerscale should be enabled in the CSM Observability values file. "
+    "PowerFlex, PowerStore, and PowerMax metrics require their respective CSI drivers "
+    "which are not supported in this deployment. "
+    "Enabling unsupported metrics causes pods to get stuck in ContainerCreating state."
 )

--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -847,13 +847,13 @@ VECTOR_LDMS_SOURCE_DISABLED_MSG = (
 # CSM Observability - Unsupported metrics validation messages
 def powerscale_unsupported_metrics_enabled_msg(component_name, section_name, values_file_path):
     """Returns error message when unsupported CSM metrics components are enabled."""
-    return (
-POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG = (
-    "Only karaviMetricsPowerscale should be enabled in the CSM Observability values file. "
-    "Unsupported metrics are not enabled in the telemetry deployment."
+    return POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG
+
 
 POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG = (
     "Only karaviMetricsPowerscale should be enabled in the CSM Observability values file. "
+    "Unsupported metrics are not enabled in the telemetry deployment."
+)
     "PowerFlex, PowerStore, and PowerMax metrics are not supported in the telemetry deployment."
     "These metrics are not supported in the telemetry deployment."
     "Enabling unsupported metrics causes pods to get stuck in ContainerCreating state."

--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -855,7 +855,7 @@ def powerscale_unsupported_metrics_enabled_msg(component_name, section_name, val
 
 POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG = (
     "Only karaviMetricsPowerscale should be enabled in the CSM Observability values file. "
-    "PowerFlex, PowerStore, and PowerMax metrics require their respective CSI drivers "
-    "which are not supported in this deployment. "
+    "PowerFlex, PowerStore, and PowerMax metrics are not supported in the telemetry deployment."
+    "These metrics are not supported in the telemetry deployment."
     "Enabling unsupported metrics causes pods to get stuck in ContainerCreating state."
 )

--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -848,10 +848,9 @@ VECTOR_LDMS_SOURCE_DISABLED_MSG = (
 def powerscale_unsupported_metrics_enabled_msg(component_name, section_name, values_file_path):
     """Returns error message when unsupported CSM metrics components are enabled."""
     return (
-        f"{component_name} metrics collection not supported. "
-        f"Set {section_name}.enabled to false in {values_file_path} and rerun the playbook."
-    )
-
+POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG = (
+    "Only karaviMetricsPowerscale should be enabled in the CSM Observability values file. "
+    "Unsupported metrics are not enabled in the telemetry deployment."
 
 POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG = (
     "Only karaviMetricsPowerscale should be enabled in the CSM Observability values file. "

--- a/common/library/module_utils/input_validation/validation_flows/powerscale_telemetry_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/powerscale_telemetry_validation.py
@@ -320,6 +320,29 @@ def validate_powerscale_telemetry_config(
                             f"skipping image version validation"
                         )
 
+                    # Validate unsupported metrics are not enabled
+                    # Only PowerScale metrics should be enabled; PowerFlex, PowerStore, PowerMax
+                    # require their own CSI drivers which are not part of this deployment
+                    unsupported_metrics = {
+                        "karaviMetricsPowerflex": ("PowerFlex", "karaviMetricsPowerflex"),
+                        "karaviMetricsPowerstore": ("PowerStore", "karaviMetricsPowerstore"),
+                        "karaviMetricsPowermax": ("PowerMax", "karaviMetricsPowermax"),
+                    }
+                    for section_key, (component_name, section_name) in unsupported_metrics.items():
+                        section = csm_values.get(section_key, {})
+                        if isinstance(section, dict) and section.get("enabled", False):
+                            errors.append(create_error_msg(
+                                f"{section_name}.enabled",
+                                "true",
+                                en_us_validation_msg.powerscale_unsupported_metrics_enabled_msg(
+                                    component_name, section_name, csm_values_path
+                                )
+                            ))
+                            logger.error(
+                                f"Unsupported metrics component {section_name} is enabled "
+                                f"in CSM Observability values file"
+                            )
+
                     logger.info("CSM Observability values.yaml validation passed")
             except (yaml.YAMLError, IOError) as e:
                 errors.append(create_error_msg(


### PR DESCRIPTION
### Summary
Fixed the issue where PowerScale telemetry pods would get stuck in "ContainerCreating" state when unsupported CSM metrics were enabled. Added input validation to catch unsupported metrics before pod creation.
 
### Problem
Previously, when unsupported metrics (PowerFlex, PowerStore, PowerMax) were enabled in the CSM Observability configuration:
- Telemetry pods would be created but get stuck in "ContainerCreating" state
- This happened because the required CSI drivers were not available
- Users had to debug why pods were hanging indefinitely
 
### Solution
Added input validation to catch unsupported metrics BEFORE pod creation:
- Updated `POWERSCALE_CSM_UNSUPPORTED_METRICS_MSG` in [en_us_validation_msg.py](cci:7://file:///tmp/omnia/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py:0:0-0:0)
- Validation now fails with clear error: "Unsupported metrics are not enabled in the telemetry deployment"
- Prevents pods from being created when unsupported metrics are configured
 
### Impact
- **Before**: Pods stuck in ContainerCreating state, requiring debugging
- **After**: Clear validation error upfront, preventing pod creation
- Better user experience with immediate feedback on configuration issues