### PR TITLE
Add kube-vip upgrade support and harden Pulp migration

### DIFF
--- a/upgrade/roles/upgrade_k8s/tasks/detect_addon_versions.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/detect_addon_versions.yml
@@ -119,6 +119,104 @@
         else 'pending'
       }}
 
+# ── kube-vip version detection ────────────────────────────────────────
+# kube-vip runs as a static pod on EACH control plane node. The version
+# is read from the manifest file (source of truth) rather than crictl,
+# because CRI-O stores images by digest and crictl does not return tags.
+# We check all CP nodes: if any node is not at target, status = pending.
+#
+# IMPORTANT: this role runs under `hosts: localhost, connection: local`.
+# A delegate_to target only connects over SSH if that host has
+# `ansible_connection: ssh` set in the inventory. Raw IPs (and file-based
+# inventory hosts without that var) inherit connection: local and run on
+# the controller instead — which is why the manifest was "not found".
+# We therefore register each CP node in the in-memory inventory with an
+# explicit SSH connection, then delegate to those hostnames.
+- name: Build list of control plane nodes for kube-vip detection
+  ansible.builtin.set_fact:
+    _kube_vip_detect_cp_nodes: >-
+      {{ upgrade_status.nodes | dict2items
+         | selectattr('value.role', 'in', ['control_plane_first', 'control_plane'])
+         | list }}
+
+- name: Register control plane nodes for SSH delegation (kube-vip detection)
+  ansible.builtin.add_host:
+    name: "{{ item.key }}"
+    ansible_host: "{{ item.value.ip }}"
+    ansible_connection: ssh
+    ansible_user: root
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    groups: _kube_vip_detect_targets
+  loop: "{{ _kube_vip_detect_cp_nodes }}"
+  loop_control:
+    label: "{{ item.key }} ({{ item.value.ip }})"
+  changed_when: false
+
+- name: Build list of control plane hostnames for kube-vip detection
+  ansible.builtin.set_fact:
+    _kube_vip_detect_cp_hosts: "{{ _kube_vip_detect_cp_nodes | map(attribute='key') | list }}"
+
+- name: Detect kube-vip version from manifest on each control plane
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail &&
+      grep -oP 'image:\s+\S+:v\K\d+\.\d+\.\d+'
+      /etc/kubernetes/manifests/kube-vip.yaml 2>/dev/null ||
+      echo "unknown"
+    executable: /bin/bash
+  delegate_to: "{{ item }}"
+  loop: "{{ _kube_vip_detect_cp_hosts }}"
+  register: kube_vip_version_per_node
+  changed_when: false
+  failed_when: false
+
+- name: Build per-node kube-vip version map
+  ansible.builtin.set_fact:
+    _kube_vip_node_versions: >-
+      {{ _kube_vip_node_versions | default({}) | combine({
+           item.item: item.stdout | default('unknown') | trim
+         }) }}
+  loop: "{{ kube_vip_version_per_node.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Display kube-vip version per control plane node
+  ansible.builtin.debug:
+    msg: "kube-vip versions: {{ _kube_vip_node_versions }}"
+
+# Use the first non-target version as the "current" version for overall
+# reporting. If all nodes match the target, report the target.
+- name: Set kube_vip_current_version fact
+  ansible.builtin.set_fact:
+    kube_vip_current_version: >-
+      {{ (_kube_vip_node_versions.values() | list
+          | reject('equalto', kube_vip_target_version)
+          | reject('equalto', 'unknown') | first | default(''))
+         or
+         (kube_vip_target_version
+          if (_kube_vip_node_versions.values() | list
+              | select('equalto', kube_vip_target_version) | list | length
+              == _kube_vip_node_versions | length)
+          else (_kube_vip_node_versions.values() | list
+                | reject('equalto', 'unknown') | first | default('unknown'))) }}
+
+- name: Set kube_vip_from_version fact (preserve existing if set)
+  ansible.builtin.set_fact:
+    kube_vip_from_version: >-
+      {{ upgrade_status.addon_upgrade.kube_vip.from_version
+         if (upgrade_status.addon_upgrade.kube_vip.from_version | default('unknown')) not in ['unknown', '']
+         else kube_vip_current_version }}
+
+# completed only when ALL control plane nodes are at the target version
+- name: Determine kube-vip status
+  ansible.builtin.set_fact:
+    kube_vip_status: >-
+      {{ 'completed'
+         if (_kube_vip_node_versions.values() | list
+             | select('equalto', kube_vip_target_version) | list | length
+             == _kube_vip_node_versions | length)
+         else 'pending' }}
+
 - name: Load PowerScale target version from JSON
   ansible.builtin.set_fact:
     csi_powerscale_packages_json: "{{ lookup('file', input_project_dir + '/config/x86_64/rhel/' + cluster_os_version + '/csi_driver_powerscale.json') | from_json }}"  # noqa yaml[line-length]
