### PR TITLE
pulp upgraded from 3.113 to 3.114.2 version

### DIFF
--- a/common/library/modules/pulp_pgsql_backup_restore.py
+++ b/common/library/modules/pulp_pgsql_backup_restore.py
@@ -20,7 +20,7 @@ Backup and restore Pulp PostgreSQL data for upgrade/rollback.
 
 Handles the PostgreSQL version incompatibility between Pulp versions:
   - Pulp 3.80 uses PostgreSQL 12/13
-  - Pulp 3.113 uses PostgreSQL 16
+  - Pulp 3.114.2 uses PostgreSQL 16
 
 Backup (action=backup):
   - Validates source PostgreSQL data exists

--- a/common/vars/image_vars.yml
+++ b/common/vars/image_vars.yml
@@ -16,7 +16,7 @@
 # Usage: get_container_image_list.yml
 container_tag: "latest"
 squid_tag: "6.6-24.04_beta"
-pulp_tag: "3.113"
+pulp_tag: "3.114.2"
 mysql_tag: "9.3.0"
 prometheus_tag: "v3.4.1"
 activemq_tag: "5.19.7"

--- a/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/pulp/vars/main.yml
@@ -25,7 +25,7 @@ device_name: "/dev/fuse:/dev/fuse:rwm"
 pulp_container_name: "pulp"
 pulp_protocol_https: true
 # Tag is fixed for the Pulp container image as of 10-06-2025
-pulp_image: "docker.io/pulp/pulp:3.113"
+pulp_image: "docker.io/pulp/pulp:3.114.2"
 
 # Usage: deployment_prereq.yml - pull image retries
 pull_image_retries: 5

--- a/rollback/roles/rollback_pulp/tasks/main.yml
+++ b/rollback/roles/rollback_pulp/tasks/main.yml
@@ -16,7 +16,7 @@
 # ============================================================================
 # rollback_pulp — Main Orchestration
 # ============================================================================
-# Reverse the Pulp upgrade (3.113 → 3.80) by:
+# Reverse the Pulp upgrade (3.114.2 → 3.80) by:
 #   1. Resolving admin NIC IP for health checks
 #   2. Pre-rollback checks (verify Pulp is deployed, backup exists)
 #   3. Stopping the current Pulp container
@@ -29,7 +29,7 @@
 #
 # IMPORTANT: PostgreSQL data must be restored because:
 # - Pulp 3.80 uses PostgreSQL 12/13
-# - Pulp 3.113 uses PostgreSQL 16
+# - Pulp 3.114.2 uses PostgreSQL 16
 # - PostgreSQL cannot downgrade data files between major versions
 #
 # No idempotency check — rollback always executes regardless of current

--- a/rollback/roles/rollback_pulp/tasks/rollback_pulp_container.yml
+++ b/rollback/roles/rollback_pulp/tasks/rollback_pulp_container.yml
@@ -14,7 +14,7 @@
 ---
 
 # ============================================================================
-# Pulp Container Rollback (3.113 → 3.80)
+# Pulp Container Rollback (3.114.2 → 3.80)
 #
 # Steps:
 #   1. Pull the v2.1 Pulp image (3.80)

--- a/rollback/roles/rollback_pulp/vars/main.yml
+++ b/rollback/roles/rollback_pulp/vars/main.yml
@@ -16,7 +16,7 @@
 # ============================================================================
 # rollback_pulp — Variables
 # ============================================================================
-# Rollback target: Pulp 3.80 (from Pulp 3.113)
+# Rollback target: Pulp 3.80 (from Pulp 3.114.2)
 # Reverses the upgrade performed by upgrade_pulp role.
 # ============================================================================
 
@@ -74,7 +74,7 @@ pulp_pgsql_path: "{{ pulp_data_base_path }}/pgsql"
 # PostgreSQL backup paths
 # PostgreSQL data must be restored during rollback because:
 # - Pulp 3.80 uses PostgreSQL 12/13
-# - Pulp 3.113 uses PostgreSQL 16
+# - Pulp 3.114.2 uses PostgreSQL 16
 # - PostgreSQL cannot downgrade data files between major versions
 pulp_backup_dir: "/opt/omnia/backups/upgrade/version_2.1.0.0/pulp"
 pulp_pgsql_backup_path: "{{ pulp_backup_dir }}/pgsql"

--- a/upgrade/playbooks/upgrade_oim.yml
+++ b/upgrade/playbooks/upgrade_oim.yml
@@ -21,7 +21,7 @@
 #
 # Flow:
 #   1. Pre-flight: read manifest, check idempotency
-#   2. Phase 1: Pulp container upgrade (3.80 → 3.113)
+#   2. Phase 1: Pulp container upgrade (3.80 → 3.114.2)
 #   3. Phase 2: OpenCHAMI container upgrade (pg_dump, deployment-recipes,
 #      image pull, ordered restart, DB migration, validation)
 #   4. Mark OIM as completed in manifest

--- a/upgrade/roles/upgrade_pulp/tasks/backup_pulp_data.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/backup_pulp_data.yml
@@ -18,7 +18,7 @@
 #
 # PostgreSQL data must be backed up before upgrade because:
 # - Pulp 3.80 uses PostgreSQL 12/13
