### PR TITLE
fix(storage): rename nfs_slurm source path from omnia to omnia_slurm

### DIFF
--- a/input/storage_config.yml
+++ b/input/storage_config.yml
@@ -110,7 +110,7 @@
 #   #   /mnt/vast/node001/tmp      /tmp      none  bind  0  0
 mounts:
   - name: "nfs_slurm"
-    source: "172.16.107.168:/mnt/share/omnia"
+    source: "172.16.107.168:/mnt/share/omnia_slurm"
     mount_point: "/share_omnia"
     fs_type: "nfs"
     mnt_opts: "nosuid,rw,sync,hard,intr"


### PR DESCRIPTION
## Summary
Rename the default NFS source path for the nfs_slurm mount from
/mnt/share/omnia to /mnt/share/omnia_slurm for naming consistency.
 
## Problem
The nfs_k8s mount uses a descriptive path (/mnt/share/omnia_k8s),
but nfs_slurm uses a generic path (/mnt/share/omnia). This makes
it unclear what the mount is for.
 
Before:
  nfs_slurm source: "172.16.107.168:/mnt/share/omnia"       ← unclear
  nfs_k8s   source: "172.16.107.121:/mnt/share/omnia_k8s"   ← clear
 
After:
  nfs_slurm source: "172.16.107.168:/mnt/share/omnia_slurm" ← clear
  nfs_k8s   source: "172.16.107.121:/mnt/share/omnia_k8s"   ← clear
 
## Change
- File: input/storage_config.yml (line 113)
- /mnt/share/omnia → /mnt/share/omnia_slurm
 
## Impact
- Sample/default config file — users customize it for their environment
- No functional change to Omnia code
- Improves UX by making mount purpose obvious from the path name
