### PR TITLE
Update download_container_image.sh.j2 to provide default tmp path

### DIFF
--- a/provision/roles/slurm_config/templates/download_container_image.sh.j2
+++ b/provision/roles/slurm_config/templates/download_container_image.sh.j2
@@ -3,10 +3,11 @@
 # Deployed via NFS share for all nodes
 # Reads container images from container_image.list file and downloads them as SIF files
 # Downloads from Pulp mirror only (no internet fallback)
-# Usage: download_container_image.sh <tmp_dir>
+# Usage: download_container_image.sh
 
 LOGFILE="/var/log/container_image_download.log"
 exec > >(tee -a "$LOGFILE") 2>&1
+set -o pipefail
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,23 +15,10 @@ CONTAINER_IMAGE_LIST="${SCRIPT_DIR}/container_image.list"
 DOWNLOAD_DIR="/hpc_tools/container_images"
 PULP_SERVER="{{ hostvars['localhost']['admin_nic_ip'] }}:2225"
 
-# Temporary/work directory for Apptainer pull (user input)
-# Accepts first positional argument or TMP_DIR environment variable
-TMP_DIR="${1:-${TMP_DIR:-}}"
-
-if [ -z "$TMP_DIR" ]; then
-    echo "[ERROR] tmp_dir is required."
-    echo "[INFO] Usage: $0 <tmp_dir>"
-    echo "[INFO] Example: $0 /tmp/apptainer_tmp"
-    exit 1
-fi
-
-# Basic sanitization: only allow absolute paths with safe characters
-if [[ "$TMP_DIR" =~ [^/A-Za-z0-9_.-] ]]; then
-    echo "[ERROR] Invalid tmp_dir: $TMP_DIR"
-    echo "[INFO] Path must be absolute and contain only letters, digits, '_', '.', '-', or '/'"
-    exit 1
-fi
+# Temporary/work directory for Apptainer pull
+# By default, use the same location as DOWNLOAD_DIR
+# Edit this value if Apptainer temp files need to go elsewhere
+TMP_DIR="/hpc_tools/container_images"
 
 echo "===== Starting Container Image Download Script (Pulp Only) ====="
 echo "[INFO] Timestamp: $(date)"

--- a/provision/roles/slurm_config/templates/download_container_image.sh.j2
+++ b/provision/roles/slurm_config/templates/download_container_image.sh.j2
@@ -3,7 +3,7 @@
 # Deployed via NFS share for all nodes
 # Reads container images from container_image.list file and downloads them as SIF files
 # Downloads from Pulp mirror only (no internet fallback)
-# Usage: download_container_image.sh
+# Usage: download_container_image.sh <tmp_dir>
 
 LOGFILE="/var/log/container_image_download.log"
 exec > >(tee -a "$LOGFILE") 2>&1
@@ -13,6 +13,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTAINER_IMAGE_LIST="${SCRIPT_DIR}/container_image.list"
 DOWNLOAD_DIR="/hpc_tools/container_images"
 PULP_SERVER="{{ hostvars['localhost']['admin_nic_ip'] }}:2225"
+
+# Temporary/work directory for Apptainer pull (user input)
+# Accepts first positional argument or TMP_DIR environment variable
+TMP_DIR="${1:-${TMP_DIR:-}}"
+
+if [ -z "$TMP_DIR" ]; then
+    echo "[ERROR] tmp_dir is required."
+    echo "[INFO] Usage: $0 <tmp_dir>"
+    echo "[INFO] Example: $0 /tmp/apptainer_tmp"
+    exit 1
+fi
+
+# Basic sanitization: only allow absolute paths with safe characters
+if [[ "$TMP_DIR" =~ [^/A-Za-z0-9_.-] ]]; then
+    echo "[ERROR] Invalid tmp_dir: $TMP_DIR"
+    echo "[INFO] Path must be absolute and contain only letters, digits, '_', '.', '-', or '/'"
+    exit 1
+fi
 
 echo "===== Starting Container Image Download Script (Pulp Only) ====="
 echo "[INFO] Timestamp: $(date)"
@@ -36,8 +54,14 @@ fi
 
 # Navigate to download directory
 mkdir -p "$DOWNLOAD_DIR"
+mkdir -p "$TMP_DIR"
+
+# Point Apptainer temp and cache to the user-provided tmp_dir
+export APPTAINER_TMPDIR="$TMP_DIR"
+export APPTAINER_CACHEDIR="$TMP_DIR"
 
 echo "[INFO] Download directory: $DOWNLOAD_DIR"
+echo "[INFO] Apptainer temp directory: $TMP_DIR"
 
 if [ ! -d "$DOWNLOAD_DIR" ]; then
     echo "[ERROR] Download directory does not exist: $DOWNLOAD_DIR"
@@ -123,7 +147,7 @@ while IFS= read -r line || [ -n "$line" ]; do
         echo "[INFO] Starting pull (this may take several minutes for large images)..."
 
         # Use timeout to prevent hanging (30 minutes)
-        timeout 1800 apptainer pull --disable-cache --name "$CONTAINER_IMAGE" --dir "$DOWNLOAD_DIR" --tmpdir "$DOWNLOAD_DIR" "$PULP_IMAGE" 2>&1 | tee -a /var/log/apptainer_pull.log
+        timeout 1800 apptainer pull --disable-cache --name "$CONTAINER_IMAGE" --dir "$DOWNLOAD_DIR" --tmpdir "$TMP_DIR" "$PULP_IMAGE" 2>&1 | tee -a /var/log/apptainer_pull.log
         PULL_EXIT_CODE=$?
 
         # Check the actual exit code from timeout command


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
