### PR TITLE
fix: change additional_subnets router IP validation from error to warning

### DIFF
--- a/common/library/module_utils/input_validation/validation_flows/provision_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/provision_validation.py
@@ -1534,7 +1534,7 @@ def validate_network_spec(
             additional = admin_net.get("additional_subnets", [])
             if additional:
                 errors.extend(_validate_additional_subnets(
-                    additional, admin_net
+                    additional, admin_net, module
                 ))
 
     return errors
@@ -1750,13 +1750,13 @@ def _validate_ip_ranges(dynamic_range, network_type, netmask_bits):
     return errors
 
 
-def _validate_additional_subnets(additional_subnets, admin_net):
+def _validate_additional_subnets(additional_subnets, admin_net, module=None):
     """
     Validates additional_subnets entries for multi-subnet / multi-RAC DHCP support.
 
     Checks:
         - Each subnet/netmask_bits forms a valid CIDR network.
-        - Router IP is a valid IPv4 address within the subnet.
+        - Router IP is a valid IPv4 address within the subnet (warning if not).
         - dynamic_range is valid and falls within the subnet.
         - Additional subnets do not overlap with the admin network.
         - Additional subnets do not overlap with each other.
@@ -1765,6 +1765,7 @@ def _validate_additional_subnets(additional_subnets, admin_net):
     Args:
         additional_subnets (list): List of additional subnet dicts.
         admin_net (dict): The admin_network configuration dict.
+        module (AnsibleModule): Ansible module instance for issuing warnings (optional).
 
     Returns:
         list: Validation error messages.
@@ -1822,17 +1823,15 @@ def _validate_additional_subnets(additional_subnets, admin_net):
             )
             continue
 
-        # Validate router is within subnet
+        # Validate router is within subnet (warning if not)
         try:
             router_ip = ipaddress.IPv4Address(router)
             if router_ip not in subnet_network:
-                errors.append(
-                    create_error_msg(
-                        f"{prefix}.router",
-                        router,
-                        en_us_validation_msg.ADDITIONAL_SUBNET_ROUTER_NOT_IN_SUBNET_MSG,
+                if module:
+                    module.warn(
+                        f"{prefix}.router: {router} - "
+                        f"{en_us_validation_msg.ADDITIONAL_SUBNET_ROUTER_NOT_IN_SUBNET_MSG}"
                     )
-                )
         except (ValueError, TypeError):
             errors.append(
                 create_error_msg(

--- a/common/library/modules/tests/test_additional_subnets_validation.py
+++ b/common/library/modules/tests/test_additional_subnets_validation.py
@@ -151,7 +151,7 @@ class TestValidateAdditionalSubnets(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_router_outside_subnet(self):
-        """Router IP outside the subnet triggers an error."""
+        """Router IP outside the subnet triggers a warning (not an error)."""
         additional = [{
             "subnet": TEST_SUBNET_1,
             "netmask_bits": "24",
@@ -159,7 +159,8 @@ class TestValidateAdditionalSubnets(unittest.TestCase):
             "dynamic_range": "10.40.1.100-10.40.1.200",
         }]
         errors = _validate_additional_subnets(additional, self._admin_net())
-        self.assertTrue(any("router" in str(e) for e in errors))
+        # Router outside subnet now generates a warning, not an error
+        self.assertEqual(errors, [])
 
     def test_range_outside_subnet(self):
         """dynamic_range outside the subnet triggers an error."""


### PR DESCRIPTION
Router IP not within the additional subnet now issues a warning via module.warn() instead of blocking the flow with an error. Invalid router IP format (non-IPv4) remains an error.