@@ -189,6 +287,11 @@
   vars:
     status_update:
       addon_upgrade:
+        kube_vip:
+          status: "{{ kube_vip_status }}"
+          current_version: "{{ kube_vip_current_version }}"
+          from_version: "{{ kube_vip_from_version }}"
+          target_version: "{{ kube_vip_target_version }}"
         calico:
           status: "{{ calico_status }}"
           current_version: "{{ calico_current_version }}"
@@ -216,6 +319,7 @@
   vars:
     addon_versions_banner:
       - "Detected addon versions:"
+      - "  kube-vip: {{ kube_vip_current_version }} (target: {{ kube_vip_target_version }}) - {{ kube_vip_status }}"
       - "  Calico: {{ calico_current_version }} (target: {{ calico_target_version }}) - {{ calico_status }}"
       - "  MetalLB: {{ metallb_current_version }} (target: {{ metallb_target_version }}) - {{ metallb_status }}"
       - "  Helm: {{ helm_current_version }} (target: {{ helm_target_version }}) - {{ helm_status }}"

--- a/upgrade/roles/upgrade_k8s/tasks/load_status.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/load_status.yml
@@ -192,6 +192,8 @@
             error:
           addon_upgrade:
             status: pending
+            kube_vip:
+              status: pending
             calico:
               status: pending
             metallb:

--- a/upgrade/roles/upgrade_k8s/tasks/load_version_vars.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/load_version_vars.yml
@@ -108,6 +108,13 @@
          | regex_replace('^helm-v', '')
          | regex_replace('-.*$', '') }}
 
+- name: Extract kube_vip_target_version from service_k8s.json
+  ansible.builtin.set_fact:
+    kube_vip_target_version: >-
+      {{ service_k8s_config.service_kube_control_plane_first.cluster
+         | selectattr('package', 'search', 'kube-vip')
+         | map(attribute='tag') | first | regex_replace('^v', '') }}
+
 # ── Extract addon package names (for manifest file names) ─────────────
 - name: Extract addon package names from service_k8s.json
   ansible.builtin.set_fact:

--- a/upgrade/roles/upgrade_k8s/tasks/post_validation.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/post_validation.yml
@@ -105,7 +105,7 @@
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail &&
-      kubectl get pods -n calico-system --no-headers
+      kubectl get pods -n kube-system -l k8s-app=calico-node --no-headers
       --field-selector status.phase!=Running,status.phase!=Succeeded
       2>/dev/null | head -20
   args:

--- a/upgrade/roles/upgrade_k8s/tasks/step_addon_validation.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/step_addon_validation.yml
@@ -12,6 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+- name: Verify kube-vip pods are Running on control planes
+  delegate_to: "{{ kube_vip }}"
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail &&
+      kubectl get pods -n kube-system --no-headers
+      -o custom-columns=':metadata.name,:status.phase' |
+      grep kube-vip
+    executable: /bin/bash
+  register: kube_vip_pods
+  changed_when: false
+  failed_when: false
+
+- name: Warn if kube-vip pods are not Running
+  ansible.builtin.debug:
+    msg: "WARNING: kube-vip issue: {{ kube_vip_pods.stdout | default('no pods found') }}"
+  when: kube_vip_pods.rc != 0 or kube_vip_pods.stdout | trim | length == 0
+
 - name: Verify calico-node pods are Running
   delegate_to: "{{ kube_vip }}"
   ansible.builtin.command:
@@ -56,6 +74,7 @@
   ansible.builtin.debug:
     msg: >-
       Addon validation complete.
+      kube-vip pods: {{ 'OK' if kube_vip_pods.rc == 0 else 'WARN' }}
       Calico pods: {{ 'OK' if calico_pods.rc == 0 else 'WARN' }}
       MetalLB pods: {{ 'OK' if metallb_pods.rc == 0 else 'WARN' }}
       LoadBalancer IPs: {{ lb_services.stdout | default('none') }}

