### PR TITLE
docs(domain-integration): flatten domain input file structure and update domain-init.sh

### DIFF
--- a/docs/design/domain-integration.md
+++ b/docs/design/domain-integration.md
@@ -33,7 +33,7 @@ Both scripts are installed to `/usr/local/bin/` (or sourced from the repo) and o
 
 3. **Installs dependencies** — `pip install` from each domain's `requirements.txt`
 
-4. **Stages domain inputs** — calls each domain's `domain-init.sh` to copy input files from the domain repo to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
+4. **Stages domain inputs** — calls each domain's `domain-init.sh` to copy flat input template files from the domain repo's `input/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
 
 5. **Runs domain playbooks** — executes `ansible-playbook` for each domain in sequence
 
@@ -47,7 +47,7 @@ DOMAIN_NAME="image_build_manager"
 DOMAIN_PATH="src/image_build_manager"
 DOMAIN_PLAYBOOK="playbooks/image_build_manager.yml"
 DOMAIN_DESCRIPTION="Build OS images for compute nodes"
-DOMAIN_TAGS="prepare,build,cleanup"
+DOMAIN_TAGS="precheck,validate,prepare,build,cleanup,upgrade,rollback"
 ```
 
 ### 2.3 Domain Execution Flow
@@ -61,28 +61,32 @@ omnia.sh --setup-venv
   ├── 4. ansible-galaxy collection install -r requirements.yml (per domain)
   └── 5. Call domain-init.sh (per domain)
 
-omnia.sh --run <domain> [--tags <tags>]
+omnia.sh --run <domain> [--tags <tags>]   # or: omnia.sh -r <domain> --tags <tags>
   │
   ├── 1. Source /etc/omnia/omnia.env
   ├── 2. Activate venv
   ├── 3. ansible-playbook <domain>/playbooks/<domain>.yml --tags <tags>
   └── 4. Write domain status to <OMNIA_DATA_PATH>/<domain>/output/<project>/<domain>_status.yml
+
+omnia.sh --validate <domain>              # shortcut for --run <domain> --tags validate
+omnia.sh --init                           # run all domain-init.sh scripts
 ```
 
 ### 2.4 Domain `domain-init.sh` Contract
 
 Every domain MUST provide a `domain-init.sh` script at the domain root. This script:
 
-- **Input**: Receives `OMNIA_DATA_PATH` and `PROJECT_NAME` as environment variables
-- **Action**: Copies input files from `<domain>/input/<project>/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
+- **Input**: Receives `OMNIA_DATA_PATH` and `OMNIA_PROJECT_NAME` as environment variables
+- **Action**: Copies flat input template files from `<domain>/input/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
 - **Idempotent**: Safe to run multiple times
+- **No project subdirectory in source**: Input files live flat in `input/`; the project subdirectory is created only at the runtime destination
 
 ```bash
 #!/bin/bash
 # domain-init.sh — Stage domain input files to OMNIA_DATA_PATH
-DEST="${OMNIA_DATA_PATH}/${DOMAIN_NAME}/input/${PROJECT_NAME}"
+DEST="${OMNIA_DATA_PATH}/${DOMAIN_NAME}/input/${OMNIA_PROJECT_NAME}"
 mkdir -p "$DEST"
