### PR TITLE
Fix stale OpenCHAMI container image tags in upgrade vars

### DIFF
--- a/upgrade/roles/upgrade_openchami/vars/main.yml
+++ b/upgrade/roles/upgrade_openchami/vars/main.yml
@@ -95,14 +95,15 @@ openchami_legacy_quadlet_files:
   - "/etc/containers/systemd/coresmd.container"
 
 # OpenCHAMI component version tags (Omnia 2.2 target)
+# These MUST match prepare_oim/roles/deploy_containers/openchami/vars/main.yml
 openchami_local_ca_tag: "v0.2.6"
-openchami_opaal_tag: "v0.3.12"
-openchami_smd_tag: "v2.19.3"
-openchami_bss_tag: "v1.32.2"
-openchami_cloud_init_tag: "v1.3.0"
-openchami_coresmd_tag: "v0.4.3"
+openchami_opaal_tag: "v0.3.14"
+openchami_smd_tag: "v2.20.6"
+openchami_bss_tag: "v1.32.4"
+openchami_cloud_init_tag: "v1.4.9"
+openchami_coresmd_tag: "v0.6.3"
 minio_release_tag: "RELEASE.2026-08-04T00-00-00Z"
-postgres_tag: "11.5-alpine"
+postgres_tag: "17-alpine"
 hydra_tag: "v2.3"
 haproxy_tag: "latest"
 registry_tag: "3.1.1"


### PR DESCRIPTION
## Summary

The upgrade role's `vars/main.yml` had outdated image tags that were out of sync with `prepare_oim/roles/deploy_containers/openchami/vars/main.yml`, causing `manifest unknown` errors during the 2.1 → 2.2 upgrade when podman tried to pull non-existent image versions.

**Updated tags to match the prepare_oim source of truth:**

| Variable | Old (Wrong) | New (Correct) |
|---|---|---|
| `openchami_opaal_tag` | v0.3.12 | v0.3.14 |
| `openchami_smd_tag` | v2.19.3 | v2.20.6 |
| `openchami_bss_tag` | v1.32.2 | v1.32.4 |
| `openchami_cloud_init_tag` | v1.3.0 | v1.4.9 |
| `openchami_coresmd_tag` | v0.4.3 | v0.6.3 |
| `postgres_tag` | 11.5-alpine | 17-alpine |

Added a comment noting these must stay in sync with prepare_oim vars.

#### Test plan

- [x] Verified all 13 image tags match between upgrade and prepare_oim vars
- [x] Verified all base images in `openchami_target_images` match `openchami_images`
- [x] Verified all quadlet image references have corresponding target image entries
- [x] Verified RPM names/URLs match exactly
- [x] Verified no stale old tags remain anywhere in the upgrade codebase
- [x] Full end-to-end upgrade flow reviewed (pre-check → backup → container upgrade → DB migration → cert renewal → cloud-init reload → post-check)