### PR TITLE
Allow NTP clients from all admin subnets, including additional_subnets

### DIFF
--- a/prepare_oim/roles/deploy_containers/common/tasks/configure_chrony.yml
+++ b/prepare_oim/roles/deploy_containers/common/tasks/configure_chrony.yml
@@ -18,11 +18,30 @@
     name: chrony
     state: present
 
+- name: Build list of additional subnets allowed by chrony
+  ansible.builtin.set_fact:
+    chrony_additional_subnets: "{{ chrony_additional_subnets | default([]) + [item.subnet + '/' + item.netmask_bits] }}"
+  loop: "{{ hostvars['localhost']['network_data']['admin_network']['additional_subnets'] | default([]) }}"
+
+- name: Build complete list of subnets allowed by chrony
+  ansible.builtin.set_fact:
+    chrony_allowed_subnets:
+      - "{{ hostvars['localhost']['admin_net_addr'] }}/{{ hostvars['localhost']['admin_netmask_bits'] }}"
+      - "{{ chrony_additional_subnets | default([]) }}"
+
+- name: Flatten chrony allowed subnets
+  ansible.builtin.set_fact:
+    chrony_allowed_subnets: "{{ chrony_allowed_subnets | flatten | select('string') | list }}"
+
 - name: Update chrony.conf
-  ansible.builtin.lineinfile:
+  ansible.builtin.blockinfile:
     path: "{{ chrony_conf_path }}"
-    regexp: ^#allow
-    line: "allow {{ hostvars['localhost']['admin_net_addr'] }}/{{ hostvars['localhost']['admin_netmask_bits'] }}"
+    marker: "# {mark} ANSIBLE MANAGED CHRONY ALLOW SUBNETS"
+    block: |
+      {% for subnet in chrony_allowed_subnets %}
+      allow {{ subnet }}
+      {% endfor %}
+    insertafter: "^#allow"
     state: present
 
 - name: Enable and start chronyd service


### PR DESCRIPTION
### Description of the Solution

**Problem**
The OIM acts as the NTP server for provisioned nodes. Chrony’s allow directive was generated only for the primary admin subnet (admin_net_addr/admin_netmask_bits). Nodes in additional_subnets defined in network_spec.yml were therefore denied NTP access, causing time synchronization to fail on multi-subnet deployments.

**Root Cause**
configure_chrony.yml used a single lineinfile/allow entry based only on hostvars['localhost']['admin_net_addr']. It did not consume admin_network.additional_subnets, so nodes in those PXE subnets could not reach chronyd.

**Changes**
In configure_chrony.yml:
Build chrony_additional_subnets from network_data.admin_network.additional_subnets (subnet/netmask_bits).
Merge primary admin subnet with additional subnets.
Flatten and de-duplicate the list.
Use blockinfile to write multiple allow <subnet> lines to chrony.conf under an Ansible-managed marker.
Files Modified
configure_chrony.yml

**Verification**
Deploy or rerun prepare_oim.yml.
On the OIM, verify chrony.conf contains allow entries for the primary admin subnet and every additional_subnets entry.
From a node in an additional subnet, run chronyc sources -v and confirm the OIM IP appears as a reachable source.
chronyc tracking should show a valid reference ID and Leap status: Normal.

**Impact**
Single-subnet deployments: behavior unchanged (one allow line).
Multi-subnet deployments: all PXE subnets can now sync time with the OIM NTP server.
Backward compatible: additional_subnets defaults to empty list.

### Suggested Reviewers
@abhishek-sa1 @priti-parate 
