### PR TITLE
fix rollback: Check upgrade manifest status before skipping components during rollback

### DIFF
--- a/rollback/playbooks/rollback_k8s.yml
+++ b/rollback/playbooks/rollback_k8s.yml
@@ -36,31 +36,49 @@
       when:
         - rollback_manifest.component_status[component_name] | default('pending') == 'completed'
 
-    - name: "Mark as skipped — BuildStream terminal gate active (C-24)"
-      ansible.builtin.copy:
-        content: >-
-          {{ rollback_manifest | combine({
-               'component_status': rollback_manifest.component_status | combine({
-                 component_name: 'skipped'
-               })
-             }) | to_nice_yaml }}
-        dest: "{{ rollback_manifest_path }}"
-        mode: '0644'
+    - name: "BuildStream terminal gate active (C-24)"
       when:
         - hostvars['localhost']['build_stream_terminal'] | default(false) | bool
         - hostvars['localhost']['upgrade_manifest'] is defined
         - hostvars['localhost']['upgrade_manifest'].component_status is defined
         - hostvars['localhost']['upgrade_manifest'].component_status.k8s | default('pending') not in ['completed', 'in-progress', 'failed']
         - hostvars['localhost']['upgrade_manifest'].component_status.telemetry | default('pending') not in ['completed', 'in-progress', 'failed']
+      block:
+        - name: "Mark as skipped — BuildStream terminal gate active (C-24)"
+          ansible.builtin.copy:
+            content: >-
+              {{ rollback_manifest | combine({
+                   'component_status': rollback_manifest.component_status | combine({
+                     component_name: 'skipped'
+                   })
+                 }) | to_nice_yaml }}
+            dest: "{{ rollback_manifest_path }}"
+            mode: '0644'
 
-    - name: "Skip — BuildStream terminal gate active (C-24)"
-      ansible.builtin.meta: end_play
+        - name: "Skip — BuildStream terminal gate active (C-24)"
+          ansible.builtin.meta: end_play
+
+    # ── Gate 3: Skip rollback if k8s/telemetry were never started during upgrade ──
+    - name: "K8s/telemetry never started during upgrade"
       when:
-        - hostvars['localhost']['build_stream_terminal'] | default(false) | bool
         - hostvars['localhost']['upgrade_manifest'] is defined
         - hostvars['localhost']['upgrade_manifest'].component_status is defined
         - hostvars['localhost']['upgrade_manifest'].component_status.k8s | default('pending') not in ['completed', 'in-progress', 'failed']
         - hostvars['localhost']['upgrade_manifest'].component_status.telemetry | default('pending') not in ['completed', 'in-progress', 'failed']
+      block:
+        - name: "Mark as skipped — k8s/telemetry never started during upgrade"
+          ansible.builtin.copy:
+            content: >-
+              {{ rollback_manifest | combine({
+                   'component_status': rollback_manifest.component_status | combine({
+                     component_name: 'skipped'
+                   })
+                 }) | to_nice_yaml }}
+            dest: "{{ rollback_manifest_path }}"
+            mode: '0644'
+
+        - name: "Skip — k8s/telemetry never started during upgrade"
+          ansible.builtin.meta: end_play
 
     # ── Pre-check: Skip rollback if service_k8s is not in software_config.json ──
     - name: "Load software_config.json"

--- a/rollback/playbooks/rollback_k8s.yml
+++ b/rollback/playbooks/rollback_k8s.yml
@@ -48,11 +48,19 @@
         mode: '0644'
       when:
         - hostvars['localhost']['build_stream_terminal'] | default(false) | bool
+        - hostvars['localhost']['upgrade_manifest'] is defined
+        - hostvars['localhost']['upgrade_manifest'].component_status is defined
+        - hostvars['localhost']['upgrade_manifest'].component_status.k8s | default('pending') not in ['completed', 'in-progress', 'failed']
+        - hostvars['localhost']['upgrade_manifest'].component_status.telemetry | default('pending') not in ['completed', 'in-progress', 'failed']
 
     - name: "Skip — BuildStream terminal gate active (C-24)"
       ansible.builtin.meta: end_play
       when:
         - hostvars['localhost']['build_stream_terminal'] | default(false) | bool
