### PR TITLE
Fix for OS Command Injection Vulnerability in local_repo

### DIFF
--- a/common/library/module_utils/input_validation/schema/local_repo_config.json
+++ b/common/library/module_utils/input_validation/schema/local_repo_config.json
@@ -83,7 +83,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(?!\\s*$).+"
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._-]+$"
           },
           "policy": {
             "type": "string",
@@ -219,7 +220,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(?!\\s*$).+"
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._-]+$"
           },
           "policy": {
             "type": "string",
@@ -355,7 +357,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(?!\\s*$).+"
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._-]+$"
           },
           "policy": {
             "type": "string",
@@ -491,7 +494,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(?!\\s*$).+"
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._-]+$"
           },
           "policy": {
             "type": "string",
@@ -644,7 +648,8 @@
           },
           "name": {
             "type": "string",
-            "pattern": "^(?!\\s*$).+",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "maxLength": 64,
             "minLength": 1
           },
           "policy": {
@@ -780,7 +785,8 @@
           },
           "name": {
             "type": "string",
-            "pattern": "^(?!\\s*$).+",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "maxLength": 64,
             "minLength": 1
           },
           "policy": {
@@ -898,7 +904,8 @@
           },
           "name": {
             "type": "string",
-            "pattern": "^(?!\\s*$).+",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "maxLength": 64,
             "minLength": 1
           },
           "sslcacert": {
@@ -1027,7 +1034,8 @@
           },
           "name": {
             "type": "string",
-            "pattern": "^(?!\\s*$).+",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "maxLength": 64,
             "minLength": 1
           },
           "sslcacert": {
@@ -1157,7 +1165,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(?!\\s*$).+"
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._-]+$"
           },
           "policy": {
             "type": "string",
@@ -1215,7 +1224,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(?!\\s*$).+"
+            "maxLength": 64,
+            "pattern": "^[A-Za-z0-9._-]+$"
           },
           "policy": {
             "type": "string",

--- a/common/library/module_utils/local_repo/parse_and_download.py
+++ b/common/library/module_utils/local_repo/parse_and_download.py
@@ -21,6 +21,7 @@ and repository operations used across the local repo management system.
 
 import os
 import subprocess
+import shlex
 import json
 import re
 from multiprocessing import Lock
@@ -57,12 +58,13 @@ def execute_command(cmd_string, logger, type_json=False):
         logger.info(f"Executing command: {safe_cmd_string}")
 
         # Run the command
+        cmd_list = shlex.split(cmd_string)
         cmd = subprocess.run(
-            cmd_string,
+            cmd_list,
             universal_newlines=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            shell=True,
+            shell=False,
         )
         status["returncode"] = cmd.returncode
         status["stdout"] = cmd.stdout.strip() if cmd.stdout else None

--- a/common/library/modules/pulp_cleanup.py
+++ b/common/library/modules/pulp_cleanup.py
@@ -29,6 +29,7 @@ import glob
 import json
 import shutil
 import subprocess
+import shlex
 import re
 import yaml
 from typing import Dict, List, Any, Tuple
@@ -92,7 +93,8 @@ def format_pretty_table(results: List[Dict[str, Any]]) -> str:
 def run_cmd(cmd: str, logger) -> Dict[str, Any]:
     """Execute shell command and return result."""
     try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=300)
+        cmd_list = shlex.split(cmd)
+        result = subprocess.run(cmd_list, shell=False, capture_output=True, text=True, timeout=300)
         return {"rc": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
     except (subprocess.SubprocessError, OSError) as e:
         logger.error(f"Command failed: {cmd} - {e}")


### PR DESCRIPTION
## PR: Fix OS Command Injection (GHSA-qq9v-3f7q-9437)

Eliminates all remaining `shell=True` subprocess calls and strengthens input validation to prevent arbitrary command execution via malicious repository names.

### Changes
- **[parse_and_download.py](cci:7://file:///local_share/omnia/staging_fixes/omnia/common/library/module_utils/local_repo/parse_and_download.py:0:0-0:0)** / **[pulp_cleanup.py](cci:7://file:///local_share/omnia/staging_fixes/omnia/common/library/modules/pulp_cleanup.py:0:0-0:0)**: Replaced `shell=True` with `shlex.split()` + `shell=False`
- **[local_repo_config.json](cci:7://file:///local_share/omnia/staging_fixes/omnia/common/library/module_utils/input_validation/schema/local_repo_config.json:0:0-0:0)**: Hardened all `name` field regex from `^(?!\\s*$).+` → `^[A-Za-z0-9._-]+$` with `maxLength: 64`

**Severity**: High (CWE-78) | **Advisory**: GHSA-qq9v-3f7q-9437
