### PR TITLE
Fix iDRAC telemetry removal to query all pods for IP cleanup

### DIFF
--- a/input/storage_config.yml
+++ b/input/storage_config.yml
@@ -281,8 +281,9 @@ mount_params:
 #   - "minio": Use MinIO container deployed locally on OIM
 #
 # endpoint_url: S3 endpoint URL.
-#   - Required when provider is "powerscale" (e.g., "https://10.43.1.11:9021")
+#   - Required when provider is "powerscale" (e.g., "http://10.43.1.11:9020")
 #   - Leave empty ("") when provider is "minio" (auto-configured to local MinIO)
+#   - NOTE: Only HTTP protocol is supported for PowerScale endpoint.
 #
 # Credentials:
 #   - s3_access_id and s3_secret_key are prompted during prepare_oim credential setup

--- a/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
@@ -52,12 +52,21 @@
   loop: "{{ idrac_podname_idracips.idrac_podname_ips | dict2items }}"
   when: idrac_podname_idracips.idrac_podname_ips is defined and (idrac_podname_idracips.idrac_podname_ips | length > 0)
 
+- name: Build list of all idrac telemetry pod names from service cluster metadata
+  ansible.builtin.set_fact:
+    all_idrac_podnames: >-
+      {{ service_cluster_metadata.values()
+         | selectattr('idrac_podname', 'defined')
+         | map(attribute='idrac_podname')
+         | list
+         | unique }}
+
 - name: Read the existing BMC IP's from mysqlDB of the idrac telemetry pods
   block:
     - name: Read the existing BMC IP's from mysqlDB
       read_idracips_from_mysqldb:
         telemetry_namespace: "{{ telemetry_namespace }}"
-        idrac_podnames: "{{ idrac_podname_idracips.idrac_podname_ips.keys() | list }}"
+        idrac_podnames: "{{ all_idrac_podnames }}"
         mysqldb_k8s_name: "{{ mysqldb_k8s_name }}"
         mysqldb_name: "{{ mysqldb_name }}"
         mysqldb_user: "{{ hostvars['localhost']['mysqldb_user'] }}"
@@ -87,9 +96,6 @@
   ansible.builtin.debug:
     msg: "Filtered BMC IPs: {{ filtered_bmc_ip_list }}"
 
-- name: Remove deleted nodes from telemetry (nodes not in bmc_data.csv)
-  ansible.builtin.include_tasks: remove_deleted_nodes.yml
-
 - name: Convert filtered_bmc_ip_list to a dictionary with bmc_ip
   ansible.builtin.set_fact:
     filtered_bmc_ip_dict_list: "{{ filtered_bmc_ip_list | map('community.general.dict_kv', 'bmc_ip') | list }}"
@@ -98,6 +104,8 @@
 # The play runs on control plane (via kube-vip) which cannot reach BMC subnets,
 # so we delegate validation to worker nodes that have network access.
 # If any BMCs are unreachable from the first worker, retry from the next.
+# NOTE: Worker node must be resolved before remove_deleted_nodes.yml
+# because it needs worker_node to disable telemetry via Redfish.
 - name: Get all worker node IPs for BMC validation
   ansible.builtin.set_fact:
     worker_node_list: >-
@@ -126,6 +134,9 @@
     msg: >-
       Worker node for BMC validation: {{ worker_node | default('none') }},
       All worker nodes: {{ worker_node_list | default([]) }}
+
+- name: Remove deleted nodes from telemetry (nodes not in bmc_data.csv)
+  ansible.builtin.include_tasks: remove_deleted_nodes.yml
 
 # Delegate BMC validation directly to worker node.
 # No pre-flight ping check needed — the update_bmc_group_entry module

--- a/telemetry/roles/idrac_telemetry/tasks/remove_deleted_nodes.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/remove_deleted_nodes.yml
@@ -37,6 +37,8 @@
         password: "{{ hostvars['localhost']['bmc_password'] }}"
         timeout: "{{ redfish_timeout }}"
       register: disable_telemetry_result
+      delegate_to: "{{ worker_node }}"
+      when: worker_node is defined
       ignore_errors: true
 
     - name: Show successfully disabled telemetry IPs
@@ -59,7 +61,7 @@
     - name: Delete iDRAC IPs from mysqldb
       delete_idracips_from_mysqldb:
         telemetry_namespace: "{{ telemetry_namespace }}"