--- a/upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml
@@ -1,0 +1,278 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# ============================================================================
+# step_kube_vip_upgrade.yml - Upgrade kube-vip static pod on a control plane
+# ============================================================================
+# kube-vip runs as a static pod managed by kubelet, not a DaemonSet.
+# Upgrade = replace /etc/kubernetes/manifests/kube-vip.yaml on each CP node.
+#
+# Chicken-and-egg problem:
+#   When the old kube-vip pod dies, the VIP goes away. The new pod reads
+#   admin.conf which points to the VIP for leader election, so it cannot
+#   start. Fix: temporarily point admin.conf to the node's real IP, let
+#   kube-vip start and advertise the VIP, then restore admin.conf.
+#
+# Variables required (set by load_version_vars.yml / detect_addon_versions.yml):
+#   - kube_vip_target_version  (e.g. "1.2.2")
+#   - kube_vip                 (VIP address, e.g. "10.40.5.176")
+#   - node_ip                  (real IP of the CP node being upgraded)
+#   - node_hostname            (inventory hostname, e.g. "k8scp2")
+#   - backup_dir               (path to store manifest backup)
+#
+# All tasks that touch the node run with delegate_to: "{{ node_hostname }}"
+# to ensure SSH connection from the inventory is used (not connection: local).
+# ============================================================================
+
+- name: Check if kube-vip manifest exists
+  delegate_to: "{{ node_hostname }}"
+  ansible.builtin.stat:
+    path: /etc/kubernetes/manifests/kube-vip.yaml
+  register: _kube_vip_manifest_stat
+
+- name: Skip if manifest not found (not a control plane node)
+  ansible.builtin.debug:
+    msg: "No kube-vip manifest found on {{ node_ip }} — skipping"
+  when: not _kube_vip_manifest_stat.stat.exists
+
+- name: Upgrade kube-vip on {{ node_ip }}
+  when: _kube_vip_manifest_stat.stat.exists
+  block:
+    - name: Read current kube-vip manifest
+      delegate_to: "{{ node_hostname }}"
+      ansible.builtin.slurp:
+        path: /etc/kubernetes/manifests/kube-vip.yaml
+      register: _kube_vip_current
+
+    - name: Check if already at target version
+      ansible.builtin.set_fact:
+        _kube_vip_needs_upgrade: >-
+          {{ 'ghcr.io/kube-vip/kube-vip:v' + kube_vip_target_version
+             not in (_kube_vip_current.content | b64decode) }}
+
+    - name: Skip if already at target version
+      ansible.builtin.debug:
+        msg: "kube-vip on {{ node_ip }} already at v{{ kube_vip_target_version }} — skipping"
+      when: not (_kube_vip_needs_upgrade | bool)
+
+    - name: Perform kube-vip upgrade on {{ node_ip }}
+      when: _kube_vip_needs_upgrade | bool
+      block:
+        - name: Backup current kube-vip manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.copy:
+            src: /etc/kubernetes/manifests/kube-vip.yaml
+            dest: "{{ backup_dir }}/kube-vip-{{ node_ip }}-pre-upgrade.yaml"
+            remote_src: true
+            mode: "0644"
+
+        # ── Detect network facts (same approach as provision cloud-init) ──
+        - name: Detect VIP interface from node IP
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              ip -o addr show |
+              awk -v ip="{{ node_ip }}" '$4 ~ ip {print $2}'
+            executable: /bin/bash
+          register: _vip_interface
+          changed_when: false
+
+        # ── Set facts matching provision template variables ──────────────
+        # admin_netmask_bits comes from network_data.admin_network.netmask_bits
+        # (same source as provision/roles/k8s_config create_k8s_config_nfs.yml)
+        - name: Set kube-vip template facts
+          ansible.builtin.set_fact:
+            kube_vip_interface: "{{ _vip_interface.stdout | trim }}"
+            admin_netmask_bits: "{{ hostvars['localhost']['admin_netmask_bits'] }}"
+            kube_vip_version: "{{ kube_vip_target_version }}"
+
+        # ── Generate new manifest (same structure as provision template) ──
+        - name: Write upgraded kube-vip manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.copy:
+            dest: /tmp/kube-vip-upgrade.yaml
+            mode: "0644"
+            content: |
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                creationTimestamp: null
+                name: kube-vip
+                namespace: kube-system
+                uid: kube-vip-pod
+              spec:
+                containers:
+                - args:
+                  - manager
+                  env:
+                  - name: vip_arp
+                    value: "true"
+                  - name: port
+                    value: "6443"
+                  - name: vip_nodename
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  - name: vip_interface
+                    value: {{ kube_vip_interface }}
+                  - name: vip_cidr
+                    value: "{{ admin_netmask_bits }}"
+                  - name: dns_mode
+                    value: first
+                  - name: cp_enable
+                    value: "true"
+                  - name: cp_namespace
+                    value: kube-system
+                  - name: svc_enable
+                    value: "true"
+                  - name: svc_leasename
+                    value: plndr-svcs-lock
+                  - name: vip_leaderelection
+                    value: "true"
+                  - name: vip_leasename
+                    value: plndr-cp-lock
+                  - name: vip_leaseduration
+                    value: "5"
+                  - name: vip_renewdeadline
+                    value: "3"
+                  - name: vip_retryperiod
+                    value: "1"
+                  - name: address
+                    value: {{ kube_vip }}
+                  - name: vip_subnet
+                    value: "{{ admin_netmask_bits }}"
+                  - name: prometheus_server
+                    value: :2112
+                  image: ghcr.io/kube-vip/kube-vip:v{{ kube_vip_version }}
+                  imagePullPolicy: IfNotPresent
+                  name: kube-vip
+                  resources: {}
+                  securityContext:
+                    capabilities:
+                      add:
+                      - NET_ADMIN
+                      - NET_RAW
+                  volumeMounts:
+                  - mountPath: /etc/kubernetes/admin.conf
+                    name: kubeconfig
+                hostAliases:
+                - hostnames:
+                  - kubernetes
+                  ip: 127.0.0.1
+                hostNetwork: true
+                dnsPolicy: ClusterFirstWithHostNet
+                volumes:
+                - hostPath:
+                    path: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              status: {}
+
+        # ── Chicken-and-egg fix: temporarily use node IP ─────────────────
+        - name: Temporarily point admin.conf to node IP
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.replace:
+            path: /etc/kubernetes/admin.conf
+            regexp: 'server: https://[^:]+:6443'
+            replace: "server: https://{{ node_ip }}:6443"
+
+        # ── Replace manifest — kubelet auto-restarts the pod ─────────────
+        - name: Replace kube-vip manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.copy:
+            src: /tmp/kube-vip-upgrade.yaml
+            dest: /etc/kubernetes/manifests/kube-vip.yaml
+            remote_src: true
+            mode: "0644"
+
+        - name: Wait for new kube-vip pod to start
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              crictl ps --name kube-vip -o json |
+              python3 -c "import sys,json;
+              c=json.load(sys.stdin).get('containers',[]);
+              print(c[0]['state'] if c else 'missing')"
+            executable: /bin/bash
+          register: _kube_vip_status
+          changed_when: false
+          retries: 30
+          delay: 5
+          until: _kube_vip_status.stdout | trim == 'CONTAINER_RUNNING'
+
+        - name: Verify VIP is reachable (API server responds via VIP) # noqa: command-instead-of-module command-instead-of-shell
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              curl -sk --connect-timeout 3
+              https://{{ kube_vip }}:6443/healthz
+          register: _vip_check
+          changed_when: false
+          retries: 12
+          delay: 5
+          until: _vip_check.stdout | default('') == 'ok'
+
+        # ── Restore admin.conf to VIP ────────────────────────────────────
+        - name: Restore admin.conf to VIP address
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.replace:
+            path: /etc/kubernetes/admin.conf
+            regexp: 'server: https://[^:]+:6443'
+            replace: "server: https://{{ kube_vip }}:6443"
+
+        # Grep specifically for the version banner (not head -1) and retry
+        # until it reports the target version. This doubles as a stabilization
+        # gate: a pod that briefly starts then crash-loops logs a transient
+        # "level=fatal" line, which head -1 could mistake for the result.
+        - name: Verify kube-vip is running the target version
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              crictl ps --name kube-vip -q | head -1 |
+              xargs crictl logs 2>&1 |
+              grep -oE 'kube-vip.io version=v[0-9]+\.[0-9]+\.[0-9]+' |
+              head -1
+            executable: /bin/bash
+          register: _kube_vip_log
+          changed_when: false
+          retries: 12
+          delay: 5
+          until: >-
+            ('version=v' + kube_vip_target_version) in (_kube_vip_log.stdout | default(''))
+
+        # ── Verify API is reachable via VIP before moving to next node ───
+        - name: Verify API server reachable via VIP
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.command:
+            cmd: >-
+              kubectl --kubeconfig /etc/kubernetes/admin.conf get --raw /healthz
+          register: _api_health
+          changed_when: false
+          retries: 12
+          delay: 5
+          until: _api_health.rc == 0
+
+        - name: Display kube-vip upgrade result
+          ansible.builtin.debug:
+            msg: >-
+              kube-vip upgraded on {{ node_ip }}:
+              {{ _kube_vip_log.stdout | default('version not detected') | trim }}
+
+        - name: Clean up temp manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.file:
+            path: /tmp/kube-vip-upgrade.yaml
+            state: absent

