### PR TITLE
Update etcd-fstab-update.sh.j2

### DIFF
--- a/provision/roles/configure_ochami/templates/k8s-scripts/etcd-fstab-update.sh.j2
+++ b/provision/roles/configure_ochami/templates/k8s-scripts/etcd-fstab-update.sh.j2
@@ -115,12 +115,16 @@ runq systemctl daemon-reload
 
 # ── etcd permissions ─────────────────────────────────────────────────────────
 echo "$(ts) [STEP] Setting etcd permissions"
+# Ensure etcd user/group exist (may be missing after reboot)
+getent group etcd >/dev/null || run groupadd --system etcd
+id etcd >/dev/null 2>&1     || run useradd --system -M -s /sbin/nologin -g etcd etcd
+
 if id etcd >/dev/null 2>&1; then
     run chown etcd:etcd "$MOUNT"
     run chmod 700 "$MOUNT"
     echo "$(ts) [OK] Permissions set: etcd:etcd 700"
 else
-    echo "$(ts) [INFO] etcd user not found — skipping"
+    echo "$(ts) [WARN] etcd user could not be created — skipping chown"
 fi
 
 # ── Final Summary ────────────────────────────────────────────────────────────


### PR DESCRIPTION
The modification adds logic to ensure the etcd user and group exist after reboot (they may be missing), which aligns with the existing logic in etcd-disk-setu
p.sh.j2 (lines 160-161).