### PR TITLE
Fix variable initialization and remove redundant CRI-O restart

### DIFF
--- a/rollback/roles/rollback_k8s/tasks/fix_vip_split_brain.yml
+++ b/rollback/roles/rollback_k8s/tasks/fix_vip_split_brain.yml
@@ -18,6 +18,14 @@
 # the split-brain and cleans up stale VIP addresses so only the
 # rightful lease holder owns the VIP.
 
+# ── Set default _stale_vip_nodes if fix_vip already completed ─────
+# This ensures _stale_vip_nodes variable is always defined, even when
+# fix_vip stage is skipped because it's already completed.
+- name: Set default _stale_vip_nodes when fix_vip already completed
+  ansible.builtin.set_fact:
+    _stale_vip_nodes: []
+  when: (rollback_status.stages.fix_vip.status | default('pending')) == 'completed'
+
 - name: Skip fix_vip if already completed
   ansible.builtin.debug:
     msg: "fix_vip already completed — skipping."

--- a/rollback/roles/rollback_k8s/tasks/stop_cluster.yml
+++ b/rollback/roles/rollback_k8s/tasks/stop_cluster.yml
@@ -18,6 +18,14 @@
 #   2. Non-leader CPs
 #   3. VIP leader last (keeps API accessible as long as possible)
 
+# ── Set default cp_shutdown_order if stop_cluster already completed ─────
+# This ensures cp_shutdown_order variable is always defined, even when
+# stop_cluster stage is skipped because it's already completed.
+- name: Set default cp_shutdown_order when stop_cluster already completed
+  ansible.builtin.set_fact:
+    cp_shutdown_order: "{{ all_cp_nodes }}"
+  when: (rollback_status.stages.stop_cluster.status | default('pending')) == 'completed'
+
 - name: Skip stop_cluster if already completed
   ansible.builtin.debug:
     msg: "stop_cluster already completed — skipping."

--- a/upgrade/roles/upgrade_k8s/tasks/step_kubelet_restart.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/step_kubelet_restart.yml
@@ -26,21 +26,17 @@
     daemon_reload: true
   delegate_to: "{{ current_node_name }}"
 
-# Part 4: Restart crio service
-- name: Restart crio on {{ current_node_name }}
-  ansible.builtin.systemd:
-    name: crio
-    state: restarted
-  delegate_to: "{{ current_node_name }}"
-
-# Part 5: Restart kubelet service
+# Part 4: Restart kubelet service
+# Note: CRI-O was already restarted during the crio_install step.
+# Restarting it again here is redundant and causes unnecessary pod disruption.
+# Only kubelet needs to be restarted to apply the config.yaml and feature gate changes.
 - name: Restart kubelet on {{ current_node_name }}
   ansible.builtin.systemd:
     name: kubelet
     state: restarted
   delegate_to: "{{ current_node_name }}"
 
-# Part 6: Wait for node to become Ready with correct version
+# Part 5: Wait for node to become Ready with correct version
 - name: Wait for node to become Ready
   ansible.builtin.command: >-
     kubectl get node {{ node_ip }}


### PR DESCRIPTION
**Changes:**

1. Fix variable initialization in rollback tasks

  • Added default initialization for _stale_vip_nodes in fix_vip_split_brain.yml
  • Added default initialization for cp_shutdown_order in stop_cluster.yml
  • These variables are now set to safe defaults when their respective stages are already completed, preventing undefined variable
  errors in subsequent tasks

2. Remove redundant CRI-O restart during kubelet restart

  • Removed duplicate CRI-O restart from step_kubelet_restart.yml
  • CRI-O is already restarted during the crio_install step
  • Restarting it again causes unnecessary pod disruption
  • Only kubelet restart is needed to apply config.yaml and feature gate changes

**Impact:**

  • Prevents potential Ansible errors when rollback stages are skipped
  • Reduces unnecessary service restarts during Kubernetes upgrades
  • Improves upgrade stability by minimizing pod disruptions
