### PR TITLE
fix: Allow aarch64_inventory_host_ip to be in a different subnet than OIM admin IP

### DIFF
--- a/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
+++ b/common/library/module_utils/input_validation/common_utils/en_us_validation_msg.py
@@ -702,11 +702,6 @@ BUILD_STREAM_CONFIG_EMPTY_MSG = (
     "build_stream_config.yml file is empty or has syntax errors. "
     "It must contain valid YAML with 'enable_build_stream' field."
 )
-AARCH64_INVENTORY_HOST_IP_INVALID_SUBNET_MSG = (
-    "Field 'aarch64_inventory_host_ip' must be in the same subnet as OIM admin IP. "
-    "Check network_spec.yml for admin network configuration."
-)
-
 AARCH64_INVENTORY_HOST_IP_REQUIRED_MSG = (
     "Field 'aarch64_inventory_host_ip' is required when PXE mapping file "
     "contains aarch64 functional groups. Provide the admin IP of the "

--- a/common/library/module_utils/input_validation/validation_flows/build_stream_validation.py
+++ b/common/library/module_utils/input_validation/validation_flows/build_stream_validation.py
@@ -273,19 +273,6 @@ def validate_build_stream_config(input_file_path, data,
                                           "Invalid IPv4 address format"))
             return errors
 
-        # Check if it's in the same subnet as admin IP
-        try:
-            admin_network = ipaddress.IPv4Network(f"{admin_ip}/{netmask_bits}", strict=False)
-
-            if aarch64_ip not in admin_network:
-                errors.append(create_error_msg(
-                    build_stream_yml,
-                    "aarch64_inventory_host_ip",
-                    msg.AARCH64_INVENTORY_HOST_IP_INVALID_SUBNET_MSG
-                ))
-        except ValueError as e:
-            logger.error("Failed to validate subnet for aarch64_inventory_host_ip: %s", str(e))
-
         # Check aarch64 host IP reachability using socket (safer than subprocess)
         try:
             # Try to connect to SSH port which is usually open on inventory hosts


### PR DESCRIPTION
PR Description

## Problem
The build_stream_config validation rejects `aarch64_inventory_host_ip` values
that are not in the same subnet as the OIM admin IP. This is overly restrictive
since the aarch64 inventory host can legitimately be on a different network.

## Changes
- Removed the subnet validation check (`IPv4Network` membership test) for
  `aarch64_inventory_host_ip` in `build_stream_validation.py`
- Removed the corresponding error message constant
  `AARCH64_INVENTORY_HOST_IP_INVALID_SUBNET_MSG` from `en_us_validation_msg.py`

## What's preserved
- IPv4 address format validation
- SSH reachability check (port 22)
- PXE mapping aarch64 group detection (requiring the field when aarch64 groups exist)

## Testing
- Verified no remaining references to the removed constant across the codebase
- Existing IP format and reachability validations remain functional

@abhishek-sa1 Please review