### PR TITLE
refactor(openchami): remove dead coresmd v0.4.x fallback from coredhcp template

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/templates/coredhcp/coredhcp.yaml.j2
+++ b/prepare_oim/roles/deploy_containers/openchami/templates/coredhcp/coredhcp.yaml.j2
@@ -1,6 +1,3 @@
-{% set coresmd_ver = openchami_coresmd_tag | regex_replace('^v', '') %}
-{% set multisubnet_native = coresmd_ver is version('0.6.0', '>=') %}
-{% set has_additional_subnets = additional_subnets | default([]) | length > 0 %}
 server4:
   listen:
     - "%{{ cluster_boot_interface }}"
@@ -9,8 +6,6 @@ server4:
     - dns: {{ coredhcp_dns_server }}
     - router: {{ coredhcp_router }}
     - netmask: {{ coredhcp_netmask }}
-{% if multisubnet_native %}
-    # Key=value config format (coresmd v0.6.x+)
     - coresmd: |
         svc_base_uri=https://{{ cluster_name }}.{{ cluster_domain }}:8443
         ipxe_base_uri=http://{{ cluster_boot_ip }}:8081
@@ -35,8 +30,3 @@ server4:
 {% set range_parts = s.dynamic_range | split('-') %}
         subnet_pool={{ s.subnet }}/{{ s.netmask_bits }},{{ range_parts[0] }},{{ range_parts[1] }}
 {% endfor %}
-{% else %}
-    # Single-subnet mode: positional argument format (coresmd v0.4.x)
-    - coresmd: https://{{ cluster_name }}.{{ cluster_domain }}:8443 http://{{ cluster_boot_ip }}:8081 /root_ca/root_ca.crt {{ coredhcp_cache_validity }} {{ coredhcp_lease_duration }} {{ coredhcp_tftp_single_port_mode | lower }}
-    - bootloop: /tmp/coredhcp.db {{ coredhcp_custom_ipxe }} {{ coredhcp_tmp_lease_duration }} {{ coredhcp_dhcp_pool }}
-{% endif %}


### PR DESCRIPTION
## Summary
- Remove the `coresmd_ver` / `multisubnet_native` version check from `coredhcp.yaml.j2`
- Remove the dead v0.4.x positional argument fallback (coresmd v0.6.3 is the only version shipped)
- Both single-subnet and multi-subnet deployments work through the same key=value config format

#### Test plan
- [x] Single-subnet deployment verified
- [ ] Multi-subnet deployment verified

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>