-        idrac_podnames: "{{ idrac_podname_idracips.idrac_podname_ips.keys() | list }}"
+        idrac_podnames: "{{ all_idrac_podnames }}"
         mysqldb_k8s_name: "{{ mysqldb_k8s_name }}"
         mysqldb_name: "{{ mysqldb_name }}"
         mysqldb_user: "{{ hostvars['localhost']['mysqldb_user'] }}"
@@ -96,6 +98,6 @@
     deleted_idrac_ips: "{{ delete_idrac_result.deleted_ips | default([]) }}"
     failed_delete_count: "{{ delete_idrac_result.failed_ips | default([]) | length }}"
     failed_delete_ips: "{{ delete_idrac_result.failed_ips | default([]) }}"
-    disabled_telemetry_count: "{{ disable_telemetry_result.disabled_ips | default([]) | length }}"
-    disabled_telemetry_ips: "{{ disable_telemetry_result.disabled_ips | default([]) }}"
+    disabled_telemetry_count: "{{ (disable_telemetry_result | default({})).disabled_ips | default([]) | length }}"
+    disabled_telemetry_ips: "{{ (disable_telemetry_result | default({})).disabled_ips | default([]) }}"
   when: ips_to_remove | length > 0

--- a/telemetry/roles/idrac_telemetry/tasks/retry_unreachable_bmcs.yml
+++ b/telemetry/roles/idrac_telemetry/tasks/retry_unreachable_bmcs.yml
@@ -69,3 +69,10 @@
     idrac_unreachable: "{{ retry_bmc_result.unreachable_bmc | default([]) }}"
     idrac_invalid_creds: "{{ (idrac_invalid_creds | default([])) + (retry_bmc_result.invalid_creds | default([])) }}"
     idrac_redfish_disabled: "{{ (idrac_redfish_disabled | default([])) + (retry_bmc_result.redfish_disabled | default([])) }}"
+
+- name: Recalculate invalid_idrac_count and invalid_idrac_list after retry
+  ansible.builtin.set_fact:
+    invalid_idrac_count: >-
+      {{ (idrac_invalid_creds | default([]) | length) + (idrac_unreachable | default([]) | length) + (idrac_redfish_disabled | default([]) | length) }}
+    invalid_idrac_list: >-
+      {{ (idrac_invalid_creds | default([])) + (idrac_unreachable | default([])) + (idrac_redfish_disabled | default([])) }}


### PR DESCRIPTION
PR Description:

This PR fixes critical issues in the iDRAC telemetry removal workflow where IPs removed from bmc_group_data.csv were not being properly cleaned up from all telemetry pods' databases.

Key Changes:

  1. Fixed worker_node undefined error (initiate_telemetry_service_cluster.yml)
    • Moved remove_deleted_nodes.yml include to occur after worker node resolution
    • This ensures worker_node variable is available when disabling telemetry via Redfish
  2. Read from ALL telemetry pods for removal identification (initiate_telemetry_service_cluster.yml)
    • Added task to build all_idrac_podnames from service cluster metadata (all pods, not just those with current CSV entries)
    • Changed read_idracips_from_mysqldb to query all telemetry pods instead of only pods with current CSV entries
    • This ensures IPs present in DB but removed from CSV are identified across all pods
  3. Delete from ALL telemetry pods (remove_deleted_nodes.yml)
    • Changed delete_idracips_from_mysqldb to target all telemetry pods using all_idrac_podnames
    • This ensures complete cleanup across the distributed telemetry system
  4. Added safe variable handling (remove_deleted_nodes.yml)
    • Added safe default handling for disable_telemetry_result variables to prevent errors when telemetry disable task is skipped
    • Added delegate_to and when: worker_node is defined conditions for disable telemetry task
  5. Fixed telemetry report accuracy (retry_unreachable_bmcs.yml)
    • Added task to recalculate invalid_idrac_count and invalid_idrac_list after BMC retry attempts
    • This ensures the telemetry report reflects accurate information after retry operations

Issue Fixed: Previously, when IPs were removed from bmc_group_data.csv, the code only checked telemetry pods that had entries in the current CSV. This meant IPs assigned to pods that no longer had any CSV
entries were never identified for removal, leading to stale data in the database and inaccurate telemetry reports.