### PR TITLE
rhel subscription validation fix

### DIFF
--- a/input_validation/validate_config.yml
+++ b/input_validation/validate_config.yml
@@ -50,6 +50,11 @@
   tags:
     - always
   tasks:
+    - name: Enable subscription check when validate_config.yml is run directly
+      ansible.builtin.set_fact:
+        run_subscription_check: true
+      when: run_subscription_check is not defined and omnia_run_tags is not defined
+
     - name: Run subscription validation tasks
       when: "'local_repo' in (omnia_run_tags | default(ansible_run_tags | default([]) | list)) or 'all' in (ansible_run_tags | default([]) | list)"
       block:
@@ -94,7 +99,7 @@
       ansible.builtin.include_role:
         name: validate_subscription
         tasks_from: check_rhel_subscription.yml
-      when: "'local_repo' in (hostvars['localhost']['omnia_run_tags'] | default([]))"
+      when: "hostvars['localhost']['run_subscription_check'] | default(false) | bool"
 
 - name: Configure RHEL repository URLs
   hosts: localhost
@@ -107,7 +112,7 @@
       ansible.builtin.include_role:
         name: validate_subscription
         tasks_from: configure_rhel_os_urls.yml
-      when: "'local_repo' in (omnia_run_tags | default([]))"
+      when: "run_subscription_check | default(false) | bool"
 
 - name: Validate omnia input config
   hosts: localhost

--- a/local_repo/local_repo.yml
+++ b/local_repo/local_repo.yml
@@ -29,6 +29,10 @@
         omnia_run_tags: "{{ (ansible_run_tags | default([]) | list + ['local_repo']) | unique }}"
         cacheable: true
 
+    - name: Enable subscription check for local_repo
+      ansible.builtin.set_fact:
+        run_subscription_check: true
+
     - name: Include metadata vars
       ansible.builtin.include_vars: "/opt/omnia/.data/oim_metadata.yml"
       register: include_metadata


### PR DESCRIPTION
Root Cause
Subscription validation tasks were skipped because validate_config.yml used inconsistent when conditions that couldn't distinguish between:
Running standalone (should run subscription check)
Imported from local_repo.yml (should run)
Imported from prepare_oim.yml (should NOT run)

Resolution
Added run_subscription_check flag control - explicit boolean flag instead of unreliable tag-based detection
Fixed local_repo.yml - separated cached omnia_run_tags from non-cached run_subscription_check: true
Updated validate_config.yml - auto-set flag when run directly, use flag to control subscription tasks