### PR TITLE
input: do not explicitly prohibit 'admin' as a password.

### DIFF
--- a/common/library/module_utils/input_validation/schema/credential_rules.json
+++ b/common/library/module_utils/input_validation/schema/credential_rules.json
@@ -105,7 +105,7 @@
       "s3_secret_key": {
         "minLength": 8,
         "maxLength": 128,
-        "pattern": "^(?!admin$)[^\\\\'\"]+$",
+        "pattern": "^[^\\\\\\-'\"]+$",
         "description": "S3 Secret Key for storage backend (MinIO password or Dell PowerScale S3 Secret Key). Should not be kept 'admin'. Length must be between 8 and 128 characters and must not contain backslashes (\\), single quotes ('), or double quotes (\\\")."
       },
       "s3_access_id": {

--- a/common/library/module_utils/input_validation/schema/credential_rules.json
+++ b/common/library/module_utils/input_validation/schema/credential_rules.json
@@ -106,7 +106,7 @@
         "minLength": 8,
         "maxLength": 128,
         "pattern": "^[^\\\\\\-'\"]+$",
-        "description": "S3 Secret Key for storage backend (MinIO password or Dell PowerScale S3 Secret Key). Should not be kept 'admin'. Length must be between 8 and 128 characters and must not contain backslashes (\\), single quotes ('), or double quotes (\\\")."
+        "description": "S3 Secret Key for storage backend (MinIO password or Dell PowerScale S3 Secret Key). Length must be between 8 and 128 characters and must not contain backslashes (\\), single quotes ('), or double quotes (\\\")."
       },
       "s3_access_id": {
         "minLength": 4,


### PR DESCRIPTION
input: allow admin as a password


Fixes #4830
