### PR TITLE
fix: ADMIN_IP subnet consistency validation - remove HA duplicate and add file path in error

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
@@ -23,7 +23,6 @@ from ansible.module_utils.input_validation.common_utils import config
 from ansible.module_utils.input_validation.common_utils import en_us_validation_msg
 from ansible.module_utils.input_validation.validation_flows.vip_pxe_validation import (
     validate_vip_vs_pxe_mapping_host_ips,
-    validate_all_host_ips_same_subnet_as_vip
 )
 
 file_names = config.files
@@ -401,9 +400,6 @@ def validate_vip_address(
     if pxe_mapping_file_path:
         # Check VIP doesn't conflict with any HOST_IP in PXE mapping
         validate_vip_vs_pxe_mapping_host_ips(errors, config_type, vip_address, pxe_mapping_file_path)
-        
-        # Check all HOST_IPs are in same subnet as VIP
-        validate_all_host_ips_same_subnet_as_vip(errors, vip_address, pxe_mapping_file_path, admin_netmaskbits, additional_subnets, oim_admin_ip)
 
 def validate_service_k8s_cluster_ha(
     errors,

--- a/common/library/module_utils/input_validation/validation_flows/provision_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/provision_validation.py
@@ -913,7 +913,7 @@ def validate_pxe_admin_ips_subnet_consistency(
         if not in_additional:
             errors.append(
                 create_error_msg(
-                    "ADMIN_IP subnet consistency",
+                    f"{pxe_mapping_file_path}: ADMIN_IP subnet consistency",
                     host_ip,
                     f"Node ADMIN_IP {host_ip} does not belong to the primary "
                     f"admin subnet ({oim_admin_ip}/{admin_netmaskbits}) or any "

--- a/common/library/modules/tests/test_additional_subnets_validation.py
+++ b/common/library/modules/tests/test_additional_subnets_validation.py
@@ -314,6 +314,7 @@ class TestPXEMappingSubnetValidation(unittest.TestCase):
             )
             self.assertTrue(len(errors) > 0)
             self.assertTrue("192.168.100.10" in str(errors))
+            self.assertIn(pxe_file, errors[0]["error_key"])
         finally:
             os.unlink(pxe_file)
 
@@ -333,6 +334,7 @@ class TestPXEMappingSubnetValidation(unittest.TestCase):
             )
             self.assertTrue(len(errors) > 0)
             self.assertTrue("10.40.2.10" in str(errors))
+            self.assertIn(pxe_file, errors[0]["error_key"])
         finally:
             os.unlink(pxe_file)
 
@@ -347,6 +349,7 @@ class TestPXEMappingSubnetValidation(unittest.TestCase):
             self.assertEqual(len(errors), 1)
             self.assertTrue("192.168.100.10" in str(errors))
             self.assertFalse("172.16.0.10" in str(errors))
+            self.assertIn(pxe_file, errors[0]["error_key"])
         finally:
             os.unlink(pxe_file)
 


### PR DESCRIPTION
## Summary
Fixes two issues with the ADMIN_IP subnet consistency validation for multi-subnet DHCP:

### Issue 1: Duplicate error from high_availability_config.yml
The same subnet consistency check ran in **both** `provision_validation.py` and `high_availability_validation.py`, causing the error to appear twice — once against each config file. Removed the duplicate call from HA validation since it's already covered by provision validation.

### Issue 2: Error message missing PXE mapping file path
The error message did not include the PXE mapping file path, making it unclear which file contained the misconfigured ADMIN_IP. The `error_key` now includes the file path:

**Before:**
```
Validation Error at ADMIN_IP subnet consistency: '10.40.1.150' Node ADMIN_IP 10.40.1.150 does not belong to...
```

**After:**
```
Validation Error at /path/to/pxe_mapping_file.csv: ADMIN_IP subnet consistency: '10.40.1.150' Node ADMIN_IP 10.40.1.150 does not belong to...
```

## Files Changed
- **`high_availability_validation.py`** — removed `validate_all_host_ips_same_subnet_as_vip` call and unused import
- **`provision_validation.py`** — prepend `pxe_mapping_file_path` to `error_key`
- **`test_additional_subnets_validation.py`** — added assertions verifying file path is present in error key

## Tests
All 23 tests pass: `python3 common/library/modules/tests/test_additional_subnets_validation.py -v`

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>