### PR TITLE
fix: add ADMIN_IP subnet consistency validation for PXE mapping

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/provision_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/provision_validation.py
@@ -25,6 +25,7 @@ import ipaddress
 from ansible.module_utils.input_validation.common_utils import validation_utils
 from ansible.module_utils.input_validation.common_utils import config
 from ansible.module_utils.input_validation.common_utils import en_us_validation_msg
+from ansible.module_utils.input_validation.common_utils.validation_utils import is_ip_in_subnet
 from ansible.module_utils.input_validation.validation_flows import common_validation
 
 file_names = config.files
@@ -861,6 +862,68 @@ def validate_parent_service_tag_hierarchy(pxe_mapping_file_path):
 #
 #     return errors
 
+
+def validate_pxe_admin_ips_subnet_consistency(
+        errors, pxe_mapping_file_path, oim_admin_ip, admin_netmaskbits,
+        additional_subnets=None):
+    """
+    Validate that every ADMIN_IP in the PXE mapping file belongs to a known
+    subnet: either the primary admin subnet or one of the additional_subnets
+    defined in network_spec.yml.
+
+    Args:
+        errors (list): List to append error messages to.
+        pxe_mapping_file_path (str): Path to the PXE mapping CSV file.
+        oim_admin_ip (str): Primary OIM admin IP address.
+        admin_netmaskbits (str): Netmask bits for the primary admin subnet.
+        additional_subnets (list, optional): List of additional subnet dicts
+            with 'subnet' and 'netmask_bits' keys.
+    """
+    if additional_subnets is None:
+        additional_subnets = []
+
+    pxe_admin_ips = []
+    try:
+        with open(pxe_mapping_file_path, "r", encoding="utf-8") as fh:
+            raw_lines = [ln for ln in fh.readlines()
+                         if ln.strip() and not ln.strip().startswith('#')]
+        reader = csv.DictReader(raw_lines)
+        fieldname_map = {fn.strip().upper(): fn for fn in reader.fieldnames}
+        admin_ip_col = fieldname_map.get("ADMIN_IP")
+        if admin_ip_col:
+            for row in reader:
+                val = (row.get(admin_ip_col) or "").strip()
+                if val and validation_utils.validate_ipv4(val):
+                    pxe_admin_ips.append(val)
+    except (OSError, csv.Error):
+        return
+
+    for host_ip in pxe_admin_ips:
+        if is_ip_in_subnet(oim_admin_ip, admin_netmaskbits, host_ip):
+            continue
+        in_additional = any(
+            is_ip_in_subnet(
+                s.get("subnet", ""),
+                s.get("netmask_bits", ""),
+                host_ip
+            )
+            for s in additional_subnets
+            if s.get("subnet") and s.get("netmask_bits")
+        )
+        if not in_additional:
+            errors.append(
+                create_error_msg(
+                    "ADMIN_IP subnet consistency",
+                    host_ip,
+                    f"Node ADMIN_IP {host_ip} does not belong to the primary "
+                    f"admin subnet ({oim_admin_ip}/{admin_netmaskbits}) or any "
+                    "subnet defined in network_spec.yml additional_subnets. "
+                    "Please ensure all ADMIN_IPs in the PXE mapping file are "
+                    "covered by a subnet in network_spec.yml."
+                )
+            )
+
+
 def validate_aarch64_local_path_compatibility(pxe_mapping_file_path):
     """
     Validates that aarch64 nodes are not present when using local share path.
@@ -1256,13 +1319,40 @@ def validate_provision_config(
             validate_aarch64_local_path_compatibility(pxe_mapping_file_path)
             validate_functional_groups_software_consistency(pxe_mapping_file_path, software_config_json, logger)
 
-            # Validate ADMIN_IPs against network_spec.yml ranges
-            # network_spec_path = create_file_path(input_file_path, file_names["network_spec"])
-            # if os.path.isfile(network_spec_path):
-            #     admin_ip_errors = validate_admin_ips_against_network_spec(
-            #         pxe_mapping_file_path, network_spec_path
-            #     )
-            #     errors.extend(admin_ip_errors)
+            # Validate ADMIN_IPs against network_spec.yml subnets (including additional_subnets)
+            network_spec_path = create_file_path(input_file_path, file_names["network_spec"])
+            if os.path.isfile(network_spec_path):
+                try:
+                    with open(network_spec_path, "r", encoding="utf-8") as f:
+                        network_spec_json = yaml.safe_load(f)
+
+                    # Extract admin network configuration
+                    admin_netmaskbits = None
+                    oim_admin_ip = None
+                    additional_subnets = []
+
+                    for network in (network_spec_json or {}).get("Networks", []):
+                        if "admin_network" in network and isinstance(network["admin_network"], dict):
+                            admin_net = network["admin_network"]
+                            admin_netmaskbits = admin_net.get("netmask_bits")
+                            oim_admin_ip = admin_net.get("primary_oim_admin_ip")
+                            additional_subnets = admin_net.get("additional_subnets") or []
+                            break
+
+                    if admin_netmaskbits and oim_admin_ip:
+                        validate_pxe_admin_ips_subnet_consistency(
+                            errors, pxe_mapping_file_path,
+                            oim_admin_ip, admin_netmaskbits,
+                            additional_subnets
+                        )
+                except (yaml.YAMLError, IOError) as e:
+                    errors.append(
+                        create_error_msg(
+                            "network_spec.yml",
+                            network_spec_path,
+                            f"Failed to load or parse network_spec.yml: {str(e)}"
+                        )
+                    )
         except ValueError as e:
             errors.append(
                 create_error_msg(

--- a/common/library/modules/tests/test_additional_subnets_validation.py
+++ b/common/library/modules/tests/test_additional_subnets_validation.py
@@ -73,9 +73,16 @@ sys.modules["ansible.module_utils.input_validation.validation_flows.common_valid
     types.ModuleType("ansible.module_utils.input_validation.validation_flows.common_validation")
 )
 
+# Register is_ip_in_subnet on the validation_utils stub so provision_validation can import it
+_vu_mod = sys.modules["ansible.module_utils.input_validation.common_utils.validation_utils"]
+if not hasattr(_vu_mod, "is_ip_in_subnet"):
+    import input_validation.common_utils.validation_utils as _real_vu
+    setattr(_vu_mod, "is_ip_in_subnet", _real_vu.is_ip_in_subnet)
+
 from input_validation.validation_flows.provision_validation import (  # noqa: E402
     _validate_additional_subnets,
     _ranges_overlap,
+    validate_pxe_admin_ips_subnet_consistency,
 )
 
 
@@ -252,6 +259,108 @@ class TestValidateAdditionalSubnets(unittest.TestCase):
         errors = _validate_additional_subnets(additional, self._admin_net())
         # These have different CIDRs and non-overlapping ranges — should be clean
         self.assertEqual(errors, [])
+
+
+class TestPXEMappingSubnetValidation(unittest.TestCase):
+    """Tests for validate_pxe_admin_ips_subnet_consistency."""
+
+    def _create_temp_pxe_mapping(self, admin_ips):
+        """Create a temporary PXE mapping file with given ADMIN_IPs."""
+        import tempfile
+        fd, path = tempfile.mkstemp(suffix=".csv")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("FUNCTIONAL_GROUP_NAME,GROUP_NAME,SERVICE_TAG,PARENT_SERVICE_TAG,HOSTNAME,ADMIN_MAC,ADMIN_IP,BMC_MAC,BMC_IP\n")
+            for i, admin_ip in enumerate(admin_ips):
+                f.write(f"slurm_node,grp0,SVCTAG{i},,node{i},00:11:22:33:44:55,{admin_ip},00:11:22:33:44:66,10.0.0.1\n")
+        return path
+
+    def test_admin_ip_in_admin_subnet(self):
+        """ADMIN_IP in primary admin subnet should pass validation."""
+        pxe_file = self._create_temp_pxe_mapping(["172.16.0.10"])
+        errors = []
+        try:
+            validate_pxe_admin_ips_subnet_consistency(
+                errors, pxe_file, TEST_ADMIN_IP, "24", []
+            )
+            self.assertEqual(errors, [])
+        finally:
+            os.unlink(pxe_file)
+
+    def test_admin_ip_in_additional_subnet(self):
+        """ADMIN_IP in additional subnet should pass validation."""
+        pxe_file = self._create_temp_pxe_mapping(["10.40.1.10"])
+        additional = [{
+            "subnet": TEST_SUBNET_1,
+            "netmask_bits": "24",
+            "router": TEST_ROUTER_1,
+            "dynamic_range": "10.40.1.100-10.40.1.200",
+        }]
+        errors = []
+        try:
+            validate_pxe_admin_ips_subnet_consistency(
+                errors, pxe_file, TEST_ADMIN_IP, "24", additional
+            )
+            self.assertEqual(errors, [])
+        finally:
+            os.unlink(pxe_file)
+
+    def test_admin_ip_in_undefined_subnet(self):
+        """ADMIN_IP in undefined subnet should fail validation."""
+        pxe_file = self._create_temp_pxe_mapping(["192.168.100.10"])
+        errors = []
+        try:
+            validate_pxe_admin_ips_subnet_consistency(
+                errors, pxe_file, TEST_ADMIN_IP, "24", []
+            )
+            self.assertTrue(len(errors) > 0)
+            self.assertTrue("192.168.100.10" in str(errors))
+        finally:
+            os.unlink(pxe_file)
+
+    def test_admin_ip_in_additional_subnet_undefined_in_network_spec(self):
+        """ADMIN_IP in subnet not defined in additional_subnets should fail validation."""
+        pxe_file = self._create_temp_pxe_mapping(["10.40.2.10"])
+        additional = [{
+            "subnet": TEST_SUBNET_1,
+            "netmask_bits": "24",
+            "router": TEST_ROUTER_1,
+            "dynamic_range": "10.40.1.100-10.40.1.200",
+        }]
+        errors = []
+        try:
+            validate_pxe_admin_ips_subnet_consistency(
+                errors, pxe_file, TEST_ADMIN_IP, "24", additional
+            )
+            self.assertTrue(len(errors) > 0)
+            self.assertTrue("10.40.2.10" in str(errors))
+        finally:
+            os.unlink(pxe_file)
+
+    def test_mixed_valid_and_invalid_admin_ips(self):
+        """Mix of valid (in admin subnet) and invalid (undefined subnet) ADMIN_IPs."""
+        pxe_file = self._create_temp_pxe_mapping(["172.16.0.10", "192.168.100.10"])
+        errors = []
+        try:
+            validate_pxe_admin_ips_subnet_consistency(
+                errors, pxe_file, TEST_ADMIN_IP, "24", []
+            )
+            self.assertEqual(len(errors), 1)
+            self.assertTrue("192.168.100.10" in str(errors))
+            self.assertFalse("172.16.0.10" in str(errors))
+        finally:
+            os.unlink(pxe_file)
+
+    def test_no_additional_subnets_defaults_to_empty(self):
+        """Passing None for additional_subnets should not crash."""
+        pxe_file = self._create_temp_pxe_mapping(["172.16.0.10"])
+        errors = []
+        try:
+            validate_pxe_admin_ips_subnet_consistency(
+                errors, pxe_file, TEST_ADMIN_IP, "24", None
+            )
+            self.assertEqual(errors, [])
+        finally:
+            os.unlink(pxe_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add input validation to ensure ADMIN_IP addresses in the PXE mapping file (pxe_mapping_file.csv) belong to a subnet defined in network_spec.yml — either the primary admin_network or one of the additional_subnets.

## Problem

The input validation framework failed to validate consistency between ADMIN_IP addresses in the PXE mapping file and subnets defined in network_spec.yml. This allowed ADMIN_IPs from undefined subnets to pass validation silently, leading to:
- Network connectivity issues during PXE boot and node provisioning
- Difficult debugging in multi-RAC/multi-subnet deployments
- Issues only manifesting at runtime deployment

## Changes

### `provision_validation.py`
- Add `validate_pxe_admin_ips_subnet_consistency()` as a standalone, testable function
- Call it from `validate_provision_config()` after loading network_spec.yml
- Import `is_ip_in_subnet` directly — no cross-dependency on HA-specific `vip_pxe_validation` module
- Guard against `yaml.safe_load` returning `None` for empty network_spec
- Clear error messages referencing primary admin subnet and additional_subnets (no misleading VIP references)

### `test_additional_subnets_validation.py`
- 6 tests exercising the production code path:
  - ADMIN_IP in primary admin subnet (pass)
  - ADMIN_IP in additional subnet (pass)
  - ADMIN_IP in undefined subnet (fail)
  - ADMIN_IP in subnet not in additional_subnets (fail)
  - Mixed valid/invalid ADMIN_IPs (only invalid flagged)
  - `None` additional_subnets doesn't crash

## Test Results

All 23 tests pass (`python3 common/library/modules/tests/test_additional_subnets_validation.py -v`)

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>