-# - Pulp 3.113 uses PostgreSQL 16
+# - Pulp 3.114.2 uses PostgreSQL 16
 # - PostgreSQL cannot downgrade data files between major versions
 #
 # Without this backup, rollback is not possible.

--- a/upgrade/roles/upgrade_pulp/tasks/main.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/main.yml
@@ -16,13 +16,13 @@
 # ===========================================================================
 # Upgrade Pulp Role - Main Entry Point
 #
-# This role upgrades the Pulp container from 3.80 to 3.113.
+# This role upgrades the Pulp container from 3.80 to 3.114.2.
 # Pulp stores all data in persistent volumes mounted from shared storage,
 # so data is preserved during the upgrade.
 #
 # IMPORTANT: PostgreSQL data must be backed up before upgrade because:
 # - Pulp 3.80 uses PostgreSQL 12/13
-# - Pulp 3.113 uses PostgreSQL 16
+# - Pulp 3.114.2 uses PostgreSQL 16
 # - PostgreSQL cannot downgrade data files between major versions
 # Without the backup, rollback is not possible.
 #
@@ -30,7 +30,7 @@
 #   1. Resolve admin NIC IP for health check endpoints
 #   2. Pre-upgrade health check (verify Pulp is deployed and accessible)
 #   3. Backup PostgreSQL data (required for rollback)
-#   4. Pull the new Pulp image (3.113)
+#   4. Pull the new Pulp image (3.114.2)
 #   5. Stop the Pulp container
 #   6. Update the quadlet file with the new image tag
 #   7. Reload systemd daemon and restart container

--- a/upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml
@@ -14,7 +14,7 @@
 ---
 
 # ===========================================================================
-# Upgrade Pulp Container (3.80 → 3.113)
+# Upgrade Pulp Container (3.80 → 3.114.2)
 #
 # Steps:
 #   1. Pull new Pulp image

--- a/upgrade/roles/upgrade_pulp/vars/main.yml
+++ b/upgrade/roles/upgrade_pulp/vars/main.yml
@@ -14,7 +14,7 @@
 ---
 
 # ===========================================================================
-# Pulp Container Upgrade Configuration (3.80 → 3.113)
+# Pulp Container Upgrade Configuration (3.80 → 3.114.2)
 # ===========================================================================
 
 # File permissions
@@ -23,7 +23,7 @@ file_permissions_644: "0644"
 
 # Pulp container settings
 pulp_container_name: "pulp"
-pulp_target_tag: "3.113"
+pulp_target_tag: "3.114.2"
 pulp_target_image: "docker.io/pulp/pulp:{{ pulp_target_tag }}"
 
 # Pulp quadlet file path
@@ -60,7 +60,7 @@ pulp_pgsql_path: "{{ pulp_data_base_path }}/pgsql"
 # Backup settings
 # PostgreSQL data must be backed up before upgrade because:
 # - Pulp 3.80 uses PostgreSQL 12/13
-# - Pulp 3.113 uses PostgreSQL 16
+# - Pulp 3.114.2 uses PostgreSQL 16
 # - PostgreSQL cannot downgrade data files between major versions
 pulp_backup_dir: "/opt/omnia/backups/upgrade/version_2.1.0.0/pulp"
 pulp_pgsql_backup_path: "{{ pulp_backup_dir }}/pgsql"

--- a/upgrade/upgrade.yml
+++ b/upgrade/upgrade.yml
@@ -453,7 +453,7 @@
 
           ── Omnia Upgrade Execution Plan (in order) ──────────────────
             1. oim           → Upgrade OpenCHAMI control-plane containers
-                               and Pulp container (3.80 → 3.113) on the OIM
+                               and Pulp container (3.80 → 3.114.2) on the OIM
             2. build_stream  → SKIPPED (not enabled in build_stream_config.yml)
             3. local_repo    → Synchronize Omnia 2.2 packages into the
                                local Pulp repository for cluster nodes


### PR DESCRIPTION
Overall Vulnerability Summary
=============================

| Severity   | 3.113 | 3.114.2 | Change         |
|------------|-------|---------|----------------|
| CRITICAL   | 5     | 5       | No change      |
| HIGH       | 284   | 169     | ✅ -115        |
| MEDIUM     | 3583  | 3483    | ✅ -100        |
| LOW        | 1958  | 1908    | ✅ -50         |
| NEGLIGIBLE | 14    | 14      | No change      |
| UNKNOWN    | 33    | 33      | No change      |
| **Total**  | **5844** | **5612** | **✅ -232 (4% reduction)** |

Key Improvements in 3.114.2
-----------------------------

- **gnutls package removed** — eliminates 11 vulnerabilities (4 HIGH, 6 MEDIUM, 1 LOW)
- **setuptools package removed** — eliminates 1 MEDIUM vulnerability
- **libxml2 upgraded** — from 2.9.13-15.el9 to 2.9.13-16.el9
- **p11-kit upgraded** — from 0.26.2-1.el9 to 0.26.4-1.el9

**Total vulnerability reduction:** 232 vulnerabilities (4% overall reduction)  
**HIGH severity reduction:** 115 vulnerabilities (40% reduction in HIGH severity)