### PR TITLE
Issue #4833: Disable Pulp pagination for distribution list commands

### DIFF
--- a/src/playbooks/build_image_aarch64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
+++ b/src/playbooks/build_image_aarch64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
@@ -17,7 +17,7 @@
   block:
     - name: Fetch pulp endpoints for aarch64
       ansible.builtin.command: >
-        pulp rpm distribution list --field name,base_url
+        pulp rpm distribution list --field name,base_url --limit 0
       register: pulp_endpoints
       changed_when: false
 

--- a/src/playbooks/build_image_x86_64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
+++ b/src/playbooks/build_image_x86_64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
@@ -17,7 +17,7 @@
   block:
     - name: Fetch pulp endpoints for x86_64
       ansible.builtin.command: >
-        pulp rpm distribution list --field name,base_url
+        pulp rpm distribution list --field name,base_url --limit 0
       register: pulp_endpoints
       changed_when: false
 


### PR DESCRIPTION
## Description

This PR fixes issue #4833 — the `pulp rpm distribution list` command uses Pulp's default pagination, which truncates results when the number of repositories exceeds the default page size. This causes downstream packages (e.g. Slurm) to not be discovered or installed because their repos fall beyond the first page of results.

## Changes

Adds `--limit 0` to the `pulp rpm distribution list` commands in both architecture-specific `fetch_pulp_repos.yml` files. The `--limit 0` flag disables Pulp pagination entirely, ensuring all distributions are returned regardless of count.

### Files modified
- `src/playbooks/build_image_aarch64/roles/fetch_packages/tasks/fetch_pulp_repos.yml`
- `src/playbooks/build_image_x86_64/roles/fetch_packages/tasks/fetch_pulp_repos.yml`

## How to verify

1. Configure Pulp with more repos than the default page size (typically >100)
2. Run the build_image playbook for either aarch64 or x86_64
3. Confirm all distributions are returned and downstream packages (e.g. Slurm) are found

This PR closes #4833