### PR TITLE
Updates for slapd.conf overwritting 

### DIFF
--- a/prepare_oim/roles/deploy_containers/auth/tasks/configure_slapd_conf.yml
+++ b/prepare_oim/roles/deploy_containers/auth/tasks/configure_slapd_conf.yml
@@ -17,7 +17,45 @@
   ansible.builtin.set_fact:
     reqd_domain_name: "{{ (domain_name.split('.') | map('regex_replace', '^', 'dc=') | list) | join(',') }}"
 
+- name: Check if auth service container is already running
+  containers.podman.podman_container_info:
+    name: "{{ auth_service_container_name }}"
+  register: slapd_auth_container_check
+  failed_when: false
+
+- name: Set auth container running status
+  ansible.builtin.set_fact:
+    auth_container_running: "{{ slapd_auth_container_check.containers | default([]) | length > 0 and
+      (slapd_auth_container_check.containers[0].State.Status | default('')) == 'running' }}"
+
+- name: Check if slapd.conf already exists on disk
+  ansible.builtin.stat:
+    path: "{{ slapd_conf_dest }}"
+  register: existing_slapd_conf
+
+- name: Skip slapd.conf update - auth container already running
+  ansible.builtin.debug:
+    msg: >-
+      Auth container {{ auth_service_container_name }} is already running.
+      Skipping slapd.conf copy to preserve existing configuration.
+      If you need to reset slapd.conf to defaults, stop and remove the container first,
+      then re-run prepare_oim.yml.
+  when: auth_container_running | bool
+
+- name: Skip slapd.conf update - existing slapd.conf found
+  ansible.builtin.debug:
+    msg: >-
+      Existing slapd.conf found at {{ slapd_conf_dest }}.
+      Skipping copy to preserve existing configuration.
+      To reset to defaults, remove the file and re-run prepare_oim.yml.
+  when:
+    - not (auth_container_running | bool)
+    - existing_slapd_conf.stat.exists
+
 - name: Update slapd.conf file auth service deployment
+  when:
+    - not (auth_container_running | bool)
+    - not existing_slapd_conf.stat.exists
   block:
 
     - name: Copy slapd.conf file

--- a/prepare_oim/roles/deploy_containers/common/tasks/configure_chrony.yml
+++ b/prepare_oim/roles/deploy_containers/common/tasks/configure_chrony.yml
@@ -18,11 +18,30 @@
     name: chrony
     state: present
 
+- name: Build list of additional subnets allowed by chrony
+  ansible.builtin.set_fact:
+    chrony_additional_subnets: "{{ chrony_additional_subnets | default([]) + [item.subnet + '/' + item.netmask_bits] }}"
+  loop: "{{ hostvars['localhost']['network_data']['admin_network']['additional_subnets'] | default([]) }}"
+
+- name: Build complete list of subnets allowed by chrony
+  ansible.builtin.set_fact:
+    chrony_allowed_subnets:
+      - "{{ hostvars['localhost']['admin_net_addr'] }}/{{ hostvars['localhost']['admin_netmask_bits'] }}"
+      - "{{ chrony_additional_subnets | default([]) }}"
+
+- name: Flatten chrony allowed subnets
+  ansible.builtin.set_fact:
+    chrony_allowed_subnets: "{{ chrony_allowed_subnets | flatten | select('string') | list }}"
+
 - name: Update chrony.conf
-  ansible.builtin.lineinfile:
+  ansible.builtin.blockinfile:
     path: "{{ chrony_conf_path }}"
-    regexp: ^#allow
-    line: "allow {{ hostvars['localhost']['admin_net_addr'] }}/{{ hostvars['localhost']['admin_netmask_bits'] }}"
+    marker: "# {mark} ANSIBLE MANAGED CHRONY ALLOW SUBNETS"
+    block: |
+      {% for subnet in chrony_allowed_subnets %}
+      allow {{ subnet }}
+      {% endfor %}
+    insertafter: "^#allow"
     state: present
 
 - name: Enable and start chronyd service


### PR DESCRIPTION
### Description of the Solution

Check if omnia_auth container is already running via podman_container_info
If running → skip the entire slapd.conf copy block, log a message preserving user's config
If not running (first-time deploy) → copy default slapd.conf and apply domain/password substitutions as before
### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@abhishek-sa1 @priti-parate 