### PR TITLE
skip approval update for omnia playbooks

### DIFF
--- a/local_repo/pulp_cleanup.yml
+++ b/local_repo/pulp_cleanup.yml
@@ -98,7 +98,7 @@
 
     - name: Set force skip confirmation flag
       ansible.builtin.set_fact:
-        force_skip_confirmation: "{{ force | default(false) | bool }}"
+        force_skip_confirmation: "{{ force | default(false) | bool or skip_approval | default(false) | bool }}"
 
     - name: Get user confirmation
       ansible.builtin.pause:
@@ -109,7 +109,7 @@
           Type 'yes' to continue or 'no' to abort
         echo: true
       register: user_input
-      when: not force_skip_confirmation
+      when: not force_skip_confirmation | bool
 
     - name: Set user confirmed flag
       ansible.builtin.set_fact:
@@ -119,13 +119,13 @@
       ansible.builtin.debug:
         msg: "Cleanup cancelled by user. Exiting."
       when:
-        - not force_skip_confirmation
+        - not force_skip_confirmation | bool
         - not user_confirmed
 
     - name: Abort if not confirmed
       ansible.builtin.meta: end_play
       when:
-        - not force_skip_confirmation
+        - not force_skip_confirmation | bool
         - not user_confirmed
 
   tasks:

--- a/upgrade/roles/upgrade_telemetry/tasks/detect_victoria_state.yml
+++ b/upgrade/roles/upgrade_telemetry/tasks/detect_victoria_state.yml
@@ -187,7 +187,9 @@
       {{ victoria_unhealthy_pods | length }} unhealthy Victoria pod(s) found.
       They will be deleted and re-created during upgrade.
       Press ENTER to continue or Ctrl+C to abort.
-  when: victoria_unhealthy_pods | length > 0
+  when:
+    - not (skip_approval | default(false) | bool)
+    - victoria_unhealthy_pods | length > 0
 
 - name: Delete unhealthy Victoria pods
   ansible.builtin.command:

--- a/utils/delete_migrated_pulp_rpm_repos.yml
+++ b/utils/delete_migrated_pulp_rpm_repos.yml
@@ -38,6 +38,7 @@
 #
 #   # Skip user confirmation prompt:
 #   ansible-playbook delete_migrated_pulp_rpm_repos.yml -e "repo_format=old" -e "force=true"
+#   ansible-playbook delete_migrated_pulp_rpm_repos.yml -e "repo_format=old" -e "skip_approval=true"
 
 - name: Delete Migrated Pulp RPM Repositories by Format
   hosts: localhost
@@ -121,13 +122,13 @@
           This action cannot be undone.
           Type 'yes' to continue or press Ctrl+C to abort
       register: user_input
-      when: not (force | default(false)) | bool
+      when: not (force | default(false) | bool or skip_approval | default(false) | bool)
 
     - name: Abort if not confirmed
       ansible.builtin.fail:
         msg: "Deletion cancelled by user"
       when:
-        - not (force | default(false)) | bool
+        - not (force | default(false) | bool or skip_approval | default(false) | bool)
         - user_input.user_input | default('') | lower != 'yes'
 
   tasks:

--- a/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_k8s.yml
+++ b/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_k8s.yml
@@ -156,11 +156,14 @@
       ansible.builtin.pause:
         prompt: "I understand this will delete NFS data affecting all nodes. Type {{ k8s_cleanup_confirm_token }} to continue"
       register: k8s_cleanup_confirm
+      when: not (skip_approval | default(false) | bool)
 
     - name: Fail if cleanup not confirmed
       ansible.builtin.fail:
         msg: "K8s cleanup aborted"
-      when: k8s_cleanup_confirm.user_input | lower != k8s_cleanup_confirm_token | lower
+      when:
+        - not (skip_approval | default(false) | bool)
+        - k8s_cleanup_confirm.user_input | lower != k8s_cleanup_confirm_token | lower
 
     - name: Delete all k8s directories
       ansible.builtin.file:

--- a/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_slurm.yml
+++ b/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_slurm.yml
@@ -156,11 +156,14 @@
       ansible.builtin.pause:
         prompt: "I understand this will delete NFS data affecting all nodes. Type {{ slurm_cleanup_confirm_token }} to continue"
       register: cleanup_confirm
