### PR TITLE
fix(provision): fix DNS resolution on slurm/login nodes when dns_enabled is true

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/tasks/configs/firewall.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/configs/firewall.yml
@@ -33,6 +33,16 @@
     state: enabled
   loop: "{{ udp_ports }}"
 
+- name: Open DNS port for CoreDNS (when dns_enabled)
+  ansible.posix.firewalld:
+    port: "{{ item }}"
+    permanent: true
+    state: enabled
+  loop:
+    - 53/tcp
+    - 53/udp
+  when: dns_enabled | default(false) | bool
+
 - name: Add Podman interfaces to trusted zone
   ansible.posix.firewalld:
     interface: "{{ item }}"

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -198,6 +198,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         - /usr/local/bin/configure_vast_installation.sh
         # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -198,6 +198,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         - /usr/local/bin/configure_vast_installation.sh
         # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -154,6 +154,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         - /usr/local/bin/configure_vast_installation.sh
         # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -153,6 +153,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         - /usr/local/bin/configure_vast_installation.sh
         # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -286,6 +286,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         # DOCA prerequisites - moved early to ensure RDMA is ready before vendor_data mounts
         - mkdir -p {{ client_mount_path }}/slurm/ssh
         - mkdir -p {{ slurm_ctld_log_dir_effective }} {{ slurmdbd_log_dir_effective }} {{ slurm_ctld_pid_dir_effective }} {{ slurmdbd_pid_dir_effective }} {{ slurm_state_save_location_effective }} {% if slurm_sched_log_dir_effective %}{{ slurm_sched_log_dir_effective }} {% endif %}/etc/slurm {{ home_dir }} /etc/my.cnf.d /etc/munge /var/lib/mysql /var/log/mariadb /cert /var/log/track /var/lib/packages

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -408,6 +408,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         - /usr/local/bin/configure_vast_installation.sh
         # DOCA prerequisites - moved early to ensure RDMA is ready before vendor_data mounts
         - /usr/local/bin/configure_dirs_and_mounts.sh

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -414,6 +414,12 @@
 
       runcmd:
         - /usr/local/bin/set-ssh.sh
+{% if dns_enabled | default(false) | bool %}
+        - |
+          # Restore CoreDNS resolv.conf after set-ssh.sh (nmcli con up may overwrite it)
+          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
+          chattr +i /etc/resolv.conf || true
+{% endif %}
         - /usr/local/bin/configure_vast_installation.sh
         # DOCA prerequisites - moved early to ensure RDMA is ready before vendor_data mounts
         - /usr/local/bin/configure_dirs_and_mounts.sh


### PR DESCRIPTION
## Problem
When `dns_enabled` is true, slurm and login nodes cannot resolve `nid`-format hostnames:

```
[root@nid001 ~]# ping nid002
ping: nid002: Name or service not known

[root@nid001 ~]# ssh nid002
ssh: Could not resolve hostname nid002: Name or service not known

[root@nid001 ~]# sinfo
slurm_load_partitions: Unable to contact slurm controller (connect failure)

slurmctld.log:
error: _xgetaddrinfo: getaddrinfo(nid001:6819) failed: Name or service not known
```

## Root Cause — Two Issues

### 1. OIM firewall blocks port 53 (DNS) from external nodes

CoreDNS on the OIM binds to `admin_nic_ip:53` and serves `nid` hostname records via the coresmd plugin. However, the OIM firewalld configuration only opens ports for DHCP (67/68), TFTP (69), HTTP (8081), and HTTPS (8443). **Port 53 (DNS) is not opened.**

From the OIM itself, DNS works because podman interfaces are in the `trusted` zone (local traffic bypasses the firewall). But from compute nodes, UDP/TCP queries to `10.x.x.x:53` are silently dropped.

### 2. NetworkManager overwrites `/etc/resolv.conf` after cloud-init

Cloud-init `write_files` correctly sets `/etc/resolv.conf` with the CoreDNS nameserver. Then `runcmd` runs `set-ssh.sh`, which calls `nmcli con add ... ipv4.method auto` and `nmcli con up`. This triggers **NetworkManager to overwrite `/etc/resolv.conf`** with DHCP-provided DNS servers, removing the CoreDNS entry.

The K8s templates protect against this with `chattr +i`, but slurm and login templates were missing this protection.

## Fix

### Fix 1: Open port 53 in OIM firewall

Added DNS port opening (53/tcp + 53/udp) in `firewall.yml`, guarded by `dns_enabled`:

```yaml
- name: Open DNS port for CoreDNS (when dns_enabled)
  ansible.posix.firewalld:
    port: "{{ item }}"
    permanent: true
    state: enabled
  loop:
    - 53/tcp
    - 53/udp
  when: dns_enabled | default(false) | bool
```

### Fix 2: Protect resolv.conf on slurm/login nodes

After `set-ssh.sh` completes, restore and lock `/etc/resolv.conf`:

```yaml
{% if dns_enabled | default(false) | bool %}
        - |
          printf 'search {{ domain_name }}\nnameserver {{ admin_nic_ip }}\noptions timeout:1 attempts:2\n' > /etc/resolv.conf
          chattr +i /etc/resolv.conf || true
{% endif %}
```

## Files Changed (8 files)

**OIM firewall:**
- `prepare_oim/roles/deploy_containers/openchami/tasks/configs/firewall.yml`

**Slurm nodes:**
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2`
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2`
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2`

**Login nodes:**
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2`
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2`
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2`
- `provision/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2`

## Testing
1. **`dns_enabled: true`** — All nodes resolve `nid` hostnames, `sinfo` works, `ssh nid002` works
2. **`dns_enabled: false`** — No change in behavior (all fixes guarded by Jinja condition)
3. Verify `firewall-cmd --list-ports` on OIM shows `53/tcp 53/udp`
4. Verify `/etc/resolv.conf` on nodes contains CoreDNS nameserver
5. Verify `lsattr /etc/resolv.conf` shows immutable flag on nodes