### PR TITLE
Fix to handle the intermittent missing header issue in localrepo

### DIFF
--- a/common/library/module_utils/local_repo/software_utils.py
+++ b/common/library/module_utils/local_repo/software_utils.py
@@ -38,6 +38,7 @@ from ansible.module_utils.local_repo.config import (
     CSV_COLUMNS,
     SOFTWARE_CONFIG_SUBDIR,
     DEFAULT_STATUS_FILENAME,
+    STATUS_CSV_HEADER,
     RPM_LABEL_TEMPLATE,
     RHEL_OS_URL,
     SOFTWARES_KEY,
@@ -853,6 +854,16 @@ def check_csv_existence(path):
 
 def read_status_csv(csv_path):
     """Reads the status.csv file and returns a list of row dictionaries."""
+    # Ensure file has valid header before reading
+    if os.path.exists(csv_path) and os.path.getsize(csv_path) > 0:
+        with open(csv_path, 'r', encoding='utf-8') as file:
+            lines = file.readlines()
+            if lines and lines[0].strip() != STATUS_CSV_HEADER.strip():
+                # Header missing or invalid - prepend header to existing data
+                with open(csv_path, 'w', encoding='utf-8') as wfile:
+                    wfile.write(STATUS_CSV_HEADER)
+                    wfile.writelines(lines)
+
     with open(csv_path, mode='r', newline='', encoding='utf-8') as file:
         reader = csv.DictReader(file)
         return [row for row in reader]

--- a/common/library/modules/parallel_tasks.py
+++ b/common/library/modules/parallel_tasks.py
@@ -160,9 +160,19 @@ def determine_function(
 
         # Construct the status file path using DEFAULT_STATUS_FILENAME.
         status_file = os.path.join(csv_file_path, DEFAULT_STATUS_FILENAME)
+
+        # Ensure file exists with valid header
         if not os.path.exists(status_file) or os.stat(status_file).st_size == 0:
             with open(status_file, 'w', encoding="utf-8") as file:
                 file.write(STATUS_CSV_HEADER)
+        else:
+            with open(status_file, 'r', encoding="utf-8") as file:
+                lines = file.readlines()
+                if lines and lines[0].strip() != STATUS_CSV_HEADER.strip():
+                    # Header missing or invalid - prepend header to existing data
+                    with open(status_file, 'w', encoding="utf-8") as wfile:
+                        wfile.write(STATUS_CSV_HEADER)
+                        wfile.writelines(lines)
 
 
         task_type = task.get("type")


### PR DESCRIPTION
Both functions now:

Check if file exists and has content
Read the first line and validate it matches STATUS_CSV_HEADER
If header is missing/invalid → prepend header to existing data (preserves all existing package status)
If header is valid → proceed normally
This ensures that whenever a status.csv file is read, the header is validated and fixed if needed, preventing the KeyError: 'name' error.
