### PR TITLE
Fix: Additional cloud init support for kube control plane first

### DIFF
--- a/provision/roles/configure_ochami/templates/nodes/groups_additional_fg.yaml.j2
+++ b/provision/roles/configure_ochami/templates/nodes/groups_additional_fg.yaml.j2
@@ -2,7 +2,7 @@
   members:
     ids:
 {% for item in nodes | sort(attribute='value.XNAME') %}
-{% if item.value.FUNCTIONAL_GROUP_NAME == functional_group_name %}
+{% if item.value.FUNCTIONAL_GROUP_NAME | replace('_first_', '_') == functional_group_name %}
       - {{ item.value.XNAME }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Description

Fixed functional group name matching in the OCHAMI additional functional group template.

The comparison now normalizes functional group names by replacing the `_first_` substring with `_` before evaluating against `functional_group_name`. This ensures that entries containing the `_first_` naming convention like kube_control_plane_first which used internally are correctly mapped and processed during template rendering.

## Issue Resolved

- Corrects mismatches when functional group names contain the `_first_` suffix pattern.
- Ensures consistent functional group identification and generation of `groups_additional_fg.yaml`.

## Changes Made

- Updated the conditional check in:
  `provision/roles/configure_ochami/templates/nodes/groups_additional_fg.yaml.j2`
- Added normalization logic:
  ```jinja2
  item.value.FUNCTIONAL_GROUP_NAME | replace('_first_', '_')