### PR TITLE
fix(provision): use control plane nodes subnet for Calico IP autodetection

### DIFF
--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -524,7 +524,7 @@
             cp {{ k8s_client_mount_path }}/calico/{{ calico_package }}.yml {{ k8s_client_mount_path }}/calico/updated-{{ calico_package }}.yml
 
             CALICO_YAML="{{ k8s_client_mount_path }}/calico/updated-{{ calico_package }}.yml"
-            ADMIN_NIC_CIDR="{{ admin_nic_cidr }}"
+            ADMIN_NIC_CIDR="{{ calico_cidr }}"
 
             # Only add if not already present
             if ! grep -q 'name: IP_AUTODETECTION_METHOD' "$CALICO_YAML"; then

--- a/provision/roles/k8s_config/tasks/create_k8s_config_nfs.yml
+++ b/provision/roles/k8s_config/tasks/create_k8s_config_nfs.yml
@@ -66,6 +66,37 @@
   ansible.builtin.set_fact:
     admin_nic_cidr: "{{ (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') }}"
 
+- name: Read PXE mapping to find control plane node subnet
+  community.general.read_csv:
+    path: "{{ hostvars['localhost']['pxe_mapping_file_path'] }}"
+  register: pxe_data_for_cidr
+
+- name: Determine Calico CIDR from control plane nodes subnet
+  ansible.builtin.set_fact:
+    calico_cidr: >-
+      {%- set kcp_ips = pxe_data_for_cidr.list
+          | selectattr('FUNCTIONAL_GROUP_NAME', 'match', '^service_kube_control_plane')
+          | map(attribute='ADMIN_IP') | list -%}
+      {%- if kcp_ips | length > 0 -%}
+        {%- set ref_ip = kcp_ips[0] -%}
+        {%- set primary_net = (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') -%}
+        {%- if ref_ip | ansible.utils.ipaddr(primary_net) -%}
+          {{ primary_net }}
+        {%- else -%}
+          {%- set additional = hostvars['localhost']['network_data']['admin_network']['additional_subnets'] | default([]) -%}
+          {%- set ns = namespace(found='') -%}
+          {%- for s in additional if not ns.found -%}
+            {%- set subnet_cidr = (s.subnet + '/' + s.netmask_bits) | ansible.utils.ipaddr('network/prefix') -%}
+            {%- if ref_ip | ansible.utils.ipaddr(subnet_cidr) -%}
+              {%- set ns.found = subnet_cidr -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ ns.found if ns.found else primary_net }}
+        {%- endif -%}
+      {%- else -%}
+        {{ (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') }}
+      {%- endif -%}
+
 - name: Fetch server_ip and server_share_path from list when nfs sever is localhost
   ansible.builtin.set_fact:
     nfs_server_ip: "{{ hostvars['127.0.0.1']['admin_nic_ip'] }}"


### PR DESCRIPTION
## Defect
Calico CrashLoopBackOff in multi-subnet K8s deployment

## Problem
In multi-subnet deployments, all system pods fail on the K8s control plane node:
- Calico node: **CrashLoopBackOff** (33+ restarts)
- CoreDNS, Calico kube-controllers: stuck in **ContainerCreating**
- Other nodes cannot join the cluster

Calico fails with:
```
Unable to auto-detect an IPv4 address using interface cidr [10.40.1.0/24]:
no valid IPv4 addresses found on the host interfaces
```

### Environment
- OIM admin NIC: `10.40.1.111` (subnet `10.40.1.0/24`)
- Service K8s nodes: `10.40.2.11`, `10.40.2.12`, `10.40.2.14` (subnet `10.40.2.0/24`)
- Calico was configured with `IP_AUTODETECTION_METHOD=cidr=10.40.1.0/24` (wrong subnet)

## Root Cause
`admin_nic_cidr` is computed from the OIM admin NIC IP (`primary_oim_admin_ip`) in `create_k8s_config_nfs.yml`:
```yaml
admin_nic_cidr: "{{ (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') }}"
```
This always produces the OIM subnet CIDR (e.g., `10.40.1.0/24`). When control plane nodes are in a different subnet (`10.40.2.0/24`), Calico cannot find a matching interface IP.

## Fix
### 1. Compute `calico_cidr` from control plane nodes' actual subnet (`create_k8s_config_nfs.yml`)
- Read PXE mapping to find `service_kube_control_plane` node ADMIN_IPs
- Check if the first control plane node IP is in the primary admin subnet
- If not, iterate through `additional_subnets` from `network_spec.yml` to find the matching subnet
- Set `calico_cidr` to the matched subnet CIDR
- Falls back to `admin_nic_cidr` if no control plane nodes found

### 2. Use `calico_cidr` in cloud-init template (`ci-group-service_kube_control_plane_first_x86_64.yaml.j2`)
```diff
-ADMIN_NIC_CIDR="{{ admin_nic_cidr }}"
+ADMIN_NIC_CIDR="{{ calico_cidr }}"
```

### Upgrade path — intentionally unchanged
The upgrade flow (`step_calico_upgrade.yml`) continues to use `admin_nic_cidr`. Multi-subnet is a fresh deployment feature, and changing the upgrade path could impact existing single-subnet deployments where Calico is already running with `admin_nic_cidr`.

## Testing
1. **Multi-subnet**: OIM at `10.40.1.0/24`, K8s nodes at `10.40.2.0/24` → Calico uses `cidr=10.40.2.0/24` ✓
2. **Single-subnet**: All nodes in `10.40.1.0/24` → Calico uses `cidr=10.40.1.0/24` (unchanged) ✓

## Files Changed
- `provision/roles/k8s_config/tasks/create_k8s_config_nfs.yml` — compute `calico_cidr` from PXE mapping
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2` — use `calico_cidr`
