### PR TITLE
fix(discovery): prompt for OME credentials when not available

### DIFF
--- a/discovery/discovery.yml
+++ b/discovery/discovery.yml
@@ -30,10 +30,6 @@
         omnia_run_tags: "{{ (ansible_run_tags | default([]) | list + ['discovery']) | unique }}"
         cacheable: true
 
-- name: Invoke validate_config.yml to perform L1 and L2 validations with discovery tag
-  ansible.builtin.import_playbook: ../input_validation/validate_config.yml
-  tags: always
-
 - name: Load discovery configuration
   hosts: localhost
   connection: local
@@ -42,6 +38,18 @@
       ansible.builtin.include_vars:
         file: "{{ input_project_dir }}/discovery_config.yml"
       failed_when: false
+
+    - name: Set enable_bmc_discovery for credential utility
+      ansible.builtin.set_fact:
+        enable_bmc_discovery: "{{ true if (discovery_mechanism | default('')) == 'ome' else (enable_bmc_discovery | default(false) | bool) }}"
+        cacheable: true
+
+- name: Invoke validate_config.yml to perform L1 and L2 validations with discovery tag
+  ansible.builtin.import_playbook: ../input_validation/validate_config.yml
+  tags: always
+
+- name: Invoke get_config_credentials.yml
+  ansible.builtin.import_playbook: ../utils/credential_utility/get_config_credentials.yml
 
 - name: BMC Discovery Playbook
   hosts: localhost

--- a/discovery/roles/ome_discovery/tasks/get_ome_credentials.yml
+++ b/discovery/roles/ome_discovery/tasks/get_ome_credentials.yml
@@ -60,9 +60,9 @@
     msg: "ome_ip must be provided in discovery_config.yml."
   when: ome_ip is not defined or ome_ip == ''
 
-- name: Validate OME credentials are set
+- name: Validate OME credentials are available
   ansible.builtin.fail:
-    msg: "OME credentials (ome_username, ome_password) must be provided. Run prepare_oim or get_config_credentials first."
+    msg: "OME credentials (ome_username, ome_password) are not set. Cannot proceed with discovery."
   when: >
     ome_username is not defined or ome_username == '' or
     ome_password is not defined or ome_password == ''


### PR DESCRIPTION
When running discovery.yml without prior prepare_oim.yml execution, the playbook previously failed with a hard error instructing users to run prepare_oim.yml first.

Now discovery.yml handles credential collection directly:
- If credential file exists: loads credentials as before
- If credentials are missing: prompts user for OME username/password
- Validates input (non-empty, password confirmation)
- Saves credentials to omnia_config_credentials.yml
- Encrypts the file with ansible-vault
- Proceeds with discovery

This is consistent with how other Omnia playbooks handle credentials.


### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
