### PR TITLE
handle stale mount and fstab entries during

### DIFF
--- a/omnia.sh
+++ b/omnia.sh
@@ -853,6 +853,28 @@ init_container_config() {
         echo -e "${BLUE} Creating omnia shared path directory if it does not exist.${NC}"
         mkdir -p $omnia_path
 
+        # Remove any stale mount or fstab entry for omnia_path before reuse
+        echo -e "${BLUE} Checking for existing mount at $omnia_path.${NC}"
+        if mountpoint -q "$omnia_path" 2>/dev/null; then
+            echo -e "${YELLOW} Existing mount found at $omnia_path. Unmounting before reuse.${NC}"
+            if ! umount "$omnia_path" 2>/dev/null && ! umount -l "$omnia_path" 2>/dev/null; then
+                echo -e "${RED} Failed to unmount existing share at $omnia_path. Please unmount manually and retry.${NC}"
+                exit 1
+            fi
+        fi
+
+        fstab_file="/etc/fstab"
+        if [ -f "$fstab_file" ]; then
+            omnia_path_trimmed="${omnia_path%/}"
+            if awk -v mp="$omnia_path_trimmed" '$2 == mp {found=1} END {exit !found}' "$fstab_file"; then
+                echo -e "${YELLOW} Removing stale /etc/fstab entry for $omnia_path.${NC}"
+                if [ ! -f "$fstab_file.bak" ]; then
+                    cp "$fstab_file" "$fstab_file.bak"
+                fi
+                awk -v mp="$omnia_path_trimmed" '$2 != mp' "$fstab_file" > "${fstab_file}.tmp" && mv "${fstab_file}.tmp" "$fstab_file"
+            fi
+        fi
+
         # Mount NFS server share path in Omnia share path
         if [[ "$nfs_type" == "external" ]]; then
 

--- a/omnia.sh
+++ b/omnia.sh
@@ -645,27 +645,30 @@ cleanup_config(){
     echo -e "${BLUE} Removing Omnia core configuration.${NC}"
     rm -rf $omnia_path/omnia/{hosts,input,log,pulp,provision,pcs,ssh_config,tmp,.data}
 
-    # Remove any stale mount or fstab entry for omnia_path during uninstall.
+    # Remove any stale NFS mount or fstab entry for omnia_path during uninstall.
+    # Only external NFS shares are mounted by Omnia; local/internal paths are not mounted.
     if [ -n "$omnia_path" ]; then
-        echo -e "${BLUE} Checking for existing mount at $omnia_path.${NC}"
+        omnia_path_trimmed="${omnia_path%/}"
+        echo -e "${BLUE} Checking for existing NFS mount at $omnia_path.${NC}"
         if mountpoint -q "$omnia_path" 2>/dev/null; then
-            if umount "$omnia_path" 2>/dev/null || umount -l "$omnia_path" 2>/dev/null; then
-                echo -e "${GREEN} Omnia shared path has been unmounted.${NC}"
-            else
-                echo -e "${RED} Failed to unmount Omnia shared path at $omnia_path.${NC}"
+            if awk -v mp="$omnia_path_trimmed" '$2 == mp && ($3 == "nfs" || $3 == "nfs4") {found=1} END {exit !found}' /proc/mounts; then
+                if umount "$omnia_path" 2>/dev/null || umount -l "$omnia_path" 2>/dev/null; then
+                    echo -e "${GREEN} Omnia shared path has been unmounted.${NC}"
+                else
+                    echo -e "${RED} Failed to unmount Omnia shared path at $omnia_path.${NC}"
+                fi
             fi
         fi
 
-        # Remove the entry from /etc/fstab
+        # Remove the NFS entry from /etc/fstab
         fstab_file="/etc/fstab"
         if [ -f "$fstab_file" ]; then
-            omnia_path_trimmed="${omnia_path%/}"
-            if awk -v mp="$omnia_path_trimmed" '$2 == mp {found=1} END {exit !found}' "$fstab_file"; then
+            if awk -v mp="$omnia_path_trimmed" '$2 == mp && ($3 == "nfs" || $3 == "nfs4") {found=1} END {exit !found}' "$fstab_file"; then
                 echo -e "${YELLOW} Removing stale /etc/fstab entry for $omnia_path.${NC}"
                 if [ ! -f "$fstab_file.bak" ]; then
                     cp "$fstab_file" "$fstab_file.bak"
                 fi
-                awk -v mp="$omnia_path_trimmed" '$2 != mp' "$fstab_file" > "${fstab_file}.tmp" && mv "${fstab_file}.tmp" "$fstab_file"
+                awk -v mp="$omnia_path_trimmed" '$2 == mp && ($3 == "nfs" || $3 == "nfs4") {next} {print}' "$fstab_file" > "${fstab_file}.tmp" && mv "${fstab_file}.tmp" "$fstab_file"
             fi
         fi
     fi
@@ -856,25 +859,27 @@ init_container_config() {
         echo -e "${BLUE} Creating omnia shared path directory if it does not exist.${NC}"
         mkdir -p $omnia_path
 
-        # Remove any stale mount or fstab entry for omnia_path before reuse
-        echo -e "${BLUE} Checking for existing mount at $omnia_path.${NC}"
+        # Remove any stale NFS mount or fstab entry for omnia_path before reuse
+        omnia_path_trimmed="${omnia_path%/}"
+        echo -e "${BLUE} Checking for existing NFS mount at $omnia_path.${NC}"
         if mountpoint -q "$omnia_path" 2>/dev/null; then
-            echo -e "${YELLOW} Existing mount found at $omnia_path. Unmounting before reuse.${NC}"
-            if ! umount "$omnia_path" 2>/dev/null && ! umount -l "$omnia_path" 2>/dev/null; then
-                echo -e "${RED} Failed to unmount existing share at $omnia_path. Please unmount manually and retry.${NC}"
-                exit 1
+            if awk -v mp="$omnia_path_trimmed" '$2 == mp && ($3 == "nfs" || $3 == "nfs4") {found=1} END {exit !found}' /proc/mounts; then
+                echo -e "${YELLOW} Existing NFS mount found at $omnia_path. Unmounting before reuse.${NC}"
+                if ! umount "$omnia_path" 2>/dev/null && ! umount -l "$omnia_path" 2>/dev/null; then
+                    echo -e "${RED} Failed to unmount existing share at $omnia_path. Please unmount manually and retry.${NC}"
+                    exit 1
+                fi
             fi
         fi
 
         fstab_file="/etc/fstab"
         if [ -f "$fstab_file" ]; then
-            omnia_path_trimmed="${omnia_path%/}"
-            if awk -v mp="$omnia_path_trimmed" '$2 == mp {found=1} END {exit !found}' "$fstab_file"; then
+            if awk -v mp="$omnia_path_trimmed" '$2 == mp && ($3 == "nfs" || $3 == "nfs4") {found=1} END {exit !found}' "$fstab_file"; then
                 echo -e "${YELLOW} Removing stale /etc/fstab entry for $omnia_path.${NC}"
                 if [ ! -f "$fstab_file.bak" ]; then
                     cp "$fstab_file" "$fstab_file.bak"
                 fi
-                awk -v mp="$omnia_path_trimmed" '$2 != mp' "$fstab_file" > "${fstab_file}.tmp" && mv "${fstab_file}.tmp" "$fstab_file"
+                awk -v mp="$omnia_path_trimmed" '$2 == mp && ($3 == "nfs" || $3 == "nfs4") {next} {print}' "$fstab_file" > "${fstab_file}.tmp" && mv "${fstab_file}.tmp" "$fstab_file"
             fi
         fi
 

--- a/omnia.sh
+++ b/omnia.sh
@@ -645,24 +645,27 @@ cleanup_config(){
     echo -e "${BLUE} Removing Omnia core configuration.${NC}"
     rm -rf $omnia_path/omnia/{hosts,input,log,pulp,provision,pcs,ssh_config,tmp,.data}
 
-    # Unmount the NFS shared path if the share option is NFS.
-    if [ "$share_option" = "NFS" ] && [ "$nfs_type" = "external" ]; then
-        umount "$omnia_path"
-        if [ $? -eq 0 ]; then
-            echo -e "${GREEN} NFS shared path has been unmounted.${NC}"
-        else
-            echo -e "${RED} Failed to unmount NFS shared path.${NC}"
+    # Remove any stale mount or fstab entry for omnia_path during uninstall.
+    if [ -n "$omnia_path" ]; then
+        echo -e "${BLUE} Checking for existing mount at $omnia_path.${NC}"
+        if mountpoint -q "$omnia_path" 2>/dev/null; then
+            if umount "$omnia_path" 2>/dev/null || umount -l "$omnia_path" 2>/dev/null; then
+                echo -e "${GREEN} Omnia shared path has been unmounted.${NC}"
+            else
+                echo -e "${RED} Failed to unmount Omnia shared path at $omnia_path.${NC}"
+            fi
         fi
+
         # Remove the entry from /etc/fstab
         fstab_file="/etc/fstab"
         if [ -f "$fstab_file" ]; then
-            # Create a backup of the fstab file.
-            cp "$fstab_file" "$fstab_file.bak"
-
-            # Remove the line from the fstab file.
-             sed -i "\#$omnia_path#d" "$fstab_file"
-             if [ $? -ne 0 ]; then
-                echo -e "${RED} Failed to remove the entry from /etc/fstab.${NC}"
+            omnia_path_trimmed="${omnia_path%/}"
+            if awk -v mp="$omnia_path_trimmed" '$2 == mp {found=1} END {exit !found}' "$fstab_file"; then
+                echo -e "${YELLOW} Removing stale /etc/fstab entry for $omnia_path.${NC}"
+                if [ ! -f "$fstab_file.bak" ]; then
+                    cp "$fstab_file" "$fstab_file.bak"
+                fi
+                awk -v mp="$omnia_path_trimmed" '$2 != mp' "$fstab_file" > "${fstab_file}.tmp" && mv "${fstab_file}.tmp" "$fstab_file"
             fi
         fi
     fi

--- a/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_k8s.yml
+++ b/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_k8s.yml
@@ -219,3 +219,22 @@
           {% endif %}
           {% endfor %}
       when: k8s_cleanup_needed | default(false)
+
+    - name: Build list of K8s OIM mounts to unmount
+      ansible.builtin.set_fact:
+        k8s_mounts_to_unmount: >-
+          {{ k8s_storage_mounts | selectattr('mount_on_oim', 'defined') | selectattr('mount_on_oim') | list }}
+
+    - name: Unmount K8s OIM mounts
+      ansible.posix.mount:
+        path: "{{ item.mount_point }}"
+        state: unmounted
+      loop: "{{ k8s_mounts_to_unmount }}"
+      failed_when: false
+
+    - name: Remove K8s OIM mount entries from /etc/fstab
+      ansible.posix.mount:
+        path: "{{ item.mount_point }}"
+        state: absent_from_fstab
+      loop: "{{ k8s_mounts_to_unmount }}"
+      failed_when: false

--- a/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_slurm.yml
+++ b/utils/roles/oim_cleanup/oim_container_cleanup/tasks/cleanup_slurm.yml
@@ -203,3 +203,23 @@
           {% endfor %}
           {% endfor %}
       when: cleanup_needed | default(false)
+
+    - name: Build list of Slurm OIM mounts to unmount
+      ansible.builtin.set_fact:
+        slurm_mounts_to_unmount: >-
+          {{ mounts | selectattr('name', 'in', unique_storage_mounts | map(attribute='storage_name') | list)
+             | selectattr('mount_on_oim', 'defined') | selectattr('mount_on_oim') | list }}
+
+    - name: Unmount Slurm OIM mounts
+      ansible.posix.mount:
+        path: "{{ item.mount_point }}"
+        state: unmounted
+      loop: "{{ slurm_mounts_to_unmount }}"
+      failed_when: false
+
+    - name: Remove Slurm OIM mount entries from /etc/fstab
+      ansible.posix.mount:
+        path: "{{ item.mount_point }}"
+        state: absent_from_fstab
+      loop: "{{ slurm_mounts_to_unmount }}"
+      failed_when: false


### PR DESCRIPTION
After this fix, omnia.sh --install does the following before mounting:

  1. Checks if omnia_path is already a mount point.
    • If yes, it unmounts the existing share.
    • If umount fails, it tries a lazy unmount.
    • If both fail, it exits with a clear error and asks the user to unmount manually.
  2. Checks /etc/fstab for an existing entry for omnia_path.
    • If found, it backs up /etc/fstab and removes the stale entry.
  3. Then proceeds with mounting the new NFS share and adding a single clean /etc/fstab entry.
