### PR TITLE
fix(validation): validate HA VIP against service_kube_control_plane subnet

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
@@ -315,7 +315,9 @@ def validate_vip_address(
     admin_netmaskbits,
     oim_admin_ip,
     pxe_mapping_file_path=None,
-    additional_subnets=None
+    additional_subnets=None,
+    kcp_subnet_ip=None,
+    kcp_subnet_bits=None
 ):
     """
         Validate a virtual IP address against a list of existing service node VIPs,
@@ -330,6 +332,9 @@ def validate_vip_address(
         - admin_netmaskbits (str): The netmask bits value of the admin network.
         - oim_admin_ip (str): The IP address of the OIM admin interface.
         - pxe_mapping_file_path (str, optional): Path to PXE mapping file for additional validation.
+        - additional_subnets (list, optional): List of additional subnet dicts from network_spec.yml.
+        - kcp_subnet_ip (str, optional): Reference IP of the control plane nodes' subnet.
+        - kcp_subnet_bits (str, optional): Netmask bits of the control plane nodes' subnet.
 
         Returns:
         - None: The function does not return any value, it only appends
@@ -359,8 +364,12 @@ def validate_vip_address(
             )
         )
 
-    # validate virtual_ip_address is in the admin subnet
-    if not validation_utils.is_ip_in_subnet(oim_admin_ip, admin_netmaskbits, vip_address):
+    # validate virtual_ip_address is in the expected subnet
+    # If control plane subnet info is provided, validate VIP against that subnet;
+    # otherwise fall back to the primary admin subnet.
+    subnet_ref_ip = kcp_subnet_ip if kcp_subnet_ip else oim_admin_ip
+    subnet_ref_bits = kcp_subnet_bits if kcp_subnet_bits else admin_netmaskbits
+    if not validation_utils.is_ip_in_subnet(subnet_ref_ip, subnet_ref_bits, vip_address):
         errors.append(
             create_error_msg(
                 f"{config_type} virtual_ip_address",
@@ -434,6 +443,26 @@ def validate_service_k8s_cluster_ha(
         pxe_admin_ips = [item["ADMIN_IP"] for item in pxe_list]
         pxe_bmc_ips   = [item["BMC_IP"]   for item in pxe_list]
 
+    # Determine control plane nodes' subnet for VIP validation
+    additional_subnets = network_spec_data.get("additional_subnets", [])
+    kcp_ips = [item["ADMIN_IP"] for item in pxe_list
+               if item.get("FUNCTIONAL_GROUP_NAME", "").startswith("service_kube_control_plane")]
+    kcp_subnet_ip = None
+    kcp_subnet_bits = None
+    if kcp_ips:
+        ref_ip = kcp_ips[0]
+        if validation_utils.is_ip_in_subnet(oim_admin_ip, admin_netmaskbits, ref_ip):
+            kcp_subnet_ip = oim_admin_ip
+            kcp_subnet_bits = admin_netmaskbits
+        elif additional_subnets:
+            for subnet_entry in additional_subnets:
+                s_addr = subnet_entry.get("subnet", "")
+                s_bits = subnet_entry.get("netmask_bits", "")
+                if s_addr and s_bits and validation_utils.is_ip_in_subnet(s_addr, s_bits, ref_ip):
+                    kcp_subnet_ip = s_addr
+                    kcp_subnet_bits = s_bits
+                    break
+
     with open(os.path.join(input_file_path, "omnia_config.yml"), "r", encoding="utf-8") as omniacfg:
         omnia_config =  yaml.safe_load(omniacfg)
         pod_external_ip_list = [item.get("pod_external_ip_range")
@@ -478,7 +507,9 @@ def validate_service_k8s_cluster_ha(
                 admin_netmaskbits,
                 oim_admin_ip,
                 prov_cfg.get('pxe_mapping_file_path'),
-                network_spec_data.get("additional_subnets", [])
+                additional_subnets,
+                kcp_subnet_ip,
+                kcp_subnet_bits
             )
 
 


### PR DESCRIPTION
## Defect
HA VIP validation rejects valid multi-subnet configurations

## Problem
In multi-subnet deployments, the K8s HA virtual IP validation incorrectly requires the VIP to be in the same subnet as the OIM admin NIC. This blocks legitimate configurations where service K8s control plane nodes are in a different subnet:

- **OIM admin NIC subnet:** `10.40.1.0/24` (`primary_oim_admin_ip: 10.40.1.111`)
- **Service K8s control plane subnet:** `10.40.2.0/24` (`kcp1: 10.40.2.11`, `kcp2: 10.40.2.12`)
- **Configured VIP:** `10.40.2.100` (correctly in the control plane nodes subnet)

The validation fails with:
```
virtual ip address provided is not in admin subnet. Check high_availability_config.yml and network_spec.yml
```

## Root Cause
`validate_vip_address()` in `high_availability_validation.py` (lines 362-370) only checks if the VIP is in the primary admin subnet using `is_ip_in_subnet(oim_admin_ip, admin_netmaskbits, vip_address)`. It does not consider that the control plane nodes may be in an `additional_subnet`.

## Fix
The VIP must be in the **same subnet as the `service_kube_control_plane` nodes**, not necessarily the OIM admin subnet.

### Changes in `validate_service_k8s_cluster_ha()`:
1. Extract control plane node ADMIN_IPs from PXE mapping (rows where `FUNCTIONAL_GROUP_NAME` starts with `service_kube_control_plane`)
2. Determine which subnet (primary admin or additional) the first control plane node belongs to
3. Pass the resolved control plane subnet (`kcp_subnet_ip`, `kcp_subnet_bits`) to `validate_vip_address()`

### Changes in `validate_vip_address()`:
1. Added optional `kcp_subnet_ip` and `kcp_subnet_bits` parameters
2. If control plane subnet info is provided, validate VIP against that subnet
3. Falls back to the primary admin subnet when no control plane subnet is resolved (backward compatible)

### Example flow (multi-subnet):
```
PXE mapping:
  service_kube_control_plane_x86_64, 10.40.2.11
  service_kube_control_plane_x86_64, 10.40.2.12

network_spec.yml:
  primary admin: 10.40.1.0/24
  additional_subnets:
    - subnet: 10.40.2.0, netmask_bits: 24

Result:
  kcp_subnet_ip = 10.40.2.0, kcp_subnet_bits = 24
  VIP 10.40.2.100 is in 10.40.2.0/24 → PASS ✓
```

## Testing
1. **Multi-subnet**: Configure control plane nodes in `10.40.2.0/24` (additional subnet), set VIP to `10.40.2.100` → validation passes
2. **Single-subnet**: Control plane nodes in primary admin subnet → behavior unchanged, VIP must be in admin subnet
3. **VIP outside all subnets**: Set VIP to `10.40.3.100` → validation correctly rejects

## Files Changed
- `common/library/module_utils/input_validation/validation_flows/high_availability_validation.py`