### PR TITLE
Openchami upgrade/rollback fix for utility

### DIFF
--- a/utils/roles/update_cloud_init_bss/tasks/main.yml
+++ b/utils/roles/update_cloud_init_bss/tasks/main.yml
@@ -73,7 +73,6 @@
           ansible.builtin.command: /usr/bin/ochami cloud-init service status
           register: ci_preflight_check
           changed_when: false
-          failed_when: false
           retries: "{{ ochami_recheck_retries }}"
           delay: "{{ ochami_recheck_delay }}"
           until: ci_preflight_check.rc == 0

--- a/utils/roles/update_cloud_init_bss/tasks/main.yml
+++ b/utils/roles/update_cloud_init_bss/tasks/main.yml
@@ -45,6 +45,113 @@
         (hostname_file_path is defined and hostname_file_path | length > 0)
     fail_msg: "{{ no_input_files_msg }}"
 
+- name: Ensure OpenCHAMI services are reachable before ochami commands
+  block:
+    - name: Check ochami cloud-init service status
+      ansible.builtin.command: /usr/bin/ochami cloud-init service status
+      register: ci_preflight_check
+      changed_when: false
+      failed_when: false
+      retries: "{{ ochami_recheck_retries }}"
+      delay: "{{ ochami_recheck_delay }}"
+      until: ci_preflight_check.rc == 0
+
+    - name: Recover OpenCHAMI services if unreachable
+      when: ci_preflight_check.rc != 0
+      block:
+        - name: Restart acme-deploy to deploy renewed certificate to HAProxy
+          ansible.builtin.systemd:
+            name: acme-deploy.service
+            state: restarted
+          failed_when: false
+
+        - name: Wait for certificate deployment to HAProxy volume
+          ansible.builtin.pause:
+            seconds: "{{ acme_deploy_wait_seconds }}"
+
+        - name: Check ochami cloud-init service status
+          ansible.builtin.command: /usr/bin/ochami cloud-init service status
+          register: ci_preflight_check
+          changed_when: false
+          failed_when: false
+          retries: "{{ ochami_recheck_retries }}"
+          delay: "{{ ochami_recheck_delay }}"
+          until: ci_preflight_check.rc == 0
+      rescue:
+        - name: Stop HAProxy to clear stale backend DNS cache
+          ansible.builtin.systemd:
+            name: haproxy.service
+            state: stopped
+
+        - name: Start HAProxy with renewed certificate
+          ansible.builtin.systemd:
+            name: haproxy.service
+            state: started
+
+        - name: Wait for HAProxy to stabilize
+          ansible.builtin.pause:
+            seconds: "{{ haproxy_stabilize_wait_seconds }}"
+
+        # Start coresmd (v2.1) or coredhcp/coredns (v2.2) — depends on HAProxy
+        # Try both; only the version-appropriate service will exist.
+        - name: Start coresmd after HAProxy Start (v2.1)
+          ansible.builtin.systemd:
+            name: coresmd.service
+            state: started
+          failed_when: false
+
+        - name: Start coresmd-coredhcp after HAProxy Start (v2.2)
+          ansible.builtin.systemd:
+            name: coresmd-coredhcp.service
+            state: started
+          failed_when: false
+
+        - name: Start coresmd-coredns after HAProxy Start (v2.2)
+          ansible.builtin.systemd:
+            name: coresmd-coredns.service
+            state: started
+          failed_when: false
+
+        - name: Wait for coresmd services to stabilize
+          ansible.builtin.pause:
+            seconds: 10
+
+        - name: Recheck ochami cloud-init service status after recovery
+          ansible.builtin.command: /usr/bin/ochami cloud-init service status
+          register: ci_recheck
+          changed_when: false
+          failed_when: false
+          retries: "{{ ochami_recheck_retries }}"
+          delay: "{{ ochami_recheck_delay }}"
+          until: ci_recheck.rc == 0
+
+        - name: Restart openchami.target if still unreachable
+          ansible.builtin.systemd:
+            name: openchami.target
+            state: restarted
+          failed_when: false
+          when: ci_recheck.rc != 0
+
+        - name: Wait for openchami to initialize
+          ansible.builtin.pause:
+            seconds: 15
+          when: ci_recheck.rc != 0
+
+        - name: Final recheck ochami cloud-init service status
+          ansible.builtin.command: /usr/bin/ochami cloud-init service status
+          register: ci_final_recheck
+          changed_when: false
+          failed_when: false
+          retries: "{{ ochami_recheck_retries }}"
+          delay: "{{ ochami_recheck_delay }}"
+          until: ci_final_recheck.rc == 0
+          when: ci_recheck.rc != 0
+
+        - name: Fail if OpenCHAMI services still unreachable
+          ansible.builtin.fail:
+            msg: "{{ openchami_unreachable_fail_msg }}"
+          when: (ci_final_recheck.rc | default(ci_recheck.rc) | default(1)) != 0
+
 - name: Update ci-defaults configuration
   ansible.builtin.include_tasks: update_ci_defaults.yml
   when:

