### PR TITLE
Update gitlab_runner_image: v18.8.0 -> v19.2.0

### DIFF
--- a/gitlab/roles/hosted_gitlab/vars/main.yml
+++ b/gitlab/roles/hosted_gitlab/vars/main.yml
@@ -78,10 +78,10 @@ gitlab_initial_root_password_path: "/etc/gitlab/initial_root_password"
 gitlab_root_token_file_path: "/root/.gitlab_root_token"
 
 # Runner container
-gitlab_runner_image: "docker.io/gitlab/gitlab-runner:v18.8.0"
+gitlab_runner_image: "docker.io/gitlab/gitlab-runner:v19.2.0"
 gitlab_runner_default_image: "docker.io/library/alpine:3.23.3"
 gitlab_runner_helper_image_registry: "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper"
-gitlab_runner_helper_image_version: "v18.8.0"
+gitlab_runner_helper_image_version: "v19.2.0"
 gitlab_runner_container_name: "gitlab-runner"
 gitlab_restart_policy: "always"
 gitlab_runner_description: "Omnia Hosted Runner"


### PR DESCRIPTION
Update gitlab_runner_helper_image_version: v18.8.0 -> v19.2.0 Confirmed fixes:

CVE-2026-34986 (HIGH) in golang.org/x/net
CVE-2026-33186 (CRITICAL) in google.golang.org/grpc Additional Go dependency CVEs expected to be resolved by the v19.2.0 base image and module updates.



### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@priti-parate @abhishek-sa1 