### PR TITLE
fix(provision): fix invalid YAML in cloud-init template when dns_enabled is true

### DIFF
--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -640,27 +640,22 @@
 {% if dns_enabled | default(false) | bool %}
             # Forward cluster-internal DNS domain to OIM CoreDNS
             # This allows K8s pods to resolve Slurm/MPI hostnames via CoreDNS
-            python3 - "$cfg" << 'PYEOF'
-import sys, yaml
-cfg_path = sys.argv[1]
-with open(cfg_path) as f:
-    doc = yaml.safe_load(f)
-corefile = doc['data']['Corefile']
-fwd_block = """{{ domain_name }}:53 {
-    errors
-    cache 30
-    forward . {{ admin_nic_ip }}
-}
-"""
-if '{{ domain_name }}:53' not in corefile:
-    corefile = fwd_block + corefile
-    doc['data']['Corefile'] = corefile
-    with open(cfg_path, 'w') as f:
-        yaml.dump(doc, f, default_flow_style=False)
-    print("Added {{ domain_name }} forward zone to K8s CoreDNS")
-else:
-    print("{{ domain_name }} forward zone already present in K8s CoreDNS")
-PYEOF
+            python3 -c '
+            import sys, yaml
+            cfg_path = sys.argv[1]
+            with open(cfg_path) as f:
+                doc = yaml.safe_load(f)
+            corefile = doc["data"]["Corefile"]
+            fwd_block = "{{ domain_name }}:53 {\n    errors\n    cache 30\n    forward . {{ admin_nic_ip }}\n}\n"
+            if "{{ domain_name }}:53" not in corefile:
+                corefile = fwd_block + corefile
+                doc["data"]["Corefile"] = corefile
+                with open(cfg_path, "w") as f:
+                    yaml.dump(doc, f, default_flow_style=False)
+                print("Added {{ domain_name }} forward zone to K8s CoreDNS")
+            else:
+                print("{{ domain_name }} forward zone already present in K8s CoreDNS")
+            ' "$cfg"
 {% endif %}
 
             # Apply the patched ConfigMap


### PR DESCRIPTION
## Defect
Provisioning fails when dns_service is enabled in telemetry_config.yml

## Problem
When `dns_enabled` is `true`, the `configure_ochami` role generates a cloud-init group YAML file (`ci-group-service_kube_control_plane_first_x86_64.yaml`) with invalid YAML syntax, causing `ochami cloud-init group set` to fail:

```
unable to unmarshal yaml bytes into value: failed to unmarshal data into YAML: yaml: line 1363: could not find expected :
```

## Root Cause
The cloud-init template `ci-group-service_kube_control_plane_first_x86_64.yaml.j2` uses a YAML literal block scalar (`content: |`) to embed the entire cloud-init configuration. Inside this block, there is a conditional Python heredoc (`<< PYEOF`) for patching the CoreDNS ConfigMap when `dns_enabled` is true.

The heredoc content (`import sys, yaml`, `cfg_path = sys.argv[1]`, etc.) starts at **column 0** (no indentation). In a YAML `|` block, all content lines must be indented at the established indent level (6+ spaces). Lines at column 0 **prematurely terminate** the literal block scalar, causing the YAML parser to interpret subsequent lines as top-level YAML keys — which fails because they are Python code, not valid YAML.

The `PYEOF` heredoc terminator also must be at column 0 for bash to recognize it, making the heredoc approach fundamentally incompatible with YAML `|` blocks.

## Fix
Replace the Python heredoc with `python3 -c` where all lines are properly indented at 12 spaces to stay within the YAML `content: |` block. Python treats the consistent leading whitespace as base-level indentation, so the code executes identically.

### Before (broken)
```
content: |
      ...
      runcmd:
        - |
          ...
          python3 - "$cfg" << PYEOF
import sys, yaml          # <-- column 0: breaks YAML | block
cfg_path = sys.argv[1]
...
PYEOF                     # <-- column 0: also breaks YAML | block
```

### After (fixed)
```
content: |
      ...
      runcmd:
        - |
          ...
          python3 -c '
            import sys, yaml        # indented: stays within YAML | block
            cfg_path = sys.argv[1]
            ...
            ' "$cfg"
```

## Testing
- Run `provision.yml` with `dns_enabled: true` (dns_service enabled)
- Verify `ci-group-service_kube_control_plane_first_x86_64.yaml` is valid YAML
- Verify `ochami cloud-init group set` succeeds for the control plane group

## Files Changed
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2`