### PR TITLE
fix: add SELinux context mount option for VAST NFS share to resolve d…

### DIFF
--- a/provision/roles/mount_config/vars/main.yml
+++ b/provision/roles/mount_config/vars/main.yml
@@ -19,7 +19,7 @@ storage_to_be_mounted: []
 software_config_file: "{{ hostvars['localhost']['input_project_dir'] }}/software_config.json"
 # Usage: nfs_client.yml
 mounted_dir_perm: "0755"
-default_client_mount_options: "nosuid,rw,sync,hard,intr"
+default_client_mount_options: 'nosuid,rw,sync,hard,intr,context="system_u:object_r:nfs_t:s0"'
 slurm_nfs_fail_msg: "Failed to mount NFS share. Please check if the NFS server is reachable or NFS is configured properly."
 oim_nfs_fail_msg: "Failed to mount NFS share on OIM node. Verify NFS server connectivity, mount options, and fstab configuration."
 default_oim_mount_options: "nosuid,rw,sync,hard,intr"


### PR DESCRIPTION
Directory creation failure

Ansible file module fails to create nested directories on NFS-mounted VAST storage when executed from within a container. The container's restricted SELinux domain (container_t) computes an incorrect target context (usr_t) for NFS paths, detects a mismatch with the current context (unlabeled_t), and attempts to set the SELinux label via setfattr, which NFS/VAST does not support (ENOTSUP).

Added context="system_u:object_r:nfs_t:s0" to the NFS mount options, which assigns a fixed SELinux label at the kernel level, eliminating context mismatches and preventing setfattr calls entirely.

