### PR TITLE
fix(validation): check primary admin subnet in HA VIP subnet consistency

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
@@ -398,8 +398,8 @@ def validate_vip_address(
         # Check VIP doesn't conflict with any HOST_IP in PXE mapping
         validate_vip_vs_pxe_mapping_host_ips(errors, config_type, vip_address, pxe_mapping_file_path)
         
-        # Check all HOST_IPs are in same subnet as VIP
-        validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_file_path, admin_netmaskbits, additional_subnets)
+        # Check all HOST_IPs are in a known subnet
+        validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_file_path, admin_netmaskbits, additional_subnets, oim_admin_ip)
 
 def validate_service_k8s_cluster_ha(
     errors,

--- a/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py
@@ -96,10 +96,10 @@ def validate_vip_vs_pxe_mapping_host_ips(
 
 def validate_all_host_ips_same_subnet_as_vip(
         errors, vip_address, pxe_mapping_file_path, admin_netmaskbits,
-        additional_subnets=None):
+        additional_subnets=None, oim_admin_ip=None):
     """
     Validate that all ADMIN_IPs in PXE mapping are in a known subnet
-    (primary admin subnet or any additional subnet).
+    (primary admin subnet, VIP subnet, or any additional subnet).
 
     Parameters:
         errors (list): List to append error messages
@@ -108,13 +108,19 @@ def validate_all_host_ips_same_subnet_as_vip(
         admin_netmaskbits (str): Netmask bits for subnet validation
         additional_subnets (list, optional): List of additional subnet
             dicts with 'subnet' and 'netmask_bits' keys.
+        oim_admin_ip (str, optional): OIM admin IP for primary subnet check.
     """
     host_ips = extract_host_ips_from_pxe_mapping(pxe_mapping_file_path)
     if additional_subnets is None:
         additional_subnets = []
 
     for host_ip in host_ips:
-        # Check if host_ip is in the primary admin subnet (VIP subnet)
+        # Check if host_ip is in the primary admin subnet
+        if oim_admin_ip and validation_utils.is_ip_in_subnet(
+                oim_admin_ip, admin_netmaskbits, host_ip):
+            continue
+
+        # Check if host_ip is in the VIP subnet (may differ from admin)
         if validation_utils.is_ip_in_subnet(
                 vip_address, admin_netmaskbits, host_ip):
             continue


### PR DESCRIPTION
## Problem
PR #4723 fixed VIP validation to check against the KCP subnet, but `validate_all_host_ips_same_subnet_as_vip` still fails in multi-subnet setups.

**Error:**
```
Validation Error at ADMIN_IP subnet consistency: '10.40.1.21' Node ADMIN_IP 10.40.1.21
must be in the same subnet as VIP 10.40.2.100 or in one of the configured additional_subnets.
```

## Root Cause

`validate_all_host_ips_same_subnet_as_vip` checks each PXE ADMIN_IP against:
1. **VIP subnet** (`vip_address/admin_netmaskbits`) — e.g. 10.40.2.0/24
2. **additional_subnets** from network_spec.yml — e.g. 10.40.3.0/24

It **misses the primary admin subnet** (`oim_admin_ip/admin_netmaskbits` — e.g. 10.40.1.0/24).

In multi-subnet deployments the VIP is in an additional subnet (10.40.2.x), so nodes in the primary admin subnet (10.40.1.x, where the OIM lives) are incorrectly flagged as "not in a known subnet".

## Fix

- Add `oim_admin_ip` parameter to `validate_all_host_ips_same_subnet_as_vip`
- Check each ADMIN_IP against the **primary admin subnet first**, then VIP subnet, then additional_subnets
- Pass `oim_admin_ip` from the caller in `validate_vip_address`

## Files Changed
- `common/library/module_utils/input_validation/validation_flows/vip_pxe_validation.py`
- `common/library/module_utils/input_validation/validation_flows/high_availability_validation.py`

## Testing
Multi-subnet scenario:
- OIM: 10.40.1.21/24 (primary admin subnet)
- KCP nodes: 10.40.2.11, 10.40.2.12 (additional subnet)
- VIP: 10.40.2.100
- Slurm nodes: 10.40.3.31 (another additional subnet)

All nodes should pass subnet consistency validation.