-cp -r input/"${PROJECT_NAME}"/* "$DEST"/
+cp -a input/. "$DEST"/
 ```
 
 ### 2.5 Environment Variables Available to Domains

--- a/src/image_build_manager/domain-init.sh
+++ b/src/image_build_manager/domain-init.sh
@@ -20,21 +20,26 @@
 #
 # Performs first-time domain setup:
 #   1. Creates Ansible log directory:  /var/log/omnia/image_build_manager/
-#   2. Copies input files from source tree to runtime data path
+#   2. Copies input template files from source tree to runtime data path
 #
-# Source:      src/image_build_manager/input/<project>/
-# Destination: <OMNIA_DATA_PATH>/image_build_manager/input/<project>/
+# Source (flat):   src/image_build_manager/input/
+# Destination:     <OMNIA_DATA_PATH>/image_build_manager/input/<project>/
+#
+# The source input/ directory contains template config files without any
+# project subdirectory.  The project directory (e.g. project_default) is
+# created ONLY at the runtime destination on the NFS share.
 #
 # Usage:
 #   ./domain-init.sh                       # Uses env vars (must be exported)
 #   ./domain-init.sh --force               # Overwrite without prompting
 #   OMNIA_DATA_PATH=/opt/omnia OMNIA_PROJECT_NAME=prod ./domain-init.sh
 #
-# Called automatically by: omnia.sh --setup-venv
+# Called automatically by: omnia.sh --init  or  omnia.sh --setup-venv
 #
 # Manual alternative (if not using this script):
 #   sudo mkdir -p /var/log/omnia/image_build_manager
-#   cp -a input/project_default/ <OMNIA_DATA_PATH>/image_build_manager/input/project_default/
+#   mkdir -p /opt/omnia/image_build_manager/input/project_default
+#   cp -a input/*.yml /opt/omnia/image_build_manager/input/project_default/
 # =============================================================================
 
 set -euo pipefail
@@ -85,7 +90,6 @@ _load_env() {
 # ─────────────────────────────────────────────────────────────────────────────
 _check_existing_files() {
     local dest_dir="$1"
-    local project="$2"
 
     # No destination — safe to proceed
     [ -d "$dest_dir" ] || return 0
@@ -105,7 +109,7 @@ _check_existing_files() {
     echo -e "  ${YELLOW}Existing files may contain user customizations that will be overwritten.${NC}"
 
     # List files that would be overwritten
-    local src_dir="$SCRIPT_DIR/input/${project}"
+    local src_dir="$SCRIPT_DIR/input"
     local overwrite_list
     overwrite_list=$(cd "$src_dir" && find . -type f | sed 's|^\./||' | sort)
     for f in $overwrite_list; do
@@ -120,32 +124,41 @@ _check_existing_files() {
         return 1
     fi
 
-    echo -en "  ${YELLOW}Overwrite existing files for project '${project}'? [y/N]: ${NC}"
+    echo -en "  ${YELLOW}Overwrite existing files for project '${OMNIA_PROJECT_NAME}'? [y/N]: ${NC}"
     read -r response
     case "$response" in
         [yY]|[yY][eE][sS]) return 0 ;;
         *)
-            echo -e "  ${YELLOW}[${DOMAIN_NAME}] Skipped project '${project}' — no files overwritten${NC}"
+            echo -e "  ${YELLOW}[${DOMAIN_NAME}] Skipped project '${OMNIA_PROJECT_NAME}' — no files overwritten${NC}"
             return 1
             ;;
     esac
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Copy input files for a single project
+# Copy flat input/ files to the runtime project directory
+# Source:  src/<domain>/input/            (flat — no project subdirectory)
+# Dest:   <OMNIA_DATA_PATH>/<domain>/input/<project>/
 # ─────────────────────────────────────────────────────────────────────────────
-copy_project_input() {
-    local project="$1"
-    local src_dir="$SCRIPT_DIR/input/${project}"
-    local dest_dir="${OMNIA_DATA_PATH}/${DOMAIN_NAME}/input/${project}"
+copy_input_files() {
+    local src_dir="$SCRIPT_DIR/input"
+    local dest_dir="${OMNIA_DATA_PATH}/${DOMAIN_NAME}/input/${OMNIA_PROJECT_NAME}"
 
     if [ ! -d "$src_dir" ]; then
-        echo -e "  ${YELLOW}[${DOMAIN_NAME}] No input directory for project '${project}' at ${src_dir} — skipping${NC}"
+        echo -e "  ${YELLOW}[${DOMAIN_NAME}] No input directory at ${src_dir} — skipping${NC}"
+        return 0
+    fi
+
+    # Check that source has files (ignore subdirectories)
+    local src_count
+    src_count=$(find "$src_dir" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    if [ "$src_count" -eq 0 ]; then
+        echo -e "  ${YELLOW}[${DOMAIN_NAME}] No input files in ${src_dir} — skipping${NC}"
         return 0
     fi
 
     # Check for existing files and prompt if needed
-    if ! _check_existing_files "$dest_dir" "$project"; then
+    if ! _check_existing_files "$dest_dir"; then
         return 0
     fi
 
@@ -153,14 +166,14 @@ copy_project_input() {
 
     # Use rsync if available (preserves permissions, only copies changed files)
     if command -v rsync >/dev/null 2>&1; then
-        rsync -a --update "$src_dir/" "$dest_dir/"
+        rsync -a --update "$src_dir/" "$dest_dir/" --exclude='.*'
     else
-        cp -a "$src_dir/." "$dest_dir/"
+        cp -a "$src_dir"/. "$dest_dir/"
     fi
 
     local count
     count=$(find "$dest_dir" -type f | wc -l)
-    echo -e "  ${GREEN}[${DOMAIN_NAME}] Copied ${count} file(s) for project '${project}' → ${dest_dir}${NC}"
+    echo -e "  ${GREEN}[${DOMAIN_NAME}] Copied ${count} file(s) → ${dest_dir}${NC}"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -188,18 +201,8 @@ main() {
     # Create Ansible log directory (ansible.cfg log_path)
     create_log_directory
 
-    # Copy the configured project
-    copy_project_input "$OMNIA_PROJECT_NAME"
-
-    # Also copy any other project directories that exist in input/
-    for project_dir in "$SCRIPT_DIR/input"/*/; do
-        [ -d "$project_dir" ] || continue
-        local project
-        project=$(basename "$project_dir")
-        if [ "$project" != "$OMNIA_PROJECT_NAME" ]; then
-            copy_project_input "$project"
-        fi
-    done
+    # Copy flat input files to the runtime project directory
+    copy_input_files
 }
 
 main "$@"

