### PR TITLE
Upgrade from 2.1.0.0 → 2.2.0.0 container swap phase.

### DIFF
--- a/omnia.sh
+++ b/omnia.sh
@@ -2070,7 +2070,7 @@ phase4_container_swap() {
     # Flush pending NFS writes inside the container before stopping to prevent
     # the container-stop from blocking on dirty NFS buffers (slow-network hang).
     echo "[INFO] [ORCHESTRATOR] Flushing filesystem caches before container stop..."
-    podman exec -u root omnia_core sync >/dev/null 2>&1 || true
+    timeout 30 podman exec -u root omnia_core sync >/dev/null 2>&1 || true
 
     # Use timeout (120s) around systemctl stop to avoid indefinite hang when
     # NFS I/O is slow.  Without this, systemctl stop waits forever and the
@@ -2087,6 +2087,7 @@ phase4_container_swap() {
         podman kill omnia_core >/dev/null 2>&1 || true
         sleep 2
     fi
+    systemctl reset-failed omnia_core.service >/dev/null 2>&1 || true
 
     if podman ps --format '{{.Names}}' | grep -qw "omnia_core"; then
         echo "[ERROR] [ORCHESTRATOR] Failed to stop omnia_core container"

--- a/omnia.sh
+++ b/omnia.sh
@@ -1855,8 +1855,11 @@ backup_openchami_data() {
         mkdir -p '${backup_base%/}/openchami/openchami_data'
         cp -a /opt/omnia/openchami/. '${backup_base%/}/openchami/openchami_data/' 2>&1
     "; then
-        echo "[WARN] [ORCHESTRATOR] Failed to backup OpenCHAMI data — upgrade will continue"
-        return 0
+        echo "[ERROR] [ORCHESTRATOR] Failed to backup OpenCHAMI data"
+        echo "[ERROR] [ORCHESTRATOR] Upgrade cannot proceed without complete OpenCHAMI backup (rollback safety)"
+        # Clean any partial backup to avoid misleading rollback attempts
+        podman exec -u root omnia_core bash -c "rm -rf '${backup_base%/}/openchami/openchami_data'" >/dev/null 2>&1 || true
+        return 1
     fi
 
     # Verify configs_vars.yaml was captured

--- a/omnia.sh
+++ b/omnia.sh
@@ -1322,13 +1322,18 @@ post_setup_config() {
     fi
 
     # Copy input files from /omnia to /opt/omnia/project_default/ inside omnia_core container
-    podman exec -u root omnia_core bash -c "cd /omnia && git pull"
+    # Use timeout to prevent hang on slow NFS
+    timeout 120 podman exec -u root omnia_core bash -c "cd /omnia && git pull" || {
+        echo -e "${YELLOW} Warning: git pull timed out or failed, continuing...${NC}"
+    }
     echo -e "${BLUE} Moving input files from /omnia dir to project_default folder.${NC}"
-    podman exec -u root omnia_core bash -c "
+    timeout 300 podman exec -u root omnia_core bash -c "
     mkdir -p /opt/omnia/input/project_default
     cp -r /omnia/input/* /opt/omnia/input/project_default
     rm -rf /omnia/input
-    rm -rf /omnia/omnia.sh"
+    rm -rf /omnia/omnia.sh" || {
+        echo -e "${YELLOW} Warning: input file copy timed out or failed${NC}"
+    }
 }
 
 validate_nfs_server() {
@@ -1844,7 +1849,8 @@ backup_openchami_data() {
     fi
 
     # Create openchami backup directory structure
-    if ! podman exec -u root omnia_core bash -c "
+    # Use timeout (300s) to prevent indefinite hang on slow NFS
+    if ! timeout 300 podman exec -u root omnia_core bash -c "
         set -e
         mkdir -p '${backup_base%/}/openchami/openchami_data'
         cp -a /opt/omnia/openchami/. '${backup_base%/}/openchami/openchami_data/' 2>&1
@@ -1915,7 +1921,8 @@ phase3_backup_creation() {
         return 1
     fi
 
-    if ! podman exec -u root omnia_core bash -c "
+    # Use timeout (300s) around backup copy to prevent indefinite hang on slow NFS
+    if ! timeout 300 podman exec -u root omnia_core bash -c "
         set -e
         rm -rf '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'
         mkdir -p '${backup_base%/}/input' '${backup_base%/}/metadata' '${backup_base%/}/configs'
@@ -2059,11 +2066,26 @@ phase4_container_swap() {
     fi
 
     echo "[INFO] [ORCHESTRATOR] Stopping omnia_core $OMNIA_CORE_CONTAINER_TAG container"
-    systemctl stop omnia_core.service >/dev/null 2>&1 || true
+
+    # Flush pending NFS writes inside the container before stopping to prevent
+    # the container-stop from blocking on dirty NFS buffers (slow-network hang).
+    echo "[INFO] [ORCHESTRATOR] Flushing filesystem caches before container stop..."
+    podman exec -u root omnia_core sync >/dev/null 2>&1 || true
+
+    # Use timeout (120s) around systemctl stop to avoid indefinite hang when
+    # NFS I/O is slow.  Without this, systemctl stop waits forever and the
+    # fallback podman-stop is never reached.
+    timeout 120 systemctl stop omnia_core.service >/dev/null 2>&1 || true
 
     if podman ps --format '{{.Names}}' | grep -qw "omnia_core"; then
-        echo "[WARN] [ORCHESTRATOR] omnia_core still running; forcing stop"
+        echo "[WARN] [ORCHESTRATOR] omnia_core still running; forcing stop via podman"
         podman stop -t 30 omnia_core >/dev/null 2>&1 || true
+    fi
+
+    if podman ps --format '{{.Names}}' | grep -qw "omnia_core"; then
+        echo "[WARN] [ORCHESTRATOR] omnia_core still running; force killing container"
+        podman kill omnia_core >/dev/null 2>&1 || true
+        sleep 2
     fi
 
     if podman ps --format '{{.Names}}' | grep -qw "omnia_core"; then

--- a/omnia.sh
+++ b/omnia.sh
@@ -1967,7 +1967,10 @@ phase3_backup_creation() {
     echo "[INFO] [ORCHESTRATOR] Backup created at: $backup_base"
 
     # Backup OpenCHAMI data (workdir, configs_vars, deployment-recipes, quadlets)
-    backup_openchami_data "$backup_base"
+    if ! backup_openchami_data "$backup_base"; then
+        echo "[ERROR] [ORCHESTRATOR] Phase 3 failed: OpenCHAMI backup incomplete"
+        return 1
+    fi
 
     echo "[INFO] [ORCHESTRATOR] Phase 3: Backup completed"
     return 0


### PR DESCRIPTION
### Description of the Solution

**Problem**
Upgrade from 2.1.0.0 → 2.2.0.0 hangs indefinitely at Phase 4 Container Swap when external NFS is slow (multi-subnet clusters). The issue occurs because:

systemctl stop omnia_core.service has no timeout and blocks forever flushing dirty NFS buffers
Backup copy operations (cp -a) over NFS have no timeout and can stall
This causes the NFS share to become unavailable to all clients

**Solution**
Added timeout guards to all NFS-dependent operations in omnia.sh:

phase4_container_swap(): Added sync before stop + timeout 120 on systemctl stop + podman kill escalation
phase3_backup_creation(): Added timeout 300 to input/metadata copy operations
backup_openchami_data(): Added timeout 300 to OpenCHAMI data copy
post_setup_config(): Added timeout 120 to git pull + timeout 300 to file copy

### Suggested Reviewers
@priti-parate @abhishek-sa1 