+        - hostvars['localhost']['upgrade_manifest'] is defined
+        - hostvars['localhost']['upgrade_manifest'].component_status is defined
+        - hostvars['localhost']['upgrade_manifest'].component_status.k8s | default('pending') not in ['completed', 'in-progress', 'failed']
+        - hostvars['localhost']['upgrade_manifest'].component_status.telemetry | default('pending') not in ['completed', 'in-progress', 'failed']
 
     # ── Pre-check: Skip rollback if service_k8s is not in software_config.json ──
     - name: "Load software_config.json"

--- a/rollback/playbooks/rollback_slurm.yml
+++ b/rollback/playbooks/rollback_slurm.yml
@@ -57,8 +57,11 @@
         cacheable: true
 
     - name: "Handle BuildStream terminal gate (C-24)"
-      when: ((build_stream_terminal | default(false) | bool) or
-            (manifest.component_status.build_stream | default('pending') == 'completed'))
+      when:
+        - (build_stream_terminal | default(false) | bool) or (manifest.component_status.build_stream | default('pending') == 'completed')
+        - hostvars['localhost']['upgrade_manifest'] is defined
+        - hostvars['localhost']['upgrade_manifest'].component_status is defined
+        - hostvars['localhost']['upgrade_manifest'].component_status.slurm | default('pending') not in ['completed', 'in-progress', 'failed']
       block:
         - name: "Mark as skipped — BuildStream terminal gate active"
           ansible.builtin.copy:

--- a/rollback/playbooks/rollback_slurm.yml
+++ b/rollback/playbooks/rollback_slurm.yml
@@ -22,6 +22,7 @@
   gather_facts: false
   vars:
     rollback_manifest_path: /opt/omnia/.data/rollback_manifest.yml
+    upgrade_manifest_path: /opt/omnia/.data/upgrade_manifest.yml
     component_name: slurm
   tasks:
     - name: Check if rollback manifest exists
@@ -40,45 +41,47 @@
     - name: Read rollback_manifest.yml
       ansible.builtin.include_vars:
         file: "{{ rollback_manifest_path }}"
-        name: manifest
+        name: rollback_manifest
+
+    - name: Read upgrade_manifest.yml
+      ansible.builtin.include_vars:
+        file: "{{ upgrade_manifest_path }}"
+        name: upgrade_manifest
+      failed_when: false
+
+    - name: Set upgrade_manifest to empty dict if not found
+      ansible.builtin.set_fact:
+        slurm_skip: false
+        upgrade_manifest: "{{ hostvars['localhost']['upgrade_manifest'] }}"
 
     - name: Read software_config.json
       ansible.builtin.include_vars:
-        file: "{{ manifest.backup_dir }}/input/project_default/software_config.json"
+        file: "{{ rollback_manifest.backup_dir }}/input/project_default/software_config.json"
         name: software_config
 
     - name: Determine slurm_skip status
       ansible.builtin.set_fact:
-        slurm_skip: >-
-          {{
-            (manifest.component_status[component_name] | default('pending') == 'completed')
-            or (software_config.softwares | selectattr('name', 'equalto', 'slurm_custom') | list | length == 0)
-          }}
+        slurm_skip: true
         cacheable: true
+      when: >
+        (rollback_manifest.component_status.slurm | default('pending') == 'completed')
+        or (software_config.softwares | selectattr('name', 'equalto', 'slurm_custom') | list | length == 0)
+        or (build_stream_terminal | default(false) | bool)
+        or (upgrade_manifest.component_status.slurm | default('pending') not in ['completed', 'in-progress', 'failed'])
 
     - name: "Handle BuildStream terminal gate (C-24)"
-      when:
-        - (build_stream_terminal | default(false) | bool) or (manifest.component_status.build_stream | default('pending') == 'completed')
-        - hostvars['localhost']['upgrade_manifest'] is defined
-        - hostvars['localhost']['upgrade_manifest'].component_status is defined
-        - hostvars['localhost']['upgrade_manifest'].component_status.slurm | default('pending') not in ['completed', 'in-progress', 'failed']
+      when: slurm_skip
       block:
         - name: "Mark as skipped — BuildStream terminal gate active"
           ansible.builtin.copy:
             content: >-
