### PR TITLE
fix: delegate BMC validation to worker node for telemetry and add subnet validation for kube-vip and update calico_cidr

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,4 +4,4 @@ skip_list:
   - fqcn[canonical]
   - internal-error
   - role-name[path]
-  - load-failure
+  - no-changed-when

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,4 +4,4 @@ skip_list:
   - fqcn[canonical]
   - internal-error
   - role-name[path]
-  - no-changed-when
+  - load-failure

--- a/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/high_availability_validation.py
@@ -443,23 +443,25 @@ def validate_service_k8s_cluster_ha(
         pxe_admin_ips = [item["ADMIN_IP"] for item in pxe_list]
         pxe_bmc_ips   = [item["BMC_IP"]   for item in pxe_list]
 
-    # Determine control plane nodes' subnet for VIP validation
+    # Determine control plane nodes' subnet for VIP validation.
+    # Use the first control plane node's ADMIN_IP from pxe_mapping_file.csv
+    # as the subnet reference instead of deriving from OIM admin IP.
     additional_subnets = network_spec_data.get("additional_subnets", [])
     kcp_ips = [item["ADMIN_IP"] for item in pxe_list
                if item.get("FUNCTIONAL_GROUP_NAME", "").startswith("service_kube_control_plane")]
     kcp_subnet_ip = None
     kcp_subnet_bits = None
     if kcp_ips:
-        ref_ip = kcp_ips[0]
-        if validation_utils.is_ip_in_subnet(oim_admin_ip, admin_netmaskbits, ref_ip):
-            kcp_subnet_ip = oim_admin_ip
+        kcp_subnet_ip = kcp_ips[0]
+        # Find the netmask for the subnet this CP node belongs to
+        if validation_utils.is_ip_in_subnet(oim_admin_ip, admin_netmaskbits, kcp_subnet_ip):
             kcp_subnet_bits = admin_netmaskbits
-        elif additional_subnets:
+        else:
             for subnet_entry in additional_subnets:
                 s_addr = subnet_entry.get("subnet", "")
                 s_bits = subnet_entry.get("netmask_bits", "")
-                if s_addr and s_bits and validation_utils.is_ip_in_subnet(s_addr, s_bits, ref_ip):
-                    kcp_subnet_ip = s_addr
+                if s_addr and s_bits and validation_utils.is_ip_in_subnet(
+                        s_addr, s_bits, kcp_subnet_ip):
                     kcp_subnet_bits = s_bits
                     break
 
@@ -511,6 +513,57 @@ def validate_service_k8s_cluster_ha(
                 kcp_subnet_ip,
                 kcp_subnet_bits
             )
+
+    # Validate kube-vip, control plane admin NIC IPs, and pod_external_ip_range
+    # are all in the same subnet. MetalLB L2 mode requires LoadBalancer
+    # IPs to be on the same L2 broadcast domain as the nodes advertising them.
+    if kcp_subnet_ip and kcp_subnet_bits:
+        # Collect all VIPs from ha_data for subnet check
+        ha_list = ha_data if isinstance(ha_data, list) else [ha_data]
+        for hdata in ha_list:
+            vip = hdata.get("virtual_ip_address")
+            if vip and not validation_utils.is_ip_in_subnet(
+                    kcp_subnet_ip, kcp_subnet_bits, vip):
+                errors.append(
+                    create_error_msg(
+                        f"{config_type} subnet_mismatch",
+                        vip,
+                        f"virtual_ip_address '{vip}' is not in the same subnet "
+                        f"as control plane nodes ({kcp_subnet_ip}/{kcp_subnet_bits}). "
+                        f"The kube-vip VIP must be in the control plane admin NIC subnet."))
+
+        # Check pod_external_ip_range is in CP subnet
+        for pod_ext in pod_external_ip_list:
+            if not pod_ext:
+                continue
+            if "-" in str(pod_ext):
+                range_start = str(pod_ext).split("-")[0].strip()
+                range_end = str(pod_ext).split("-")[1].strip()
+            elif "/" in str(pod_ext):
+                range_start = str(pod_ext).split("/")[0].strip()
+                range_end = range_start
+            else:
+                range_start = str(pod_ext).strip()
+                range_end = range_start
+
+            if not validation_utils.is_ip_in_subnet(
+                    kcp_subnet_ip, kcp_subnet_bits, range_start):
+                errors.append(
+                    create_error_msg(
+                        f"{config_type} subnet_mismatch",
+                        pod_ext,
+                        f"pod_external_ip_range '{pod_ext}' is not in the same subnet "
+                        f"as control plane nodes ({kcp_subnet_ip}/{kcp_subnet_bits}). "
+                        f"MetalLB LoadBalancer IPs must be in the control plane admin NIC subnet."))
+            elif not validation_utils.is_ip_in_subnet(
+                    kcp_subnet_ip, kcp_subnet_bits, range_end):
+                errors.append(
+                    create_error_msg(
+                        f"{config_type} subnet_mismatch",
+                        pod_ext,
+                        f"pod_external_ip_range '{pod_ext}' end address is not in the same subnet "
+                        f"as control plane nodes ({kcp_subnet_ip}/{kcp_subnet_bits}). "
+                        f"The entire range must be within the control plane admin NIC subnet."))
 
 
 def load_network_spec(input_file_path):

--- a/provision/roles/k8s_config/tasks/create_k8s_config_nfs.yml
+++ b/provision/roles/k8s_config/tasks/create_k8s_config_nfs.yml
@@ -74,30 +74,36 @@
   connection: local
   run_once: true
 
-- name: Determine Calico CIDR from control plane nodes subnet
+- name: Determine Calico CIDRs from all K8s node subnets
   ansible.builtin.set_fact:
     calico_cidr: >-
       {%- set kcp_ips = pxe_data_for_cidr.list
           | selectattr('FUNCTIONAL_GROUP_NAME', 'match', '^service_kube_control_plane')
           | map(attribute='ADMIN_IP') | list -%}
-      {%- if kcp_ips | length > 0 -%}
-        {%- set ref_ip = kcp_ips[0] -%}
-        {%- set primary_net = (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') -%}
-        {%- if ref_ip | ansible.utils.ipaddr(primary_net) -%}
-          {{ primary_net }}
-        {%- else -%}
-          {%- set additional = hostvars['localhost']['network_data']['admin_network']['additional_subnets'] | default([]) -%}
-          {%- set ns = namespace(found='') -%}
-          {%- for s in additional if not ns.found -%}
-            {%- set subnet_cidr = (s.subnet + '/' + s.netmask_bits) | ansible.utils.ipaddr('network/prefix') -%}
-            {%- if ref_ip | ansible.utils.ipaddr(subnet_cidr) -%}
-              {%- set ns.found = subnet_cidr -%}
+      {%- set worker_ips = pxe_data_for_cidr.list
+          | selectattr('FUNCTIONAL_GROUP_NAME', 'match', '^service_kube_node')
+          | map(attribute='ADMIN_IP') | list -%}
+      {%- set all_node_ips = kcp_ips + worker_ips -%}
+      {%- set primary_net = (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') -%}
+      {%- set additional = hostvars['localhost']['network_data']['admin_network']['additional_subnets'] | default([]) -%}
+      {%- set found_subnets = [] -%}
+      {%- if all_node_ips | length > 0 -%}
+        {%- for ip in all_node_ips -%}
+          {%- if ip | ansible.utils.ipaddr(primary_net) and primary_net not in found_subnets -%}
+            {%- set _ = found_subnets.append(primary_net) -%}
+          {%- endif -%}
+        {%- endfor -%}
+        {%- for s in additional -%}
+          {%- set subnet_cidr = (s.subnet + '/' + s.netmask_bits) | ansible.utils.ipaddr('network/prefix') -%}
+          {%- for ip in all_node_ips -%}
+            {%- if ip | ansible.utils.ipaddr(subnet_cidr) and subnet_cidr not in found_subnets -%}
+              {%- set _ = found_subnets.append(subnet_cidr) -%}
             {%- endif -%}
           {%- endfor -%}
-          {{ ns.found if ns.found else primary_net }}
-        {%- endif -%}
+        {%- endfor -%}
+        {{ found_subnets | join(',') if found_subnets else primary_net }}
       {%- else -%}
-        {{ (admin_nic_ip + '/' + admin_netmask_bits) | ansible.utils.ipaddr('network/prefix') }}
+        {{ primary_net }}
       {%- endif -%}
 
 - name: Fetch server_ip and server_share_path from list when nfs sever is localhost

--- a/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
@@ -94,8 +94,53 @@
   ansible.builtin.set_fact:
     filtered_bmc_ip_dict_list: "{{ filtered_bmc_ip_list | map('community.general.dict_kv', 'bmc_ip') | list }}"
 
-- name: Validate BMC reachability
+# Pick the first worker node to run BMC validation from.
+# The play runs on control plane which cannot reach BMC subnets,
+# so we delegate validation to a worker node that has network access.
+- name: Get first worker node for BMC validation
+  ansible.builtin.set_fact:
+    worker_node: "{{ groups['service_kube_node_x86_64'][0] }}"
+  when: groups['service_kube_node_x86_64'] is defined and (groups['service_kube_node_x86_64'] | length > 0)
+
+- name: Test BMC subnet connectivity from worker node
+  ansible.builtin.command: "ping -c 1 -W 2 {{ filtered_bmc_ip_list[0] }}"
+  register: bmc_connectivity_check
+  failed_when: false
+  ignore_errors: true
+  delegate_to: "{{ worker_node }}"
+  when:
+    - worker_node is defined
+    - filtered_bmc_ip_list | length > 0
+
+- name: Set BMC reachability flag
+  ansible.builtin.set_fact:
+    bmc_reachable_from_worker: "{{ bmc_connectivity_check.rc | default(1) == 0 }}"
+
+- name: Log BMC reachability status
+  ansible.builtin.debug:
+    msg: >-
+      BMC reachability from worker {{ worker_node | default('none') }}: {{ bmc_reachable_from_worker | default(false) }}
+
+# Run validation from first worker node
+- name: Validate BMC reachability from worker node
   ansible.builtin.include_tasks: validate_bmcips_reachability.yml
+  when:
+    - bmc_reachable_from_worker | default(false) | bool
+    - filtered_bmc_ip_list | length > 0
+
+# If worker cannot reach BMC subnet, fall back to no validation
+- name: Set default telemetry variables (validation skipped - no BMC reachable)
+  ansible.builtin.set_fact:
+    telemetry_idrac: "{{ filtered_bmc_ip_list }}"
+    telemetry_idrac_count: "{{ filtered_bmc_ip_list | length }}"
+    failed_idrac_count: 0
+    failed_idrac: []
+    idrac_redfish_disabled: []
+    idrac_invalid_creds: []
+    idrac_unreachable: []
+    invalid_idrac_count: 0
+    invalid_idrac_list: []
+  when: not (bmc_reachable_from_worker | default(false) | bool)
 
 - name: Add iDRAC details in mysqldb
   when: telemetry_idrac is defined and (telemetry_idrac | length > 0)

--- a/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
@@ -94,53 +94,63 @@
   ansible.builtin.set_fact:
     filtered_bmc_ip_dict_list: "{{ filtered_bmc_ip_list | map('community.general.dict_kv', 'bmc_ip') | list }}"
 
-# Pick the first worker node to run BMC validation from.
-# The play runs on control plane which cannot reach BMC subnets,
-# so we delegate validation to a worker node that has network access.
-- name: Get first worker node for BMC validation
+# Build list of all worker node management IPs for BMC validation.
+# The play runs on control plane (via kube-vip) which cannot reach BMC subnets,
+# so we delegate validation to worker nodes that have network access.
+# If any BMCs are unreachable from the first worker, retry from the next.
+- name: Get all worker node IPs for BMC validation
   ansible.builtin.set_fact:
-    worker_node: "{{ groups['service_kube_node_x86_64'][0] }}"
-  when: groups['service_kube_node_x86_64'] is defined and (groups['service_kube_node_x86_64'] | length > 0)
+    worker_node_list: >-
+      {{ hostvars['localhost']['nodes']
+         | selectattr('group', 'match', '^service_kube_node')
+         | map(attribute='interfaces')
+         | map('first')
+         | map(attribute='ip_addrs')
+         | map('selectattr', 'name', 'equalto', 'management')
+         | map('map', attribute='ip_addr')
+         | map('first')
+         | list }}
+  when: >
+    hostvars['localhost']['nodes'] is defined and
+    (hostvars['localhost']['nodes']
+     | selectattr('group', 'match', '^service_kube_node')
+     | list | length > 0)
 
-- name: Test BMC subnet connectivity from worker node
-  ansible.builtin.command: "ping -c 1 -W 2 {{ filtered_bmc_ip_list[0] }}"
-  register: bmc_connectivity_check
-  failed_when: false
-  ignore_errors: true
-  delegate_to: "{{ worker_node }}"
+- name: Set first worker node for BMC validation
+  ansible.builtin.set_fact:
+    worker_node: "{{ worker_node_list[0] }}"
+  when: worker_node_list | default([]) | length > 0
+
+- name: Log worker node for BMC validation
+  ansible.builtin.debug:
+    msg: >-
+      Worker node for BMC validation: {{ worker_node | default('none') }},
+      All worker nodes: {{ worker_node_list | default([]) }}
+
+# Delegate BMC validation directly to worker node.
+# No pre-flight ping check needed — the update_bmc_group_entry module
+# handles unreachable BMCs gracefully by marking them as unreachable.
+- name: Validate BMC reachability from worker node
+  ansible.builtin.include_tasks: validate_bmcips_reachability.yml
   when:
     - worker_node is defined
     - filtered_bmc_ip_list | length > 0
 
-- name: Set BMC reachability flag
-  ansible.builtin.set_fact:
-    bmc_reachable_from_worker: "{{ bmc_connectivity_check.rc | default(1) == 0 }}"
-
-- name: Log BMC reachability status
-  ansible.builtin.debug:
-    msg: >-
-      BMC reachability from worker {{ worker_node | default('none') }}: {{ bmc_reachable_from_worker | default(false) }}
-
-# Run validation from first worker node
-- name: Validate BMC reachability from worker node
-  ansible.builtin.include_tasks: validate_bmcips_reachability.yml
+# If there are unreachable BMCs and a second worker node is available,
+# retry those BMCs from the second worker node.
+- name: Retry unreachable BMCs from second worker node
   when:
-    - bmc_reachable_from_worker | default(false) | bool
-    - filtered_bmc_ip_list | length > 0
+    - idrac_unreachable | default([]) | length > 0
+    - worker_node_list | default([]) | length > 1
+  block:
+    - name: Build retry BMC list from unreachable IPs
+      ansible.builtin.set_fact:
+        retry_bmc_ip_list: "{{ idrac_unreachable }}"
+        retry_bmc_ip_dict_list: "{{ idrac_unreachable | map('community.general.dict_kv', 'bmc_ip') | list }}"
+        retry_worker_node: "{{ worker_node_list[1] }}"
 
-# If worker cannot reach BMC subnet, fall back to no validation
-- name: Set default telemetry variables (validation skipped - no BMC reachable)
-  ansible.builtin.set_fact:
-    telemetry_idrac: "{{ filtered_bmc_ip_list }}"
-    telemetry_idrac_count: "{{ filtered_bmc_ip_list | length }}"
-    failed_idrac_count: 0
-    failed_idrac: []
-    idrac_redfish_disabled: []
-    idrac_invalid_creds: []
-    idrac_unreachable: []
-    invalid_idrac_count: 0
-    invalid_idrac_list: []
-  when: not (bmc_reachable_from_worker | default(false) | bool)
+    - name: Retry unreachable BMCs from second worker node
+      ansible.builtin.include_tasks: retry_unreachable_bmcs.yml
 
 - name: Add iDRAC details in mysqldb
   when: telemetry_idrac is defined and (telemetry_idrac | length > 0)

--- a/telemetry/roles/idrac_telemetry/tasks/retry_unreachable_bmcs.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/retry_unreachable_bmcs.yml
@@ -1,0 +1,71 @@
+# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Retry unreachable BMCs from the second worker node.
+
+- name: Log retry attempt for unreachable BMCs
+  ansible.builtin.debug:
+    msg: >-
+      Retrying {{ retry_bmc_ip_list | length }} unreachable BMC(s) from worker {{ retry_worker_node }}:
+      {{ retry_bmc_ip_list | join(', ') }}
+
+- name: Validate unreachable BMCs from second worker node
+  update_bmc_group_entry:
+    nodes: "{{ retry_bmc_ip_dict_list }}"
+    bmc_username: "{{ hostvars['localhost']['bmc_username'] }}"
+    bmc_password: "{{ hostvars['localhost']['bmc_password'] }}"
+    verify_bmc: true
+  register: retry_bmc_result
+  delegate_to: "{{ retry_worker_node }}"
+
+- name: Log retry results
+  ansible.builtin.debug:
+    msg: >-
+      Retry from {{ retry_worker_node }} -
+      Verified: {{ retry_bmc_result.verified_bmc | default([]) | join(', ') }},
+      Still unreachable: {{ retry_bmc_result.unreachable_bmc | default([]) | join(', ') }}
+
+- name: Update telemetry variables with newly verified BMCs
+  when: retry_bmc_result.verified_bmc | default([]) | length > 0
+  block:
+    - name: Filter newly verified iDRACs for telemetry pre-requisites
+      idrac_telemetry_filter:
+        bmc_ip_list: "{{ retry_bmc_result.verified_bmc }}"
+        bmc_username: "{{ hostvars['localhost']['bmc_username'] }}"
+        bmc_password: "{{ hostvars['localhost']['bmc_password'] }}"
+        min_firmware_version_reqd: "{{ min_firmware_version_reqd }}"
+      register: retry_filter_output
+      delegate_to: "{{ retry_worker_node }}"
+
+    - name: Enable telemetry on newly verified iDRACs
+      enable_telemetry_service:
+        idrac_ips: "{{ retry_filter_output.telemetry_idrac }}"
+        username: "{{ hostvars['localhost']['bmc_username'] }}"
+        password: "{{ hostvars['localhost']['bmc_password'] }}"
+      delegate_to: "{{ retry_worker_node }}"
+      when: retry_filter_output.telemetry_idrac | default([]) | length > 0
+
+    - name: Merge newly verified BMCs into telemetry_idrac
+      ansible.builtin.set_fact:
+        telemetry_idrac: "{{ (telemetry_idrac | default([])) + retry_filter_output.telemetry_idrac }}"
+        telemetry_idrac_count: "{{ (telemetry_idrac | default([]) | length) + (retry_filter_output.telemetry_idrac | length) }}"
+        failed_idrac: "{{ (failed_idrac | default([])) + (retry_filter_output.failed_idrac | default([])) }}"
+        failed_idrac_count: "{{ (failed_idrac | default([]) | length) + (retry_filter_output.failed_idrac | default([]) | length) }}"
+      when: retry_filter_output.telemetry_idrac is defined
+
+- name: Update unreachable and invalid lists after retry
+  ansible.builtin.set_fact:
+    idrac_unreachable: "{{ retry_bmc_result.unreachable_bmc | default([]) }}"
+    idrac_invalid_creds: "{{ (idrac_invalid_creds | default([])) + (retry_bmc_result.invalid_creds | default([])) }}"
+    idrac_redfish_disabled: "{{ (idrac_redfish_disabled | default([])) + (retry_bmc_result.redfish_disabled | default([])) }}"

--- a/telemetry/roles/idrac_telemetry/tasks/validate_bmcips_reachability.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/validate_bmcips_reachability.yml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Validate BMC reachability from first worker node.
+# The play runs on control plane (service_kube_cp_group) which cannot reach
+# BMC subnets, so we delegate to a worker node that has network access.
 - name: Validate BMC reachability
   update_bmc_group_entry:
     nodes: "{{ filtered_bmc_ip_dict_list }}"
@@ -19,6 +22,7 @@
     bmc_password: "{{ hostvars['localhost']['bmc_password'] }}"
     verify_bmc: true
   register: bmc_result
+  delegate_to: "{{ worker_node }}"
 
 - name: Show verified BMC entries
   when: bmc_result.verified_bmc | length > 0
@@ -69,6 +73,7 @@
         bmc_password: "{{ hostvars['localhost']['bmc_password'] }}"
         min_firmware_version_reqd: "{{ min_firmware_version_reqd }}"
       register: filter_idrac_output
+      delegate_to: "{{ worker_node }}"
       when:
         - bmc_result.verified_bmc is defined
         - bmc_result.verified_bmc | length > 0
@@ -93,6 +98,7 @@
     username: "{{ hostvars['localhost']['bmc_username'] }}"
     password: "{{ hostvars['localhost']['bmc_password'] }}"
   register: enable_telemetry_output
+  delegate_to: "{{ worker_node }}"
 
 - name: Show Enable Telemetry Service Output
   ansible.builtin.debug:


### PR DESCRIPTION
- telemetry: Delegate BMC HTTPS validation tasks to first worker node Control plane nodes cannot reach BMC subnets, so validation now runs from worker nodes which have network access to BMCs.

- validation: Add subnet validation for kube-vip and MetalLB Ensure kube-vip VIP, pod_external_ip_range, and control plane admin NIC IPs are all in the same subnet. MetalLB L2 mode requires LoadBalancer IPs to be on the same L2 broadcast domain as the nodes advertising them.

- validation: Use CP node ADMIN_IP as subnet reference Changed from using OIM admin IP to using the first control plane node's ADMIN_IP from pxe_mapping_file.csv as the subnet reference for validation.

- k8s_config: Update calico_cidr to include all K8s node subnets Now collects CIDRs from both control plane and worker node subnets.

