### PR TITLE
fix(openchami): rebuild RPM from correct source tree (openchami/release)

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/files/openchami-0.1.7-1.noarch.tar.gz
+++ b/prepare_oim/roles/deploy_containers/openchami/files/openchami-0.1.7-1.noarch.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6be06242fc4c6d14c16fc44c2d259193eb3bf2ef7673dc75350a0e491f6b64e2
-size 15984
+oid sha256:15f8e7e5c6623f6c966a64a7784c0ffd303e4c7bc87613abb81a8cc050005e07
+size 13818


### PR DESCRIPTION
## Summary
- Rebuilt openchami-0.1.7 RPM from `openchami/release/` instead of `release/`
- The previous RPM shipped an incomplete tokensmith-based architecture that conflicted with the deployed container images (opaal, bss, hydra, cloud-init)
- Fixes: missing podman secrets, missing env vars, wrong gen_access_token, extraneous services (tokensmith, boot-service, metadata-service)

#### Test plan
- [x] Deploy OpenCHAMI via prepare_oim playbook
- [x] Verify all services in openchami.target are green
- [x] Verify `ochami bss service status` succeeds
- [x] Verify `ochami smd service status` succeeds

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>