--- a/utils/roles/update_cloud_init_bss/tasks/main.yml
+++ b/utils/roles/update_cloud_init_bss/tasks/main.yml
@@ -81,11 +81,13 @@
           ansible.builtin.systemd:
             name: haproxy.service
             state: stopped
+          failed_when: false
 
         - name: Start HAProxy with renewed certificate
           ansible.builtin.systemd:
             name: haproxy.service
             state: started
+          failed_when: false
 
         - name: Wait for HAProxy to stabilize
           ansible.builtin.pause:
@@ -149,7 +151,7 @@
         - name: Fail if OpenCHAMI services still unreachable
           ansible.builtin.fail:
             msg: "{{ openchami_unreachable_fail_msg }}"
-          when: (ci_final_recheck.rc | default(ci_recheck.rc) | default(1)) != 0
+          when: (ci_final_recheck.rc | default(ci_recheck.rc | default(1))) != 0
 
 - name: Update ci-defaults configuration
   ansible.builtin.include_tasks: update_ci_defaults.yml

--- a/utils/roles/update_cloud_init_bss/vars/main.yml
+++ b/utils/roles/update_cloud_init_bss/vars/main.yml
@@ -59,3 +59,14 @@ no_input_files_msg: >
   ci_common_file_path, or hostname_file_path must be provided.
   Pass them as extra variables:
   -e bss_file_path=/path/to/bss.yaml -e cloud_init_file_path=/path/to/ci-group.yaml
+
+# Pre-flight OpenCHAMI service recovery timings
+acme_register_wait_seconds: 15
+acme_deploy_wait_seconds: 10
+haproxy_stabilize_wait_seconds: 10
+ochami_recheck_retries: 3
+ochami_recheck_delay: 10
+openchami_unreachable_fail_msg: >
+  OpenCHAMI services are unreachable after certificate renewal and HAProxy restart.
+  Check: ochami cloud-init service status, systemctl status haproxy.service,
+  and podman logs cloud-init-server for details.


### PR DESCRIPTION
**PR #4856 Summary: OpenCHAMI Upgrade/Rollback Fix for Utility**

**Files Changed:** 2 commits to [main.yml](cci:7://file:///c:/Users/Abhishek_Sa1/OneDrive%20-%20Dell%20Technologies/Github/omnia-q1-dev/upgrade/roles/upgrade_openchami/vars/main.yml:0:0-0:0) (likely [utils/roles/update_cloud_init_bss/tasks/main.yml](cci:7://file:///c:/Users/Abhishek_Sa1/OneDrive%20-%20Dell%20Technologies/Github/omnia-q1-dev/utils/roles/update_cloud_init_bss/tasks/main.yml:0:0-0:0) and [utils/roles/update_cloud_init_bss/vars/main.yml](cci:7://file:///c:/Users/Abhishek_Sa1/OneDrive%20-%20Dell%20Technologies/Github/omnia-q1-dev/utils/roles/update_cloud_init_bss/vars/main.yml:0:0-0:0))

**What This PR Does:**

This PR adds preflight checks and recovery logic to the `update_cloud_init_bss` utility role:

1. **Preflight Service Reachability Check** ([tasks/main.yml](cci:7://file:///c:/Users/Abhishek_Sa1/OneDrive%20-%20Dell%20Technologies/Github/omnia-q1-dev/utils/roles/update_cloud_init_bss/tasks/main.yml:0:0-0:0)):
   - Added `ochami cloud-init service status` check before running any `ochami` commands
   - Retry mechanism with 3 attempts and 10-second delay between retries
   - Prevents immediate failure if services are still starting after certificate renewal

2. **Conditional Recovery Blocks** ([tasks/main.yml](cci:7://file:///c:/Users/Abhishek_Sa1/OneDrive%20-%20Dell%20Technologies/Github/omnia-q1-dev/utils/roles/update_cloud_init_bss/tasks/main.yml:0:0-0:0)):
   - If cloud-init unreachable → restart `acme-deploy`, stop/start HAProxy, start coresmd, restart `openchami.target`
   - Wait times for each service to stabilize (15s for acme-deploy, 10s for HAProxy)
   - Fail with actionable error message if services remain unreachable

3. **Timing Variables** ([vars/main.yml](cci:7://file:///c:/Users/Abhishek_Sa1/OneDrive%20-%20Dell%20Technologies/Github/omnia-q1-dev/upgrade/roles/upgrade_openchami/vars/main.yml:0:0-0:0)):
   - `acme_register_wait_seconds: 15`
   - `acme_deploy_wait_seconds: 10`
   - `haproxy_stabilize_wait_seconds: 10`
   - `ochami_recheck_retries: 3`
   - `ochami_recheck_delay: 10`
   - `openchami_unreachable_fail_msg` for error reporting

**Why This Change Was Made:**

- The `update_cloud_init_bss` utility is invoked during both upgrade and rollback flows
- Without this fix, the utility playbook would fail immediately with "connection refused" errors
- The preflight check and recovery ensure services are stabilized before attempting BSS/cloud-init updates
