### PR TITLE
defect fix for vector-ome for ome.telemetry topic

### DIFF
--- a/provision/roles/telemetry/templates/telemetry/vector/vector-ome-config.toml.j2
+++ b/provision/roles/telemetry/templates/telemetry/vector/vector-ome-config.toml.j2
@@ -86,24 +86,42 @@ inputs = ["parse_ome_topic"]
 # ============================================================================
 # Step 3: Handles three OME metric data formats:
 #   Redfish format ({{ ome_id }}.telemetry):
-#     System[] array with nested Metric[] sub-arrays — flattened to individual metric events.
+#     Flat message: Identifier and Metric[] at top level (no System[] wrapper).
+#     Each Metric[].MetricId is split into (Type, MetricName, Aggregation, Interval) parts.
 #   Inventory format ({{ ome_id }}.inventory, {{ ome_id }}.event):
 #     System[] array with Component[].Data[].Properties — numeric/boolean properties extracted.
 #   Health format  ({{ ome_id }}.health):
 #     System[] array with flat fields — all numeric/boolean fields are dynamically extracted as metrics.
-#   _unmatched: best-effort processing — events without System[] are dropped gracefully.
+#   _unmatched: best-effort processing — events without System[] or Metric[] are dropped gracefully.
 [transforms.metric_enricher]
 type = "remap"
 inputs = ["ome_topic_router.metrics", "ome_topic_router._unmatched"]
 source = '''
   all_metrics = []
-  SystemArr = array(.System) ?? []
+  # Capture source_topic now — this field is on the event root and will be lost
+  # after `. = all_metrics` fan-out. Embed it in every parsed_metric so the
+  # downstream log_to_metric transform can expose it as a Prometheus label,
+  # enabling queries like: {source_subsystem="ome", source_topic="ome.telemetry"}
+  source_topic_val = to_string(.source_topic) ?? "unknown"
+
+  # Normalize: ome.inventory/health wrap data in System[{Identifier,...}] at the top level.
+  # ome.telemetry sends a flat message with Identifier and Metric[] directly at the top level
+  # (no System[] wrapper). Detect the flat format and synthesize a System entry so the
+  # existing for_each loop can process it uniformly without any other changes.
+  SystemArr = if exists(.System) && is_array(.System) {
+    array!(.System)
+  } else if exists(.Metric) && is_array(.Metric) {
+    # ome.telemetry flat format: build a synthetic System entry from top-level fields
+    [{"Identifier": to_string(.Identifier) ?? "unknown", "Metric": .Metric}]
+  } else {
+    array(.System) ?? []
+  }
 
   for_each(SystemArr) -> |_index, system| {
     identifier = to_string(system.Identifier) ?? "unknown"
 
     if system.Metric != null && is_array(system.Metric) {
-      # Redfish telemetry format: System[].Metric[] arrays
+      # Redfish telemetry format: System[].Metric[] arrays (also ome.telemetry flat format)
       for_each(array!(system.Metric)) -> |_index1, metric| {
         id_replaced = replace!(metric.MetricId, ".", "_")
         parts = split(id_replaced, "_")
@@ -115,13 +133,14 @@ source = '''
             } else {
                 "System"
             }
-        parsed_metric, _ = [{
+        parsed_metric = [{
           "MetricName": metric_name,
-          "MetricValue": to_float(metric.MetricValue[0]),
+          "MetricValue": to_float(metric.MetricValue[0]) ?? 0.0,
           "ComponentId": componentId,
           "TimeStamp": metric.TimeStamp[0],
           "Identifier": identifier,
-          "Type": parts[0]
+          "Type": parts[0],
+          "SourceTopic": source_topic_val
         }]
 
         all_metrics = append(all_metrics, parsed_metric)
@@ -145,7 +164,8 @@ source = '''
                   "ComponentId": comp_type,
                   "TimeStamp": ts,
                   "Identifier": identifier,
-                  "Type": "inventory"
+                  "Type": "inventory",
+                  "SourceTopic": source_topic_val
                 }]
                 all_metrics = append(all_metrics, parsed_metric)
               }
@@ -166,7 +186,8 @@ source = '''
             "ComponentId": "System",
             "TimeStamp": ts,
             "Identifier": identifier,
-            "Type": "health"
+            "Type": "health",
+            "SourceTopic": source_topic_val
           }]
           all_metrics = append(all_metrics, parsed_metric)
         }
@@ -197,6 +218,7 @@ inputs = ["metric_enricher"]
     component = "{{ ComponentId }}"
     identifier = "{{ Identifier }}"
     type = "{{ Type }}"
+    source_topic = "{{ SourceTopic }}"
 {% endraw %}
     source_subsystem = "{{ ome_id }}"
 {% endif %}
@@ -325,3 +347,4 @@ timeout_secs = 60
 enabled = true
 address = "0.0.0.0:{{ vector.ome.metrics_port }}"
 playground = false
+


### PR DESCRIPTION
### Description of the Solution

Problem: ome.telemetry Kafka messages use a flat JSON structure ({Identifier, Metric[]}) at the root, but the Vector transform expected a System[] wrapper like ome.inventory/health. This caused all
telemetry metrics to be silently dropped.

Fix: Modified metric_enricher transform in vector-ome-config.toml.j2 to detect the flat format and normalize it:

  1. Added format detection: Check if .Metric exists at root (flat format) vs .System (wrapped format)
  2. Synthetic System entry: For flat format, wrap it as [{"Identifier": ..., "Metric": ...}] so existing loop processes it
  3. Added source_topic label: Capture .source_topic before fan-out and embed it as SourceTopic in every metric, then expose as Prometheus label
  4. Fixed VRL error handling: Changed parsed_metric, _ = [...] to parsed_metric = [...] (required after adding ?? 0.0 fallback)

Result: 184 telemetry series now flowing to VictoriaMetrics with labels source_subsystem="ome", source_topic="ome.telemetry", and type="Power/PMP/PSU/Thermal/SystemUtilization".


### Suggested Reviewers
@abhishek-sa1 @priti-parate 
