### PR TITLE
resolve kube-vip VIP failover failure after node reboot by adding kubernetes_addr env var

### DIFF
--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -215,8 +215,6 @@
                       fieldPath: spec.nodeName
                 - name: vip_interface
                   value: vip_interface
-                - name: vip_cidr
-                  value: "{{ admin_netmask_bits }}"
                 - name: dns_mode
                   value: first
                 - name: cp_enable
@@ -243,6 +241,8 @@
                   value: "{{ admin_netmask_bits }}"
                 - name: prometheus_server
                   value: :2112
+                - name: kubernetes_addr
+                  value: {% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}:6443
                 image: {{ kube_vip_image }}
                 imagePullPolicy: IfNotPresent
                 name: kube-vip

--- a/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2
@@ -185,8 +185,6 @@
                           fieldPath: spec.nodeName
                     - name: vip_interface
                       value: vip_interface
-                    - name: vip_cidr
-                      value: "{{ admin_netmask_bits }}"
                     - name: dns_mode
                       value: first
                     - name: cp_enable
@@ -213,6 +211,8 @@
                       value: "{{ admin_netmask_bits }}"
                     - name: prometheus_server
                       value: :2112
+                    - name: kubernetes_addr
+                      value: {% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}:6443
                   image: {{ kube_vip_image }}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip

--- a/upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml
+++ b/upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml
@@ -18,11 +18,12 @@
 # kube-vip runs as a static pod managed by kubelet, not a DaemonSet.
 # Upgrade = replace /etc/kubernetes/manifests/kube-vip.yaml on each CP node.
 #
-# Chicken-and-egg problem:
+# Chicken-and-egg problem (solved):
 #   When the old kube-vip pod dies, the VIP goes away. The new pod reads
 #   admin.conf which points to the VIP for leader election, so it cannot
-#   start. Fix: temporarily point admin.conf to the node's real IP, let
-#   kube-vip start and advertise the VIP, then restore admin.conf.
+#   start. Fix: the kubernetes_addr env var in the manifest tells kube-vip
+#   to connect to the local API server (node_ip:6443) instead of the VIP,
+#   so no admin.conf modification is needed.
 #
 # Variables required (set by load_version_vars.yml / detect_addon_versions.yml):
 #   - kube_vip_target_version  (e.g. "1.2.2")
@@ -127,8 +128,6 @@
                         fieldPath: spec.nodeName
                   - name: vip_interface
                     value: {{ kube_vip_interface }}
-                  - name: vip_cidr
-                    value: "{{ admin_netmask_bits }}"
                   - name: dns_mode
                     value: first
                   - name: cp_enable
@@ -155,6 +154,8 @@
                     value: "{{ admin_netmask_bits }}"
                   - name: prometheus_server
                     value: :2112
+                  - name: kubernetes_addr
+                    value: {{ node_ip }}:6443
                   image: ghcr.io/kube-vip/kube-vip:v{{ kube_vip_version }}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
@@ -179,15 +180,9 @@
                   name: kubeconfig
               status: {}
 
-        # ── Chicken-and-egg fix: temporarily use node IP ─────────────────
-        - name: Temporarily point admin.conf to node IP
-          delegate_to: "{{ node_hostname }}"
-          ansible.builtin.replace:
-            path: /etc/kubernetes/admin.conf
-            regexp: 'server: https://[^:]+:6443'
-            replace: "server: https://{{ node_ip }}:6443"
-
         # ── Replace manifest — kubelet auto-restarts the pod ─────────────
+        # kubernetes_addr env var in the manifest tells kube-vip to connect
+        # to the local API server, so no admin.conf modification is needed.
         - name: Replace kube-vip manifest
           delegate_to: "{{ node_hostname }}"
           ansible.builtin.copy:
@@ -223,14 +218,6 @@
           retries: 12
           delay: 5
           until: _vip_check.stdout | default('') == 'ok'
-
-        # ── Restore admin.conf to VIP ────────────────────────────────────
-        - name: Restore admin.conf to VIP address
-          delegate_to: "{{ node_hostname }}"
-          ansible.builtin.replace:
-            path: /etc/kubernetes/admin.conf
-            regexp: 'server: https://[^:]+:6443'
-            replace: "server: https://{{ kube_vip }}:6443"
 
         # Grep specifically for the version banner (not head -1) and retry
         # until it reports the target version. This doubles as a stabilization


### PR DESCRIPTION

**Problem**

After upgrading kube-vip from v0.8.9 to v1.2.2, the API VIP (Virtual IP) fails to failover to another control-plane node when theVIP leader node reboots. All nodes go NotReady and kube-vip logs show:

Error retrieving lease lock: Get "https://<VIP>:6443/...": dial tcp <VIP>:6443: connect: connection refused

**Root Cause**

In kube-vip v0.8.9, when cp_enable=true and admin.conf exists, the code overrode the API server URL to kubernetes:6443. Combined with hostAliases mapping kubernetes → 127.0.0.1, kube-vip always connected to the local API server for leader election —
regardless of VIP state.

In kube-vip v1.2.2, a new code path was added for explicit kubeconfig files (K8sConfigFile). Since the default value of this
config is /etc/kubernetes/admin.conf and the file exists, this new path matches before the old cp_enable logic runs. kube-vip
reads admin.conf as-is (which points to the VIP), and the kubernetes:6443 override never executes.

This creates a circular dependency: kube-vip needs to connect to the API server to acquire the leader lease, but the API server
is only reachable via the VIP, which is only assigned by the kube-vip leader.

**Fix**

Add the kubernetes_addr environment variable to the kube-vip static pod manifest, set to the node's own IP with port (<node_ip>:6443). This is a built-in kube-vip feature that overrides the API server address used by the Kubernetes client, regardless of
what's in the kubeconfig file. Each control-plane node's kube-vip talks to its own local API server for leader election, breakingthe circular dependency.

This approach is:

  • Minimal — one env var addition, no new files
  • Safe — admin.conf stays untouched, still points to VIP for all other components
  • Built-in — uses kube-vip's own kubernetes_addr config option, not a workaround

**Changes**

1. provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_first_x86_64.yaml.j2

Added kubernetes_addr env var to kube-vip manifest:

- name: kubernetes_addr
  value: {{ ds.meta_data.instance_data.local_ipv4 }}:6443

2. provision/roles/configure_ochami/templates/cloud_init/ci-group-service_kube_control_plane_x86_64.yaml.j2

Same change — added kubernetes_addr env var to kube-vip manifest for additional control-plane nodes.

3. upgrade/roles/upgrade_k8s/tasks/step_kube_vip_upgrade.yml

  • Added kubernetes_addr env var with value {{ node_ip }}:6443 to the generated kube-vip manifest
  • Removed "Temporarily point admin.conf to node IP" task (no longer needed)
  • Removed "Restore admin.conf to VIP address" task (no longer needed)
  • Updated header comments to reflect the new approach
