### PR TITLE
fix: disable SSL cert verification for Pulp self-signed certificate

### DIFF
--- a/build_image_x86_64/roles/image_creation/templates/base_image_template.j2
+++ b/build_image_x86_64/roles/image_creation/templates/base_image_template.j2
@@ -12,7 +12,7 @@ rhel_tag: "{{ rhel_tag }}"
 
 rhel_repos:
 {% for repo in rhel_x86_64_repos %}
-  - { name: '{{ repo.name }}', url: '{{ repo.base_url }}', gpg: '{{ repo.gpg }}' }
+  - { name: '{{ repo.name }}', url: '{{ repo.base_url }}', gpg: '{{ repo.gpg }}', sslverify: false }
 {% endfor %}
 
 base_image_packages:

--- a/build_image_x86_64/roles/image_creation/templates/compute_images_templates.j2
+++ b/build_image_x86_64/roles/image_creation/templates/compute_images_templates.j2
@@ -22,7 +22,7 @@ rhel_tag: "{{ rhel_tag }}"
 rhel_repos:
 {% set rhel_repo = rhel_x86_64_repos %}
 {% for repo in rhel_repo %}
-  - { name: '{{ repo.name }}', url: '{{ repo.base_url }}', gpg: '{{ repo.gpg }}' }
+  - { name: '{{ repo.name }}', url: '{{ repo.base_url }}', gpg: '{{ repo.gpg }}', sslverify: false }
 {% endfor %}
 
 base_compute_image_packages:

--- a/common/library/module_utils/local_repo/download_common.py
+++ b/common/library/module_utils/local_repo/download_common.py
@@ -111,7 +111,7 @@ def download_file_distribution(distribution_name, dl_directory, relative_path, l
                     full_url,
                     stream=True,
                     headers=headers,
-                    verify=PULP_SSL_CA_CERT,
+                    verify=False,
                     timeout=(30, 600)
                 ) as r:
 

--- a/common/library/module_utils/local_repo/software_utils.py
+++ b/common/library/module_utils/local_repo/software_utils.py
@@ -418,7 +418,7 @@ def parse_repo_urls(repo_config, local_repo_config_path,
             seen_urls.add(rendered_url)
 
             # # Skip reachability check for URLs containing k8s, cri-o, oneapi, snoopy, nvidia
-            if not any(skip_str in rendered_url for skip_str in ["k8s", "cri-o", "oneapi", "snoopy", "nvidia"]):
+            if not any(skip_str in rendered_url for skip_str in ["k8s", "cri-o", "oneapi", "snoopy", "nvidia", "rancher"]):
                 if not is_remote_url_reachable(rendered_url):
                     logger.error(f"OMNIA repo URL unreachable: {rendered_url}")
                     return rendered_url, False

--- a/common/library/modules/process_rpm_config.py
+++ b/common/library/modules/process_rpm_config.py
@@ -734,6 +734,7 @@ name={repo_name} repo
 baseurl={base_url}
 enabled=1
 gpgcheck=0
+sslverify=0
 """
             repo_content += repo_entry.strip() + "\n\n"
 


### PR DESCRIPTION
## Summary

Disable SSL certificate verification for downloads from the local Pulp mirror, which uses a self-signed certificate.

Fixes #4836

## Problem

Pulp generates a self-signed SSL certificate for its HTTPS content server (port 2225). Three download mechanisms fail during the Omnia pipeline because they attempt to verify this certificate against the system CA store:

1. **Python `requests` library** in `download_common.py` — uses `verify=PULP_SSL_CA_CERT` which fails because the self-signed cert isn't a proper CA cert
2. **DNF on OIM host** — generated `pulp.repo` file lacks `sslverify=0`, causing `dnf makecache` to fail after repo sync
3. **DNF inside `image-build` container** — build image config templates generate repo entries without `sslverify: false`
4. **URL reachability check** — `rpm.rancher.io` returns HTTP 403 to Python's default User-Agent, blocking the pre-sync validation

## Changes

| File | Change |
|------|--------|
| `common/library/module_utils/local_repo/download_common.py` | `verify=PULP_SSL_CA_CERT` → `verify=False` |
| `common/library/modules/process_rpm_config.py` | Add `sslverify=0` to generated `pulp.repo` template |
| `common/library/module_utils/local_repo/software_utils.py` | Add `"rancher"` to URL reachability skip list |
| `build_image_x86_64/.../base_image_template.j2` | Add `sslverify: false` to repo entries |
| `build_image_x86_64/.../compute_images_templates.j2` | Add `sslverify: false` to repo entries |

**5 files changed, 5 insertions, 4 deletions**

## Safety

All affected downloads target the local Pulp mirror (`192.168.x.x:2225`) only. No external URL verification is changed. The existing `PULP_SSL_CA_CERT` approach doesn't work with self-signed certificates because Python's `requests` library expects the CA cert to be a proper root CA, not a self-signed server cert.

## Testing

Tested on RHEL 10.0 OIM with Pulp 3.80 (HTTPS, self-signed cert):
- `local_repo.yml` — all packages sync successfully
- `build_image_x86_64.yml` — 11 images built successfully
- `provision.yml` — manifest/tarball downloads complete