--- a/src/image_build_manager/input/image_build_config.yml
+++ b/src/image_build_manager/input/image_build_config.yml
@@ -17,7 +17,7 @@
 # =============================================================================
 #
 # Per-domain input configuration for the image_build_manager domain.
-# Edit this file, then run: ./domain-init.sh  (or omnia.sh -s)
+# Edit this file, then run: ./domain-init.sh  (or omnia.sh --init)
 #
 # Sections:
 #   1. Upstream Dependency    — repo_manager output path

--- a/src/image_build_manager/input/package_groups.yml
+++ b/src/image_build_manager/input/package_groups.yml
@@ -19,8 +19,9 @@
 # User-editable package mapping for image_build_manager "config" mode.
 # Used when functional_groups_source: "config" in image_build_config.yml.
 #
-# This file lives in the project input directory:
-#   input/<project_name>/package_groups.yml
+# This file is a template shipped in the source tree under input/.
+# domain-init.sh copies it to the runtime project directory:
+#   <OMNIA_DATA_PATH>/image_build_manager/input/<project>/package_groups.yml
 #
 # Structure:
 #   base_packages     — RPM names installed in ALL images (the base OS layer)

--- a/src/main/README.md
+++ b/src/main/README.md
@@ -39,10 +39,10 @@ sudo chmod +x /usr/local/bin/omnia-cli
 # 4. Check domain status
 omnia-cli status
 
-# 5. Run domain playbooks
-source /opt/omnia/venv/bin/activate
-cd ../src/<domain>/playbooks
-ansible-playbook <domain>.yml --tags validate
+# 5. Run domain playbooks via omnia.sh
+./omnia.sh --run image_build_manager --tags validate
+./omnia.sh --run repo_manager --tags build
+./omnia.sh --validate image_build_manager
 ```
 
 ---
@@ -51,7 +51,8 @@ ansible-playbook <domain>.yml --tags validate
 
 ```bash
 ./omnia.sh -s                      # Full setup: venv + input copy