-              {{ manifest | combine({
-                   'component_status': manifest.component_status | combine({
+              {{ rollback_manifest | combine({
+                   'component_status': rollback_manifest.component_status | combine({
                      component_name: 'skipped'
                    })
                  }) | to_nice_yaml }}
             dest: "{{ rollback_manifest_path }}"
             mode: '0644'
-          when: not slurm_skip
-
-        - name: "Set slurm_skip — BuildStream terminal gate active"
-          ansible.builtin.set_fact:
-            slurm_skip: true
-            cacheable: true
 
         - name: "Skip — BuildStream terminal gate active"
           ansible.builtin.meta: end_play
@@ -89,8 +92,8 @@
         - name: Set slurm rollback status to in-progress
           ansible.builtin.copy:
             content: >-
-              {{ manifest | combine({
-                  'component_status': manifest.component_status | combine({
+              {{ rollback_manifest | combine({
+                  'component_status': rollback_manifest.component_status | combine({
                     component_name: 'in-progress'
                   })
                 }) | to_nice_yaml }}

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -262,9 +262,19 @@
     - name: Identify components skipped by BuildStream terminal gate
       ansible.builtin.set_fact:
         bs_rollback_skipped: >-
-          {{ ['slurm', 'k8s-telemetry']
-             if (build_stream_terminal | bool)
-             else [] }}
+          {%- set skipped = [] -%}
+          {%- if build_stream_terminal | bool -%}
+          {%-   if upgrade_manifest is defined and upgrade_manifest.component_status is defined -%}
+          {%-     if upgrade_manifest.component_status.slurm | default('pending') not in ['completed', 'in-progress', 'failed'] -%}
+          {%-       set _ = skipped.append('slurm') -%}
+          {%-     endif -%}
+          {%-     if (upgrade_manifest.component_status.k8s | default('pending') not in ['completed', 'in-progress', 'failed'])
+                    and (upgrade_manifest.component_status.telemetry | default('pending') not in ['completed', 'in-progress', 'failed']) -%}
+          {%-       set _ = skipped.append('k8s-telemetry') -%}
+          {%-     endif -%}
+          {%-   endif -%}
+          {%- endif -%}
+          {{ skipped }}
 
     - name: Report BuildStream terminal gate activation (rollback)
       ansible.builtin.debug:

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -285,19 +285,46 @@
           Only build_stream and oim will be rolled back.
       when: build_stream_terminal | bool
 
-    - name: Report already-rolled-back components (will be skipped)
+    - name: Report component rollback actions based on upgrade manifest
       ansible.builtin.debug:
-        msg: "Component '{{ item }}' already rolled back — will be skipped."
+        msg: >-
+          {%- if rollback_manifest.component_status[item] is defined and rollback_manifest.component_status[item] == 'completed' -%}
+          Component '{{ item }}' already rolled back — will be skipped.
+          {%- elif rollback_manifest.component_status[item] is defined and rollback_manifest.component_status[item] == 'skipped' -%}
+          Component '{{ item }}' was skipped during rollback — will be skipped.
+          {%- elif upgrade_manifest is defined and upgrade_manifest.component_status is defined -%}
+          {%-   if item == 'k8s-telemetry' -%}
+          {%-     set k8s_status = upgrade_manifest.component_status.k8s | default('pending') -%}
+          {%-     set telemetry_status = upgrade_manifest.component_status.telemetry | default('pending') -%}
+          {%-     if k8s_status == 'skipped' and telemetry_status == 'skipped' -%}
+          Component '{{ item }}' was skipped during upgrade — will be skipped during rollback.
+          {%-     elif k8s_status in ['completed', 'in-progress', 'failed'] or telemetry_status in ['completed', 'in-progress', 'failed'] -%}
+          Component '{{ item }}' will be rolled back (upgrade status: k8s={{ k8s_status }}, telemetry={{ telemetry_status }}).
+          {%-     else -%}
+          Component '{{ item }}' was not upgraded — will be skipped during rollback.
+          {%-     endif -%}
+          {%-   elif upgrade_manifest.component_status[item] is defined -%}
+          {%-     set upgrade_status = upgrade_manifest.component_status[item] -%}
+          {%-     if upgrade_status == 'skipped' -%}
+          Component '{{ item }}' was skipped during upgrade — will be skipped during rollback.
+          {%-     elif upgrade_status in ['completed', 'in-progress', 'failed'] -%}
+          Component '{{ item }}' will be rolled back (upgrade status: {{ upgrade_status }}).
+          {%-     else -%}
+          Component '{{ item }}' was not upgraded — will be skipped during rollback.
+          {%-     endif -%}
+          {%-   endif -%}
+          {%- endif -%}
       loop: "{{ requested_tags }}"
       when:
-        - rollback_manifest.component_status[item] is defined
-        - rollback_manifest.component_status[item] in ['completed', 'skipped']
+        - (rollback_manifest.component_status[item] is defined and rollback_manifest.component_status[item] in ['completed', 'skipped'])
+          or (upgrade_manifest is defined and upgrade_manifest.component_status is defined)
 
 # ──────────────────────────────────────────────────────────────────────
 # Load credentials (provision_password etc.) from omnia_config_credentials.yml
 # Mirrors upgrade pattern: ../utils/credential_utility/get_config_credentials.yml
 # Read-only — no interactive prompts, no re-encryption.
 # ──────────────────────────────────────────────────────────────────────
+ 
 - name: Load rollback credentials
   ansible.builtin.import_playbook: playbooks/load_rollback_credentials.yml
   tags: [build_stream, buildstream, oim]

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -256,7 +256,7 @@
           {{ (build_stream_config.enable_build_stream | default(false) | bool)
              or ((upgrade_manifest is defined)
              and (upgrade_manifest.component_status is defined)
-             and (upgrade_manifest.component_status.build_stream | default('pending') == 'completed')) }}
+             and (upgrade_manifest.component_status.build_stream | default('pending') in ['completed'])) }}
         cacheable: true
 
     - name: Identify components skipped by BuildStream terminal gate

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -256,7 +256,7 @@
           {{ (build_stream_config.enable_build_stream | default(false) | bool)
              or ((upgrade_manifest is defined)
              and (upgrade_manifest.component_status is defined)
-             and (upgrade_manifest.component_status.build_stream | default('pending') in ['completed', 'skipped'])) }}
+             and (upgrade_manifest.component_status.build_stream | default('pending') == 'completed')) }}
         cacheable: true
 
     - name: Identify components skipped by BuildStream terminal gate

--- a/rollback/rollback.yml
+++ b/rollback/rollback.yml
@@ -289,30 +289,30 @@
       ansible.builtin.debug:
         msg: >-
           {%- if rollback_manifest.component_status[item] is defined and rollback_manifest.component_status[item] == 'completed' -%}
-          Component '{{ item }}' already rolled back — will be skipped.
+            Component '{{ item }}' already rolled back — will be skipped.
           {%- elif rollback_manifest.component_status[item] is defined and rollback_manifest.component_status[item] == 'skipped' -%}
-          Component '{{ item }}' was skipped during rollback — will be skipped.
+            Component '{{ item }}' was skipped during rollback — will be skipped.
           {%- elif upgrade_manifest is defined and upgrade_manifest.component_status is defined -%}
-          {%-   if item == 'k8s-telemetry' -%}
-          {%-     set k8s_status = upgrade_manifest.component_status.k8s | default('pending') -%}
-          {%-     set telemetry_status = upgrade_manifest.component_status.telemetry | default('pending') -%}
-          {%-     if k8s_status == 'skipped' and telemetry_status == 'skipped' -%}
-          Component '{{ item }}' was skipped during upgrade — will be skipped during rollback.
+            {%-   if item == 'k8s-telemetry' -%}
+              {%-     set k8s_status = upgrade_manifest.component_status.k8s | default('pending') -%}
+              {%-     set telemetry_status = upgrade_manifest.component_status.telemetry | default('pending') -%}
+              {%-     if k8s_status == 'skipped' and telemetry_status == 'skipped' -%}
+                Component '{{ item }}' was skipped during upgrade — will be skipped during rollback.
           {%-     elif k8s_status in ['completed', 'in-progress', 'failed'] or telemetry_status in ['completed', 'in-progress', 'failed'] -%}
-          Component '{{ item }}' will be rolled back (upgrade status: k8s={{ k8s_status }}, telemetry={{ telemetry_status }}).
+                Component '{{ item }}' will be rolled back (upgrade status: k8s={{ k8s_status }}, telemetry={{ telemetry_status }}).
           {%-     else -%}
-          Component '{{ item }}' was not upgraded — will be skipped during rollback.
+                Component '{{ item }}' was not upgraded — will be skipped during rollback.
           {%-     endif -%}
-          {%-   elif upgrade_manifest.component_status[item] is defined -%}
-          {%-     set upgrade_status = upgrade_manifest.component_status[item] -%}
-          {%-     if upgrade_status == 'skipped' -%}
-          Component '{{ item }}' was skipped during upgrade — will be skipped during rollback.
+            {%-   elif upgrade_manifest.component_status[item] is defined -%}
+              {%-     set upgrade_status = upgrade_manifest.component_status[item] -%}
+              {%-     if upgrade_status == 'skipped' -%}
+                Component '{{ item }}' was skipped during upgrade — will be skipped during rollback.
           {%-     elif upgrade_status in ['completed', 'in-progress', 'failed'] -%}
-          Component '{{ item }}' will be rolled back (upgrade status: {{ upgrade_status }}).
+                Component '{{ item }}' will be rolled back (upgrade status: {{ upgrade_status }}).
           {%-     else -%}
-          Component '{{ item }}' was not upgraded — will be skipped during rollback.
+                Component '{{ item }}' was not upgraded — will be skipped during rollback.
           {%-     endif -%}
-          {%-   endif -%}
+            {%-   endif -%}
           {%- endif -%}
       loop: "{{ requested_tags }}"
       when:
@@ -324,7 +324,7 @@
 # Mirrors upgrade pattern: ../utils/credential_utility/get_config_credentials.yml
 # Read-only — no interactive prompts, no re-encryption.
 # ──────────────────────────────────────────────────────────────────────
- 
+
 - name: Load rollback credentials
   ansible.builtin.import_playbook: playbooks/load_rollback_credentials.yml
   tags: [build_stream, buildstream, oim]


### PR DESCRIPTION
**Summary**

Fixed a bug where rollback incorrectly skipped components that were actually upgraded. The BuildStream terminal gate logic was unconditionally
skipping k8s-telemetry and slurm rollback without checking if these components were actually upgraded during the upgrade process.

Problem

When rollback is triggered after a failed/interrupted upgrade, components like k8s-telemetry were being skipped even though they were partially
upgraded (in-progress status). This left the cluster in an inconsistent state.

Example scenario:

  • Upgrade manifest shows k8s: in-progress, telemetry: pending, build_stream: skipped
  • Rollback incorrectly skipped k8s-telemetry because BuildStream terminal gate was active
  • Result: K8s cluster left in partially upgraded state with no rollback

Root Cause

The rollback logic checked only if BuildStream terminal gate was active, but did not verify the actual upgrade status of each component in the
upgrade manifest.

Previous logic:

# Unconditionally skip if BuildStream terminal gate is active
when:
  - build_stream_terminal | default(false) | bool

Solution

Modified the rollback logic to check the upgrade manifest and only skip components that were never upgraded (status = pending or skipped).
Components that were actually upgraded (status = completed, in-progress, or failed) will now be properly rolled back.

New logic:

# Skip only if component was never upgraded
when:
  - build_stream_terminal | default(false) | bool
  - upgrade_manifest.component_status.<component> not in ['completed', 'in-progress', 'failed']

Files Changed

  • rollback/playbooks/rollback_k8s.yml - Added upgrade manifest checks before skipping k8s-telemetry rollback
  • rollback/playbooks/rollback_slurm.yml - Added upgrade manifest checks before skipping slurm rollback
  • rollback/rollback.yml - Updated bs_rollback_skipped calculation to check actual upgrade status

Behavior After Fix

┌────────────────┬──────────────────────────────────────────────────────┐
│ Upgrade Status                │ Rollback Behavior                                    
├────────────────┼──────────────────────────────────────────────────────┤
│ completed                        │ Rollback proceeds                                    
├────────────────┼──────────────────────────────────────────────────────┤
│ in-progress                       │ Rollback proceeds                                    
├────────────────┼──────────────────────────────────────────────────────┤
│ failed                                │ Rollback proceeds                                    
├────────────────┼──────────────────────────────────────────────────────┤
│ skipped                            │ Rollback skipped (component was never upgraded)      
├────────────────┼──────────────────────────────────────────────────────┤
│ pending                           │ Rollback skipped (component was never started)       
└────────────────┴──────────────────────────────────────────────────────┘

