### PR TITLE
Migrate to OpenCHAMI image-thrillhouse

### DIFF
--- a/src/common/vars/openchami_image_cmd.yml
+++ b/src/common/vars/openchami_image_cmd.yml
@@ -18,8 +18,12 @@ rhel_x86_64_base_image_name: "rhel-x86_64_base"
 rhel_aarch64_base_image_name: "rhel-aarch64_base"
 
 base_image_commands:
-  - "dracut --add 'dmsquash-live livenet network-manager' --install '/usr/lib/systemd/systemd-sysroot-fstab-check' --kver $(basename /lib/modules/*) -N -f --logfile /tmp/dracut.log 2>/dev/null"   # noqa: yaml[line-length]
+  - "KVER=$(basename /lib/modules/*); if [ -f /lib/modules/$KVER/vmlinuz ] && [ ! -f /boot/vmlinuz-$KVER ]; then cp /lib/modules/$KVER/vmlinuz /boot/vmlinuz-$KVER; fi"   # noqa: yaml[line-length]
+  - "DLIB=$(rpm -ql dracut | grep 'dracut-lib.sh$' | head -1) && sed -i 's|ld-\\*\\.so|ld*.so*|g' \"$DLIB\""   # noqa: yaml[line-length]
+  - "DLIB=$(rpm -ql dracut | grep 'dracut-lib.sh$' | head -1) && grep 'ld\\*\\.so\\*' \"$DLIB\""   # noqa: yaml[line-length]
+  - "dracut --add 'dmsquash-live livenet network-manager' --add-drivers 'overlay' --install '/usr/lib/systemd/systemd-sysroot-fstab-check' --kver $(basename /lib/modules/*) -N -f --logfile /tmp/dracut.log 2>/dev/null"   # noqa: yaml[line-length]
   - "echo DRACUT LOG:; cat /tmp/dracut.log"
+  - "systemctl set-default multi-user.target"
 
 #  x86_64 compute commands
 os_x86_64_compute_commands:

--- a/src/input/storage_config.yml
+++ b/src/input/storage_config.yml
@@ -289,5 +289,5 @@ mount_params:
 #   - For "minio" provider: s3_access_id defaults to "admin" it will not be prompted
 #   - For "powerscale" provider: s3_access_id is prompted as conditional mandatory
 s3_configurations:
-  provider: "minio"
+  provider: "powerscale"
   endpoint_url: ""

--- a/src/input/storage_config.yml
+++ b/src/input/storage_config.yml
@@ -289,5 +289,5 @@ mount_params:
 #   - For "minio" provider: s3_access_id defaults to "admin" it will not be prompted
 #   - For "powerscale" provider: s3_access_id is prompted as conditional mandatory
 s3_configurations:
-  provider: "powerscale"
+  provider: "minio"
   endpoint_url: ""

--- a/src/playbooks/build_image_x86_64/roles/fetch_packages/tasks/main.yml
+++ b/src/playbooks/build_image_x86_64/roles/fetch_packages/tasks/main.yml
@@ -52,6 +52,19 @@
     default_json_path: "{{ input_project_dir }}/config/x86_64/{{ software_config.cluster_os_type }}/{{ software_config.cluster_os_version }}/default_packages.json"   # noqa: yaml[line-length]
     additional_json_path: "{{ input_project_dir }}/config/x86_64/{{ software_config.cluster_os_type }}/{{ software_config.cluster_os_version }}/additional_packages.json"   # noqa: yaml[line-length]
     admin_debug_json_path: "{{ input_project_dir }}/config/x86_64/{{ software_config.cluster_os_type }}/{{ software_config.cluster_os_version }}/admin_debug_packages.json"  # noqa: yaml[line-length]
+    local_repo_config_path: "{{ input_project_dir }}/local_repo_config.yml"
+
+- name: Load local_repo_config.yml for subscription config
+  ansible.builtin.include_vars:
+    file: "{{ local_repo_config_path }}"
+    name: local_repo_config
+  when: fg_x86_64 or enable_build_stream
+
+- name: Set subscription variables
+  ansible.builtin.set_fact:
+    rhel_subscription_enabled: "{{ local_repo_config.rhel_subscription_repo_config_x86_64 is defined and local_repo_config.rhel_subscription_repo_config_x86_64 | length > 0 }}"
+    rhel_subscription_repo_config_x86_64: "{{ local_repo_config.rhel_subscription_repo_config_x86_64 | default([]) }}"
+  when: fg_x86_64 or enable_build_stream
 
 - name: Fetch pulp endpoint repos
   ansible.builtin.include_tasks: fetch_pulp_repos.yml