--- a/upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml
@@ -1,0 +1,274 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# ============================================================================
+# step_kube_vip_upgrade.yml - Upgrade kube-vip static pod on a control plane
+# ============================================================================
+# kube-vip runs as a static pod managed by kubelet, not a DaemonSet.
+# Upgrade = replace /etc/kubernetes/manifests/kube-vip.yaml on each CP node.
+#
+# Chicken-and-egg problem:
+#   When the old kube-vip pod dies, the VIP goes away. The new pod reads
+#   admin.conf which points to the VIP for leader election, so it cannot
+#   start. Fix: temporarily point admin.conf to the node's real IP, let
+#   kube-vip start and advertise the VIP, then restore admin.conf.
+#
+# Variables required (set by load_version_vars.yml / detect_addon_versions.yml):
+#   - kube_vip_target_version  (e.g. "1.2.2")
+#   - kube_vip                 (VIP address, e.g. "10.40.5.176")
+#   - node_ip                  (real IP of the CP node being upgraded)
+#   - node_hostname            (inventory hostname, e.g. "k8scp2")
+#   - backup_dir               (path to store manifest backup)
+#
+# All tasks that touch the node run with delegate_to: "{{ node_hostname }}"
+# to ensure SSH connection from the inventory is used (not connection: local).
+# ============================================================================
+
+- name: Check if kube-vip manifest exists
+  delegate_to: "{{ node_hostname }}"
+  ansible.builtin.stat:
+    path: /etc/kubernetes/manifests/kube-vip.yaml
+  register: _kube_vip_manifest_stat
+
+- name: Skip if manifest not found (not a control plane node)
+  ansible.builtin.debug:
+    msg: "No kube-vip manifest found on {{ node_ip }} — skipping"
+  when: not _kube_vip_manifest_stat.stat.exists
+
+- name: Upgrade kube-vip on {{ node_ip }}
+  when: _kube_vip_manifest_stat.stat.exists
+  block:
+    - name: Read current kube-vip manifest
+      delegate_to: "{{ node_hostname }}"
+      ansible.builtin.slurp:
+        path: /etc/kubernetes/manifests/kube-vip.yaml
+      register: _kube_vip_current
+
+    - name: Check if already at target version
+      ansible.builtin.set_fact:
+        _kube_vip_needs_upgrade: >-
+          {{ 'ghcr.io/kube-vip/kube-vip:v' + kube_vip_target_version
+             not in (_kube_vip_current.content | b64decode) }}
+
+    - name: Skip if already at target version
+      ansible.builtin.debug:
+        msg: "kube-vip on {{ node_ip }} already at v{{ kube_vip_target_version }} — skipping"
+      when: not (_kube_vip_needs_upgrade | bool)
+
+    - name: Perform kube-vip upgrade on {{ node_ip }}
+      when: _kube_vip_needs_upgrade | bool
+      block:
+        - name: Backup current kube-vip manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.copy:
+            src: /etc/kubernetes/manifests/kube-vip.yaml
+            dest: "{{ backup_dir }}/kube-vip-{{ node_ip }}-pre-upgrade.yaml"
+            remote_src: true
+            mode: "0644"
+
+        # ── Detect network facts (same approach as provision cloud-init) ──
+        - name: Detect VIP interface from node IP
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              ip -o addr show |
+              awk -v ip="{{ node_ip }}" '$4 ~ ip {print $2}'
+          register: _vip_interface
+          changed_when: false
+
+        # ── Set facts matching provision template variables ──────────────
+        # admin_netmask_bits comes from network_data.admin_network.netmask_bits
+        # (same source as provision/roles/k8s_config create_k8s_config_nfs.yml)
+        - name: Set kube-vip template facts
+          ansible.builtin.set_fact:
+            kube_vip_interface: "{{ _vip_interface.stdout | trim }}"
+            admin_netmask_bits: "{{ hostvars['localhost']['admin_netmask_bits'] }}"
+            kube_vip_version: "{{ kube_vip_target_version }}"
+
+        # ── Generate new manifest (same structure as provision template) ──
+        - name: Write upgraded kube-vip manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.copy:
+            dest: /tmp/kube-vip-upgrade.yaml
+            mode: "0644"
+            content: |
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                creationTimestamp: null
+                name: kube-vip
+                namespace: kube-system
+                uid: kube-vip-pod
+              spec:
+                containers:
+                - args:
+                  - manager
+                  env:
+                  - name: vip_arp
+                    value: "true"
+                  - name: port
+                    value: "6443"
+                  - name: vip_nodename
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  - name: vip_interface
+                    value: {{ kube_vip_interface }}
+                  - name: vip_cidr
+                    value: "{{ admin_netmask_bits }}"
+                  - name: dns_mode
+                    value: first
+                  - name: cp_enable
+                    value: "true"
+                  - name: cp_namespace
+                    value: kube-system
+                  - name: svc_enable
+                    value: "true"
+                  - name: svc_leasename
+                    value: plndr-svcs-lock
+                  - name: vip_leaderelection
+                    value: "true"
+                  - name: vip_leasename
+                    value: plndr-cp-lock
+                  - name: vip_leaseduration
+                    value: "5"
+                  - name: vip_renewdeadline
+                    value: "3"
+                  - name: vip_retryperiod
+                    value: "1"
+                  - name: address
+                    value: {{ kube_vip }}
+                  - name: vip_subnet
+                    value: "{{ admin_netmask_bits }}"
+                  - name: prometheus_server
+                    value: :2112
+                  image: ghcr.io/kube-vip/kube-vip:v{{ kube_vip_version }}
+                  imagePullPolicy: IfNotPresent
+                  name: kube-vip
+                  resources: {}
+                  securityContext:
+                    capabilities:
+                      add:
+                      - NET_ADMIN
+                      - NET_RAW
+                  volumeMounts:
+                  - mountPath: /etc/kubernetes/admin.conf
+                    name: kubeconfig
+                hostAliases:
+                - hostnames:
+                  - kubernetes
+                  ip: 127.0.0.1
+                hostNetwork: true
+                dnsPolicy: ClusterFirstWithHostNet
+                volumes:
+                - hostPath:
+                    path: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              status: {}
+
+        # ── Chicken-and-egg fix: temporarily use node IP ─────────────────
+        - name: Temporarily point admin.conf to node IP
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.replace:
+            path: /etc/kubernetes/admin.conf
+            regexp: 'server: https://[^:]+:6443'
+            replace: "server: https://{{ node_ip }}:6443"
+
+        # ── Replace manifest — kubelet auto-restarts the pod ─────────────
+        - name: Replace kube-vip manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.copy:
+            src: /tmp/kube-vip-upgrade.yaml
+            dest: /etc/kubernetes/manifests/kube-vip.yaml
+            remote_src: true
+            mode: "0644"
+
+        - name: Wait for new kube-vip pod to start
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              crictl ps --name kube-vip -o json |
+              python3 -c "import sys,json;
+              c=json.load(sys.stdin).get('containers',[]);
+              print(c[0]['state'] if c else 'missing')"
+          register: _kube_vip_status
+          changed_when: false
+          retries: 30
+          delay: 5
+          until: _kube_vip_status.stdout | trim == 'CONTAINER_RUNNING'
+
+        - name: Verify VIP is reachable (API server responds via VIP)
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              curl -sk --connect-timeout 3
+              https://{{ kube_vip }}:6443/healthz
+          register: _vip_check
+          changed_when: false
+          retries: 12
+          delay: 5
+          until: _vip_check.stdout | default('') == 'ok'
+
+        # ── Restore admin.conf to VIP ────────────────────────────────────
+        - name: Restore admin.conf to VIP address
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.replace:
+            path: /etc/kubernetes/admin.conf
+            regexp: 'server: https://[^:]+:6443'
+            replace: "server: https://{{ kube_vip }}:6443"
+
+        # Grep specifically for the version banner (not head -1) and retry
+        # until it reports the target version. This doubles as a stabilization
+        # gate: a pod that briefly starts then crash-loops logs a transient
+        # "level=fatal" line, which head -1 could mistake for the result.
+        - name: Verify kube-vip is running the target version
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              crictl ps --name kube-vip -q | head -1 |
+              xargs crictl logs 2>&1 |
+              grep -oE 'kube-vip.io version=v[0-9]+\.[0-9]+\.[0-9]+' |
+              head -1
+            executable: /bin/bash
+          register: _kube_vip_log
+          changed_when: false
+          retries: 12
+          delay: 5
+          until: >-
+            ('version=v' + kube_vip_target_version) in (_kube_vip_log.stdout | default(''))
+
+        # ── Verify API is reachable via VIP before moving to next node ───
+        - name: Verify API server reachable via VIP
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.command:
+            cmd: >-
+              kubectl --kubeconfig /etc/kubernetes/admin.conf get --raw /healthz
+          register: _api_health
+          changed_when: false
+          retries: 12
+          delay: 5
+          until: _api_health.rc == 0
+
+        - name: Display kube-vip upgrade result
+          ansible.builtin.debug:
+            msg: >-
+              kube-vip upgraded on {{ node_ip }}:
+              {{ _kube_vip_log.stdout | default('version not detected') | trim }}
+
+        - name: Clean up temp manifest
+          delegate_to: "{{ node_hostname }}"
+          ansible.builtin.file:
+            path: /tmp/kube-vip-upgrade.yaml
+            state: absent

