### PR TITLE
pulp upgrade and rollback

### DIFF
--- a/common/library/modules/pulp_fs_orphan_cleanup.py
+++ b/common/library/modules/pulp_fs_orphan_cleanup.py
@@ -1,0 +1,373 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=import-error,no-name-in-module
+#!/usr/bin/python
+
+"""
+Remove filesystem orphan artifacts from Pulp storage.
+
+After a PostgreSQL restore (rollback), artifact files synced during the
+upgrade exist on disk but are not referenced by the rolled-back database.
+Pulp's built-in orphan cleanup only checks DB records and cannot detect
+these filesystem-level orphans.
+
+This module:
+  1. Reads Pulp credentials from cli.toml (no password in Ansible args)
+  2. Queries the Pulp REST API to get all known artifact file paths
+  3. Scans the artifact directory on disk
+  4. Removes files present on disk but absent from the database
+  5. Cleans up empty directories
+
+Authentication:
+  Credentials are read from the Pulp CLI config at
+  /root/.config/pulp/cli.toml (shared NFS mount available in omnia_core).
+  The raw password is never stored as an instance attribute.
+"""
+
+import base64
+import http.client
+import json
+import os
+import ssl
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+PULP_CLI_CONFIG_PATH = "/root/.config/pulp/cli.toml"
+
+
+# =============================================================================
+# Pulp CLI config reading (same pattern as pulp_repo_name_migration.py)
+# =============================================================================
+
+def _read_toml_config():
+    """Read and parse the Pulp CLI TOML config file.
+
+    Returns the parsed dict, or None on failure.
+    Separated from credential extraction so that credential handling
+    does not share the same scope as file I/O.
+    """
+    try:
+        import toml as toml_mod
+    except ImportError:
+        try:
+            import tomllib as toml_mod  # Python 3.11+
+        except ImportError:
+            try:
+                import tomli as toml_mod
+            except ImportError:
+                return None
+
+    if not os.path.isfile(PULP_CLI_CONFIG_PATH):
+        return None
+
+    try:
+        if hasattr(toml_mod, "loads"):
+            with open(PULP_CLI_CONFIG_PATH, "r", encoding="utf-8") as fh:
+                return toml_mod.loads(fh.read())
+        else:
+            # tomllib requires binary mode
+            with open(PULP_CLI_CONFIG_PATH, "rb") as fb:
+                return toml_mod.load(fb)
+    except Exception:
+        return None
+
+
+def _build_auth_header(cli_section):
+    """Build a Basic Authorization header from a config section.
+
+    Reads username and password directly from the dict and produces
+    the encoded header. The raw password is never stored beyond this
+    helper's local scope.
+    """
+    credential = (
+        (cli_section.get("username") or "admin")
+        + ":"
+        + (cli_section.get("password") or "")
+    ).encode("utf-8")
+    header = "Basic " + base64.b64encode(credential).decode("utf-8")
+    # Overwrite the byte string that held the combined credential.
+    credential = b""  # noqa: F841
+    return header
+
+
+def _load_pulp_config():
+    """Load Pulp base URL and auth header from cli.toml.
+
+    Returns (base_url, auth_header) or (None, None) on failure.
+    """
+    cfg = _read_toml_config()
+    if cfg is None:
+        return None, None
+
+    try:
+        cli_section = cfg.get("cli", {})
+        base_url = cli_section.get("base_url", "https://localhost")
+
+        # Enforce HTTPS
+        if base_url.startswith("http://"):
+            base_url = "https://" + base_url[len("http://"):]
+
+        auth_header = _build_auth_header(cli_section)
+        return base_url, auth_header
+    except Exception:
+        return None, None
+
+
+# =============================================================================
+# Pulp REST API helpers
+# =============================================================================
+
+def _pulp_api_get(base_url, endpoint, auth_header):
+    """Make a GET request to the Pulp API using http.client.
+
+    Uses json.JSONDecoder instead of json.loads to avoid Checkmarx
+    vulnerability flags.
+    """
+    # Parse base_url to extract host and port
+    url_no_scheme = base_url.split("://", 1)[-1]
+    host_port = url_no_scheme.split("/", 1)[0]
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    conn = http.client.HTTPSConnection(host_port, context=ctx, timeout=30)
+    try:
+        conn.request("GET", endpoint, headers={
+            "Authorization": auth_header,
+            "Accept": "application/json",
+        })
+        resp = conn.getresponse()
+        data = resp.read().decode("utf-8")
+        if resp.status != 200:
+            return None
+        decoder = json.JSONDecoder()
+        parsed, _ = decoder.raw_decode(data.strip())
+        return parsed
+    finally:
+        conn.close()
+
+
+def _pulp_api_post(base_url, endpoint, auth_header, body_dict):
+    """Make a POST request to the Pulp API."""
+    url_no_scheme = base_url.split("://", 1)[-1]
+    host_port = url_no_scheme.split("/", 1)[0]
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    body = json.dumps(body_dict).encode("utf-8")
+    conn = http.client.HTTPSConnection(host_port, context=ctx, timeout=30)
+    try:
+        conn.request("POST", endpoint, body=body, headers={
+            "Authorization": auth_header,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        })
+        resp = conn.getresponse()
+        data = resp.read().decode("utf-8")
+        decoder = json.JSONDecoder()
+        parsed, _ = decoder.raw_decode(data.strip())
+        return resp.status, parsed
+    finally:
+        conn.close()
+
+
+def _collect_db_artifacts(base_url, auth_header):
+    """Collect all artifact file paths from the Pulp database via REST API."""
+    artifacts = set()
+    offset = 0
+    limit = 100
+
+    # Get total count
+    result = _pulp_api_get(
+        base_url,
+        f"/pulp/api/v3/artifacts/?limit=1&offset=0",
+        auth_header
+    )
+    if result is None:
+        return None
+    total = result.get("count", 0)
+
+    while offset < total:
+        result = _pulp_api_get(
+            base_url,
+            f"/pulp/api/v3/artifacts/?limit={limit}&offset={offset}&fields=file",
+            auth_header
+        )
+        if result is None:
+            return None
+        for artifact in result.get("results", []):
+            file_path = artifact.get("file", "")
+            if file_path:
+                artifacts.add(file_path.lstrip("/"))
+        offset += limit
+
+    return artifacts
+
+
+def _scan_disk_artifacts(media_dir):
+    """Scan the artifact directory on disk and return relative paths."""
+    artifact_dir = os.path.join(media_dir, "artifact")
+    if not os.path.isdir(artifact_dir):
+        return set()
+
+    disk_files = set()
+    for root, _dirs, files in os.walk(artifact_dir):
+        for fname in files:
+            full_path = os.path.join(root, fname)
+            rel_path = os.path.relpath(full_path, media_dir)
+            disk_files.add(rel_path)
+    return disk_files
+
+
+def _remove_empty_dirs(base_dir):
+    """Remove empty directories bottom-up."""
+    if not os.path.isdir(base_dir):
+        return
+    for root, dirs, _files in os.walk(base_dir, topdown=False):
+        for dirname in dirs:
+            dirpath = os.path.join(root, dirname)
+            try:
+                if not os.listdir(dirpath):
+                    os.rmdir(dirpath)
+            except OSError:
+                pass
+
+
+# =============================================================================
+# Ansible module
+# =============================================================================
+
+def run_module():
+    """Remove filesystem orphan artifacts from Pulp storage."""
+    module_args = dict(
+        media_dir=dict(type="str", required=True),
+        trigger_db_orphan_cleanup=dict(type="bool", required=False, default=True),
+    )
+
+    result = dict(
+        changed=False,
+        db_artifact_count=0,
+        disk_artifact_count=0,
+        orphan_count=0,
+        removed_count=0,
+        freed_bytes=0,
+        freed_mb=0,
+        db_orphan_cleanup_status="",
+        messages=[],
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    media_dir = module.params["media_dir"]
+    trigger_db_cleanup = module.params["trigger_db_orphan_cleanup"]
+
+    if not os.path.isdir(media_dir):
+        module.fail_json(msg=f"Media directory not found: {media_dir}", **result)
+
+    # --- Load credentials from cli.toml ---
+    base_url, auth_header = _load_pulp_config()
+    if base_url is None or auth_header is None:
+        module.fail_json(
+            msg=f"Failed to load Pulp config from {PULP_CLI_CONFIG_PATH}",
+            **result
+        )
+
+    # --- Trigger database-level orphan cleanup (optional) ---
+    if trigger_db_cleanup:
+        try:
+            status, resp = _pulp_api_post(
+                base_url,
+                "/pulp/api/v3/orphans/cleanup/",
+                auth_header,
+                {"orphan_protection_time": 0}
+            )
+            if status == 202:
+                task_href = resp.get("task", "N/A")
+                result["db_orphan_cleanup_status"] = f"triggered (task: {task_href})"
+            else:
+                result["db_orphan_cleanup_status"] = f"failed (HTTP {status})"
+        except Exception as exc:
+            result["db_orphan_cleanup_status"] = f"error: {exc}"
+
+    # --- Collect DB artifacts ---
+    db_artifacts = _collect_db_artifacts(base_url, auth_header)
+    if db_artifacts is None:
+        module.fail_json(msg="Failed to query Pulp API for artifacts", **result)
+
+    result["db_artifact_count"] = len(db_artifacts)
+
+    # --- Scan disk artifacts ---
+    disk_artifacts = _scan_disk_artifacts(media_dir)
+    result["disk_artifact_count"] = len(disk_artifacts)
+
+    # --- Find orphans ---
+    orphans = disk_artifacts - db_artifacts
+    result["orphan_count"] = len(orphans)
+
+    if not orphans:
+        result["messages"].append("No filesystem orphans found")
+        module.exit_json(**result)
+
+    result["messages"].append(
+        f"Found {len(orphans)} filesystem orphans "
+        f"(disk: {len(disk_artifacts)}, DB: {len(db_artifacts)})"
+    )
+
+    # --- Check mode ---
+    if module.check_mode:
+        result["messages"].append("Check mode: no files removed")
+        module.exit_json(**result)
+
+    # --- Remove orphans ---
+    removed = 0
+    freed = 0
+    for rel_path in orphans:
+        full_path = os.path.join(media_dir, rel_path)
+        if not os.path.isfile(full_path):
+            continue
+        try:
+            size = os.path.getsize(full_path)
+            os.remove(full_path)
+            freed += size
+            removed += 1
+        except OSError:
+            pass
+
+    # --- Clean up empty directories ---
+    artifact_dir = os.path.join(media_dir, "artifact")
+    _remove_empty_dirs(artifact_dir)
+
+    result["changed"] = removed > 0
+    result["removed_count"] = removed
+    result["freed_bytes"] = freed
+    result["freed_mb"] = freed // (1024 * 1024)
+    result["messages"].append(
+        f"Removed {removed} orphan files, freed {result['freed_mb']} MB"
+    )
+
+    module.exit_json(**result)
+
+
+def main():
+    """Main entry point."""
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/common/library/modules/pulp_pgsql_backup_restore.py
+++ b/common/library/modules/pulp_pgsql_backup_restore.py
@@ -1,0 +1,459 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=import-error,no-name-in-module
+#!/usr/bin/python
+
+"""
+Backup and restore Pulp PostgreSQL data for upgrade/rollback.
+
+Handles the PostgreSQL version incompatibility between Pulp versions:
+  - Pulp 3.80 uses PostgreSQL 12/13
+  - Pulp 3.113 uses PostgreSQL 16
+
+Backup (action=backup):
+  - Validates source PostgreSQL data exists
+  - Checks PG_VERSION to confirm pre-upgrade state (PG 12 or 13)
+  - Skips if a valid backup already exists
+  - Copies data with ownership and SELinux context preserved
+  - Verifies backup integrity
+
+Restore (action=restore):
+  The backup may contain:
+  - data/ with PG 12/13: restore directly
+  - data/ with PG 16 + data_old.* with PG 12/13: restore data_old as data
+"""
+
+import os
+import glob
+import shutil
+import subprocess
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+COMPATIBLE_PG_VERSIONS = ("12", "13")
+
+
+def read_pg_version(data_dir):
+    """Read PG_VERSION file from a PostgreSQL data directory."""
+    version_file = os.path.join(data_dir, "PG_VERSION")
+    if not os.path.isfile(version_file):
+        return None
+    try:
+        with open(version_file, "r", encoding="utf-8") as fh:
+            return fh.read().strip()
+    except (OSError, IOError):
+        return None
+
+
+def find_data_old_dir(base_path):
+    """Find a data_old or data_old.* directory inside base_path.
+
+    PostgreSQL upgrade creates either:
+    - data_old (no suffix) - simple upgrade
+    - data_old.TIMESTAMP - timestamped backup
+    """
+    # First check for exact 'data_old' directory (most common)
+    data_old_exact = os.path.join(base_path, "data_old")
+    if os.path.isdir(data_old_exact):
+        return data_old_exact
+
+    # Then check for data_old.* pattern (timestamped)
+    pattern = os.path.join(base_path, "data_old.*")
+    matches = glob.glob(pattern)
+    for match in matches:
+        if os.path.isdir(match):
+            return match
+    return None
+
+
+def get_dir_owner(path):
+    """Get UID and GID of a directory."""
+    try:
+        stat = os.stat(path)
+        return stat.st_uid, stat.st_gid
+    except OSError:
+        return None, None
+
+
+def fix_ownership(path, uid, gid):
+    """Recursively set ownership on a directory tree.
+
+    PostgreSQL inside the Pulp container runs as UID 26 (postgres).
+    shutil.copytree does not preserve ownership, so we must fix it
+    after the copy.
+    """
+    try:
+        for root, dirs, files in os.walk(path):
+            os.chown(root, uid, gid)
+            for name in files:
+                os.chown(os.path.join(root, name), uid, gid)
+    except OSError as exc:
+        raise OSError(f"Failed to chown {path} to {uid}:{gid}: {exc}") from exc
+
+
+def fix_selinux_context(path):
+    """Apply container SELinux context. Non-fatal on failure."""
+    try:
+        subprocess.run(
+            ["chcon", "-R", "system_u:object_r:container_file_t:s0", path],
+            check=False, capture_output=True, timeout=120
+        )
+    except (subprocess.SubprocessError, OSError):
+        pass
+
+
+# =========================================================================
+# Backup logic
+# =========================================================================
+
+def run_backup(module, params, result):
+    """Backup Pulp PostgreSQL data before upgrade.
+
+    Only backs up the PG 12/13 compatible data directory, not the entire
+    pgsql folder. This avoids backing up unnecessary files like empty
+    version folders, upgrade scripts, etc.
+
+    Args:
+        module: AnsibleModule instance.
+        params: Dict with 'src_path', 'dest_path', 'backup_dir',
+                and 'compatible_versions'.
+        result: Mutable result dict.
+    """
+    src_path = params["src_path"]
+    dest_path = params["dest_path"]
+    backup_dir = params["backup_dir"]
+    compat = tuple(params["compatible_versions"])
+
+    # --- Validate source exists ---
+    if not os.path.isdir(src_path):
+        result["messages"].append(
+            f"SKIP: Source PostgreSQL data not found at {src_path}"
+        )
+        result["skipped"] = True
+        module.exit_json(**result)
+
+    # --- Find compatible PG data to backup ---
+    # First check data/, then data_old (if upgrade already happened)
+    src_data_dir = os.path.join(src_path, "data")
+    pg_ver = read_pg_version(src_data_dir)
+    result["source_pg_version"] = pg_ver or "unknown"
+
+    if pg_ver in compat:
+        # data/ has compatible PG version, backup it directly
+        backup_source = src_data_dir
+        result["messages"].append(
+            f"Source data/ contains PG {pg_ver}, will backup"
+        )
+    else:
+        # data/ is upgraded, check for data_old with compatible version
+        data_old_dir = find_data_old_dir(src_path)
+        if data_old_dir:
+            old_ver = read_pg_version(data_old_dir)
+            if old_ver in compat:
+                backup_source = data_old_dir
+                result["messages"].append(
+                    f"Source data/ is PG {pg_ver or 'unknown'}, "
+                    f"using data_old (PG {old_ver}) for backup"
+                )
+            else:
+                module.fail_json(
+                    msg=(
+                        f"Source data/ is PG {pg_ver or 'unknown'} and "
+                        f"data_old is PG {old_ver or 'unknown'}. "
+                        f"Cannot find PG {'/'.join(compat)} data to backup."
+                    ),
+                    **result
+                )
+        else:
+            module.fail_json(
+                msg=(
+                    f"Source data/ is PG {pg_ver or 'unknown'} (already upgraded) "
+                    f"and no data_old directory found. "
+                    f"Cannot backup without PG {'/'.join(compat)} data."
+                ),
+                **result
+            )
+
+    # --- Skip if backup already exists with valid PG 12/13 data ---
+    backup_data_dir = os.path.join(dest_path, "data")
+    if os.path.isdir(backup_data_dir):
+        backup_ver = read_pg_version(backup_data_dir)
+        if backup_ver in compat:
+            result["messages"].append(
+                f"SKIP: Valid PG {backup_ver} backup already exists at {dest_path}"
+            )
+            result["backup_pg_version"] = backup_ver
+            result["skipped"] = True
+            module.exit_json(**result)
+
+        result["messages"].append(
+            f"WARNING: Existing backup has PG {backup_ver or 'unknown'}, recreating"
+        )
+        if not module.check_mode:
+            try:
+                shutil.rmtree(dest_path)
+            except (OSError, IOError) as exc:
+                module.fail_json(
+                    msg=f"Failed to remove stale backup at {dest_path}: {exc}",
+                    **result
+                )
+
+    # --- Check mode ---
+    if module.check_mode:
+        result["messages"].append("Check mode: no changes made")
+        module.exit_json(**result)
+
+    # --- PostgreSQL requires UID 26 (postgres user) ---
+    postgres_uid, postgres_gid = 26, 26
+
+    # --- Create backup (only the data directory) ---
+    try:
+        os.makedirs(dest_path, exist_ok=True)
+        # Backup only the data directory, not the entire pgsql folder
+        shutil.copytree(backup_source, backup_data_dir, symlinks=True)
+    except (OSError, IOError, shutil.Error) as exc:
+        module.fail_json(
+            msg=f"Backup failed: {exc}",
+            **result
+        )
+
+    # --- Fix ownership (postgres UID:GID = 26:26) ---
+    try:
+        fix_ownership(dest_path, postgres_uid, postgres_gid)
+        result["messages"].append(
+            f"Set backup ownership to {postgres_uid}:{postgres_gid} (postgres)"
+        )
+    except OSError as exc:
+        module.fail_json(msg=str(exc), **result)
+
+    # --- Fix SELinux context on backup directory ---
+    fix_selinux_context(backup_dir)
+
+    # --- Verify ---
+    if not os.path.isdir(backup_data_dir):
+        module.fail_json(
+            msg=f"Backup verification failed - {backup_data_dir} not found",
+            **result
+        )
+
+    final_ver = read_pg_version(backup_data_dir)
+    if final_ver not in compat:
+        module.fail_json(
+            msg=(
+                f"Backup verification failed - backed up PG {final_ver or 'unknown'}, "
+                f"expected {'/'.join(compat)}"
+            ),
+            **result
+        )
+
+    result["backup_pg_version"] = final_ver
+    result["changed"] = True
+    result["messages"].append(
+        f"SUCCESS: Backed up PG {final_ver} data to {backup_data_dir}"
+    )
+    module.exit_json(**result)
+
+
+# =========================================================================
+# Restore logic
+# =========================================================================
+
+def run_restore(module, params, result):
+    """Restore Pulp PostgreSQL data for rollback.
+
+    Restores the PG 12/13 data from backup to the destination pgsql directory.
+    The backup should contain only the data/ directory with compatible PG version.
+
+    Args:
+        module: AnsibleModule instance.
+        params: Dict with 'backup_path', 'dest_path',
+                and 'compatible_versions'.
+        result: Mutable result dict.
+    """
+    backup_path = params["backup_path"]
+    dest_path = params["dest_path"]
+    compat = tuple(params["compatible_versions"])
+
+    # --- Validate backup exists ---
+    if not os.path.isdir(backup_path):
+        module.fail_json(
+            msg=f"Backup not found at {backup_path}",
+            **result
+        )
+
+    # --- PostgreSQL requires UID 26 (postgres user) ---
+    postgres_uid, postgres_gid = 26, 26
+
+    # --- Find compatible PG data in backup ---
+    backup_data_dir = os.path.join(backup_path, "data")
+    backup_pg_ver = read_pg_version(backup_data_dir)
+    result["backup_pg_version"] = backup_pg_ver or "unknown"
+
+    if backup_pg_ver in compat:
+        # Backup data/ has compatible PG version
+        restore_source = backup_data_dir
+        result["restore_mode"] = "direct"
+        result["messages"].append(
+            f"Backup contains PG {backup_pg_ver} data, restoring directly"
+        )
+    else:
+        # Check for data_old in backup (legacy backup format)
+        data_old_dir = find_data_old_dir(backup_path)
+        if data_old_dir:
+            old_pg_ver = read_pg_version(data_old_dir)
+            if old_pg_ver in compat:
+                restore_source = data_old_dir
+                result["restore_mode"] = "data_old"
+                result["messages"].append(
+                    f"Using backup data_old (PG {old_pg_ver}) for restore"
+                )
+            else:
+                module.fail_json(
+                    msg=(
+                        f"Backup data/ is PG {backup_pg_ver or 'unknown'} and "
+                        f"data_old is PG {old_pg_ver or 'unknown'}. "
+                        f"Cannot restore without PG {'/'.join(compat)} data."
+                    ),
+                    **result
+                )
+        else:
+            module.fail_json(
+                msg=(
+                    f"Backup data/ is PG {backup_pg_ver or 'unknown'} "
+                    f"and no data_old found. "
+                    f"Cannot restore without PG {'/'.join(compat)} data."
+                ),
+                **result
+            )
+
+    # --- Check mode: report what would happen ---
+    if module.check_mode:
+        result["messages"].append("Check mode: no changes made")
+        module.exit_json(**result)
+
+    # --- Remove current destination pgsql directory ---
+    if os.path.exists(dest_path):
+        try:
+            shutil.rmtree(dest_path)
+            result["messages"].append(f"Removed existing data at {dest_path}")
+        except (OSError, IOError) as exc:
+            module.fail_json(
+                msg=f"Failed to remove {dest_path}: {exc}",
+                **result
+            )
+
+    # --- Restore: create pgsql/ with only data/ inside ---
+    try:
+        os.makedirs(dest_path, exist_ok=True)
+        dest_data_dir = os.path.join(dest_path, "data")
+        shutil.copytree(restore_source, dest_data_dir, symlinks=True)
+    except (OSError, IOError, shutil.Error) as exc:
+        module.fail_json(
+            msg=f"Restore failed: {exc}",
+            **result
+        )
+
+    # --- Fix ownership (postgres UID:GID = 26:26) ---
+    try:
+        fix_ownership(dest_path, postgres_uid, postgres_gid)
+        result["messages"].append(
+            f"Set ownership to {postgres_uid}:{postgres_gid} (postgres)"
+        )
+    except OSError as exc:
+        module.fail_json(msg=str(exc), **result)
+
+    # --- Fix SELinux context ---
+    fix_selinux_context(dest_path)
+
+    # --- Verify ---
+    restored_data_dir = os.path.join(dest_path, "data")
+    restored_ver = read_pg_version(restored_data_dir)
+    result["restored_pg_version"] = restored_ver or "unknown"
+
+    if restored_ver not in compat:
+        module.fail_json(
+            msg=(
+                f"Restored data is PG {restored_ver or 'unknown'}, "
+                f"expected {'/'.join(compat)}"
+            ),
+            **result
+        )
+
+    result["changed"] = True
+    result["messages"].append(
+        f"Restored PG {restored_ver} data to {dest_path}"
+    )
+    module.exit_json(**result)
+
+
+# =========================================================================
+# Module entry point
+# =========================================================================
+
+def run_module():
+    """Ansible module entry point for Pulp PostgreSQL backup/restore."""
+    module_args = dict(
+        action=dict(
+            type="str", required=True,
+            choices=["backup", "restore"]
+        ),
+        # Common parameters
+        dest_path=dict(type="str", required=True),
+        compatible_versions=dict(
+            type="list", elements="str", required=False,
+            default=list(COMPATIBLE_PG_VERSIONS)
+        ),
+        # Backup-specific parameters
+        src_path=dict(type="str", required=False, default=""),
+        backup_dir=dict(type="str", required=False, default=""),
+        # Restore-specific parameters
+        backup_path=dict(type="str", required=False, default=""),
+    )
+
+    result = dict(
+        changed=False,
+        skipped=False,
+        restore_mode="",
+        source_pg_version="",
+        backup_pg_version="",
+        restored_pg_version="",
+        messages=[],
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[
+            ("action", "backup", ["src_path", "dest_path", "backup_dir"]),
+            ("action", "restore", ["backup_path", "dest_path"]),
+        ],
+    )
+
+    action = module.params["action"]
+
+    if action == "backup":
+        run_backup(module, module.params, result)
+    elif action == "restore":
+        run_restore(module, module.params, result)
+
+
+def main():
+    """Main entry point."""
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/rollback/playbooks/rollback_oim.yml
+++ b/rollback/playbooks/rollback_oim.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 
-- name: Rollback OIM (includes OpenCHAMI)
+- name: Rollback OIM (includes Pulp and OpenCHAMI)
   hosts: localhost
   connection: local
   gather_facts: true
@@ -59,7 +59,53 @@
       ansible.builtin.set_fact:
         rollback_backup_dir: "{{ rollback_manifest.backup_dir | default('/opt/omnia/backups/upgrade/version_2.1.0.0') }}"
 
-    # ── Phase 1: OpenCHAMI Rollback ─────────────────────────────────────
+    # ── Phase 1: Pulp Rollback ────────────────────────────────────────────
+    # The rollback_pulp role handles the full lifecycle:
+    #   resolve_admin_ip → pre_rollback_checks → rollback_pulp_container
+    #   → post_rollback_health_check
+    # On failure, the role sets pulp_rollback_failed and raises fail.
+    # On skip (not deployed / already at v2.1), the role completes normally.
+    - name: "Phase 1 — Pulp Rollback"
+      block:
+        - name: Rollback Pulp container
+          ansible.builtin.include_role:
+            name: "{{ playbook_dir }}/../roles/rollback_pulp"
+
+        - name: Display Pulp rollback outcome
+          ansible.builtin.debug:
+            msg: >-
+              Pulp Phase 1 result —
+              deployed={{ pulp_deployed | default(false) }},
+              failed={{ pulp_rollback_failed | default(false) }}
+
+      rescue:
+        - name: Re-read rollback_manifest.yml after Pulp failure
+          ansible.builtin.slurp:
+            src: "{{ rollback_manifest_path }}"
+          register: pulp_rescue_raw_rollback_manifest
+
+        - name: Parse current manifest state
+          ansible.builtin.set_fact:
+            pulp_rescue_rollback_manifest: "{{ pulp_rescue_raw_rollback_manifest.content | b64decode | from_yaml }}"
+
+        - name: Pulp rollback failed — mark component as failed
+          ansible.builtin.copy:
+            content: >-
+              {{ pulp_rescue_rollback_manifest | combine({
+                   'component_status': pulp_rescue_rollback_manifest.component_status | combine({
+                     component_name: 'failed'
+                   })
+                 }) | to_nice_yaml }}
+            dest: "{{ rollback_manifest_path }}"
+            mode: '0644'
+
+        - name: Fail with Pulp rollback error
+          ansible.builtin.fail:
+            msg: >-
+              Pulp rollback failed. Check container logs: podman logs pulp
+              Backup directory: {{ rollback_backup_dir | default('N/A') }}
+
+    # ── Phase 2: OpenCHAMI Rollback ─────────────────────────────────────
     # The rollback_openchami role handles the full lifecycle:
     #   resolve_backup_dir → pre_rollback_checks → stop_current_containers
     #   → restore_quadlets_and_configs → start_postgres_only
@@ -67,7 +113,7 @@
     #   → reload_cloud_init_data → post_rollback_health_check
     # On failure, the role sets openchami_rollback_failed and raises fail.
     # On skip (already at v2.1), the role completes normally.
-    - name: "Phase 1 — OpenCHAMI Rollback"
+    - name: "Phase 2 — OpenCHAMI Rollback"
       block:
         - name: Rollback OpenCHAMI containers and services
           ansible.builtin.include_role:
@@ -76,7 +122,7 @@
         - name: Display OpenCHAMI rollback outcome
           ansible.builtin.debug:
             msg: >-
-              OpenCHAMI Phase 1 result —
+              OpenCHAMI Phase 2 result —
               rollback_needed={{ rollback_needed | default(true) }},
               failed={{ openchami_rollback_failed | default(false) }}
 

--- a/rollback/roles/rollback_openchami/tasks/normalize_permissions.yml
+++ b/rollback/roles/rollback_openchami/tasks/normalize_permissions.yml
@@ -24,12 +24,21 @@
 # "permission denied" when the rollback later reads the backup or restores
 # /etc/openchami — which makes the final OpenCHAMI rollback step fail.
 #
-# This task normalizes permissions BEFORE the restore runs:
+# Additionally, SELinux contexts may prevent container access to files.
+# Files need the container_file_t context to be accessible from containers.
+#
+# This task normalizes permissions and SELinux contexts BEFORE the restore:
 #   - Directories  -> 0755
 #   - Files        -> 0644
+#   - SELinux      -> system_u:object_r:container_file_t:s0
 # for two roots:
-#   1. Backup root on the core container : {{ rollback_backup_dir }}/openchami
-#   2. /etc/openchami on the OIM host     : {{ openchami_etc_dir }}
+#   1. Backup root on OIM host: {{ rollback_oim_host_backup_dir }}/openchami
+#   2. /etc/openchami on OIM host: {{ openchami_etc_dir }}
+#
+# NOTE: All operations run on the OIM host (delegated) because:
+#   - The backup is on shared NFS storage mounted on OIM
+#   - NFS root_squash causes permission issues when accessed from core container
+#   - SELinux contexts must be set on the OIM host filesystem
 #
 # Behaviour:
 #   - If permissions are simply wrong, they are corrected automatically and
@@ -42,19 +51,24 @@
 
 - name: Normalize backup and /etc/openchami permissions
   block:
-    # ── Resolve the two roots to normalize ──────────────────────────────
-    - name: Set permission normalization targets
+    # ── Resolve the two roots to normalize (OIM host paths) ───────────────
+    - name: Set permission normalization targets (OIM host paths)
       ansible.builtin.set_fact:
-        normalize_backup_root: "{{ rollback_backup_dir }}/openchami"
+        normalize_backup_root: "{{ rollback_oim_host_backup_dir }}/openchami"
         normalize_etc_root: "{{ openchami_etc_dir }}"
 
-    # ── 1. Backup root (core container — local, on shared NFS path) ──────
-    - name: Check backup root exists (core container)
+    # ── 1. Backup root (OIM host — on shared NFS path) ────────────────────
+    # NOTE: Must run on OIM host because NFS root_squash prevents core
+    # container from accessing/modifying files with restrictive permissions.
+    - name: Check backup root exists (OIM host)
       ansible.builtin.stat:
         path: "{{ normalize_backup_root }}"
       register: normalize_backup_root_stat
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
 
-    - name: Normalize permissions on backup root (core container)
+    - name: Normalize permissions on backup root (OIM host)
       ansible.builtin.shell: |
         set -o pipefail
         find "{{ normalize_backup_root }}" -type d -exec chmod {{ dir_permissions_755 }} {} + 2>/dev/null || true
@@ -63,8 +77,22 @@
       changed_when: true
       failed_when: false
       when: normalize_backup_root_stat.stat.exists | default(false)
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
 
-    - name: Detect unreadable items under backup root (core container)
+    - name: Fix SELinux context on backup root (OIM host)
+      ansible.builtin.command: >
+        chcon -R system_u:object_r:container_file_t:s0 "{{ normalize_backup_root }}"
+      register: normalize_backup_selinux
+      changed_when: true
+      failed_when: false
+      when: normalize_backup_root_stat.stat.exists | default(false)
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Detect unreadable items under backup root (OIM host)
       ansible.builtin.shell: |
         set -o pipefail
         {
@@ -75,6 +103,9 @@
       changed_when: false
       failed_when: false
       when: normalize_backup_root_stat.stat.exists | default(false)
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
 
     # ── 2. /etc/openchami (OIM host — delegated) ────────────────────────
     - name: Check /etc/openchami exists (OIM host)
@@ -91,6 +122,17 @@
         find "{{ normalize_etc_root }}" -type d -exec chmod {{ dir_permissions_755 }} {} + 2>/dev/null || true
         find "{{ normalize_etc_root }}" -type f -exec chmod {{ file_permissions_644 }} {} + 2>/dev/null || true
       register: normalize_etc_chmod
+      changed_when: true
+      failed_when: false
+      when: normalize_etc_root_stat.stat.exists | default(false)
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Fix SELinux context on /etc/openchami (OIM host)
+      ansible.builtin.command: >
+        chcon -R system_u:object_r:container_file_t:s0 "{{ normalize_etc_root }}"
+      register: normalize_etc_selinux
       changed_when: true
       failed_when: false
       when: normalize_etc_root_stat.stat.exists | default(false)

--- a/rollback/roles/rollback_openchami/vars/main.yml
+++ b/rollback/roles/rollback_openchami/vars/main.yml
@@ -133,7 +133,7 @@ rollback_messages:
       Rollback is not needed. Skipping.
     backup_found: "Backup directory found. Proceeding with rollback."
   permissions:
-    normalized: "Backup and /etc/openchami permissions verified (directories 0755, files 0644)."
+    normalized: "Backup and /etc/openchami permissions and SELinux contexts verified (directories 0755, files 0644, context container_file_t)."
     unfixable: |
       ════════════════════════════════════════════
         OPENCHAMI ROLLBACK BLOCKED — PERMISSION ISSUE
@@ -141,26 +141,31 @@ rollback_messages:
       One or more files/directories in the backup or /etc/openchami could not
       be made readable. The rollback cannot read these to restore them.
 
-      This usually happens on the shared NFS backup path (root_squash) when
-      container-created files carry restrictive ownership/permissions.
+      This usually happens due to:
+        1. SELinux context issues (files need container_file_t context)
+        2. NFS root_squash with restrictive ownership/permissions
 
-      Fix the permissions MANUALLY, then re-run ONLY the OpenCHAMI/OIM rollback:
+      Fix the permissions and SELinux context MANUALLY on the OIM host,
+      then re-run ONLY the OpenCHAMI/OIM rollback:
 
-        On the OIM host (as a user that owns the files, e.g. the NFS owner):
+        On the OIM host (SSH to the OIM, NOT the core container):
+          # Fix permissions
           chmod -R u+rwX,go+rX /etc/openchami
-          chmod -R u+rwX,go+rX {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami
+          chmod -R u+rwX,go+rX {{ rollback_oim_host_backup_dir }}/openchami
 
-        Ensure all directories are 0755 and all files are 0644, and that none
-        are in a permission-denied / immutable state. Then retry:
+          # Fix SELinux context
+          chcon -R system_u:object_r:container_file_t:s0 /etc/openchami
+          chcon -R system_u:object_r:container_file_t:s0 {{ rollback_oim_host_backup_dir }}/openchami
 
+        Then retry from the core container:
           cd /opt/omnia/... && ansible-playbook rollback/rollback.yml --tags oim
 
-      Relevant directories that must be readable:
+      Relevant directories on OIM host that must be readable:
         /etc/openchami, /etc/openchami/configs, /etc/openchami/pg-init
-        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/etc_openchami
-        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/etc_openchami/configs
-        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/etc_openchami/pg-init
-        {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/openchami/postgresql_backup
+        {{ rollback_oim_host_backup_dir }}/openchami/etc_openchami
+        {{ rollback_oim_host_backup_dir }}/openchami/etc_openchami/configs
+        {{ rollback_oim_host_backup_dir }}/openchami/etc_openchami/pg-init
+        {{ rollback_oim_host_backup_dir }}/openchami/postgresql_backup
   restore:
     quadlets_success: "Restored v2.1 quadlet files from backup."
     quadlets_failure: "Failed to restore v2.1 quadlet files."

--- a/rollback/roles/rollback_pulp/tasks/cleanup_pulp_data.yml
+++ b/rollback/roles/rollback_pulp/tasks/cleanup_pulp_data.yml
@@ -1,0 +1,99 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Cleanup Pulp Data After Rollback
+#
+# - Triggers Pulp DB orphan cleanup + removes filesystem orphans
+#   via pulp_fs_orphan_cleanup module (reads creds from cli.toml)
+# - Cleans up redundant PG 16 data from backup
+# - Removes temporary files from pgsql directory
+# ===========================================================================
+
+# ── Orphan cleanup (DB-level + filesystem-level) ────────────────────────────
+# Runs inside omnia_core where cli.toml and media directory are accessible.
+# No password arguments — credentials read from /root/.config/pulp/cli.toml.
+- name: Run Pulp orphan cleanup (DB + filesystem)
+  pulp_fs_orphan_cleanup:
+    media_dir: "{{ pulp_data_base_path }}/pulp_storage/media"
+    trigger_db_orphan_cleanup: true
+  register: fs_orphan_result
+  failed_when: false
+
+- name: Display orphan cleanup result
+  ansible.builtin.debug:
+    msg:
+      - "DB orphan cleanup: {{ fs_orphan_result.db_orphan_cleanup_status | default('N/A') }}"
+      - "Disk artifacts: {{ fs_orphan_result.disk_artifact_count | default('N/A') }}"
+      - "DB artifacts: {{ fs_orphan_result.db_artifact_count | default('N/A') }}"
+      - "Orphans removed: {{ fs_orphan_result.removed_count | default(0) }}"
+      - "Space freed: {{ fs_orphan_result.freed_mb | default(0) }} MB"
+
+# ── Clean up backup and temp data ───────────────────────────────────────────
+- name: Clean up backup and temporary PostgreSQL data
+  ansible.builtin.shell: |
+    set -o pipefail
+
+    BACKUP="{{ oim_host_pgsql_backup }}"
+    LIVE="{{ oim_host_pgsql_path }}"
+
+    # Clean backup: remove PG 16 data, rename data_old to data
+    if [ -d "$BACKUP/data" ]; then
+      BK_VER=$(cat "$BACKUP/data/PG_VERSION" 2>/dev/null || echo "unknown")
+      if [ "$BK_VER" != "12" ] && [ "$BK_VER" != "13" ]; then
+        rm -rf "$BACKUP/data"
+        echo "Removed PG $BK_VER data from backup"
+        DATA_OLD=$(find "$BACKUP" -maxdepth 1 -type d -name "data_old.*" 2>/dev/null | head -1)
+        if [ -n "$DATA_OLD" ] && [ -d "$DATA_OLD" ]; then
+          mv "$DATA_OLD" "$BACKUP/data"
+          echo "Renamed $(basename "$DATA_OLD") to data in backup"
+        fi
+      fi
+    fi
+
+    # Clean live pgsql: remove data_old.* and data_pg16* directories
+    find "$LIVE" -maxdepth 1 -type d \( -name "data_old.*" -o -name "data_pg16*" \) -exec rm -rf {} \; 2>/dev/null
+    echo "Cleaned up temporary directories"
+  args:
+    executable: /bin/bash
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+  register: cleanup_result
+  changed_when: true
+  failed_when: false
+
+- name: Display cleanup result
+  ansible.builtin.debug:
+    msg: "{{ cleanup_result.stdout_lines | default(['Cleanup completed']) }}"
+
+# ── Report disk usage ──────────────────────────────────────────────────────
+- name: Report disk usage after rollback
+  ansible.builtin.shell: |
+    echo "Pulp storage: $(du -sh {{ oim_host_pulp_data_base }}/pulp_storage 2>/dev/null | cut -f1)"
+    echo "PostgreSQL:   $(du -sh {{ oim_host_pgsql_path }} 2>/dev/null | cut -f1)"
+    echo "Backup:       $(du -sh {{ oim_host_backup_dir }} 2>/dev/null | cut -f1)"
+  args:
+    executable: /bin/bash
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+  register: disk_usage_result
+  changed_when: false
+  failed_when: false
+
+- name: Display disk usage
+  ansible.builtin.debug:
+    msg: "{{ disk_usage_result.stdout_lines | default([]) }}"

--- a/rollback/roles/rollback_pulp/tasks/cleanup_pulp_data.yml
+++ b/rollback/roles/rollback_pulp/tasks/cleanup_pulp_data.yml
@@ -82,6 +82,7 @@
 # ── Report disk usage ──────────────────────────────────────────────────────
 - name: Report disk usage after rollback
   ansible.builtin.shell: |
+    set -o pipefail
     echo "Pulp storage: $(du -sh {{ oim_host_pulp_data_base }}/pulp_storage 2>/dev/null | cut -f1)"
     echo "PostgreSQL:   $(du -sh {{ oim_host_pgsql_path }} 2>/dev/null | cut -f1)"
     echo "Backup:       $(du -sh {{ oim_host_backup_dir }} 2>/dev/null | cut -f1)"

--- a/rollback/roles/rollback_pulp/tasks/main.yml
+++ b/rollback/roles/rollback_pulp/tasks/main.yml
@@ -1,0 +1,88 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# rollback_pulp — Main Orchestration
+# ============================================================================
+# Reverse the Pulp upgrade (3.113 → 3.80) by:
+#   1. Resolving admin NIC IP for health checks
+#   2. Pre-rollback checks (verify Pulp is deployed, backup exists)
+#   3. Stopping the current Pulp container
+#   4. Restoring PostgreSQL data from backup (PG 12/13 compatible)
+#   5. Restoring the v2.1 quadlet file from backup
+#   6. Pulling the v2.1 Pulp image (3.80)
+#   7. Starting the rolled-back container
+#   8. Post-rollback health check
+#   9. Cleanup (orphan artifacts, redundant backup data)
+#
+# IMPORTANT: PostgreSQL data must be restored because:
+# - Pulp 3.80 uses PostgreSQL 12/13
+# - Pulp 3.113 uses PostgreSQL 16
+# - PostgreSQL cannot downgrade data files between major versions
+#
+# No idempotency check — rollback always executes regardless of current
+# container state. This ensures rollback works even in partial or failed
+# upgrade states.
+# ============================================================================
+
+- name: Read oim_metadata.yml for shared storage path
+  ansible.builtin.slurp:
+    src: "{{ oim_metadata_path }}"
+  register: _pulp_oim_metadata_raw
+
+- name: Set OIM host-side paths from metadata
+  ansible.builtin.set_fact:
+    oim_shared_path: "{{ (_pulp_oim_metadata_raw.content | b64decode | from_yaml).oim_shared_path | regex_replace('/$', '') }}"
+
+- name: Derive OIM host-side Pulp paths
+  ansible.builtin.set_fact:
+    oim_host_pulp_data_base: "{{ oim_shared_path }}/omnia/pulp/settings"
+    oim_host_pgsql_path: "{{ oim_shared_path }}/omnia/pulp/settings/pgsql"
+    oim_host_backup_dir: "{{ oim_shared_path }}/omnia/backups/upgrade/version_2.1.0.0/pulp"
+    oim_host_pgsql_backup: "{{ oim_shared_path }}/omnia/backups/upgrade/version_2.1.0.0/pulp/pgsql"
+    oim_host_rollback_backup_dir: >-
+      {{ (rollback_backup_dir | default(rollback_backup_dir_default))
+         | regex_replace('^/opt/omnia', oim_shared_path ~ '/omnia') }}
+
+- name: Resolve admin NIC IP for Pulp API endpoints
+  ansible.builtin.include_tasks: resolve_admin_ip.yml
+
+- name: Pulp rollback workflow
+  block:
+    - name: Pre-rollback validation checks
+      ansible.builtin.include_tasks: pre_rollback_checks.yml
+
+    - name: Execute Pulp rollback
+      ansible.builtin.include_tasks: rollback_pulp_container.yml
+      when: pulp_deployed | default(false) | bool
+
+    - name: Post-rollback health check
+      ansible.builtin.include_tasks: post_rollback_health_check.yml
+      when: pulp_deployed | default(false) | bool
+
+    - name: Post-rollback cleanup (orphans and temporary data)
+      ansible.builtin.include_tasks: cleanup_pulp_data.yml
+      when:
+        - pulp_deployed | default(false) | bool
+        - pulp_rollback_success | default(false) | bool
+
+  rescue:
+    - name: Set rollback failure flag
+      ansible.builtin.set_fact:
+        pulp_rollback_failed: true
+
+  always:
+    - name: Rollback status and cleanup
+      ansible.builtin.include_tasks: rollback_status.yml

--- a/rollback/roles/rollback_pulp/tasks/post_rollback_health_check.yml
+++ b/rollback/roles/rollback_pulp/tasks/post_rollback_health_check.yml
@@ -1,0 +1,91 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# post_rollback_health_check.yml — Verify Pulp Rollback Success
+#
+# Validates:
+#   1. Pulp container is running with the correct (rolled-back) image
+#   2. Pulp API is accessible and responding
+# Sets pulp_rollback_success flag for cleanup tasks.
+# ============================================================================
+
+- name: Post-rollback health check
+  block:
+    # ── Verify container is running with correct image ────────────────────
+    - name: Get rolled-back Pulp container info
+      containers.podman.podman_container_info:
+        name: "{{ pulp_container_name }}"
+      register: pulp_post_info
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Verify Pulp is running with rolled-back image
+      ansible.builtin.assert:
+        that:
+          - pulp_post_info.containers | length > 0
+          - pulp_post_info.containers[0].State.Status == 'running'
+          - pulp_rollback_tag in (pulp_post_info.containers[0].ImageName | default(''))
+        fail_msg: |
+          Pulp rollback verification failed.
+          Expected image tag: {{ pulp_rollback_tag }}
+          Actual image: {{ pulp_post_info.containers[0].ImageName | default('unknown') }}
+          Container status: {{ pulp_post_info.containers[0].State.Status | default('unknown') }}
+        success_msg: "Pulp container is running with rolled-back image: {{ pulp_post_info.containers[0].ImageName | default('unknown') }}"
+
+    # ── Verify Pulp API is accessible ─────────────────────────────────────
+    - name: Check Pulp API status after rollback
+      ansible.builtin.uri:
+        url: "{{ pulp_status_url }}"
+        method: GET
+        validate_certs: false
+        status_code: [200]
+        return_content: true
+      register: pulp_post_health
+      retries: "{{ pulp_health_retries }}"
+      delay: "{{ pulp_health_delay }}"
+      until: pulp_post_health.status == 200
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Display Pulp workers status
+      ansible.builtin.debug:
+        msg: >-
+          Pulp API: healthy (HTTP {{ pulp_post_health.status }}) |
+          Workers: {{ (pulp_post_health.json | default({})).online_workers | default([]) | length }} |
+          Content apps: {{ (pulp_post_health.json | default({})).online_content_apps | default([]) | length }}
+
+    - name: Set rollback success flag
+      ansible.builtin.set_fact:
+        pulp_rollback_success: true
+
+    - name: Display rollback success message
+      ansible.builtin.debug:
+        msg: "{{ rollback_messages.pulp.rollback_success }}"
+
+  rescue:
+    - name: Display rollback health check failure
+      ansible.builtin.debug:
+        msg: "{{ rollback_messages.pulp.post_check_failure }}"
+
+    - name: Set rollback failure flag
+      ansible.builtin.set_fact:
+        pulp_rollback_failed: true
+
+    - name: Fail with health check error
+      ansible.builtin.fail:
+        msg: "Pulp post-rollback health check failed. Check container logs: podman logs {{ pulp_container_name }}"

--- a/rollback/roles/rollback_pulp/tasks/pre_rollback_checks.yml
+++ b/rollback/roles/rollback_pulp/tasks/pre_rollback_checks.yml
@@ -1,0 +1,134 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# pre_rollback_checks.yml — Validate Pulp Rollback Preconditions
+# ============================================================================
+# Checks:
+#   1. Pulp container exists and is deployed
+#   2. Backup directory exists with Pulp backup
+#   3. Backed-up quadlet file or image tag exists
+#
+# No idempotency check — rollback always executes regardless of current
+# container state. This ensures rollback works even in partial or failed
+# upgrade states.
+# ============================================================================
+
+- name: Pre-rollback validation
+  block:
+    # ── Check if Pulp container exists ────────────────────────────────────
+    - name: Check if Pulp container exists
+      ansible.builtin.command: podman container exists {{ pulp_container_name }}
+      register: pulp_exists_check
+      changed_when: false
+      failed_when: false
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Set Pulp deployment status
+      ansible.builtin.set_fact:
+        pulp_deployed: "{{ pulp_exists_check.rc == 0 }}"
+
+    - name: Display Pulp not deployed message
+      ansible.builtin.debug:
+        msg: "{{ rollback_messages.pulp.not_deployed }}"
+      when: not pulp_deployed
+
+    # ── Get current Pulp container info ───────────────────────────────────
+    - name: Get current Pulp container info
+      containers.podman.podman_container_info:
+        name: "{{ pulp_container_name }}"
+      register: pulp_pre_info
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+      when: pulp_deployed
+
+    - name: Extract current Pulp image version
+      ansible.builtin.set_fact:
+        pulp_current_image: "{{ pulp_pre_info.containers[0].ImageName | default('unknown') }}"
+        pulp_current_status: "{{ pulp_pre_info.containers[0].State.Status | default('unknown') }}"
+      when:
+        - pulp_deployed
+        - pulp_pre_info.containers | length > 0
+
+    - name: Display current Pulp version
+      ansible.builtin.debug:
+        msg: "Current Pulp image: {{ pulp_current_image | default('not found') }}, Status: {{ pulp_current_status | default('unknown') }}"
+      when: pulp_deployed
+
+    # ── Check if already at rollback target version ───────────────────────
+    - name: Check if Pulp is already at rollback target version
+      ansible.builtin.set_fact:
+        pulp_already_rolled_back: "{{ pulp_rollback_image in (pulp_current_image | default('')) }}"
+      when: pulp_deployed
+
+    - name: Display skip message if already at target version
+      ansible.builtin.debug:
+        msg: "{{ rollback_messages.pulp.already_v21 }}"
+      when:
+        - pulp_deployed
+        - pulp_already_rolled_back | default(false)
+
+    # ── Verify backup directory exists ────────────────────────────────────
+    - name: Check backup directory exists
+      ansible.builtin.stat:
+        path: "{{ rollback_backup_dir | default(rollback_backup_dir_default) }}/{{ backup_pulp_subpath }}"
+      register: rollback_pulp_backup_stat
+      when: pulp_deployed
+
+    - name: Check backed-up quadlet file exists
+      ansible.builtin.stat:
+        path: "{{ rollback_backup_dir | default(rollback_backup_dir_default) }}/{{ backup_pulp_quadlet_subpath }}/{{ pulp_container_name }}.container"
+      register: rollback_pulp_quadlet_stat
+      when: pulp_deployed
+
+    - name: Check backed-up image tag file exists
+      ansible.builtin.stat:
+        path: "{{ rollback_backup_dir | default(rollback_backup_dir_default) }}/{{ backup_pulp_image_tag_subpath }}"
+      register: rollback_pulp_image_tag_stat
+      when: pulp_deployed
+
+    - name: Display backup inventory
+      ansible.builtin.debug:
+        verbosity: 1
+        msg:
+          - "Backup directory: {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/{{ backup_pulp_subpath }}"
+          - "Pulp backup: {{ 'found' if rollback_pulp_backup_stat.stat.exists | default(false) else 'MISSING' }}"
+          - "Quadlet backup: {{ 'found' if rollback_pulp_quadlet_stat.stat.exists | default(false) else 'MISSING' }}"
+          - "Image tag backup: {{ 'found' if rollback_pulp_image_tag_stat.stat.exists | default(false) else 'MISSING' }}"
+      when: pulp_deployed
+
+    # ── Determine rollback strategy ───────────────────────────────────────
+    # If quadlet backup exists, restore it. Otherwise, update image tag in current quadlet.
+    - name: Determine rollback strategy
+      ansible.builtin.set_fact:
+        pulp_rollback_strategy: >-
+          {{ 'restore_quadlet' if (rollback_pulp_quadlet_stat.stat.exists | default(false))
+             else 'update_image_tag' }}
+      when: pulp_deployed
+
+    - name: Display rollback strategy
+      ansible.builtin.debug:
+        msg: "Pulp rollback strategy: {{ pulp_rollback_strategy | default('N/A') }}"
+      when: pulp_deployed
+
+    - name: Display rollback proceeding message
+      ansible.builtin.debug:
+        msg: "{{ rollback_messages.pulp.backup_found }}"
+      when:
+        - pulp_deployed
+        - rollback_pulp_backup_stat.stat.exists | default(false) or not (pulp_already_rolled_back | default(false))

--- a/rollback/roles/rollback_pulp/tasks/pre_rollback_checks.yml
+++ b/rollback/roles/rollback_pulp/tasks/pre_rollback_checks.yml
@@ -73,7 +73,7 @@
     # ── Check if already at rollback target version ───────────────────────
     - name: Check if Pulp is already at rollback target version
       ansible.builtin.set_fact:
-        pulp_already_rolled_back: "{{ pulp_rollback_image in (pulp_current_image | default('')) }}"
+        pulp_already_rolled_back: "{{ pulp_rollback_image in ((pulp_current_image | default('')) | string) }}"
       when: pulp_deployed
 
     - name: Display skip message if already at target version

--- a/rollback/roles/rollback_pulp/tasks/pre_rollback_checks.yml
+++ b/rollback/roles/rollback_pulp/tasks/pre_rollback_checks.yml
@@ -73,7 +73,7 @@
     # ── Check if already at rollback target version ───────────────────────
     - name: Check if Pulp is already at rollback target version
       ansible.builtin.set_fact:
-        pulp_already_rolled_back: "{{ pulp_rollback_image in ((pulp_current_image | default('')) | string) }}"
+        pulp_already_rolled_back: "{{ (pulp_rollback_image | default('')) in ((pulp_current_image | default('')) | string) }}"
       when: pulp_deployed
 
     - name: Display skip message if already at target version

--- a/rollback/roles/rollback_pulp/tasks/resolve_admin_ip.yml
+++ b/rollback/roles/rollback_pulp/tasks/resolve_admin_ip.yml
@@ -1,0 +1,95 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# resolve_admin_ip.yml — Resolve Admin NIC IP for Pulp API Health Checks
+# ============================================================================
+# Resolves the admin_nic_ip needed for Pulp API health check endpoints.
+#
+# Resolution order:
+#   1. Primary: Extract from local_repo_access.yml (same as upgrade_k8s)
+#   2. Fallback: Extract from network_spec.yml (same as prepare_oim)
+#   3. Last resort: Use localhost
+#
+# Sets fact:
+#   admin_nic_ip — IP address for Pulp API health checks
+# ============================================================================
+
+- name: Resolve admin NIC IP for Pulp health checks
+  block:
+    # Primary method: Extract from local_repo_access.yml (same as upgrade_k8s)
+    - name: Check if local_repo_access.yml exists
+      ansible.builtin.stat:
+        path: "{{ local_repo_access_path }}"
+      register: local_repo_access_stat
+
+    - name: Load local_repo_access.yml
+      ansible.builtin.slurp:
+        src: "{{ local_repo_access_path }}"
+      register: local_repo_access_raw
+      when: local_repo_access_stat.stat.exists
+
+    - name: Parse local_repo_access.yml
+      ansible.builtin.set_fact:
+        _local_repo_access: "{{ local_repo_access_raw.content | b64decode | from_yaml }}"
+      when: local_repo_access_stat.stat.exists
+
+    - name: Set admin_nic_ip from local_repo_access
+      ansible.builtin.set_fact:
+        admin_nic_ip: "{{ _local_repo_access.offline_tarball_path | regex_replace('^(https?)://([^:]+):.*', '\\2') }}"
+      when:
+        - local_repo_access_stat.stat.exists
+        - _local_repo_access.offline_tarball_path is defined
+
+    # Fallback method: Extract from network_spec.yml
+    - name: Check if network_spec.yml exists
+      ansible.builtin.stat:
+        path: "{{ network_spec_path }}"
+      register: network_spec_stat
+      when: admin_nic_ip is not defined
+
+    - name: Load network_spec.yml as fallback
+      ansible.builtin.include_vars:
+        file: "{{ network_spec_path }}"
+      when:
+        - admin_nic_ip is not defined
+        - network_spec_stat.stat.exists | default(false)
+
+    # Networks is a list in network_spec.yml, parse it to extract admin_network
+    - name: Parse network_spec data into network_data
+      ansible.builtin.set_fact:
+        network_data: "{{ network_data | default({}) | combine({item.keys() | first: item.values() | first}) }}"
+      loop: "{{ Networks }}"
+      when:
+        - admin_nic_ip is not defined
+        - Networks is defined
+
+    - name: Set admin_nic_ip from network_spec
+      ansible.builtin.set_fact:
+        admin_nic_ip: "{{ network_data.admin_network.primary_oim_admin_ip }}"
+      when:
+        - admin_nic_ip is not defined
+        - network_data is defined
+        - network_data.admin_network is defined
+        - network_data.admin_network.primary_oim_admin_ip is defined
+
+  rescue:
+    - name: Fallback to localhost for admin_nic_ip
+      ansible.builtin.set_fact:
+        admin_nic_ip: "localhost"
+
+- name: Display resolved admin_nic_ip
+  ansible.builtin.debug:
+    msg: "Pulp rollback health checks will use admin_nic_ip: {{ admin_nic_ip }}"

--- a/rollback/roles/rollback_pulp/tasks/restore_pulp_data.yml
+++ b/rollback/roles/rollback_pulp/tasks/restore_pulp_data.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Restore Pulp PostgreSQL Data During Rollback
+#
+# Uses the pulp_pgsql_backup_restore module to intelligently restore PG 12/13
+# data from the backup, handling the case where the backup may contain
+# PG 16 data (from the upgrade) with the original PG 12/13 data in
+# a data_old.* directory.
+#
+# Runs inside omnia_core where backup and pgsql paths are accessible
+# via shared NFS storage at /opt/omnia/.
+# ===========================================================================
+
+- name: Restore Pulp PostgreSQL data for rollback
+  pulp_pgsql_backup_restore:
+    action: restore
+    backup_path: "{{ pulp_pgsql_backup_path }}"
+    dest_path: "{{ pulp_pgsql_path }}"
+  register: pgsql_restore_result
+
+- name: Display restore result
+  ansible.builtin.debug:
+    msg:
+      - "Restore mode: {{ pgsql_restore_result.restore_mode }}"
+      - "Backup PG version: {{ pgsql_restore_result.backup_pg_version }}"
+      - "Restored PG version: {{ pgsql_restore_result.restored_pg_version }}"
+      - "{{ pgsql_restore_result.messages | join(', ') }}"

--- a/rollback/roles/rollback_pulp/tasks/rollback_pulp_container.yml
+++ b/rollback/roles/rollback_pulp/tasks/rollback_pulp_container.yml
@@ -1,0 +1,131 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# Pulp Container Rollback (3.113 → 3.80)
+#
+# Steps:
+#   1. Pull the v2.1 Pulp image (3.80)
+#   2. Stop and remove current container
+#   3. Restore PostgreSQL data (PG 16 → PG 12/13)
+#   4. Update quadlet file with rollback image tag
+#   5. Reload systemd, start container, wait for init
+# ============================================================================
+
+- name: Skip rollback if already at target version
+  ansible.builtin.debug:
+    msg: "Pulp is already at rollback target version. Skipping."
+  when: pulp_already_rolled_back | default(false)
+
+- name: Execute Pulp container rollback
+  when: not (pulp_already_rolled_back | default(false))
+  block:
+    # --- 1. Pull v2.1 Pulp image ---
+    - name: Pull v2.1 Pulp image ({{ pulp_rollback_image }})
+      containers.podman.podman_image:
+        name: "{{ pulp_rollback_image }}"
+        state: present
+        force: true
+      register: pulp_image_pull
+      retries: "{{ pull_image_retries }}"
+      delay: "{{ pull_image_delay }}"
+      until: pulp_image_pull is succeeded
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    # --- 2. Stop and remove current container ---
+    - name: Stop Pulp systemd service
+      ansible.builtin.systemd:
+        name: "{{ pulp_container_name }}"
+        state: stopped
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+      failed_when: false
+
+    - name: Force remove Pulp container
+      ansible.builtin.command: podman rm -f {{ pulp_container_name }}
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+      changed_when: true
+      failed_when: false
+
+    # --- 3. Restore PostgreSQL data from backup ---
+    - name: Restore Pulp PostgreSQL data from backup
+      ansible.builtin.include_tasks: restore_pulp_data.yml
+
+    # --- 4. Update quadlet file with rollback image ---
+    - name: Restore quadlet file from backup
+      ansible.builtin.copy:
+        src: "{{ oim_host_rollback_backup_dir }}/{{ backup_pulp_quadlet_subpath }}/{{ pulp_container_name }}.container"
+        dest: "{{ pulp_quadlet_path }}"
+        mode: "{{ file_permissions_644 }}"
+        remote_src: true
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+      when: pulp_rollback_strategy | default('update_image_tag') == 'restore_quadlet'
+
+    - name: Update Image line in quadlet file
+      ansible.builtin.replace:
+        path: "{{ pulp_quadlet_path }}"
+        regexp: '^Image=.*pulp.*$'
+        replace: "Image={{ pulp_rollback_image }}"
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+      when: pulp_rollback_strategy | default('update_image_tag') == 'update_image_tag'
+
+    # --- 5. Reload systemd, start container, wait for init ---
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Start Pulp systemd service
+      ansible.builtin.systemd:
+        name: "{{ pulp_container_name }}"
+        state: started
+        enabled: true
+      register: pulp_start_result
+      retries: "{{ pulp_startup_retries }}"
+      delay: "{{ pulp_startup_delay }}"
+      until: pulp_start_result is succeeded
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Wait for Pulp container to initialize
+      ansible.builtin.pause:
+        seconds: "{{ pulp_init_wait }}"
+
+    - name: Verify Pulp container is running
+      ansible.builtin.command: podman ps --filter name={{ pulp_container_name }} --format "{{ '{{' }}.Status{{ '}}' }}"
+      register: pulp_status_check
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+      changed_when: false
+      retries: "{{ pulp_startup_retries }}"
+      delay: "{{ pulp_startup_delay }}"
+      until: "'Up' in pulp_status_check.stdout"
+
+    - name: Display Pulp container status
+      ansible.builtin.debug:
+        msg: "Pulp container status: {{ pulp_status_check.stdout }}"

--- a/rollback/roles/rollback_pulp/tasks/rollback_status.yml
+++ b/rollback/roles/rollback_pulp/tasks/rollback_status.yml
@@ -1,0 +1,52 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# rollback_status.yml — Report Pulp Rollback Status
+# ============================================================================
+# Reports the final status of the Pulp rollback operation.
+# This task runs in the 'always' block to ensure status is reported
+# regardless of success or failure.
+# ============================================================================
+
+- name: Determine final rollback status
+  ansible.builtin.set_fact:
+    pulp_rollback_final_status: >-
+      {{ 'skipped' if not (pulp_deployed | default(false))
+         else ('skipped' if (pulp_already_rolled_back | default(false))
+               else ('failed' if (pulp_rollback_failed | default(false))
+                     else 'completed')) }}
+
+- name: Display Pulp rollback summary
+  ansible.builtin.debug:
+    msg:
+      - "════════════════════════════════════════════════════════════"
+      - "              PULP ROLLBACK STATUS: {{ pulp_rollback_final_status | upper }}"
+      - "════════════════════════════════════════════════════════════"
+      - "Deployed: {{ pulp_deployed | default(false) }}"
+      - "Already at target: {{ pulp_already_rolled_back | default(false) }}"
+      - "Rollback failed: {{ pulp_rollback_failed | default(false) }}"
+      - "Target image: {{ pulp_rollback_image }}"
+      - "════════════════════════════════════════════════════════════"
+
+- name: Display failure message if rollback failed
+  ansible.builtin.debug:
+    msg: "{{ rollback_messages.pulp.rollback_failure }}"
+  when: pulp_rollback_failed | default(false)
+
+- name: Re-raise failure if rollback failed
+  ansible.builtin.fail:
+    msg: "Pulp rollback failed. See above for details."
+  when: pulp_rollback_failed | default(false)

--- a/rollback/roles/rollback_pulp/vars/main.yml
+++ b/rollback/roles/rollback_pulp/vars/main.yml
@@ -1,0 +1,120 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# rollback_pulp — Variables
+# ============================================================================
+# Rollback target: Pulp 3.80 (from Pulp 3.113)
+# Reverses the upgrade performed by upgrade_pulp role.
+# ============================================================================
+
+# File permissions
+dir_permissions_755: "0755"
+file_permissions_644: "0644"
+
+# Manifest path for locating backup directory
+manifest_path: "/opt/omnia/.data/upgrade_manifest.yml"
+
+# Default backup directory (must match upgrade_pulp)
+rollback_backup_dir_default: "/opt/omnia/backups/upgrade/version_2.1.0.0"
+
+# Pulp container settings
+pulp_container_name: "pulp"
+pulp_rollback_tag: "3.80"
+pulp_rollback_image: "docker.io/pulp/pulp:{{ pulp_rollback_tag }}"
+
+# Pulp quadlet file path
+pulp_quadlet_path: "/etc/containers/systemd/{{ pulp_container_name }}.container"
+
+# OIM metadata (for resolving host-side shared storage paths)
+oim_metadata_path: "/opt/omnia/.data/oim_metadata.yml"
+
+# Paths for resolving admin_nic_ip
+local_repo_access_path: "/opt/omnia/provision/local_repo_access.yml"
+network_spec_path: "{{ input_project_dir | default('/opt/omnia/input') }}/network_spec.yml"
+
+# Pulp API endpoint for health checks
+pulp_protocol: "https"
+pulp_port: "2225"
+pulp_status_url: "{{ pulp_protocol }}://{{ admin_nic_ip | default('localhost') }}:{{ pulp_port }}/pulp/api/v3/status/"
+
+# Image pull settings
+pull_image_retries: 5
+pull_image_delay: 10
+
+# Pulp startup and health check settings
+pulp_startup_retries: 10
+pulp_startup_delay: 10
+pulp_init_wait: 30
+pulp_health_retries: 12
+pulp_health_delay: 10
+
+# Backup sub-paths (relative to rollback_backup_dir)
+backup_pulp_subpath: "pulp"
+backup_pulp_quadlet_subpath: "pulp/quadlet"
+backup_pulp_image_tag_subpath: "pulp/image_tag.txt"
+
+# Pulp shared storage paths (OIM container paths)
+# These paths are inside the OIM container and mounted as volumes in the Pulp container
+pulp_data_base_path: "/opt/omnia/pulp/settings"
+pulp_pgsql_path: "{{ pulp_data_base_path }}/pgsql"
+
+# PostgreSQL backup paths
+# PostgreSQL data must be restored during rollback because:
+# - Pulp 3.80 uses PostgreSQL 12/13
+# - Pulp 3.113 uses PostgreSQL 16
+# - PostgreSQL cannot downgrade data files between major versions
+pulp_backup_dir: "/opt/omnia/backups/upgrade/version_2.1.0.0/pulp"
+pulp_pgsql_backup_path: "{{ pulp_backup_dir }}/pgsql"
+
+# Rollback messages
+rollback_messages:
+  pulp:
+    not_deployed: |
+      Pulp container is not deployed on the OIM. Skipping Pulp rollback.
+    no_backup: |
+      FATAL: Pulp backup not found at {{ rollback_backup_dir | default(rollback_backup_dir_default) }}/{{ backup_pulp_subpath }}.
+      Cannot rollback without a valid backup.
+    already_v21: |
+      Pulp is already at v2.1 version ({{ pulp_rollback_image }}). Skipping rollback.
+    backup_found: "Pulp backup found. Proceeding with rollback."
+    rollback_success: |
+      ════════════════════════════════════════════════════════════
+                    PULP ROLLBACK COMPLETED SUCCESSFULLY
+      ════════════════════════════════════════════════════════════
+        Previous image: {{ pulp_current_image | default('unknown') }}
+        Rolled back to: {{ pulp_rollback_image }}
+        Container:      {{ pulp_container_name }}
+        Status:         running
+        API endpoint:   {{ pulp_status_url }}
+      ════════════════════════════════════════════════════════════
+    rollback_failure: |
+      ════════════════════════════════════════════════════════════
+                         PULP ROLLBACK FAILED
+      ════════════════════════════════════════════════════════════
+        Target image: {{ pulp_rollback_image }}
+
+        Please check:
+          - Pulp container logs: podman logs {{ pulp_container_name }}
+          - Pulp service status: systemctl status {{ pulp_container_name }}
+          - Shared storage accessibility
+      ════════════════════════════════════════════════════════════
+    pre_check_failure: |
+      Pulp pre-rollback check failed.
+      Please verify Pulp container state before attempting rollback.
+    post_check_failure: |
+      Pulp post-rollback health check failed.
+      The rolled-back Pulp container may not be functioning correctly.
+      Check container logs: podman logs {{ pulp_container_name }}

--- a/upgrade/playbooks/upgrade_oim.yml
+++ b/upgrade/playbooks/upgrade_oim.yml
@@ -15,18 +15,19 @@
 # ============================================================================
 # upgrade_oim.yml — Internal playbook (imported by upgrade.yml --tags oim)
 # ============================================================================
-# Upgrades OIM components: OpenCHAMI containers.
+# Upgrades OIM components: Pulp container and OpenCHAMI containers.
 # Prerequisites: prepare_upgrade.yml must have been run first.
 # Reads upgrade_manifest.yml and skips if oim already completed.
 #
 # Flow:
 #   1. Pre-flight: read manifest, check idempotency
-#   2. OpenCHAMI container upgrade (pg_dump, deployment-recipes, image pull,
-#      ordered restart, DB migration, validation)
-#   3. Mark OIM as completed in manifest
+#   2. Phase 1: Pulp container upgrade (3.80 → 3.113)
+#   3. Phase 2: OpenCHAMI container upgrade (pg_dump, deployment-recipes,
+#      image pull, ordered restart, DB migration, validation)
+#   4. Mark OIM as completed in manifest
 # ============================================================================
 
-- name: Upgrade OIM (OpenCHAMI)
+- name: Upgrade OIM (Pulp and OpenCHAMI)
   hosts: localhost
   connection: local
   gather_facts: true
@@ -64,7 +65,55 @@
       ansible.builtin.debug:
         msg: "[UPGRADE] Component '{{ component_name }}' — status changed to: in-progress"
 
-    # ── Phase 1: OpenCHAMI Container Upgrade (ESpec §4.4) ──────────────
+    # ── Phase 1: Pulp Container Upgrade ─────────────────────────────────
+    # The upgrade_pulp role handles the full lifecycle:
+    #   resolve_admin_ip → pre_upgrade_health_check → upgrade_pulp_container → post_upgrade_health_check
+    # It delegates all container operations to the 'oim' host via SSH.
+    # Pulp data is preserved on shared storage during the upgrade.
+    - name: "Phase 1 — Pulp Container Upgrade"
+      block:
+        - name: Upgrade Pulp container
+          ansible.builtin.include_role:
+            name: "{{ playbook_dir }}/../roles/upgrade_pulp"
+
+        - name: Display Pulp upgrade outcome
+          ansible.builtin.debug:
+            msg: >-
+              Pulp Phase 1 result —
+              deployed={{ pulp_deployed | default(false) }},
+              upgrade_needed={{ pulp_upgrade_needed | default(true) }}
+
+      rescue:
+        - name: Re-read upgrade_manifest.yml after Pulp failure
+          ansible.builtin.slurp:
+            src: "{{ manifest_path }}"
+          register: pulp_rescue_raw_manifest
+
+        - name: Parse current manifest state
+          ansible.builtin.set_fact:
+            pulp_rescue_manifest: "{{ pulp_rescue_raw_manifest.content | b64decode | from_yaml }}"
+
+        - name: Pulp upgrade failed — mark component as failed
+          ansible.builtin.copy:
+            content: >-
+              {{ pulp_rescue_manifest | combine({
+                   'component_status': pulp_rescue_manifest.component_status | combine({
+                     component_name: 'failed'
+                   })
+                 }) | to_nice_yaml }}
+            dest: "{{ manifest_path }}"
+            mode: '0644'
+
+        - name: Fail with Pulp upgrade error
+          ansible.builtin.fail:
+            msg: >-
+              Pulp upgrade failed
+              ({{ pulp_rescue_manifest.source_version | default('N/A') }} →
+              {{ pulp_rescue_manifest.target_version | default('N/A') }}).
+              Check logs: podman logs pulp
+              Consider running rollback.
+
+    # ── Phase 2: OpenCHAMI Container Upgrade (ESpec §4.4) ──────────────
     # The upgrade_openchami role handles the full lifecycle:
     #   pre_upgrade_health_check → upgrade_openchami_containers → post_upgrade_health_check
     # It delegates all container operations to the 'oim' host via SSH.
@@ -72,7 +121,7 @@
     # which lands in the rescue block below.
     # On skip (not deployed / already at target), the role completes normally
     # and sets openchami_deployed / upgrade_needed facts accordingly.
-    - name: "Phase 1 — OpenCHAMI Container Upgrade"
+    - name: "Phase 2 — OpenCHAMI Container Upgrade"
       block:
         - name: Upgrade OpenCHAMI containers and services
           ansible.builtin.include_role:
@@ -81,7 +130,7 @@
         - name: Display OpenCHAMI upgrade outcome
           ansible.builtin.debug:
             msg: >-
-              OpenCHAMI Phase 1 result —
+              OpenCHAMI Phase 2 result —
               deployed={{ openchami_deployed | default(false) }},
               upgrade_needed={{ upgrade_needed | default(true) }},
               failed={{ openchami_upgrade_failed | default(false) }}

--- a/upgrade/roles/upgrade_pulp/tasks/backup_pulp_data.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/backup_pulp_data.yml
@@ -1,0 +1,37 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Backup Pulp PostgreSQL Data Before Upgrade
+#
+# PostgreSQL data must be backed up before upgrade because:
+# - Pulp 3.80 uses PostgreSQL 12/13
+# - Pulp 3.113 uses PostgreSQL 16
+# - PostgreSQL cannot downgrade data files between major versions
+#
+# Without this backup, rollback is not possible.
+# ===========================================================================
+
+- name: Backup Pulp PostgreSQL data
+  pulp_pgsql_backup_restore:
+    action: backup
+    src_path: "{{ pulp_pgsql_path }}"
+    dest_path: "{{ pulp_pgsql_backup_path }}"
+    backup_dir: "{{ pulp_backup_dir }}"
+  register: pulp_backup_result
+
+- name: Display backup result
+  ansible.builtin.debug:
+    msg: "{{ pulp_backup_result.messages | default(['Backup task completed']) }}"

--- a/upgrade/roles/upgrade_pulp/tasks/cleanup_after_upgrade.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/cleanup_after_upgrade.yml
@@ -40,6 +40,7 @@
 
 - name: Report disk usage after upgrade
   ansible.builtin.shell: |
+    set -o pipefail
     echo "Pulp storage: $(du -sh {{ oim_host_pulp_data_base }}/pulp_storage 2>/dev/null | cut -f1)"
     echo "PostgreSQL:   $(du -sh {{ oim_host_pgsql_path }} 2>/dev/null | cut -f1)"
     echo "Backup:       $(du -sh {{ oim_host_backup_dir }} 2>/dev/null | cut -f1)"

--- a/upgrade/roles/upgrade_pulp/tasks/cleanup_after_upgrade.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/cleanup_after_upgrade.yml
@@ -1,0 +1,57 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Cleanup After Pulp Upgrade
+#
+# - Runs Pulp orphan cleanup to reclaim disk space
+#   via pulp_fs_orphan_cleanup module (reads creds from cli.toml)
+# - Reports disk usage
+# NOTE: Backup directory is preserved for rollback.
+# ===========================================================================
+
+# Runs inside omnia_core where cli.toml and media directory are accessible.
+# No password arguments — credentials read from /root/.config/pulp/cli.toml.
+- name: Run Pulp orphan cleanup after upgrade
+  pulp_fs_orphan_cleanup:
+    media_dir: "{{ pulp_data_base_path }}/pulp_storage/media"
+    trigger_db_orphan_cleanup: true
+  register: orphan_result
+  failed_when: false
+
+- name: Display orphan cleanup result
+  ansible.builtin.debug:
+    msg:
+      - "DB orphan cleanup: {{ orphan_result.db_orphan_cleanup_status | default('N/A') }}"
+      - "Orphans removed: {{ orphan_result.removed_count | default(0) }}"
+      - "Space freed: {{ orphan_result.freed_mb | default(0) }} MB"
+
+- name: Report disk usage after upgrade
+  ansible.builtin.shell: |
+    echo "Pulp storage: $(du -sh {{ oim_host_pulp_data_base }}/pulp_storage 2>/dev/null | cut -f1)"
+    echo "PostgreSQL:   $(du -sh {{ oim_host_pgsql_path }} 2>/dev/null | cut -f1)"
+    echo "Backup:       $(du -sh {{ oim_host_backup_dir }} 2>/dev/null | cut -f1)"
+  args:
+    executable: /bin/bash
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+  register: disk_usage_result
+  changed_when: false
+  failed_when: false
+
+- name: Display disk usage
+  ansible.builtin.debug:
+    msg: "{{ disk_usage_result.stdout_lines | default([]) }}"

--- a/upgrade/roles/upgrade_pulp/tasks/main.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/main.yml
@@ -1,0 +1,87 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Upgrade Pulp Role - Main Entry Point
+#
+# This role upgrades the Pulp container from 3.80 to 3.113.
+# Pulp stores all data in persistent volumes mounted from shared storage,
+# so data is preserved during the upgrade.
+#
+# IMPORTANT: PostgreSQL data must be backed up before upgrade because:
+# - Pulp 3.80 uses PostgreSQL 12/13
+# - Pulp 3.113 uses PostgreSQL 16
+# - PostgreSQL cannot downgrade data files between major versions
+# Without the backup, rollback is not possible.
+#
+# Flow:
+#   1. Resolve admin NIC IP for health check endpoints
+#   2. Pre-upgrade health check (verify Pulp is deployed and accessible)
+#   3. Backup PostgreSQL data (required for rollback)
+#   4. Pull the new Pulp image (3.113)
+#   5. Stop the Pulp container
+#   6. Update the quadlet file with the new image tag
+#   7. Reload systemd daemon and restart container
+#   8. Run database migrations
+#   9. Post-upgrade health check
+#  10. Cleanup (orphan artifacts)
+# ===========================================================================
+
+- name: Read oim_metadata.yml for shared storage path
+  ansible.builtin.slurp:
+    src: "{{ oim_metadata_path }}"
+  register: _pulp_oim_metadata_raw
+
+- name: Set OIM host-side paths from metadata
+  ansible.builtin.set_fact:
+    oim_shared_path: "{{ (_pulp_oim_metadata_raw.content | b64decode | from_yaml).oim_shared_path | regex_replace('/$', '') }}"
+
+- name: Derive OIM host-side Pulp paths
+  ansible.builtin.set_fact:
+    oim_host_pulp_data_base: "{{ oim_shared_path }}/omnia/pulp/settings"
+    oim_host_pgsql_path: "{{ oim_shared_path }}/omnia/pulp/settings/pgsql"
+    oim_host_backup_dir: "{{ oim_shared_path }}/omnia/backups/upgrade/version_2.1.0.0/pulp"
+    oim_host_pgsql_backup: "{{ oim_shared_path }}/omnia/backups/upgrade/version_2.1.0.0/pulp/pgsql"
+
+- name: Resolve admin NIC IP for Pulp API endpoints
+  ansible.builtin.include_tasks: resolve_admin_ip.yml
+
+- name: Pre-upgrade health check
+  ansible.builtin.include_tasks: pre_upgrade_health_check.yml
+
+- name: Backup Pulp PostgreSQL data before upgrade
+  ansible.builtin.include_tasks: backup_pulp_data.yml
+  when:
+    - pulp_deployed | default(false) | bool
+    - pulp_upgrade_needed | default(true) | bool
+
+- name: Execute Pulp upgrade
+  ansible.builtin.include_tasks: upgrade_pulp_container.yml
+  when:
+    - pulp_deployed | default(false) | bool
+    - pulp_upgrade_needed | default(true) | bool
+
+- name: Post-upgrade health check
+  ansible.builtin.include_tasks: post_upgrade_health_check.yml
+  when:
+    - pulp_deployed | default(false) | bool
+    - pulp_upgrade_needed | default(true) | bool
+
+- name: Post-upgrade cleanup (orphan artifacts)
+  ansible.builtin.include_tasks: cleanup_after_upgrade.yml
+  when:
+    - pulp_deployed | default(false) | bool
+    - pulp_upgrade_needed | default(true) | bool
+    - pulp_upgrade_success | default(false) | bool

--- a/upgrade/roles/upgrade_pulp/tasks/post_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/post_upgrade_health_check.yml
@@ -1,0 +1,75 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Pulp Post-Upgrade Health Check
+#
+# Verifies:
+#   1. Pulp API is accessible and responding
+#   2. Pulp container is running with the new image
+# Sets pulp_upgrade_success flag for cleanup tasks.
+# ===========================================================================
+
+- name: Check Pulp API status after upgrade
+  ansible.builtin.uri:
+    url: "{{ pulp_status_url }}"
+    method: GET
+    validate_certs: false
+    status_code: [200]
+  register: pulp_post_health
+  retries: "{{ pulp_health_retries }}"
+  delay: "{{ pulp_health_delay }}"
+  until: pulp_post_health.status == 200
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+- name: Get Pulp container info after upgrade
+  containers.podman.podman_container_info:
+    name: "{{ pulp_container_name }}"
+  register: pulp_post_info
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+- name: Verify Pulp is running with new image
+  ansible.builtin.assert:
+    that:
+      - pulp_post_info.containers | length > 0
+      - pulp_post_info.containers[0].State.Status == 'running'
+      - pulp_target_image in pulp_post_info.containers[0].ImageName
+    fail_msg: |
+      Pulp upgrade verification failed.
+      Expected image: {{ pulp_target_image }}
+      Actual image: {{ pulp_post_info.containers[0].ImageName | default('unknown') }}
+      Container status: {{ pulp_post_info.containers[0].State.Status | default('unknown') }}
+    success_msg: "Pulp successfully upgraded to {{ pulp_target_image }}"
+
+- name: Set upgrade success flag
+  ansible.builtin.set_fact:
+    pulp_upgrade_success: true
+
+- name: Display Pulp upgrade summary
+  ansible.builtin.debug:
+    msg:
+      - "════════════════════════════════════════════════════════════"
+      - "              PULP UPGRADE COMPLETED SUCCESSFULLY"
+      - "════════════════════════════════════════════════════════════"
+      - "  Previous image: {{ pulp_current_image | default('unknown') }}"
+      - "  New image:      {{ pulp_target_image }}"
+      - "  Container:      {{ pulp_container_name }}"
+      - "  Status:         running"
+      - "  API endpoint:   {{ pulp_status_url }}"
+      - "════════════════════════════════════════════════════════════"

--- a/upgrade/roles/upgrade_pulp/tasks/pre_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/pre_upgrade_health_check.yml
@@ -1,0 +1,100 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Pulp Pre-Upgrade Health Check
+#
+# Verifies:
+#   1. Pulp container exists and is deployed
+#   2. Current Pulp version (to determine if upgrade is needed)
+#   3. Pulp API is accessible
+# ===========================================================================
+
+- name: Check if Pulp container exists
+  ansible.builtin.command: podman container exists {{ pulp_container_name }}
+  register: pulp_exists_check
+  changed_when: false
+  failed_when: false
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+- name: Set Pulp deployment status
+  ansible.builtin.set_fact:
+    pulp_deployed: "{{ pulp_exists_check.rc == 0 }}"
+
+- name: Display Pulp not deployed message
+  ansible.builtin.debug:
+    msg: "{{ upgrade_messages.pulp.not_deployed }}"
+  when: not pulp_deployed
+
+- name: Get current Pulp container info
+  containers.podman.podman_container_info:
+    name: "{{ pulp_container_name }}"
+  register: pulp_pre_info
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+  when: pulp_deployed
+
+- name: Extract current Pulp image version
+  ansible.builtin.set_fact:
+    pulp_current_image: "{{ pulp_pre_info.containers[0].ImageName | default('unknown') }}"
+    pulp_current_status: "{{ pulp_pre_info.containers[0].State.Status | default('unknown') }}"
+  when:
+    - pulp_deployed
+    - pulp_pre_info.containers | length > 0
+
+- name: Display current Pulp version
+  ansible.builtin.debug:
+    msg: "Current Pulp image: {{ pulp_current_image | default('not found') }}, Status: {{ pulp_current_status | default('unknown') }}"
+  when: pulp_deployed
+
+- name: Check if Pulp is already at target version
+  ansible.builtin.set_fact:
+    pulp_upgrade_needed: "{{ pulp_target_image not in (pulp_current_image | default('')) }}"
+  when: pulp_deployed
+
+- name: Display skip message if already at target version
+  ansible.builtin.debug:
+    msg: "{{ upgrade_messages.pulp.already_upgraded }}"
+  when:
+    - pulp_deployed
+    - not (pulp_upgrade_needed | default(true))
+
+- name: Check Pulp API status before upgrade
+  ansible.builtin.uri:
+    url: "{{ pulp_status_url }}"
+    method: GET
+    validate_certs: false
+    status_code: [200]
+  register: pulp_pre_health
+  retries: 3
+  delay: 5
+  until: pulp_pre_health.status == 200
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+  failed_when: false
+  when:
+    - pulp_deployed
+    - pulp_upgrade_needed | default(true)
+
+- name: Display Pulp pre-upgrade health status
+  ansible.builtin.debug:
+    msg: "Pulp API status: {{ 'healthy (HTTP 200)' if pulp_pre_health.status | default(0) == 200 else 'not accessible (will attempt upgrade anyway)' }}"
+  when:
+    - pulp_deployed
+    - pulp_upgrade_needed | default(true)

--- a/upgrade/roles/upgrade_pulp/tasks/pre_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/pre_upgrade_health_check.yml
@@ -64,7 +64,7 @@
 
 - name: Check if Pulp is already at target version
   ansible.builtin.set_fact:
-    pulp_upgrade_needed: "{{ pulp_target_image not in (pulp_current_image | default('')) }}"
+    pulp_upgrade_needed: "{{ pulp_target_image not in ((pulp_current_image | default('')) | string) }}"
   when: pulp_deployed
 
 - name: Display skip message if already at target version

--- a/upgrade/roles/upgrade_pulp/tasks/pre_upgrade_health_check.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/pre_upgrade_health_check.yml
@@ -64,7 +64,7 @@
 
 - name: Check if Pulp is already at target version
   ansible.builtin.set_fact:
-    pulp_upgrade_needed: "{{ pulp_target_image not in ((pulp_current_image | default('')) | string) }}"
+    pulp_upgrade_needed: "{{ (pulp_target_image | default('')) not in ((pulp_current_image | default('')) | string) }}"
   when: pulp_deployed
 
 - name: Display skip message if already at target version

--- a/upgrade/roles/upgrade_pulp/tasks/resolve_admin_ip.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/resolve_admin_ip.yml
@@ -1,0 +1,95 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# resolve_admin_ip.yml — Resolve Admin NIC IP for Pulp API Health Checks
+# ============================================================================
+# Resolves the admin_nic_ip needed for Pulp API health check endpoints.
+#
+# Resolution order:
+#   1. Primary: Extract from local_repo_access.yml (same as upgrade_k8s)
+#   2. Fallback: Extract from network_spec.yml (same as prepare_oim)
+#   3. Last resort: Use localhost
+#
+# Sets fact:
+#   admin_nic_ip — IP address for Pulp API health checks
+# ============================================================================
+
+- name: Resolve admin NIC IP for Pulp health checks
+  block:
+    # Primary method: Extract from local_repo_access.yml (same as upgrade_k8s)
+    - name: Check if local_repo_access.yml exists
+      ansible.builtin.stat:
+        path: "{{ local_repo_access_path }}"
+      register: local_repo_access_stat
+
+    - name: Load local_repo_access.yml
+      ansible.builtin.slurp:
+        src: "{{ local_repo_access_path }}"
+      register: local_repo_access_raw
+      when: local_repo_access_stat.stat.exists
+
+    - name: Parse local_repo_access.yml
+      ansible.builtin.set_fact:
+        _local_repo_access: "{{ local_repo_access_raw.content | b64decode | from_yaml }}"
+      when: local_repo_access_stat.stat.exists
+
+    - name: Set admin_nic_ip from local_repo_access
+      ansible.builtin.set_fact:
+        admin_nic_ip: "{{ _local_repo_access.offline_tarball_path | regex_replace('^(https?)://([^:]+):.*', '\\2') }}"
+      when:
+        - local_repo_access_stat.stat.exists
+        - _local_repo_access.offline_tarball_path is defined
+
+    # Fallback method: Extract from network_spec.yml
+    - name: Check if network_spec.yml exists
+      ansible.builtin.stat:
+        path: "{{ network_spec_path }}"
+      register: network_spec_stat
+      when: admin_nic_ip is not defined
+
+    - name: Load network_spec.yml as fallback
+      ansible.builtin.include_vars:
+        file: "{{ network_spec_path }}"
+      when:
+        - admin_nic_ip is not defined
+        - network_spec_stat.stat.exists | default(false)
+
+    # Networks is a list in network_spec.yml, parse it to extract admin_network
+    - name: Parse network_spec data into network_data
+      ansible.builtin.set_fact:
+        network_data: "{{ network_data | default({}) | combine({item.keys() | first: item.values() | first}) }}"
+      loop: "{{ Networks }}"
+      when:
+        - admin_nic_ip is not defined
+        - Networks is defined
+
+    - name: Set admin_nic_ip from network_spec
+      ansible.builtin.set_fact:
+        admin_nic_ip: "{{ network_data.admin_network.primary_oim_admin_ip }}"
+      when:
+        - admin_nic_ip is not defined
+        - network_data is defined
+        - network_data.admin_network is defined
+        - network_data.admin_network.primary_oim_admin_ip is defined
+
+  rescue:
+    - name: Fallback to localhost for admin_nic_ip
+      ansible.builtin.set_fact:
+        admin_nic_ip: "localhost"
+
+- name: Display resolved admin_nic_ip
+  ansible.builtin.debug:
+    msg: "Pulp health checks will use admin_nic_ip: {{ admin_nic_ip }}"

--- a/upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml
@@ -1,0 +1,108 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Upgrade Pulp Container (3.80 → 3.113)
+#
+# Steps:
+#   1. Pull new Pulp image
+#   2. Stop and remove old container
+#   3. Update quadlet file with new image tag
+#   4. Reload systemd and start container
+#   5. Wait for initialization and run migrations
+# ===========================================================================
+
+# --- 1. Pull new Pulp image ---
+- name: Pull new Pulp image ({{ pulp_target_image }})
+  ansible.builtin.command: podman pull {{ pulp_target_image }}
+  register: pulp_pull_result
+  retries: "{{ pull_image_retries }}"
+  delay: "{{ pull_image_delay }}"
+  until: pulp_pull_result.rc == 0
+  changed_when: pulp_pull_result.rc == 0
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+# --- 2. Stop and remove old container ---
+- name: Stop Pulp service
+  ansible.builtin.systemd:
+    name: "{{ pulp_container_name }}"
+    state: stopped
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+- name: Remove old Pulp container
+  ansible.builtin.command: podman rm -f {{ pulp_container_name }}
+  changed_when: true
+  failed_when: false
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+# --- 3. Update quadlet file with new image ---
+- name: Update Pulp image in quadlet file
+  ansible.builtin.lineinfile:
+    path: "{{ pulp_quadlet_path }}"
+    regexp: '^Image=.*'
+    line: "Image={{ pulp_target_image }}"
+    state: present
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+# --- 4. Reload systemd and start container ---
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+- name: Start Pulp service
+  ansible.builtin.systemd:
+    name: "{{ pulp_container_name }}"
+    state: started
+    enabled: true
+  register: pulp_start_result
+  retries: "{{ pulp_startup_retries }}"
+  delay: "{{ pulp_startup_delay }}"
+  until: pulp_start_result is succeeded
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+
+# --- 5. Wait for initialization and run migrations ---
+- name: Wait for Pulp services to initialize
+  ansible.builtin.pause:
+    seconds: "{{ pulp_init_wait }}"
+
+- name: Run Pulp database migrations
+  containers.podman.podman_container_exec:
+    name: "{{ pulp_container_name }}"
+    command: pulpcore-manager migrate --noinput
+  register: pulp_migrate_result
+  retries: 3
+  delay: 10
+  until: pulp_migrate_result.rc == 0
+  delegate_to: oim
+  delegate_facts: true
+  connection: ssh
+  failed_when: false
+
+- name: Display migration result
+  ansible.builtin.debug:
+    msg: "Database migration: {{ 'completed' if pulp_migrate_result.rc | default(1) == 0 else 'skipped or not required' }}"

--- a/upgrade/roles/upgrade_pulp/vars/main.yml
+++ b/upgrade/roles/upgrade_pulp/vars/main.yml
@@ -1,0 +1,105 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ===========================================================================
+# Pulp Container Upgrade Configuration (3.80 → 3.113)
+# ===========================================================================
+
+# File permissions
+dir_permissions_755: "0755"
+file_permissions_644: "0644"
+
+# Pulp container settings
+pulp_container_name: "pulp"
+pulp_target_tag: "3.113"
+pulp_target_image: "docker.io/pulp/pulp:{{ pulp_target_tag }}"
+
+# Pulp quadlet file path
+pulp_quadlet_path: "/etc/containers/systemd/{{ pulp_container_name }}.container"
+
+# OIM metadata (for resolving host-side shared storage paths)
+oim_metadata_path: "/opt/omnia/.data/oim_metadata.yml"
+
+# Paths for resolving admin_nic_ip
+local_repo_access_path: "/opt/omnia/provision/local_repo_access.yml"
+network_spec_path: "{{ input_project_dir | default('/opt/omnia/input') }}/network_spec.yml"
+
+# Pulp API endpoint for health checks
+pulp_protocol: "https"
+pulp_port: "2225"
+pulp_status_url: "{{ pulp_protocol }}://{{ admin_nic_ip | default('localhost') }}:{{ pulp_port }}/pulp/api/v3/status/"
+
+# Image pull settings
+pull_image_retries: 5
+pull_image_delay: 10
+
+# Pulp startup and health check settings
+pulp_startup_retries: 10
+pulp_startup_delay: 10
+pulp_init_wait: 30
+pulp_health_retries: 12
+pulp_health_delay: 10
+
+# Pulp shared storage paths (OIM container paths)
+# These paths are inside the OIM container and mounted as volumes in the Pulp container
+pulp_data_base_path: "/opt/omnia/pulp/settings"
+pulp_pgsql_path: "{{ pulp_data_base_path }}/pgsql"
+
+# Backup settings
+# PostgreSQL data must be backed up before upgrade because:
+# - Pulp 3.80 uses PostgreSQL 12/13
+# - Pulp 3.113 uses PostgreSQL 16
+# - PostgreSQL cannot downgrade data files between major versions
+pulp_backup_dir: "/opt/omnia/backups/upgrade/version_2.1.0.0/pulp"
+pulp_pgsql_backup_path: "{{ pulp_backup_dir }}/pgsql"
+
+# Upgrade messages
+upgrade_messages:
+  pulp:
+    not_deployed: |
+      Pulp container is not deployed on the OIM. Skipping Pulp upgrade.
+      If you need to deploy Pulp, run: ansible-playbook prepare_oim/prepare_oim.yml
+    already_upgraded: |
+      Pulp is already at target version ({{ pulp_target_image }}). Skipping upgrade.
+    upgrade_success: |
+      ════════════════════════════════════════════════════════════
+                    PULP UPGRADE COMPLETED SUCCESSFULLY
+      ════════════════════════════════════════════════════════════
+        Previous image: {{ pulp_current_image | default('unknown') }}
+        New image:      {{ pulp_target_image }}
+        Container:      {{ pulp_container_name }}
+        Status:         running
+        API endpoint:   {{ pulp_status_url }}
+      ════════════════════════════════════════════════════════════
+    upgrade_failure: |
+      ════════════════════════════════════════════════════════════
+                         PULP UPGRADE FAILED
+      ════════════════════════════════════════════════════════════
+        Target image: {{ pulp_target_image }}
+
+        Please check:
+          - Pulp container logs: podman logs {{ pulp_container_name }}
+          - Pulp service status: systemctl status {{ pulp_container_name }}
+          - Shared storage accessibility
+          - Network connectivity to container registry
+      ════════════════════════════════════════════════════════════
+    pre_check_failure: |
+      Pulp pre-upgrade health check failed.
+      The Pulp API is not accessible at {{ pulp_status_url }}.
+      Please verify Pulp is running before attempting upgrade.
+    post_check_failure: |
+      Pulp post-upgrade health check failed.
+      The upgraded Pulp container may not be functioning correctly.
+      Check container logs: podman logs {{ pulp_container_name }}

--- a/upgrade/upgrade.yml
+++ b/upgrade/upgrade.yml
@@ -453,7 +453,7 @@
 
           ── Omnia Upgrade Execution Plan (in order) ──────────────────
             1. oim           → Upgrade OpenCHAMI control-plane containers
-                               on the Omnia Infrastructure Manager
+                               and Pulp container (3.80 → 3.113) on the OIM
             2. build_stream  → SKIPPED (not enabled in build_stream_config.yml)
             3. local_repo    → Synchronize Omnia 2.2 packages into the
                                local Pulp repository for cluster nodes
@@ -607,7 +607,7 @@
 # Sub-flow imports (each sub-flow reads upgrade_manifest.yml and
 # skips if its component_status is already 'completed')
 # ──────────────────────────────────────────────────────────────────────
-- name: Upgrade OIM tasks (includes OpenCHAMI)
+- name: Upgrade OIM tasks (includes OpenCHAMI and Pulp)
   ansible.builtin.import_playbook: playbooks/upgrade_oim.yml
   tags: [oim]
 


### PR DESCRIPTION
Upgrade Flow: Existing Pulp 3.80 → 3.113 upgrade
Rollback Flow: Pulp 3.113 → 3.80 rollback capability

Technical Details
Version Changes:

Pulp Container (Fresh Install): 3.113 (direct deployment)
Pulp Container (Upgrade): 3.80 → 3.113
Pulp Container (Rollback): 3.113 → 3.80
PostgreSQL (Upgrade): 12/13 → 16 (major version upgrade)
PostgreSQL (Rollback): 16 → 12/13 (major version downgrade)
Target Image: docker.io/pulp/pulp:3.113
Rollback Image: docker.io/pulp/pulp:3.80