### PR TITLE
chore(aarch64): update image-builder container version to 1.2

### DIFF
--- a/build_image_aarch64/roles/prepare_arm_node/vars/main.yml
+++ b/build_image_aarch64/roles/prepare_arm_node/vars/main.yml
@@ -15,7 +15,7 @@
 
 # input files
 input_project_dir: "{{ hostvars['localhost']['input_project_dir'] }}"
-pulp_aarch64_image_name: "dellhpcomniaaisolution/image-build-aarch64:1.1"
+pulp_aarch64_image_name: "dellhpcomniaaisolution/image-build-aarch64:1.2"
 aarch64_local_tag: "aarch64-image-builder/ochami"
 pull_image_retries: "5"
 pull_image_delay: "10"


### PR DESCRIPTION
Updated the aarch64 image-builder container image tag from 1.1 to 1.2 to consume the latest image-builder updates and fixes.