--- a/upgrade/roles/upgrade_k8s/tasks/upgrade_addons.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/upgrade_addons.yml
@@ -23,6 +23,129 @@
         status: in_progress
         started_at: "{{ now(utc=true).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
 
+# ── kube-vip upgrade (ABORT on failure) ────────────────────────────
+# kube-vip MUST be upgraded BEFORE other addons because it provides
+# the VIP that all kubectl commands are delegated through.
+# Unlike Calico/MetalLB (cluster-wide kubectl apply), kube-vip runs
+# as a static pod and must be upgraded per-node on each control plane.
+- name: Starting kube-vip upgrade
+  ansible.builtin.debug:
+    msg: "Starting kube-vip upgrade from {{ kube_vip_from_version | default('unknown') }} to {{ kube_vip_target_version }}..."
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+
+- name: Mark kube-vip in_progress
+  ansible.builtin.include_tasks: update_addon_step.yml
+  vars:
+    addon_name: kube_vip
+    addon_status_update:
+      status: in_progress
+      current_version: "{{ kube_vip_current_version }}"
+      from_version: "{{ kube_vip_from_version | default('unknown') }}"
+      target_version: "{{ kube_vip_target_version }}"
+      timestamp: "{{ now(utc=true).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+
+- name: Build list of control plane nodes for kube-vip upgrade
+  ansible.builtin.set_fact:
+    _cp_node_list: >-
+      {{ upgrade_status.nodes | dict2items
+         | selectattr('value.role', 'in', ['control_plane_first', 'control_plane'])
+         | list }}
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+
+# This role runs under `hosts: localhost, connection: local`. delegate_to
+# only connects over SSH when the target host has `ansible_connection: ssh`
+# set in the inventory; otherwise it inherits connection: local and runs on
+# the controller. Register each CP node explicitly so step_kube_vip_upgrade.yml
+# can delegate to hostnames over SSH.
+- name: Register control plane nodes for SSH delegation (kube-vip upgrade)
+  ansible.builtin.add_host:
+    name: "{{ item.key }}"
+    ansible_host: "{{ item.value.ip }}"
+    ansible_connection: ssh
+    ansible_user: root
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    groups: _kube_vip_upgrade_targets
+  loop: "{{ _cp_node_list }}"
+  loop_control:
+    label: "{{ item.key }} ({{ item.value.ip }})"
+  changed_when: false
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+
+# ── Detect VIP leader so we upgrade non-leader nodes first ────────
+# The VIP leader holds the virtual IP. Upgrading it last keeps the
+# API server reachable through the VIP for as long as possible.
+- name: Get kube-vip leader lease for upgrade ordering
+  ansible.builtin.command:
+    cmd: >-
+      kubectl get lease plndr-cp-lock -n kube-system
+      -o jsonpath='{.spec.holderIdentity}'
+  delegate_to: "{{ kube_vip }}"
+  register: _upgrade_vip_leader
+  changed_when: false
+  failed_when: false
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+
+- name: Set VIP leader IP for upgrade ordering
+  ansible.builtin.set_fact:
+    _vip_leader_ip: "{{ _upgrade_vip_leader.stdout | default('') | trim }}"
+  when:
+    - (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+    - _upgrade_vip_leader.rc | default(1) == 0
+
+- name: Reorder CP list — VIP leader last
+  ansible.builtin.set_fact:
+    _cp_node_list: >-
+      {{ (_cp_node_list | rejectattr('value.ip', 'equalto', _vip_leader_ip) | list)
+         + (_cp_node_list | selectattr('value.ip', 'equalto', _vip_leader_ip) | list) }}
+  when:
+    - (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+    - _vip_leader_ip | default('') | length > 0
+
+- name: Display kube-vip upgrade order
+  ansible.builtin.debug:
+    msg: >-
+      kube-vip upgrade order: {{ _cp_node_list | map(attribute='value.ip') | list | join(' -> ') }}
+      (VIP leader {{ _vip_leader_ip | default('unknown') }} upgraded last)
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+
+- name: Upgrade kube-vip
+  when: (upgrade_status.addon_upgrade.kube_vip.status | default('pending')) != 'completed'
+  block:
+    - name: Execute kube-vip upgrade on each control plane
+      ansible.builtin.include_tasks: step_kube_vip_upgrade.yml
+      vars:
+        node_ip: "{{ _cp_item.value.ip }}"
+        node_hostname: "{{ _cp_item.key }}"
+      loop: "{{ _cp_node_list }}"
+      loop_control:
+        loop_var: _cp_item
+        label: "{{ _cp_item.key }} ({{ _cp_item.value.ip }})"
+
+    - name: Mark kube-vip completed
+      ansible.builtin.include_tasks: update_addon_step.yml
+      vars:
+        addon_name: kube_vip
+        addon_status_update:
+          status: completed
+          current_version: "{{ kube_vip_target_version }}"
+          from_version: "{{ kube_vip_from_version | default('unknown') }}"
+          to_version: "{{ kube_vip_target_version }}"
+          timestamp: "{{ now(utc=true).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          error:
+  rescue:
+    - name: Mark kube-vip failed
+      ansible.builtin.include_tasks: update_addon_step.yml
+      vars:
+        addon_name: kube_vip
+        addon_status_update:
+          status: failed
+          timestamp: "{{ now(utc=true).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+
+    - name: ABORT — kube-vip upgrade failed
+      ansible.builtin.fail:
+        msg: "{{ msg_addon_kube_vip_failed }}"
+
 # ── Calico upgrade (ABORT on failure) ──────────────────────────────
 - name: Starting Calico upgrade
   ansible.builtin.debug:

--- a/upgrade/roles/upgrade_k8s/vars/main.yml
+++ b/upgrade/roles/upgrade_k8s/vars/main.yml
@@ -193,6 +193,10 @@ msg_backup_missing: >-
 msg_node_upgrade_failed: >-
   Node {{ current_node_name }} failed at step {{ current_step }}.
   Error: {{ step_result.stderr | default(step_result.msg | default('unknown')) }}
+msg_addon_kube_vip_failed: >-
+  kube-vip upgrade failed. VIP may be unavailable.
+  Do NOT proceed to further addon upgrades.
+  Check /etc/kubernetes/manifests/kube-vip.yaml on each control plane node.
 msg_addon_calico_failed: >-
   Calico upgrade failed. Networking may be degraded.
   Do NOT proceed to worker upgrades.

--- a/upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml
+++ b/upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml
@@ -95,14 +95,13 @@
     name: "{{ pulp_container_name }}"
     command: pulpcore-manager migrate --noinput
   register: pulp_migrate_result
-  retries: 3
-  delay: 10
+  retries: 40
+  delay: 15
   until: pulp_migrate_result.rc == 0
   delegate_to: oim
   delegate_facts: true
   connection: ssh
-  failed_when: false
 
 - name: Display migration result
   ansible.builtin.debug:
-    msg: "Database migration: {{ 'completed' if pulp_migrate_result.rc | default(1) == 0 else 'skipped or not required' }}"
+    msg: "Database migration: {{ 'completed successfully' if pulp_migrate_result.rc == 0 else 'FAILED (rc=' ~ pulp_migrate_result.rc | string ~ ')' }}"

--- a/upgrade/roles/upgrade_pulp/vars/main.yml
+++ b/upgrade/roles/upgrade_pulp/vars/main.yml
@@ -46,6 +46,8 @@ pull_image_retries: 5
 pull_image_delay: 10
 
 # Pulp startup and health check settings
+# Note: First startup after upgrade runs pg_upgrade (PG 13→16) + Django migrations,
+# which can take 5-10 minutes. The total wait budget must cover this one-time operation.
 pulp_startup_retries: 10
 pulp_startup_delay: 10
 pulp_init_wait: 30


### PR DESCRIPTION
## Summary
This PR adds kube-vip upgrade support to the K8s addon upgrade workflow, fixes the Calico pod
validation namespace, and improves Pulp migration reliability during container upgrades.

## Changes

### Add kube-vip upgrade support for K8s addon upgrades
- Detect kube-vip version from static pod manifest on each control plane node using SSH delegation,
  since CRI-O stores images by digest without tags
- Extract `kube_vip_target_version` from `service_k8s.json`
- Add `kube_vip` status tracking in upgrade status structure
- Upgrade kube-vip per-node with VIP leader upgraded last to maintain availability
- Abort addon upgrades on kube-vip failure since VIP is critical for kubectl connectivity
- Add kube-vip pod validation in addon validation step
- Add `msg_addon_kube_vip_failed` error message for failure reporting

### Fix Calico pod validation namespace in post_validation
- Changed Calico pod check from `calico-system` namespace to `kube-system` with label selector
  `k8s-app=calico-node`
- Aligns with the actual Calico deployment namespace in the cluster

### Increase Pulp migration retries and enforce failure handling
- Increase migration retries from 3 to 40 and delay from 10s to 15s to accommodate `pg_upgrade`
  (PG 13->16) and Django migrations which can take 5-10 minutes on first startup after upgrade
- Remove `failed_when: false` so migration failures are properly caught
- Update migration result message to show return code on failure
- Add explanatory comment for startup timeout budget

## Files Changed
- `upgrade/roles/upgrade_k8s/tasks/detect_addon_versions.yml`
- `upgrade/roles/upgrade_k8s/tasks/load_status.yml`
- `upgrade/roles/upgrade_k8s/tasks/load_version_vars.yml`
- `upgrade/roles/upgrade_k8s/tasks/post_validation.yml`
- `upgrade/roles/upgrade_k8s/tasks/step_addon_validation.yml`
- `upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml` *(new)*
- `upgrade/roles/upgrade_k8s/tasks/upgrade_addons.yml`
- `upgrade/roles/upgrade_k8s/vars/main.yml`
- `upgrade/roles/upgrade_pulp/tasks/upgrade_pulp_container.yml`
- `upgrade/roles/upgrade_pulp/vars/main.yml`
