### PR TITLE
Fix: Remove unresolved merge conflict markers from `build_stream` Containerfile

### DIFF
--- a/src/build_stream/containers/omnia_build_stream/Containerfile
+++ b/src/build_stream/containers/omnia_build_stream/Containerfile
@@ -36,13 +36,8 @@ RUN apk update && apk add --no-cache \
     openssh \
     bash
 
-<<<<<<< HEAD
-# Install build-time dependencies, compile packages, then remove build deps
-RUN apk add --no-cache --virtual .build-deps build-base python3-dev shadow
-=======
 # Install build-time dependencies (removed after compilation in a later step)
 RUN apk add --no-cache --virtual .build-deps build-base python3-dev
->>>>>>> c14fdc8d0 (Harden Containerfiles based on PR review feedback)
 
 # security fixes (GHSA-3cv2-h65g-fgmm, GHSA-4gg8-gxpx-9rph).
 COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /usr/local/bin/


### PR DESCRIPTION
The previous PR (#4889) had merge conflict markers that were accidentally committed during a rebase operation. This commit removes those markers and keeps the correct version.

Changes:

```
Remove <<<<<<< HEAD, =======, >>>>>>> c14fdc8d0 conflict markers from Containerfile
```
Keep the corrected version: .build-deps without the shadow package (since we're not adding a non-root user)
Verification:

Container builds successfully
- Build-time dependencies (gcc, make) properly removed
- s3cmd==2.4.0 pinned
- No MINIO credentials in image metadata
- HEALTHCHECK configured