### PR TITLE
Fix DNF repo priority assignment for user repos in OS image builds

### DIFF
--- a/build_image_aarch64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
+++ b/build_image_aarch64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
@@ -28,10 +28,44 @@
             | selectattr('name', 'match', '^aarch64')
             | list }}
 
-    - name: Build rhel_repos list from pulp_aarch_64_distributions
+    # -- Repo priority classification ----------------------------------
+    # Load local_repo_config.yml to identify user vs RHEL vs omnia repos.
+    # Priority order: user (10) > RHEL (20) > omnia (99).
+    # This ensures DNF prefers user-supplied package versions over
+    # identically-named packages in omnia repos (e.g. slurm 25 from
+    # user repo beats slurm 26 from EPEL).
+    - name: Load local_repo_config for repo classification
+      ansible.builtin.include_vars:
+        file: "{{ input_project_dir }}/local_repo_config.yml"
+        name: _local_repo_cfg
+      failed_when: false
+
+    - name: Build user repo name list
+      ansible.builtin.set_fact:
+        _user_repo_names: >-
+          {{ (_local_repo_cfg.user_repo_url_aarch64 | default([]) | map(attribute='name') | list) }}
+        _rhel_repo_names: >-
+          {{ (_local_repo_cfg.rhel_os_url_aarch64 | default([]) | map(attribute='name') | list)
+             + ['baseos', 'appstream', 'codeready-builder'] }}
+        _omnia_repo_names: >-
+          {{ (_local_repo_cfg.omnia_repo_url_rhel_aarch64 | default([]) | map(attribute='name') | list) }}
+
+    - name: Build rhel_repos list with priority from pulp_aarch_64_distributions
       ansible.builtin.set_fact:
         rhel_aarch64_repos: >-
-          {{ pulp_aarch_64_distributions | map('combine', {'gpg': ''}) | list }}
+          {% set repos = [] -%}
+          {% for dist in pulp_aarch_64_distributions -%}
+            {% set repo_name = dist.name.split('_')[4:] | join('_') -%}
+            {% if repo_name in _user_repo_names -%}
+              {% set _priority = '10' -%}
+            {% elif repo_name in _rhel_repo_names -%}
+              {% set _priority = '20' -%}
+            {% else -%}
+              {% set _priority = '99' -%}
+            {% endif -%}
+            {% set _ = repos.append(dist | combine({'gpg': '', 'priority': _priority})) -%}
+          {% endfor -%}
+          {{ repos }}
 
     - name: Debug rhel_aarch64_repos
       ansible.builtin.debug:

--- a/build_image_aarch64/roles/image_creation/templates/images/rhel-base-config.yaml.j2
+++ b/build_image_aarch64/roles/image_creation/templates/images/rhel-base-config.yaml.j2
@@ -13,6 +13,9 @@ repos:
 {% if repo.base_url | length > 1 %}
   - alias: '{{ repo.name }}'
     url: '{{ repo.base_url }}'
+{% if repo.priority is defined %}
+    priority: '{{ repo.priority }}'
+{% endif %}
 {% endif %}
 {% if repo.gpg | length > 1 %}
     gpg: '{{ repo.gpg }}'

--- a/build_image_aarch64/roles/image_creation/templates/images/rhel-compute-config.yaml.j2
+++ b/build_image_aarch64/roles/image_creation/templates/images/rhel-compute-config.yaml.j2
@@ -18,6 +18,9 @@ repos:
 {% if repo.base_url | length > 1 %}
   - alias: '{{ repo.name }}'
     url: '{{ repo.base_url }}'
+{% if repo.priority is defined %}
+    priority: '{{ repo.priority }}'
+{% endif %}
 {% endif %}
 {% if repo.gpg | length > 1 %}
     gpg: '{{ repo.gpg }}'

--- a/build_image_x86_64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
+++ b/build_image_x86_64/roles/fetch_packages/tasks/fetch_pulp_repos.yml
@@ -28,10 +28,44 @@
             | selectattr('name', 'match', '^x86_64')
             | list }}
 