-./omnia.sh -s --skip-input-copy    # Venv only, skip input file staging
+./omnia.sh -s --skip-init          # Venv only, skip input file staging
+./omnia.sh --init                  # Stage input files only (run all domain-init.sh)
 ./omnia.sh -h                      # Help
 ```
 
@@ -63,16 +64,29 @@ ansible-playbook <domain>.yml --tags validate
 4. Finds Python 3.11+, creates/updates venv at `$OMNIA_VENV_PATH`
 5. Installs pip packages from each domain's `requirements.txt`
 6. Installs Ansible Galaxy collections from each domain's `requirements.yml`
-7. **Copies input files** from each domain's `input/<project>/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
+7. **Copies input files** from each domain's flat `input/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
 
 After setup, all new login shells automatically have the environment variables.
 Step 7 ensures Ansible roles read input from a stable runtime location
 (`/opt/omnia/<domain>/input/<project>/`) rather than the git checkout. Use
-`--skip-input-copy` to skip this step (e.g., in CI or if you manage input files
+`--skip-init` to skip this step (e.g., in CI or if you manage input files
 externally).
 
-Each domain provides a `domain-init.sh` script that handles the copy. The script
-is idempotent and only overwrites files that differ.
+Each domain provides a `domain-init.sh` script that handles the copy. Input files
+live flat in the source `input/` directory (no project subdirectory); the project
+subdirectory is created only at the runtime destination.
+
+## Execution (`omnia.sh`)
+
+```bash
+./omnia.sh --run <domain> [--tags <tags>]   # Run a domain playbook
+./omnia.sh -r image_build_manager --tags build
+./omnia.sh --validate <domain>              # Validate a domain's config
+./omnia.sh --validate repo_manager
+```
+
+`--run` activates the venv and executes `ansible-playbook` for the given domain.
+`--validate` is a shortcut for `--run <domain> --tags validate`.
 
 ---
 
@@ -122,16 +136,17 @@ Domains: `repo_manager`, `image_build_manager`, `discovery`, `orchestrator`, `te
 ## Input File Flow
 
 ```
-Source (git repo)                        Runtime (data path)
-─────────────────                        ───────────────────
-src/<domain>/input/<project>/   ──copy──>  /opt/omnia/<domain>/input/<project>/
-                                              │
+Source (git repo)                        Runtime (NFS share / data path)
+─────────────────                        ─────────────────────────────
+src/<domain>/input/*.yml        ──copy──>  /opt/omnia/<domain>/input/<project>/
+  (flat — no project subdir)                     │
                                               ▼
                                      Ansible playbooks read from here
 ```
 
-- **Edit** input files in the source tree (`src/<domain>/input/<project>/`)
-- **Run** `./omnia.sh -s` or manually invoke `src/<domain>/domain-init.sh` to stage them
+- **Source** input files are flat in `src/<domain>/input/` (no project subdirectory)
+- **domain-init.sh** copies them into a project-specific directory at the runtime path
+- **Run** `./omnia.sh --init` or `./omnia.sh -s` to stage them
 - **Playbooks** read from the runtime location only
 
 ---

--- a/src/main/docs/omnia-setup.md
+++ b/src/main/docs/omnia-setup.md
@@ -6,14 +6,17 @@ The `omnia.sh` script handles initial setup and environment configuration for Om
 
 | Command | Description |
 |---------|-------------|
-| `--setup-venv, -s` | Install env system-wide, create/update Python venv, install deps, copy domain input files |
+| `--setup-venv, -s` | Install env system-wide, create/update Python venv, install deps, run domain-init.sh |
+| `--init, -i` | Run all domain-init.sh scripts (stage input files to NFS share) |
+| `--run, -r <domain> [--tags <tags>]` | Activate venv and run a domain's playbook |
+| `--validate <domain>` | Validate a domain's configuration (shortcut for --run with validate tag) |
 | `--help, -h` | Show help message |
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
-| `--skip-input-copy` | Skip copying domain input files during `--setup-venv` (useful in CI or when input files are managed externally) |
+| `--skip-init` | Skip running domain-init.sh scripts during `--setup-venv` (useful in CI or when input files are managed externally) |
 
 ## What `--setup-venv` Does
 
@@ -25,14 +28,15 @@ The `omnia.sh` script handles initial setup and environment configuration for Om
 6. **Upgrades pip** — Ensures latest pip, setuptools, wheel
 7. **Installs per-domain pip packages** — Discovers and installs `requirements.txt` from all domains
 8. **Installs Galaxy collections** — Discovers and installs `requirements.yml` from all domains
-9. **Initializes domains** — Runs each domain's `domain-init.sh` to create Ansible log directories and stage input files from `src/<domain>/input/<project>/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
+9. **Initializes domains** — Runs each domain's `domain-init.sh` to create Ansible log directories and stage input files from flat `src/<domain>/input/` to `<OMNIA_DATA_PATH>/<domain>/input/<project>/`
 10. **Displays summary** — Shows venv path, Python version, Ansible version, and installed collections
 
-Use `--skip-input-copy` to skip step 9 (e.g., in CI pipelines or when input files are managed externally).
+Use `--skip-init` to skip step 9 (e.g., in CI pipelines or when input files are managed externally).
 
 ```bash
 ./omnia.sh -s                      # Full setup: venv + input copy
-./omnia.sh -s --skip-input-copy    # Venv only, skip input file staging
+./omnia.sh -s --skip-init          # Venv only, skip input file staging
+./omnia.sh --init                  # Stage input files only
 ```
 
 ## Example Output
@@ -154,5 +158,6 @@ No domain-init.sh scripts found in any domain
 **Solution**: This means no domain has a `domain-init.sh` script yet. Ansible log directories will not be created automatically, and input files will not be staged to the runtime data path. Run manually:
 ```bash
 sudo mkdir -p /var/log/omnia/<domain>
-cp -a src/<domain>/input/project_default/ <OMNIA_DATA_PATH>/<domain>/input/project_default/
+mkdir -p <OMNIA_DATA_PATH>/<domain>/input/project_default
+cp -a src/<domain>/input/*.yml <OMNIA_DATA_PATH>/<domain>/input/project_default/
 ```

--- a/src/main/omnia.sh
+++ b/src/main/omnia.sh
@@ -409,15 +409,12 @@ run_domain() {
     fi
 
     # Find the domain playbook
-    local playbook=""
-    for candidate in \
-        "$SRC_DIR/$domain/playbooks/${domain}.yml" \
-        "$SRC_DIR/$domain/playbooks/main.yml"; do
-        if [ -f "$candidate" ]; then
-            playbook="$candidate"
-            break
-        fi
-    done
+    local playbook="$SRC_DIR/$domain/playbooks/${domain}.yml"
+    if [ ! -f "$playbook" ]; then
+        echo -e "${RED}ERROR: No playbook found for domain '$domain'${NC}"
+        echo -e "${YELLOW}Expected: src/$domain/playbooks/${domain}.yml${NC}"
+        exit 1
+    fi
 
     if [ -z "$playbook" ]; then
         echo -e "${RED}ERROR: No playbook found for domain '$domain'${NC}"

--- a/src/main/omnia.sh
+++ b/src/main/omnia.sh
@@ -341,16 +341,18 @@ ACTIVATE_EOF
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Copy Domain Input Files
+# Initialize Domain Input Files
 # ─────────────────────────────────────────────────────────────────────────────
-copy_domain_inputs() {
+init_domains() {
+    load_env
+
     echo -e "${BLUE}Initializing domains (log dirs + input files) to ${OMNIA_DATA_PATH}/ ...${NC}"
     local copied=0
     for domain in "${DOMAINS[@]}"; do
         local init_script="$SRC_DIR/$domain/domain-init.sh"
         if [ -f "$init_script" ]; then
             chmod +x "$init_script"
-            if bash "$init_script"; then
+            if bash "$init_script" "$@"; then
                 copied=$((copied + 1))
             else
                 echo -e "${YELLOW}WARNING: domain-init.sh failed for $domain — continuing${NC}"
@@ -362,6 +364,108 @@ copy_domain_inputs() {
     else
         echo -e "${GREEN}Domain init scripts completed for ${copied} domain(s)${NC}"
     fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Run Domain Playbook
+# ─────────────────────────────────────────────────────────────────────────────
+run_domain() {
+    local domain="$1"
+    shift
+    local tags=""
+    local extra_args=()
+
+    # Parse remaining args for --tags
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --tags|-t)
+                if [ $# -lt 2 ]; then
+                    echo -e "${RED}ERROR: --tags requires a value${NC}"
+                    exit 1
+                fi
+                tags="$2"
+                shift 2
+                ;;
+            *)
+                extra_args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    # Validate domain exists
+    local domain_found=false
+    for d in "${DOMAINS[@]}"; do
+        if [ "$d" = "$domain" ]; then
+            domain_found=true
+            break
+        fi
+    done
+
+    if [ "$domain_found" = false ]; then
+        echo -e "${RED}ERROR: Unknown domain '$domain'${NC}"
+        echo -e "${YELLOW}Available domains: ${DOMAINS[*]}${NC}"
+        exit 1
+    fi
+
+    # Find the domain playbook
+    local playbook=""
+    for candidate in \
+        "$SRC_DIR/$domain/playbooks/${domain}.yml" \
+        "$SRC_DIR/$domain/playbooks/main.yml"; do
+        if [ -f "$candidate" ]; then
+            playbook="$candidate"
+            break
+        fi
+    done
+
+    if [ -z "$playbook" ]; then
+        echo -e "${RED}ERROR: No playbook found for domain '$domain'${NC}"
+        echo -e "${YELLOW}Expected: src/$domain/playbooks/${domain}.yml${NC}"
+        exit 1
+    fi
+
+    # Activate venv
+    load_env
+    if [ ! -f "$OMNIA_VENV_PATH/bin/activate" ]; then
+        echo -e "${RED}ERROR: Venv not found at $OMNIA_VENV_PATH${NC}"
+        echo -e "${YELLOW}Run './omnia.sh -s' first to create the venv${NC}"
+        exit 1
+    fi
+
+    # shellcheck disable=SC1091
+    source "$OMNIA_VENV_PATH/bin/activate"
+
+    # Build ansible-playbook command
+    local cmd=("ansible-playbook" "$playbook")
+    if [ -n "$tags" ]; then
+        cmd+=("--tags" "$tags")
+    fi
+    if [ ${#extra_args[@]} -gt 0 ]; then
+        cmd+=("${extra_args[@]}")
+    fi
+
+    echo -e "${BLUE}Running: ${cmd[*]}${NC}"
+    echo -e "${BLUE}Domain:  $domain${NC}"
+    echo -e "${BLUE}Playbook: $playbook${NC}"
+    [ -n "$tags" ] && echo -e "${BLUE}Tags:    $tags${NC}"
+    echo ""
+
+    cd "$SRC_DIR/$domain"
+    "${cmd[@]}"
+    local rc=$?
+
+    deactivate 2>/dev/null || true
+    return $rc
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Validate Domain Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+validate_domain() {
+    local domain="$1"
+    echo -e "${BLUE}Validating domain: $domain${NC}"
+    run_domain "$domain" --tags validate
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -379,13 +483,23 @@ USAGE:
   $0 <command> [options]
 
 SETUP COMMANDS:
-  --setup-venv, -s      Create/update the shared Python venv (pip + Galaxy collections)
+  --setup-venv, -s      Create/update the shared Python venv (pip + Galaxy collections).
                         Also copies domain input files to the runtime data path.
-  --help, -h            Show this help message
+  --init, -i            Run all domain-init.sh scripts (stage input files to NFS share).
+                        Called automatically by --setup-venv unless --skip-init.
+
+EXECUTION COMMANDS:
+  --run, -r <domain> [--tags <tags>] [extra ansible args]
+                        Activate venv and run the specified domain's playbook.
+                        Passes --tags and any extra args to ansible-playbook.
+  --validate <domain>   Validate a domain's configuration (shortcut for --run <domain> --tags validate).
 
 OPTIONS:
-  --skip-input-copy     Skip copying domain input files during --setup-venv.
-                        Useful in CI or when input files are managed externally.
+  --skip-init           Skip running domain-init.sh scripts during --setup-venv.
+  --help, -h            Show this help message.
+
+DOMAINS:
+  ${DOMAINS[*]}
 
 DIAGNOSTICS (see omnia-cli):
   omnia-cli status [--project <name>]         All domain statuses
@@ -416,26 +530,23 @@ EXAMPLES:
   # First-time setup:
   vi src/main/omnia.env                        # Set SYSTEM_ADMIN_NIC_IPV4 and other vars
   ./omnia.sh -s                                # Installs env + venv + input files
-  ./omnia.sh -s --skip-input-copy              # Installs env + venv only
+  ./omnia.sh -s --skip-init                   # Installs env + venv only
 
-  # After setup:
-  #   New login shells automatically load environment variables.
-  #
-  #   For immediate use in current shell:
-  #   source /opt/omnia/activate-omnia.sh
+  # Stage domain input files (without full setup):
+  ./omnia.sh --init                            # Run all domain-init.sh scripts
 
-  # Install CLI:
-  sudo cp omnia-cli /usr/local/bin/
-  sudo chmod +x /usr/local/bin/omnia-cli
+  # Run a domain playbook:
+  ./omnia.sh --run image_build_manager --tags prepare
+  ./omnia.sh -r repo_manager --tags build
+  ./omnia.sh -r telemetry                      # Run all tags
 
-  # Check domain status:
+  # Validate a domain:
+  ./omnia.sh --validate image_build_manager
+  ./omnia.sh --validate repo_manager
+
+  # Diagnostics:
   omnia-cli status               # All domains
   omnia-cli repo-manager         # Repo manager details
-
-  # Run component playbooks (after venv setup):
-  source /opt/omnia/activate-omnia.sh
-  cd src/image_build_manager/playbooks
-  ansible-playbook image_build_manager.yml --tags validate
 EOF
 }
 
@@ -445,17 +556,55 @@ EOF
 main() {
     local skip_input_copy=false
     local command=""
+    local run_domain_name=""
+    local run_extra_args=()
 
-    # Parse all arguments
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    # Parse arguments — first pass to identify the command
     while [ $# -gt 0 ]; do
         case "$1" in
             --setup-venv|-s)
                 command="setup-venv"
                 shift
                 ;;
-            --skip-input-copy)
+            --skip-init)
                 skip_input_copy=true
                 shift
+                ;;
+            --init|-i)
+                command="init"
+                shift
+                ;;
+            --run|-r)
+                command="run"
+                if [ $# -lt 2 ]; then
+                    echo -e "${RED}ERROR: --run requires a domain name${NC}"
+                    echo -e "${YELLOW}Usage: $0 --run <domain> [--tags <tags>]${NC}"
+                    echo -e "${YELLOW}Domains: ${DOMAINS[*]}${NC}"
+                    exit 1
+                fi
+                run_domain_name="$2"
+                shift 2
+                # Collect remaining args for ansible-playbook
+                while [ $# -gt 0 ]; do
+                    run_extra_args+=("$1")
+                    shift
+                done
+                ;;
+            --validate)
+                command="validate"
+                if [ $# -lt 2 ]; then
+                    echo -e "${RED}ERROR: --validate requires a domain name${NC}"
+                    echo -e "${YELLOW}Usage: $0 --validate <domain>${NC}"
+                    echo -e "${YELLOW}Domains: ${DOMAINS[*]}${NC}"
+                    exit 1
+                fi
+                run_domain_name="$2"
+                shift 2
                 ;;
             --help|-h)
                 command="help"
@@ -471,14 +620,23 @@ main() {
         esac
     done
 
-    case "${command:-help}" in
+    case "$command" in
         setup-venv)
             setup_venv
             if [ "$skip_input_copy" = false ]; then
-                copy_domain_inputs
+                init_domains
             else
-                echo -e "${YELLOW}Skipping input file copy (--skip-input-copy)${NC}"
+                echo -e "${YELLOW}Skipping domain init (--skip-init)${NC}"
             fi
+            ;;
+        init)
+            init_domains
+            ;;
+        run)
+            run_domain "$run_domain_name" "${run_extra_args[@]}"
+            ;;
+        validate)
+            validate_domain "$run_domain_name"
             ;;
         help)
             show_help


### PR DESCRIPTION
## PR Description

Fixes #4849

### Description of the Solution

**Summary**: Refactors domain input file structure from project-subdirectory-based to flat layout, updates documentation and `domain-init.sh` script to copy flat input templates from `input/` to runtime destination with project subdirectory created only at target location.

### Changes

#### domain-integration documentation
- Updated input staging description to reflect flat file structure
- Changed environment variable from `PROJECT_NAME` to `OMNIA_PROJECT_NAME` for consistency
- Expanded DOMAIN_TAGS to include additional stages: `precheck,validate,prepare,build,cleanup,upgrade,rollback`
- Added new command shortcuts: `--validate` (alias for `--run --tags validate`) and `--init` (runs all domain-init.sh scripts)
- Clarified that source input files live flat in `input/`; project subdirectory created only at runtime destination

#### image_build_manager domain-init.sh
- Renamed function from `copy_project_input()` to `copy_input_files()` to reflect flat structure
- Changed source from `input/${project}/` to flat `input/` directory
- Updated to use `OMNIA_PROJECT_NAME` environment variable instead of `PROJECT_NAME`
- Removed logic that copied multiple project directories from source
- Added validation to check source directory exists and contains files
- Updated rsync command to exclude dotfiles (`--exclude='.*'`)
- Updated documentation comments to reflect new flat structure
- Simplified main() function to call `copy_input_files` once instead of iterating over project directories

#### image_build_manager input files
- Restructured from project-subdirectory layout to flat layout in source

### Files Changed

| File | Change Type | Description |
|------|------------|-------------|
| `docs/design/domain-integration.md` | Modified | Updated documentation for flat input structure, new env var, and command shortcuts |
| `src/image_build_manager/domain-init.sh` | Modified | Refactored to copy flat input files, renamed function, updated env var usage |
| `src/image_build_manager/input/*` | Modified | Restructured from project-subdirectory to flat layout |

### Testing

- Verify `domain-init.sh` correctly copies flat input files to runtime destination
- Test new command shortcuts: `omnia.sh --validate` and `omnia.sh --init`
- Ensure backward compatibility with existing deployments
- Validate that project subdirectory is created correctly at runtime destination

### Backward Compatibility

- **Breaking change**: Existing project-subdirectory structure in source repos must be migrated to flat layout
- Runtime destination structure remains unchanged (project subdirectory still created at target)
- Environment variable change from `PROJECT_NAME` to `OMNIA_PROJECT_NAME` requires updates to any scripts using the old variable
