### PR TITLE
Add missing PowerVault iSCSI script generation in kube_control_plane_first cloud init template

### DIFF
--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -341,6 +341,13 @@
               ipAddressPools:
               - first-pool
 
+{% for pv_entry in cloud_init_groups_dict[functional_group_name].powervault_scripts | default([], true) %}
+        - path: /usr/local/bin/setup_iscsi_storage_{{ pv_entry.name }}.sh
+          permissions: '{{ file_mode_755 }}'
+          content: |
+            {{ pv_entry.content | indent(12) }}
+{% endfor %}
+
       runcmd:
         - /usr/local/bin/set-ssh.sh
         - "systemctl enable chronyd"


### PR DESCRIPTION
PowerVault iSCSI mount fails on the kube_control_plane_first (kcp1) node while succeeding on kcp2, kcp3, and worker nodes. The root cause is that the cloud init template for kube_control_plane_first is missing the PowerVault script generation code in the write_files section, even though it has the runcmd to execute these scripts.