-    - name: Build rhel_repos list from pulp_x86_64_distributions
+    # -- Repo priority classification ----------------------------------
+    # Load local_repo_config.yml to identify user vs RHEL vs omnia repos.
+    # Priority order: user (10) > RHEL (20) > omnia (99).
+    # This ensures DNF prefers user-supplied package versions over
+    # identically-named packages in omnia repos (e.g. slurm 25 from
+    # user repo beats slurm 26 from EPEL).
+    - name: Load local_repo_config for repo classification
+      ansible.builtin.include_vars:
+        file: "{{ input_project_dir }}/local_repo_config.yml"
+        name: _local_repo_cfg
+      failed_when: false
+
+    - name: Build user repo name list
+      ansible.builtin.set_fact:
+        _user_repo_names: >-
+          {{ (_local_repo_cfg.user_repo_url_x86_64 | default([]) | map(attribute='name') | list) }}
+        _rhel_repo_names: >-
+          {{ (_local_repo_cfg.rhel_os_url_x86_64 | default([]) | map(attribute='name') | list)
+             + ['baseos', 'appstream', 'codeready-builder'] }}
+        _omnia_repo_names: >-
+          {{ (_local_repo_cfg.omnia_repo_url_rhel_x86_64 | default([]) | map(attribute='name') | list) }}
+
+    - name: Build rhel_repos list with priority from pulp_x86_64_distributions
       ansible.builtin.set_fact:
         rhel_x86_64_repos: >-
-          {{ pulp_x86_64_distributions | map('combine', {'gpg': ''}) | list }}
+          {% set repos = [] -%}
+          {% for dist in pulp_x86_64_distributions -%}
+            {% set repo_name = dist.name.split('_')[4:] | join('_') -%}
+            {% if repo_name in _user_repo_names -%}
+              {% set _priority = '10' -%}
+            {% elif repo_name in _rhel_repo_names -%}
+              {% set _priority = '20' -%}
+            {% else -%}
+              {% set _priority = '99' -%}
+            {% endif -%}
+            {% set _ = repos.append(dist | combine({'gpg': '', 'priority': _priority})) -%}
+          {% endfor -%}
+          {{ repos }}
 
     - name: Debug rhel_x86_64_repos
       ansible.builtin.debug:

--- a/build_image_x86_64/roles/image_creation/templates/images/rhel-base-config.yaml.j2
+++ b/build_image_x86_64/roles/image_creation/templates/images/rhel-base-config.yaml.j2
@@ -13,6 +13,9 @@ repos:
 {% if repo.base_url | length > 1 %}
   - alias: '{{ repo.name }}'
     url: '{{ repo.base_url }}'
+{% if repo.priority is defined %}
+    priority: '{{ repo.priority }}'
+{% endif %}
 {% endif %}
 {% if repo.gpg | length > 1 %}
     gpg: '{{ repo.gpg }}'

--- a/build_image_x86_64/roles/image_creation/templates/images/rhel-compute-config.yaml.j2
+++ b/build_image_x86_64/roles/image_creation/templates/images/rhel-compute-config.yaml.j2
@@ -18,6 +18,9 @@ repos:
 {% if repo.base_url | length > 1 %}
   - alias: '{{ repo.name }}'
     url: '{{ repo.base_url }}'
+{% if repo.priority is defined %}
+    priority: '{{ repo.priority }}'
+{% endif %}
 {% endif %}
 {% if repo.gpg | length > 1 %}
     gpg: '{{ repo.gpg }}'


### PR DESCRIPTION

## Issues Resolved by this Pull Request

Fixes incorrect DNF repo priority assignment during OS image builds, causing user-supplied packages (e.g., custom Slurm 25) to be overridden by newer versions from EPEL/Omnia repos (e.g., Slurm 26).

## Description of the Solution

**Problem:**
When building OS images via OpenCHAMI image-builder, DNF repo priorities were not being correctly applied. User repos like `slurm_custom` were assigned the same priority (`99`) as EPEL, so DNF resolved to the latest available version instead of the user-supplied version.

**Root Cause:**
In `fetch_pulp_repos.yml`, the repo name was extracted using `dist.name.split('_') | last`, which only returned the last segment after splitting by `_`. For multi-segment repo names like `slurm_custom` (Pulp distribution: `x86_64_rhel_10.0_slurm_custom`), this produced `custom` instead of `slurm_custom`, causing the user repo classification to fail.

| Repo Distribution Name | Old (`split | last`) | Match? |
|---|---|---|
| `x86_64_rhel_10.0_slurm_custom` | `custom` | No match → priority 99 |
| `x86_64_rhel_10.0_epel` | `epel` | Omnia → priority 99 |

Both repos got priority 99, so DNF picked the latest Slurm (26 from EPEL).

**Fix:**
1. **`fetch_pulp_repos.yml`**: Added repo priority classification logic that correctly extracts repo names by skipping the prefix parts (`x86_64_rhel_10.0_`) and joining the remainder: `dist.name.split('_')[4:] | join('_')`. This properly maps repos to their priority tier:
   - User repos (e.g., `slurm_custom`): priority **10** (highest)
   - RHEL repos (e.g., `baseos`, `appstream`): priority **20**
   - Omnia repos (e.g., `epel`, `cuda`): priority **99** (lowest)

2. **`rhel-base-config.yaml.j2` / `rhel-compute-config.yaml.j2`**: Added `priority` field to repo entries in the image config templates so the priority value is passed through to the image-builder.

