### PR TITLE
fix(discovery): Clarify next steps for fresh installation vs Slurm add node scenario

### DIFF
--- a/discovery/roles/ome_discovery/tasks/generate_discovery_report.yml
+++ b/discovery/roles/ome_discovery/tasks/generate_discovery_report.yml
@@ -56,7 +56,10 @@
       - ""
       - "3. Update HOSTNAME, FUNCTIONAL_GROUP_NAME, GROUP_NAME as needed."
       - ""
-      - "4. Run:"
+      - "4. If fresh installation of Omnia, Run:"
+      - "     ansible-playbook prepare_oim/prepare_oim.yml"
+      - ""
+      - "   If Slurm add node scenario, Run:"
       - "     ansible-playbook provision/provision.yml"
       - "============================================================"
 


### PR DESCRIPTION
## Summary
Updates the OME discovery completion message to provide clearer guidance on next steps based on the deployment scenario.

## Changes
- Modified step 4 in the discovery completion message to distinguish between:
  - **Fresh installation of Omnia**: Run `prepare_oim/prepare_oim.yml`
  - **Slurm add node scenario**: Run `provision/provision.yml`

@sujit-jadhav Please Review
