### PR TITLE
fix(omnia.sh): move admin NIC IP prompt earlier, fix stdin handling f…

### DIFF
--- a/src/main/omnia.sh
+++ b/src/main/omnia.sh
@@ -813,6 +813,13 @@ init_container_config() {
             ;;
     esac
 
+    # Prompt for admin NIC IP (primary non-loopback IP of the OIM host)
+    echo -e "${BLUE} Please provide the admin NIC IP address of the OIM host:${NC}"
+    read -p "Admin NIC IP: " admin_nic_ip
+    if [ -z "$admin_nic_ip" ]; then
+        echo -e "${RED} Admin NIC IP cannot be empty. Please re-run omnia.sh --install.${NC}"
+        exit 1
+    fi
 
     # Prompt the user for the Omnia core root password.
     echo -e "${BLUE} Please provide Omnia core root password for accessing container:${NC}"
@@ -978,7 +985,7 @@ fetch_config() {
 
     # Fetch the metadata from the oim_metadata.yml file.
     echo -e "${GREEN} Fetching the metadata from the oim_metadata.yml file.${NC}"
-        core_config=$(podman exec -ti omnia_core /bin/bash -c 'cat /opt/omnia/.data/oim_metadata.yml')
+        core_config=$(podman exec omnia_core /bin/bash -c 'cat /opt/omnia/.data/oim_metadata.yml')
 
     # Split the metadata into separate lines.
     IFS=$'\n' read -r -d '' -a config_lines <<<"$core_config"
@@ -1014,6 +1021,10 @@ fetch_config() {
             nfs_type)
                 # Assign the share option.
                 nfs_type=$(echo "$value" | tr -d '[:space:]')
+                ;;
+            admin_nic_ip)
+                # Assign the admin NIC IP.
+                admin_nic_ip=$(echo "$value" | tr -d '[:space:]')
                 ;;
         esac
     done
@@ -1196,13 +1207,15 @@ EOF
     # Get version from git tag or use default
     local metadata_version=$(get_metadata_version "$omnia_release")
 
-    # Prompt for admin NIC IP (primary non-loopback IP of the OIM host)
-    local admin_nic_ip
-    read -p "Enter the admin NIC IP address of the OIM host: " admin_nic_ip
-    while [ -z "$admin_nic_ip" ]; do
-        echo -e "${RED} Admin NIC IP cannot be empty.${NC}"
+    # Use admin_nic_ip set by init_container_config() or fetch_config().
+    # Only prompt if not already set (e.g. retain-config reinstall path).
+    if [ -z "$admin_nic_ip" ]; then
         read -p "Enter the admin NIC IP address of the OIM host: " admin_nic_ip
-    done
+        if [ -z "$admin_nic_ip" ]; then
+            echo -e "${RED} Admin NIC IP cannot be empty. Please re-run omnia.sh --install.${NC}"
+            exit 1
+        fi
+    fi
 
     if [ ! -f "$oim_metadata_file" ]; then
         echo -e "${GREEN} Creating oim_metadata file${NC}"


### PR DESCRIPTION
## Summary

Improves the install/reinstall user experience and resolves stdin handling issues that affect automated (piped) execution.

## Changes

### 1. Admin NIC IP prompt moved earlier
- **Before:** Admin NIC IP was prompted late in the installation flow, after several setup operations had already completed.
- **After:** Prompted immediately after storage configuration and before the password prompt, grouping all interactive inputs together.

### 2. Infinite loop prevention
- The `while [ -z "$admin_nic_ip" ]` loop could enter an infinite loop when stdin was a pipe or heredoc because `read` returns empty on EOF.
- Replaced with a single validation check that exits with a clear error message.

### 3. Stdin handling fix
- Removed interactive stdin consumption during metadata retrieval.
- The command only reads a metadata file 