### PR TITLE
fix(openchami): rebuild RPM with correct image tags in quadlets

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/files/openchami-0.1.7-1.noarch.tar.gz
+++ b/prepare_oim/roles/deploy_containers/openchami/files/openchami-0.1.7-1.noarch.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c4eaa990b4d51381198f702d61504aa86cc379e63eeb083c57e3cae011d168e9
-size 16024
+oid sha256:6be06242fc4c6d14c16fc44c2d259193eb3bf2ef7673dc75350a0e491f6b64e2
+size 15984


### PR DESCRIPTION
## Problem
 
BSS returns HTTP 503 (Service Unavailable) during OpenCHAMI startup because the RPM quadlet files reference image tags that do not exist on Dell Docker Hub.
 
### Root Cause
 
When images were rebuilt with upstream PR fixes (second round), tags were bumped but the release quadlet files were not updated before rebuilding the RPM. The RPM installed quadlets pointing to non-existent image tags:
 
| Component | Quadlet in RPM (broken) | Image on Docker Hub (actual) |
|-----------|------------------------|------------------------------|
| bss | v1.32.3 | v1.32.4 |
| smd | v2.20.5 | v2.20.6 |
| opaal | v0.3.13 | v0.3.14 |
| cloud-init | v1.4.8 | v1.4.9 |
 
## Fix
 
Updated all quadlet files in the release repo to match the actual Dell Docker Hub image tags and rebuilt the RPM tarball (`openchami-0.1.7-1.noarch.tar.gz`).
 
## Testing
 
- Verified quadlet image tags match Dell Docker Hub
- RPM rebuilt and tarball replaced


Feedback submitted