+      when: not (skip_approval | default(false) | bool)
 
     - name: Fail if cleanup not confirmed
       ansible.builtin.fail:
         msg: "Slurm cleanup aborted"
-      when: cleanup_confirm.user_input | lower != slurm_cleanup_confirm_token | lower
+      when:
+        - not (skip_approval | default(false) | bool)
+        - cleanup_confirm.user_input | lower != slurm_cleanup_confirm_token | lower
 
     - name: Delete slurm directories (excluding slurm_backups)
       ansible.builtin.file:

--- a/utils/roles/oim_cleanup/pre_requisite/tasks/pre_requisite.yml
+++ b/utils/roles/oim_cleanup/pre_requisite/tasks/pre_requisite.yml
@@ -110,6 +110,7 @@
     prompt: "{{ postgres_credentials_backup_msg }}"
     seconds: "{{ wait_delay }}"
   when:
+    - not (skip_approval | default(false) | bool)
     - postgres_backup | bool
     - enable_build_stream
 
@@ -117,5 +118,7 @@
   ansible.builtin.pause:
     prompt: "{{ build_stream_cleanup_warning }}"
     seconds: "{{ build_stream_pause_seconds }}"
-  when: enable_build_stream | default(false) | bool
+  when:
+    - not (skip_approval | default(false) | bool)
+    - enable_build_stream | default(false) | bool
   tags: always


### PR DESCRIPTION
# Summary

## Variable: `skip_approval`

**Usage**: `-e skip_approval=true` — same variable used across the entire omnia codebase.

**Pattern** (matches existing [upgrade.yml](omnia/upgrade/upgrade.yml:0:0-0:0) convention):
```yaml
when: not (skip_approval | default(false) | bool)
```

## Files Modified

### OIM Cleanup (primary request)
| File | Prompts | Behavior when `skip_approval=true` |
|------|---------|-------------------------------------|
| [utils/roles/oim_cleanup/pre_requisite/tasks/pre_requisite.yml](omnia/utils/roles/oim_cleanup/pre_requisite/tasks/pre_requisite.yml:0:0-0:0) | 2 timed pauses | Skips 30s/10s warning delays |
| [utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_k8s.yml](omnia/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_k8s.yml:0:0-0:0) | 1 confirmation (type YES) | Auto-proceeds |
| [utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_slurm.yml](omnia/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_slurm.yml:0:0-0:0) | 1 confirmation (type YES) | Auto-proceeds |

### Utils
| File | Prompts | Behavior when `skip_approval=true` |
|------|---------|-------------------------------------|
| [utils/delete_migrated_pulp_rpm_repos.yml](omnia/utils/delete_migrated_pulp_rpm_repos.yml:0:0-0:0) | 1 confirmation | `skip_approval` added as alias for `force` |

### Local Repo
| File | Prompts | Behavior when `skip_approval=true` |
|------|---------|-------------------------------------|
| [local_repo/pulp_cleanup.yml](omnia/local_repo/pulp_cleanup.yml:0:0-0:0) | 1 confirmation | `skip_approval` added as alias for `force` |

### Upgrade/Rollback
| File | Prompts | Behavior when `skip_approval=true` |
|------|---------|-------------------------------------|
| [upgrade/upgrade.yml](omnia/upgrade/upgrade.yml:0:0-0:0) | 2 operator approval | **Already implemented** |
| [upgrade/roles/upgrade_telemetry/tasks/detect_victoria_state.yml](omnia/upgrade/roles/upgrade_telemetry/tasks/detect_victoria_state.yml:0:0-0:0) | 1 unhealthy pods | Auto-proceeds |

### NOT Modified (by design)
- **Functional waits** (`seconds: N` / `minutes: N`) in rollback/upgrade — these wait for services to stabilize, not for user approval
- **Credential prompts** in [credential_utility/](omnia/utils/credential_utility:0:0-0:0) — these require actual data input; credentials should be provided via vault files

### Example: Non-interactive OIM cleanup
```bash
ansible-playbook utils/oim_cleanup.yml -e skip_approval=true
```