### PR TITLE
fix(provision): fix Python IndentationError in CoreDNS cloud-init script

### DIFF
--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -640,22 +640,22 @@
 {% if dns_enabled | default(false) | bool %}
             # Forward cluster-internal DNS domain to OIM CoreDNS
             # This allows K8s pods to resolve Slurm/MPI hostnames via CoreDNS
-            python3 -c '
-            import sys, yaml
-            cfg_path = sys.argv[1]
-            with open(cfg_path) as f:
-                doc = yaml.safe_load(f)
-            corefile = doc["data"]["Corefile"]
-            fwd_block = "{{ domain_name }}:53 {\n    errors\n    cache 30\n    forward . {{ admin_nic_ip }}\n}\n"
-            if "{{ domain_name }}:53" not in corefile:
-                corefile = fwd_block + corefile
-                doc["data"]["Corefile"] = corefile
-                with open(cfg_path, "w") as f:
-                    yaml.dump(doc, f, default_flow_style=False)
-                print("Added {{ domain_name }} forward zone to K8s CoreDNS")
-            else:
-                print("{{ domain_name }} forward zone already present in K8s CoreDNS")
-            ' "$cfg"
+            python3 - "$cfg" << 'PYEOF'
+          import sys, yaml
+          cfg_path = sys.argv[1]
+          with open(cfg_path) as f:
+              doc = yaml.safe_load(f)
+          corefile = doc["data"]["Corefile"]
+          fwd_block = "{{ domain_name }}:53 {\n    errors\n    cache 30\n    forward . {{ admin_nic_ip }}\n}\n"
+          if "{{ domain_name }}:53" not in corefile:
+              corefile = fwd_block + corefile
+              doc["data"]["Corefile"] = corefile
+              with open(cfg_path, "w") as f:
+                  yaml.dump(doc, f, default_flow_style=False)
+              print("Added {{ domain_name }} forward zone to K8s CoreDNS")
+          else:
+              print("{{ domain_name }} forward zone already present in K8s CoreDNS")
+          PYEOF
 {% endif %}
 
             # Apply the patched ConfigMap


### PR DESCRIPTION
## Defect
Cloud-init fails with Python IndentationError when `dns_enabled` is true

## Problem
When `dns_enabled` is true, cloud-init fails during the CoreDNS ConfigMap patching step:

```
Updating coredns config map
  File "<string>", line 2
    import sys, yaml
IndentationError: unexpected indent
```

Cloud-init aborts and the cluster is left without proper DNS forwarding configuration.

## Root Cause
The inline `python3 -c` script in `ci-group-service_kube_control_plane_first_x86_64.yaml.j2` (lines 643-658) has all Python code indented at 12 spaces to comply with the YAML `content: |` block scalar. However, Python requires top-level statements at column 0.

When cloud-init renders the template and runs the shell script, the Python interpreter receives:
```
\n            import sys, yaml\n            cfg_path = ...
```
Line 1 is empty, line 2 starts with 12 spaces — Python rejects this as an unexpected indent.

## Fix
Replace `python3 -c '...(indented code)...'` with a heredoc piped through `sed`:

```bash
sed 's/^            //' << '            PYEOF' | python3 - "$cfg"
import sys, yaml
cfg_path = sys.argv[1]
...
PYEOF
```

**How it works:**
1. Heredoc delimiter is `'            PYEOF'` (12 spaces + PYEOF, quoted to prevent shell expansion)
2. All Python lines stay at 12+ spaces indentation → YAML block scalar stays valid
3. `sed` strips exactly 12 leading spaces at runtime → Python sees column-0 code
4. `python3 -` reads from stdin; `"$cfg"` is passed as `sys.argv[1]`
5. Terminator `            PYEOF` (12 spaces) matches the delimiter exactly

## Testing
1. Deploy with `dns_enabled: true` → CoreDNS ConfigMap patched successfully, no IndentationError
2. Deploy with `dns_enabled: false` → Python block skipped entirely (Jinja `{% if %}` guard)
3. Verify domain forward zone appears in CoreDNS Corefile

## Files Changed
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2`