### PR TITLE
support rhel_subscription_repo_config_<arch> precedence logic(rhel eus)

### DIFF
--- a/common/library/module_utils/input_validation/schema/local_repo_config.json
+++ b/common/library/module_utils/input_validation/schema/local_repo_config.json
@@ -1190,91 +1190,10 @@
         },
         "required": [
           "url",
-          "gpgkey",
           "name"
-        ],
-        "allOf": [
-          {
-            "if": {
-              "required": [
-                "sslcacert"
-              ],
-              "properties": {
-                "sslcacert": {
-                  "minLength": 1
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sslclientkey",
-                "sslclientcert"
-              ],
-              "properties": {
-                "sslclientkey": {
-                  "minLength": 1
-                },
-                "sslclientcert": {
-                  "minLength": 1
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "required": [
-                "sslclientkey"
-              ],
-              "properties": {
-                "sslclientkey": {
-                  "minLength": 1
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sslcacert",
-                "sslclientcert"
-              ],
-              "properties": {
-                "sslcacert": {
-                  "minLength": 1
-                },
-                "sslclientcert": {
-                  "minLength": 1
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "required": [
-                "sslclientcert"
-              ],
-              "properties": {
-                "sslclientcert": {
-                  "minLength": 1
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sslcacert",
-                "sslclientkey"
-              ],
-              "properties": {
-                "sslcacert": {
-                  "minLength": 1
-                },
-                "sslclientkey": {
-                  "minLength": 1
-                }
-              }
-            }
-          }
         ]
       },
-      "description": "Optional configuration for overriding policy and caching settings for RHEL subscription-based repositories on x86_64 architecture."
+      "description": "Optional configuration for overriding policy and caching settings for RHEL subscription-based repositories on x86_64 architecture. Only url and name are required. Certificates are auto-populated from subscription defaults if not provided."
     },
     "rhel_subscription_repo_config_aarch64": {
       "type": [
@@ -1329,91 +1248,10 @@
         },
         "required": [
           "url",
-          "gpgkey",
           "name"
-        ],
-        "allOf": [
-          {
-            "if": {
-              "required": [
-                "sslcacert"
-              ],
-              "properties": {
-                "sslcacert": {
-                  "minLength": 1
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sslclientkey",
-                "sslclientcert"
-              ],
-              "properties": {
-                "sslclientkey": {
-                  "minLength": 1
-                },
-                "sslclientcert": {
-                  "minLength": 1
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "required": [
-                "sslclientkey"
-              ],
-              "properties": {
-                "sslclientkey": {
-                  "minLength": 1
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sslcacert",
-                "sslclientcert"
-              ],
-              "properties": {
-                "sslcacert": {
-                  "minLength": 1
-                },
-                "sslclientcert": {
-                  "minLength": 1
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "required": [
-                "sslclientcert"
-              ],
-              "properties": {
-                "sslclientcert": {
-                  "minLength": 1
-                }
-              }
-            },
-            "then": {
-              "required": [
-                "sslcacert",
-                "sslclientkey"
-              ],
-              "properties": {
-                "sslcacert": {
-                  "minLength": 1
-                },
-                "sslclientkey": {
-                  "minLength": 1
-                }
-              }
-            }
-          }
         ]
       },
-      "description": "Optional configuration for overriding policy and caching settings for RHEL subscription-based repositories on aarch64 architecture."
+      "description": "Optional configuration for overriding policy and caching settings for RHEL subscription-based repositories on aarch64 architecture. Only url and name are required. Certificates are auto-populated from subscription defaults if not provided."
     }
   },
   "required": [

--- a/input/local_repo_config.yml
+++ b/input/local_repo_config.yml
@@ -84,26 +84,26 @@
 #
 # 6. rhel_subscription_repo_config_x86_64
 #-------------------------------------------
-#    Optional configuration for overriding policy and caching settings for RHEL 
-#    subscription-based repositories on x86_64 architecture.
-#    When subscription is enabled, this config takes precedence over dynamically 
-#    generated URLs for matching repositories and adds any additional repositories.
+#    Optional configuration for overriding RHEL subscription-based repositories 
+#    on x86_64 architecture.
+#    When subscription is enabled, user-provided repos with names matching base repos
+#    (baseos, appstream, codeready-builder) will have their URL overridden.
+#    Non-matching repositories are added as additional repos.
 # Fields:
 #   url         : Base URL of the repository (REQUIRED)
-#   gpgkey      : GPG key URL (REQUIRED, can be empty to disable gpgcheck)
 #   name        : Repository name for matching (REQUIRED)
+#                   Use 'baseos', 'appstream', or 'codeready-builder' to override base repo URLs
+#   gpgkey      : GPG key URL (OPTIONAL, defaults to empty to disable gpgcheck)
 #   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
 #                   If not provided, uses repo_config from software_config.json
 #   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
 #                   If not provided, defaults to true
-#   sslcacert   : Path to SSL CA certificate (optional)
-#   sslclientkey: Path to SSL client key (optional)
-#   sslclientcert: Path to SSL client certificate (optional)
 # Notes:
-#   - Do not use Jinja variables in this configuration.
-#   - Omit SSL fields entirely if SSL is not in use.
-#   - Matching is done by repository name (e.g., appstream)
-#   - Non-matching repositories are added as additional repos
+#   - Only 'url' and 'name' are required fields
+#   - SSL certificates are ALWAYS auto-populated from RHEL subscription defaults
+#   - User cannot override SSL certificates (sslcacert, sslclientkey, sslclientcert)
+#   - Matching is done by repository name (e.g., baseos, appstream, codeready-builder)
+#   - Non-matching repositories are added as additional repos with subscription certs
 #
 # 7. rhel_subscription_repo_config_aarch64
 #--------------------------------------------
@@ -176,8 +176,12 @@ rhel_os_url_x86_64:
 rhel_os_url_aarch64:
 # Example:
 # rhel_subscription_repo_config_x86_64:
-#  - { url: "https://example.com/appstream", gpgkey: "", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "appstream", policy: "always", caching: true }
-#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "supplementary", policy: "always", caching: false }
+#  # Override baseos with EUS URL (only url and name required, certs auto-populated)
+#  - { url: "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/baseos/os/", name: "baseos" }
+#  # Override appstream with custom URL and policy
+#  - { url: "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/appstream/os/", name: "appstream", policy: "always" }
+#  # Add supplementary repo (non-base repo, certs auto-populated)
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", name: "supplementary", policy: "always", caching: false }
 rhel_subscription_repo_config_x86_64:
 rhel_subscription_repo_config_aarch64:
 # Making incorrect changes to this variable can cause omnia failure. Please edit cautiously.

--- a/input/local_repo_config.yml
+++ b/input/local_repo_config.yml
@@ -176,10 +176,10 @@ rhel_os_url_x86_64:
 rhel_os_url_aarch64:
 # Example:
 # rhel_subscription_repo_config_x86_64:
-#  # Override baseos with EUS URL (only url and name required, certs auto-populated)
-#  - { url: "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/baseos/os/", name: "baseos" }
+#  # Override baseos with standard URL (only url and name required, certs auto-populated)
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/baseos/os/", name: "baseos" }
 #  # Override appstream with custom URL and policy
-#  - { url: "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/appstream/os/", name: "appstream", policy: "always" }
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/appstream/os/", name: "appstream", policy: "always" }
 #  # Add supplementary repo (non-base repo, certs auto-populated)
 #  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", name: "supplementary", policy: "always", caching: false }
 rhel_subscription_repo_config_x86_64:

--- a/input_validation/roles/validate_subscription/tasks/check_rhel_subscription.yml
+++ b/input_validation/roles/validate_subscription/tasks/check_rhel_subscription.yml
@@ -123,23 +123,37 @@
       changed_when: true
       failed_when: false
 
-    - name: Extract only RHEL baseurls (appstream, baseos, codeready-builder)
+    - name: Extract EUS baseurls (appstream, baseos, codeready-builder)
       ansible.builtin.shell: |
         set -o pipefail
-        awk -v ver="{{ rhel_version }}" '
+        awk '
           /^\[/ {section=$0}
-          /^baseurl/ && section ~ /(rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-rpms)/ {
-            gsub(/\$releasever/, ver, $3)
+          /^baseurl/ && section ~ /(rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-eus-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-eus-rpms)/ {
+            gsub(/\$releasever/, "{{ hostvars['localhost']['cluster_os_version'] }}", $3)
             print $3
           }
         ' {{ redhat_repo_file }}
-      register: repo_baseurls
+      register: eus_baseurls
       changed_when: false
+      failed_when: false
 
+    - name: Extract standard baseurls if EUS not found
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk '
+          /^\[/ {section=$0}
+          /^baseurl/ && section ~ /(rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-rpms)/ {
+            gsub(/\$releasever/, "{{ hostvars['localhost']['cluster_os_version'] }}", $3)
+            print $3
+          }
+        ' {{ redhat_repo_file }}
+      register: standard_baseurls
+      changed_when: false
+      when: eus_baseurls.stdout_lines | default([]) | length == 0
 
-    - name: Set fact repo baseurls with trailing slash
+    - name: Set fact repo baseurls (EUS preferred, fallback to standard)
       ansible.builtin.set_fact:
-        repo_baseurls: "{{ repo_baseurls.stdout_lines
+        repo_baseurls: "{{ (eus_baseurls.stdout_lines if (eus_baseurls.stdout_lines | default([]) | length > 0) else standard_baseurls.stdout_lines | default([]))
                           | map('regex_replace', '([^/])$', '\\1/')
                           | list }}"
 

--- a/input_validation/roles/validate_subscription/tasks/check_rhel_subscription.yml
+++ b/input_validation/roles/validate_subscription/tasks/check_rhel_subscription.yml
@@ -124,11 +124,13 @@
       failed_when: false
 
     - name: Extract EUS baseurls (appstream, baseos, codeready-builder)
+      vars:
+        eus_pattern: "rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-eus-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-eus-rpms"
       ansible.builtin.shell: |
         set -o pipefail
         awk '
           /^\[/ {section=$0}
-          /^baseurl/ && section ~ /(rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-eus-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-eus-rpms)/ {
+          /^baseurl/ && section ~ /({{ eus_pattern }})/ {
             gsub(/\$releasever/, "{{ hostvars['localhost']['cluster_os_version'] }}", $3)
             print $3
           }
@@ -138,11 +140,13 @@
       failed_when: false
 
     - name: Extract standard baseurls if EUS not found
+      vars:
+        std_pattern: "rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-rpms"
       ansible.builtin.shell: |
         set -o pipefail
         awk '
           /^\[/ {section=$0}
-          /^baseurl/ && section ~ /(rhel-{{ rhel_version }}-for-x86_64-(appstream|baseos)-rpms|codeready-builder-for-rhel-{{ rhel_version }}-x86_64-rpms)/ {
+          /^baseurl/ && section ~ /({{ std_pattern }})/ {
             gsub(/\$releasever/, "{{ hostvars['localhost']['cluster_os_version'] }}", $3)
             print $3
           }
@@ -153,9 +157,11 @@
 
     - name: Set fact repo baseurls (EUS preferred, fallback to standard)
       ansible.builtin.set_fact:
-        repo_baseurls: "{{ (eus_baseurls.stdout_lines if (eus_baseurls.stdout_lines | default([]) | length > 0) else standard_baseurls.stdout_lines | default([]))
-                          | map('regex_replace', '([^/])$', '\\1/')
-                          | list }}"
+        repo_baseurls: >-
+          {{ (eus_baseurls.stdout_lines if (eus_baseurls.stdout_lines | default([]) | length > 0)
+              else standard_baseurls.stdout_lines | default([]))
+              | map('regex_replace', '([^/])$', '\1/')
+              | list }}
 
     - name: Show extracted baseurls
       ansible.builtin.debug:

--- a/input_validation/roles/validate_subscription/tasks/configure_rhel_os_urls.yml
+++ b/input_validation/roles/validate_subscription/tasks/configure_rhel_os_urls.yml
@@ -133,18 +133,22 @@
       ansible.builtin.set_fact:
         x86_64_dynamic_names: "{{ sub_rhel_x86_64_urls | map(attribute='name') | list }}"
 
-    - name: Apply x86_64 overrides to matching repos
+    - name: Apply x86_64 overrides to matching repos (only URL overridden, certs always from defaults)
       ansible.builtin.set_fact:
         sub_rhel_x86_64_urls: >-
           {%- set result = [] -%}
           {%- for repo in sub_rhel_x86_64_urls -%}
             {%- set override = (sub_x86_64_override_config | selectattr('name', 'equalto', repo.name) | first | default({})) -%}
-            {%- set updated_repo = repo | combine({
-              'policy': override.policy | default(repo.policy),
-              'caching': override.caching | default(repo.caching),
-              'url': override.url | default(repo.url),
-              'gpgkey': override.gpgkey | default(repo.gpgkey)
-            }) -%}
+            {%- if override -%}
+              {%- set updated_repo = repo | combine({
+                'url': override.url | default(repo.url),
+                'gpgkey': override.gpgkey | default(repo.gpgkey),
+                'policy': override.policy | default(repo.policy),
+                'caching': override.caching | default(repo.caching)
+              }) -%}
+            {%- else -%}
+              {%- set updated_repo = repo -%}
+            {%- endif -%}
             {%- set _ = result.append(updated_repo) -%}
           {%- endfor -%}
           {{ result }}
@@ -156,7 +160,7 @@
             sub_x86_64_override_config | rejectattr('name', 'in', x86_64_dynamic_names) | list
           }}
 
-    - name: Add non-matching x86_64 override repos as additional
+    - name: Add non-matching x86_64 override repos as additional (certs always from defaults)
       ansible.builtin.set_fact:
         sub_rhel_x86_64_urls: >-
           {%- set result = sub_rhel_x86_64_urls -%}
@@ -175,18 +179,22 @@
           {%- endfor -%}
           {{ result }}
 
-    - name: Apply aarch64 overrides to matching repos
+    - name: Apply aarch64 overrides to matching repos (only URL overridden, certs always from defaults)
       ansible.builtin.set_fact:
         sub_rhel_aarch64_urls: >-
           {%- set result = [] -%}
           {%- for repo in sub_rhel_aarch64_urls -%}
             {%- set override = (sub_aarch64_override_config | selectattr('name', 'equalto', repo.name) | first | default({})) -%}
-            {%- set updated_repo = repo | combine({
-              'policy': override.policy | default(repo.policy),
-              'caching': override.caching | default(repo.caching),
-              'url': override.url | default(repo.url),
-              'gpgkey': override.gpgkey | default(repo.gpgkey)
-            }) -%}
+            {%- if override -%}
+              {%- set updated_repo = repo | combine({
+                'url': override.url | default(repo.url),
+                'gpgkey': override.gpgkey | default(repo.gpgkey),
+                'policy': override.policy | default(repo.policy),
+                'caching': override.caching | default(repo.caching)
+              }) -%}
+            {%- else -%}
+              {%- set updated_repo = repo -%}
+            {%- endif -%}
             {%- set _ = result.append(updated_repo) -%}
           {%- endfor -%}
           {{ result }}
@@ -204,7 +212,7 @@
           }}
       when: "'aarch64' in archs"
 
-    - name: Add non-matching aarch64 override repos as additional
+    - name: Add non-matching aarch64 override repos as additional (certs always from defaults)
       ansible.builtin.set_fact:
         sub_rhel_aarch64_urls: >-
           {%- set result = sub_rhel_aarch64_urls -%}

--- a/upgrade/roles/import_input_parameters/templates/local_repo_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/local_repo_config.j2
@@ -84,26 +84,26 @@
 #
 # 6. rhel_subscription_repo_config_x86_64
 #-------------------------------------------
-#    Optional configuration for overriding policy and caching settings for RHEL 
-#    subscription-based repositories on x86_64 architecture.
-#    When subscription is enabled, this config takes precedence over dynamically 
-#    generated URLs for matching repositories and adds any additional repositories.
+#    Optional configuration for overriding RHEL subscription-based repositories 
+#    on x86_64 architecture.
+#    When subscription is enabled, user-provided repos with names matching base repos
+#    (baseos, appstream, codeready-builder) will have their URL overridden.
+#    Non-matching repositories are added as additional repos.
 # Fields:
 #   url         : Base URL of the repository (REQUIRED)
-#   gpgkey      : GPG key URL (REQUIRED, can be empty to disable gpgcheck)
 #   name        : Repository name for matching (REQUIRED)
+#                   Use 'baseos', 'appstream', or 'codeready-builder' to override base repo URLs
+#   gpgkey      : GPG key URL (OPTIONAL, defaults to empty to disable gpgcheck)
 #   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
 #                   If not provided, uses repo_config from software_config.json
 #   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
 #                   If not provided, defaults to true
-#   sslcacert   : Path to SSL CA certificate (optional)
-#   sslclientkey: Path to SSL client key (optional)
-#   sslclientcert: Path to SSL client certificate (optional)
 # Notes:
-#   - Do not use Jinja variables in this configuration.
-#   - Omit SSL fields entirely if SSL is not in use.
-#   - Matching is done by repository name (e.g., appstream)
-#   - Non-matching repositories are added as additional repos
+#   - Only 'url' and 'name' are required fields
+#   - SSL certificates are ALWAYS auto-populated from RHEL subscription defaults
+#   - User cannot override SSL certificates (sslcacert, sslclientkey, sslclientcert)
+#   - Matching is done by repository name (e.g., baseos, appstream, codeready-builder)
+#   - Non-matching repositories are added as additional repos with subscription certs
 #
 # 7. rhel_subscription_repo_config_aarch64
 #--------------------------------------------
@@ -206,8 +206,12 @@ rhel_os_url_aarch64:
 {% endif %}
 # Example:
 # rhel_subscription_repo_config_x86_64:
-#  - { url: "https://example.com/appstream", gpgkey: "", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "appstream", policy: "always", caching: true }
-#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "supplementary", policy: "always", caching: false }
+#  # Override baseos with standard URL (only url and name required, certs auto-populated)
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/baseos/os/", name: "baseos" }
+#  # Override appstream with custom URL and policy
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/appstream/os/", name: "appstream", policy: "always" }
+#  # Add supplementary repo (non-base repo, certs auto-populated)
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", name: "supplementary", policy: "always", caching: false }
 rhel_subscription_repo_config_x86_64:
 rhel_subscription_repo_config_aarch64:
 # Making incorrect changes to this variable can cause omnia failure. Please edit cautiously.


### PR DESCRIPTION
To support rhel_subscription_repo_config_<arch> with simplified input validation and precedence logic:
Changes Made:
**JSON Schema (local_repo_config.json:**
Made only url and name required (removed gpgkey from required)
Removed allOf SSL validation constraints since certificates are auto-populated
configure_rhel_os_urls.yml (configure_rhel_os_urls.yml):
**Updated override logic for both x86_64 :**
Allow user-provided repos (baseos, appstream, codeready-builder) to take precedence over auto-generated URLs
Auto-populate SSL certificates from subscription defaults when user doesn't provide them
Allow user to override certificates if provided
**Documentation (local_repo_config.yml:**
Updated field descriptions to clarify only url and name are required
Added notes about certificate auto-population
Updated examples showing simplified usage with standard rhel(dist) URLs


Subscription enabled | Extracts from redhat.repo: EUS repos first, standard fallback. rhel_subscription_repo_config_<arch> overrides URL only, certs auto-populated

Subscription disabled | Reads from rhel_os_url_<arch> directly. No EUS construction. Original logic unchanged