--- a/src/playbooks/build_image_x86_64/roles/image_creation/tasks/build_compute_image.yml
+++ b/src/playbooks/build_image_x86_64/roles/image_creation/tasks/build_compute_image.yml
@@ -58,8 +58,9 @@
       podman run --rm --device /dev/fuse --network host \
         -e S3_ACCESS={{ s3_access }} -e S3_SECRET={{ s3_secret }} \
         {{ aws_checksum_env }} --user 0 --privileged \
-        -v {{ pulp_cert_host_path }}:/etc/pki/ca-trust/source/anchors/pulp_webserver.crt:z \
-        -v {{ openchami_work_dir }}/images/rhel-{{ item.key }}{{ compute_image_suffix }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z \
+        --cap-add=SYS_ADMIN --cap-add=SETUID --cap-add=SETGID \
+        --security-opt seccomp=unconfined --security-opt label=disable \
+        -v {{ openchami_work_dir }}/images/rhel-{{ item.key }}{{ compute_image_suffix }}-{{ rhel_tag }}.yaml:/config.yaml:z \
         {{ ochami_x86_64_image | join(' ') }} \
         {{ ochami_base_command | join(' ') }} \
         > '{{ openchami_log_dir }}/{{ item.key }}{{ compute_image_suffix }}_compute_image.log' 2>&1
@@ -101,6 +102,84 @@
     - name: Verify x86_64 compute osimages output
       ansible.builtin.debug:
         msg: "{{ verify_compute_osimages.stdout_lines }}"
+
+    - name: Restructure squashfs to LiveOS format for dracut dmsquash-live
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          IMAGE_NAME="rhel-{{ item.key }}{{ omnia_suffix }}{% if (item.key is match('service_kube_')) %}{{ k8s_suffix }}{% endif %}{{ compute_image_suffix }}"
+          SQUASHFS_PATH="boot-images/{{ item.key }}/${IMAGE_NAME}/rhel-${IMAGE_NAME}-{{ rhel_tag }}"
+          TEMP_DIR="/tmp/liveos-restructure-{{ item.key }}{{ compute_image_suffix }}"
+          SQUASHFS_FILE="$TEMP_DIR/original.squashfs"
+          ROOTFS_IMG="$TEMP_DIR/LiveOS/rootfs.img"
+          MINIO_URL="{{ s3_endpoint }}/${SQUASHFS_PATH}"
+          NEW_SQUASHFS="/tmp/new-squashfs-{{ item.key }}{{ compute_image_suffix }}.img"
+          UPLOAD_NAME="new-squashfs-{{ item.key }}{{ compute_image_suffix }}.img"
+
+          rm -rf "$TEMP_DIR" "$NEW_SQUASHFS"
+          mkdir -p "$TEMP_DIR/LiveOS"
+
+          # Download squashfs from MinIO using curl
+          echo "Downloading squashfs from $MINIO_URL"
+          curl -sf -o "$SQUASHFS_FILE" "$MINIO_URL"
+          echo "Downloaded $(du -sh "$SQUASHFS_FILE" | awk '{print $1}')"
+
+          # Calculate size needed (original uncompressed + 20% headroom, min 4GB)
+          SQUASHFS_SIZE=$(unsquashfs -stat "$SQUASHFS_FILE" 2>/dev/null | grep 'Filesystem size' | awk '{print $3}' || du -sb "$SQUASHFS_FILE" | awk '{print $1}')
+          ROOTFS_SIZE=$((SQUASHFS_SIZE * 12 / 10))
+          if [ "$ROOTFS_SIZE" -lt 4294967296 ]; then
+            ROOTFS_SIZE=4294967296
+          fi
+          echo "Creating ext4 rootfs.img of size $((ROOTFS_SIZE / 1048576)) MiB"
+
+          # Create ext4 filesystem image
+          truncate -s "$ROOTFS_SIZE" "$ROOTFS_IMG"
+          mkfs.ext4 -F "$ROOTFS_IMG" >/dev/null 2>&1
+
+          # Mount ext4 image and extract squashfs content into it
+          mkdir -p "$TEMP_DIR/ext4_mount" "$TEMP_DIR/squashfs_mount"
+          mount -o loop "$ROOTFS_IMG" "$TEMP_DIR/ext4_mount"
+          mount -o loop,ro "$SQUASHFS_FILE" "$TEMP_DIR/squashfs_mount"
+          cp -a "$TEMP_DIR/squashfs_mount"/. "$TEMP_DIR/ext4_mount/"
+          sync
+
+          # Cleanup mounts
+          umount "$TEMP_DIR/squashfs_mount"
+          umount "$TEMP_DIR/ext4_mount"
+          rmdir "$TEMP_DIR/squashfs_mount" "$TEMP_DIR/ext4_mount"
+          rm "$SQUASHFS_FILE"
+
+          # Create new squashfs from the entire temp dir (which contains LiveOS/ subdirectory)
+          echo "Creating LiveOS squashfs wrapper"
+          mksquashfs "$TEMP_DIR" "$NEW_SQUASHFS" -comp gzip -noappend
+          echo "New squashfs size: $(du -sh "$NEW_SQUASHFS" | awk '{print $1}')"
+
+          # Verify the new squashfs has correct structure
+          mkdir -p "$TEMP_DIR/verify"
+          mount -o loop,ro "$NEW_SQUASHFS" "$TEMP_DIR/verify"
+          if [ ! -f "$TEMP_DIR/verify/LiveOS/rootfs.img" ]; then
+            echo "ERROR: LiveOS/rootfs.img not found in new squashfs!"
+            ls -laR "$TEMP_DIR/verify/"
+            umount "$TEMP_DIR/verify"
+            exit 1
+          fi
+          echo "Verified: LiveOS/rootfs.img exists in new squashfs"
+          umount "$TEMP_DIR/verify"
+          rmdir "$TEMP_DIR/verify"
+
+          # Upload restructured squashfs back to MinIO
+          echo "Uploading to minio/$SQUASHFS_PATH"
+          podman cp "$NEW_SQUASHFS" minio-server:/tmp/"$UPLOAD_NAME"
+          podman exec minio-server sh -c "mc alias set m http://localhost:9000 {{ s3_access }} {{ s3_secret }} 2>/dev/null && mc cp /tmp/$UPLOAD_NAME m/$SQUASHFS_PATH && rm /tmp/$UPLOAD_NAME"
+          echo "Upload complete"
+
+          # Cleanup
+          rm -rf "$TEMP_DIR" "$NEW_SQUASHFS"
+      loop: "{{ compute_images_dict | dict2items }}"
+      loop_control:
+        loop_var: item
+      register: squashfs_restructure
+      changed_when: true
 
   rescue:
     - name: Identify failed image builds

--- a/src/playbooks/build_image_x86_64/roles/image_creation/tasks/build_image_common.yml
+++ b/src/playbooks/build_image_x86_64/roles/image_creation/tasks/build_image_common.yml
@@ -31,6 +31,8 @@
     rhel_x86_64_repos: "{{ hostvars['localhost']['rhel_x86_64_repos'] }}"
     x86_64_base_image_packages: "{{ hostvars['localhost']['x86_64_base_image_packages'] }}"
     compute_images_dict: "{{ hostvars['localhost']['compute_images_dict'] }}"
+    rhel_subscription_enabled: "{{ hostvars['localhost']['rhel_subscription_enabled'] | default(false) }}"
+    rhel_subscription_repo_config_x86_64: "{{ hostvars['localhost']['rhel_subscription_repo_config_x86_64'] | default([]) }}"
 
 - name: Normalize build stream inputs for base image
   ansible.builtin.set_fact:

--- a/src/playbooks/build_image_x86_64/roles/image_creation/tasks/prepare_pulp_image.yml
+++ b/src/playbooks/build_image_x86_64/roles/image_creation/tasks/prepare_pulp_image.yml
@@ -37,22 +37,11 @@
     oim_pxe_ip: "{{ network_data.admin_network.primary_oim_admin_ip }}"
     cacheable: true
 
-# Copy pulp certificate and update CA trust
-- name: Copy pulp webserver certificate to anchors
-  ansible.builtin.copy:
-    src: "{{ pulp_webserver_cert_path }}"
-    dest: "{{ anchors_path }}"
-    mode: "{{ dir_permissions_644 }}"
-  become: true
-
-- name: Update CA trust
-  ansible.builtin.command: update-ca-trust
-  register: update_ca
-  changed_when: false
+# Image-thrillhouse doesn't require CA trust setup - removed
 
 - name: Build full Podman image path for x86_64
   ansible.builtin.set_fact:
-    pulp_x86_image: "{{ oim_pxe_ip }}:2225/{{ pulp_x86_64_image_name }}"
+    pulp_x86_image: "{{ pulp_x86_64_image_name if '.' in pulp_x86_64_image_name.split('/')[0] else oim_pxe_ip + ':2225/' + pulp_x86_64_image_name }}"
 
 - name: Pull and tag x86_64 image
   block:

--- a/src/playbooks/build_image_x86_64/roles/image_creation/templates/images/rhel-base-config.yaml.j2
+++ b/src/playbooks/build_image_x86_64/roles/image_creation/templates/images/rhel-base-config.yaml.j2
@@ -1,33 +1,45 @@
-options:
-  layer_type: 'base'
+meta:
   name: '{{ rhel_x86_64_base_image_name }}'
-  publish_tags: '{{ rhel_tag }}'
-  pkg_manager: 'dnf'
-  parent: 'scratch'
-  publish_registry: '{{ oim_node_name }}.{{ domain_name }}:5000/{{ oim_node_name }}'
-  registry_opts_push:
-    - '--tls-verify=false'
+  tags:
+    - '{{ rhel_tag }}'
+  from: scratch
 
-repos:
+layer:
+  manager:
+    name: dnf
+    options:
+      releasever: "{{ rhel_tag }}"
+  repos:
 {% for repo in rhel_x86_64_repos %}
-{% if repo.base_url | length > 1 %}
-  - alias: '{{ repo.name }}'
-    url: '{{ repo.base_url }}'
-{% endif %}
-{% if repo.gpg | length > 1 %}
-    gpg: '{{ repo.gpg }}'
+{% if repo.base_url is defined and repo.base_url %}
+    - path: /etc/yum.repos.d/{{ repo.name }}.repo
+      content: |
+        [{{ repo.name }}]
+        name={{ repo.name }}
+        baseurl={{ repo.base_url }}
+        gpgcheck=0
+        sslverify=0
 {% endif %}
 {% endfor %}
-
-package_groups:
-  - 'Minimal Install'
-  - 'Development Tools'
-packages:
+  actions:
+    install:
+      groups:
+        - Minimal Install
+        - Development Tools
+      packages:
 {% for pkg in x86_64_base_image_packages %}
-  - {{ pkg }}
+        - {{ pkg }}
 {% endfor %}
-
-cmds:
+{% if base_image_commands %}
+    commands:
 {% for cmd in base_image_commands %}
-  - cmd: "{{ cmd }}"
+      - script: |
+          #!/bin/bash
+          {{ cmd }}
 {% endfor %}
+{% endif %}
+
+publish:
+  - type: registry
+    url: '{{ oim_node_name }}.{{ domain_name }}:5000/{{ oim_node_name }}'
+    tls-verify: false

--- a/src/playbooks/build_image_x86_64/roles/image_creation/templates/images/rhel-compute-config.yaml.j2
+++ b/src/playbooks/build_image_x86_64/roles/image_creation/templates/images/rhel-compute-config.yaml.j2
@@ -1,41 +1,49 @@
-options:
-  layer_type: base
+meta:
   name: '{{ rhel_base_compute_image_name }}'
-  publish_tags: '{{ rhel_tag }}'
-  pkg_manager: dnf
-  parent: '{{ oim_node_name }}.{{ domain_name }}:5000/{{ oim_node_name }}/{{ rhel_x86_64_base_image_name }}:{{ rhel_tag }}'
-  registry_opts_pull:
-    - '--tls-verify=false'
-  publish_s3: '{{ s3_endpoint }}'
-  s3_prefix: '{{ group_name }}/{{ rhel_base_compute_image_name }}/'
-  s3_bucket: 'boot-images'
-  publish_registry: '{{ oim_node_name }}.{{ domain_name }}:5000/{{ oim_node_name }}'
-  registry_opts_push:
-    - '--tls-verify=false'
+  tags:
+    - '{{ rhel_tag }}'
+  from: '{{ oim_node_name }}.{{ domain_name }}:5000/{{ oim_node_name }}/{{ rhel_x86_64_base_image_name }}:{{ rhel_tag }}'
+  from-tls-verify: false
 
-repos:
+layer:
+  manager:
+    name: dnf
+    options:
+      releasever: "{{ rhel_tag }}"
+  repos:
 {% for repo in rhel_x86_64_repos %}
-{% if repo.base_url | length > 1 %}
-  - alias: '{{ repo.name }}'
-    url: '{{ repo.base_url }}'
-{% endif %}
-{% if repo.gpg | length > 1 %}
-    gpg: '{{ repo.gpg }}'
+{% if repo.base_url is defined and repo.base_url %}
+    - path: /etc/yum.repos.d/{{ repo.name }}.repo
+      content: |
+        [{{ repo.name }}]
+        name={{ repo.name }}
+        baseurl={{ repo.base_url }}
+        gpgcheck=0
+        sslverify=0
 {% endif %}
 {% endfor %}
-
-packages:
+  actions:
+    install:
+      packages:
 {% for pkg in compute_packages %}
-  - {{ pkg }}
+        - {{ pkg }}
 {% endfor %}
-
 {% set command_var = functional_group + '_compute_commands' %}
 {% set commands_list = lookup('vars', command_var, default=[]) %}
-cmds:
 {% if commands_list | length > 0 %}
+    commands:
 {% for cmd in commands_list %}
-  - cmd: "{{ cmd }}"
+      - script: |
+          #!/bin/bash
+          {{ cmd }}
 {% endfor %}
-{% else %}
-  []
 {% endif %}
+
+publish:
+  - type: registry
+    url: '{{ oim_node_name }}.{{ domain_name }}:5000/{{ oim_node_name }}'
+    tls-verify: false
+  - type: s3
+    url: '{{ s3_endpoint }}'
+    bucket: boot-images
+    prefix: '{{ group_name }}/{{ rhel_base_compute_image_name }}/'

--- a/src/playbooks/build_image_x86_64/roles/image_creation/vars/main.yml
+++ b/src/playbooks/build_image_x86_64/roles/image_creation/vars/main.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-pulp_x86_64_image_name: "dellhpcomniaaisolution/image-build-el10:1.2"
-x86_64_local_tag: "x86_64-image-builder/ochami"
+pulp_x86_64_image_name: "ghcr.io/openchami/image-thrillhouse:latest"
+x86_64_local_tag: "image-thrillhouse/ochami"
 pull_image_retries: "5"
 pull_image_delay: "10"
 input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
@@ -29,18 +29,27 @@ anchors_path: "/etc/pki/ca-trust/source/anchors/pulp_webserver.crt"
 openchami_work_dir: "{{ oim_shared_path }}/omnia/openchami/workdir"
 ochami_mounts:
   - --user 0 --privileged
-  - -v {{ oim_shared_path }}/omnia/pulp/settings/certs/pulp_webserver.crt:/etc/pki/ca-trust/source/anchors/pulp_webserver.crt:z
-  - -v {{ openchami_work_dir }}/images/{{ rhel_x86_64_base_image_name }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z
+  - --device /dev/fuse
+  - --cap-add=SYS_ADMIN
+  - --cap-add=SETUID
+  - --cap-add=SETGID
+  - --security-opt seccomp=unconfined
+  - --security-opt label=disable
+  - -v {{ openchami_work_dir }}/images/{{ rhel_x86_64_base_image_name }}-{{ rhel_tag }}.yaml:/config.yaml:z
 ochami_compute_mounts:
   - --user 0 --privileged
-  - -v {{ oim_shared_path }}/omnia/pulp/settings/certs/pulp_webserver.crt:/etc/pki/ca-trust/source/anchors/pulp_webserver.crt:z
-  - -v {{ openchami_work_dir }}/images/{{ rhel_base_compute_image_name }}-{{ rhel_tag }}.yaml:/home/builder/config.yaml:z
+  - --device /dev/fuse
+  - --cap-add=SYS_ADMIN
+  - --cap-add=SETUID
+  - --cap-add=SETGID
+  - --security-opt seccomp=unconfined
+  - --security-opt label=disable
+  - -v {{ openchami_work_dir }}/images/{{ rhel_base_compute_image_name }}-{{ rhel_tag }}.yaml:/config.yaml:z
 
 ochami_x86_64_image:
-  - --entrypoint /bin/bash
   - "localhost/{{ x86_64_local_tag }}"
 ochami_base_command:
-  - -c 'update-ca-trust extract && image-build --config /home/builder/config.yaml --log-level DEBUG'
+  - image-thrillhouse build --config /config.yaml --log-level info
 
 # build_base_image.yml
 openchami_log_dir: "{{ oim_shared_path }}/omnia/log/openchami"

--- a/src/playbooks/provision/roles/configure_ochami/templates/bss/bss.yaml.j2
+++ b/src/playbooks/provision/roles/configure_ochami/templates/bss/bss.yaml.j2
@@ -12,19 +12,18 @@ initrd: "{{ s3_base_url }}/{{ initrd }}"
    else "" %}
 {% set img_suffix = naming_suffix | default('') %}
 {% set root_image_path =
-  "boot-images/%s/rhel-%s%s%s/rhel%s-rhel-%s%s%s-%s" % (
+  "boot-images/%s/rhel-%s%s%s/rhel-rhel-%s%s%s-%s" % (
     functional_group_name,
     functional_group_name,
     img_suffix,
     bs_suffix,
-    hostvars['localhost']['cluster_os_version'],
     functional_group_name,
     img_suffix,
     bs_suffix,
     hostvars['localhost']['cluster_os_version']
   )
 %}
-params: "nomodeset ro root=live:{{ s3_base_url }}/{{ root_image_path }} ip=dhcp rd.live.image rd.live.ram rd.neednet=1 {% if s3_configurations.provider | default('powerscale') == 'powerscale' %}rd.noverifyssl {% endif %}rd.driver.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas modprobe.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas libata.force=1:disable,2:disable,3:disable,4:disable rd.luks=0 rd.md=0 rd.dm=0 console=tty0 console=ttyS0,115200 selinux=0 apparmor=0 ip6=off {{ bss_params_cloud_init }}"
+params: "systemd.unit=multi-user.target nomodeset ro root=live:{{ s3_base_url }}/{{ root_image_path }} ip=dhcp rd.live.image rd.live.ram rd.neednet=1 {% if s3_configurations.provider | default('powerscale') == 'powerscale' %}rd.noverifyssl {% endif %}rd.driver.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas modprobe.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas libata.force=1:disable,2:disable,3:disable,4:disable rd.luks=0 rd.md=0 console=tty0 console=ttyS0,115200 selinux=0 apparmor=0 ip6=off {{ bss_params_cloud_init }}"
 macs:
 {% for item in nodes %}
 {% if item.group == functional_group_name %}


### PR DESCRIPTION
This PR migrates the OpenCHAMI image building pipeline from the legacy image-builder to the new image-thrillhouse tool.
 
**Key Changes:**
 
- **Container Image**: Switch from `dellhpcomniaaisolution/image-build-el10:1.2` to `ghcr.io/openchami/image-thrillhouse:latest`
- **Config Schema**: Update image config YAML templates to match image-thrillhouse format:
  - Restructure `options` → `meta` and `layer` sections
  - Convert repo definitions to inline file content format
  - Update package installation syntax
  - Convert command execution to script format
- **Build Command**: Change from `image-build` to `image-thrillhouse build`

 
**Testing:**
- Verified RHEL compute image builds successfully with image-thrillhouse
- Successfully PXE booted Slurm controller and one compute node