### PR TITLE
Fix: Remove existing ISO before rebuild to prevent xorriso overwrite error

### DIFF
--- a/utils/install_os/roles/iso_creation/tasks/build_nfs_iso.yml
+++ b/utils/install_os/roles/iso_creation/tasks/build_nfs_iso.yml
@@ -22,6 +22,12 @@
     dest: "{{ temp_grub_cfg }}"
     mode: "0644"
 
+- name: Remove existing custom ISO if rebuilding
+  ansible.builtin.file:
+    path: "{{ repacked_iso_path }}"
+    state: absent
+  when: rebuild_iso | bool
+
 - name: Build custom ISO using xorriso (stream modification - grub.cfg only)
   ansible.builtin.command: >-
     xorriso -indev {{ iso_source_path }}

--- a/utils/install_os/roles/iso_creation/tasks/repack_iso.yml
+++ b/utils/install_os/roles/iso_creation/tasks/repack_iso.yml
@@ -19,6 +19,12 @@
     dest: "{{ grub_cfg_path }}"
     mode: "0644"
 
+- name: Remove existing repacked ISO if rebuilding
+  ansible.builtin.file:
+    path: "{{ repacked_iso_path }}"
+    state: absent
+  when: rebuild_iso | bool
+
 - name: Repack ISO with xorrisofs
   ansible.builtin.command: >-
     xorrisofs


### PR DESCRIPTION
xorriso refuses to overwrite output files that already contain data.
Added pre-removal task in both build_nfs_iso.yml and repack_iso.yml
to clean up existing ISO when rebuild_iso is true.