### PR TITLE
fix(pxe): reload BSS boot params after PG restore in rollback and add openchami stabilization wait

### DIFF
--- a/prepare_oim/roles/deploy_containers/openchami/tasks/configs/verify.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/tasks/configs/verify.yml
@@ -22,6 +22,10 @@
         enabled: true
         daemon_reload: true
 
+    - name: Wait for OpenCHAMI services to stabilize
+      ansible.builtin.pause:
+        seconds: "{{ openchami_stabilization_wait_time }}"
+
     - name: Configure ochami
       ansible.builtin.command: >
         sudo ochami config cluster set --system --default {{ cluster_name }}
@@ -39,6 +43,10 @@
         state: restarted
         enabled: true
         daemon_reload: true
+
+    - name: Wait for OpenCHAMI services to stabilize after retry
+      ansible.builtin.pause:
+        seconds: "{{ openchami_stabilization_wait_time }}"
 
     - name: Configure ochami
       ansible.builtin.command: >

--- a/prepare_oim/roles/deploy_containers/openchami/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/openchami/vars/main.yml
@@ -136,6 +136,7 @@ podman_interfaces:
   - podman4
 
 # Retry / timeout settings
+openchami_stabilization_wait_time: 60
 wait_time: 30
 max_delay: 10
 max_retries: 10

--- a/rollback/roles/rollback_openchami/tasks/main.yml
+++ b/rollback/roles/rollback_openchami/tasks/main.yml
@@ -22,6 +22,7 @@
 #   3. Configuration files (coredhcp.yaml, Corefile, configs_vars.yaml)
 #   4. PostgreSQL database from pg_dump backup
 #   5. Cloud-init in-memory data from backup YAML files
+#   6. BSS boot parameters from backup YAML files
 #
 # Key reversals:
 #   - coresmd-coredhcp + coresmd-coredns (v2.2) → single coresmd (v2.1)
@@ -31,6 +32,7 @@
 #     PG 11 initializes fresh, then pg_dump backup is restored)
 #   - Database rolled back to pre-upgrade state
 #   - Cloud-init data reloaded from backup workdir
+#   - BSS boot parameters reloaded from backup workdir
 #
 # No idempotency check — rollback always executes regardless of current
 # container state. This ensures rollback works even in partial or failed
@@ -94,6 +96,14 @@
 
         - name: Reload cloud-init data from backup
           ansible.builtin.include_tasks: reload_cloud_init_data.yml
+
+        # BSS boot parameters are not preserved through the PG 17 → 11
+        # downgrade + data volume clear + hmsds-only pg_dump restore cycle.
+        # Without boot params, BSS returns a fallback bootscript with an
+        # empty SYSTEM_URL iPXE variable, producing a malformed chain URL
+        # (https:///apis/bss/...) that causes PXE boot failures.
+        - name: Reload BSS boot parameters from backup
+          ansible.builtin.include_tasks: reload_bss_boot_params.yml
 
         - name: Post-rollback health check
           ansible.builtin.include_tasks: post_rollback_health_check.yml

--- a/rollback/roles/rollback_openchami/tasks/reload_bss_boot_params.yml
+++ b/rollback/roles/rollback_openchami/tasks/reload_bss_boot_params.yml
@@ -1,0 +1,182 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# ============================================================================
+# reload_bss_boot_params.yml — Reload BSS Boot Parameters After Rollback
+# ============================================================================
+# During rollback, the PostgreSQL data volume is cleared for PG 17 → PG 11
+# downgrade, and restore_database.yml only restores the hmsds (SMD) database
+# from pg_dump. BSS boot parameters may be stored in a separate database
+# (bssdb) or in BSS-specific tables that are not preserved through the
+# pg_dump backup and restore cycle. When bss-init runs on startup, it
+# initializes empty BSS tables — any previously configured boot parameters
+# are lost.
+#
+# Without boot parameters, BSS returns a fallback bootscript that chains to
+# https://${SYSTEM_URL}/apis/bss/boot/v1/bootscript — but SYSTEM_URL is
+# unset in the iPXE environment, producing a malformed URL with an empty
+# hostname (https:///apis/bss/...) that causes PXE boot failures.
+#
+# This task reloads BSS boot parameter YAML files from the backup workdir
+# (created by omnia.sh --upgrade) into BSS using the ochami CLI.
+#
+# Data re-loaded:
+#   workdir/boot/bss-<group>.yaml  → ochami bss boot params set
+#
+# This mirrors the provision flow in configure_bss_group.yml.
+# ============================================================================
+
+- name: Reload BSS boot parameters from backup after rollback
+  block:
+    # ── Compute OIM host-side boot params backup path ────────────────────
+    - name: Compute OIM host-side BSS boot params backup path
+      ansible.builtin.set_fact:
+        rb_oim_host_boot_dir: >-
+          {{ rollback_oim_host_backup_dir }}/{{ backup_openchami_data_subpath }}/workdir/boot
+
+    - name: Display resolved BSS boot params path
+      ansible.builtin.debug:
+        verbosity: 1
+        msg:
+          - "BSS boot params backup dir: {{ rb_oim_host_boot_dir }}"
+
+    # ── Generate ochami access token ────────────────────────────────────
+    - name: Generate ochami access token on OIM host for BSS reload
+      ansible.builtin.shell: bash -lc 'gen_access_token'  # noqa: command-instead-of-shell
+      become: true
+      register: rb_bss_access_token_result
+      changed_when: false
+      failed_when: rb_bss_access_token_result.rc != 0 or rb_bss_access_token_result.stdout in ["", "null"]
+      retries: 5
+      delay: 5
+      until: rb_bss_access_token_result.rc == 0 and rb_bss_access_token_result.stdout not in ["", "null"]
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Set ochami environment for BSS boot params reload
+      ansible.builtin.set_fact:
+        rb_bss_ochami_env: "{{ {(rollback_cluster_name | upper | trim) ~ '_ACCESS_TOKEN': rb_bss_access_token_result.stdout} }}"
+
+    # ── Verify BSS boot params backup directory exists ──────────────────
+    - name: Check BSS boot params backup directory exists on OIM host
+      ansible.builtin.stat:
+        path: "{{ rb_oim_host_boot_dir }}"
+      register: rb_boot_dir_stat
+      delegate_to: oim
+      delegate_facts: true
+      connection: ssh
+
+    - name: Skip BSS boot params reload if backup dir not found
+      ansible.builtin.debug:
+        msg: >-
+          BSS boot params backup directory not found at {{ rb_oim_host_boot_dir }}.
+          This is expected for prepare_oim-only setups. Skipping reload.
+          Nodes will not PXE boot until boot parameters are configured
+          (e.g., via provision playbook).
+      when: not (rb_boot_dir_stat.stat.exists | default(false))
+
+    # ── Main reload block ───────────────────────────────────────────────
+    - name: Reload BSS boot parameters from backup
+      when: rb_boot_dir_stat.stat.exists | default(false)
+      block:
+        # ── Wait for BSS API readiness ──────────────────────────────────
+        - name: Wait for BSS container to be running
+          ansible.builtin.shell: |
+            set -o pipefail
+            status=$(podman inspect --format '{{ '{{' }}.State.Status{{ '}}' }}' bss 2>/dev/null || echo "not_found")
+            if [ "$status" = "running" ]; then
+              echo "running"
+              exit 0
+            fi
+            echo "status=$status"
+            exit 1
+          register: rb_bss_container_ready
+          changed_when: false
+          retries: "{{ api_readiness_retries }}"
+          delay: "{{ api_readiness_delay }}"
+          until: rb_bss_container_ready.rc == 0
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Wait for BSS to initialize
+          ansible.builtin.pause:
+            seconds: 15
+
+        # ── Discover BSS boot parameter YAML files in backup ────────────
+        - name: Find all bss-*.yaml files in backup boot directory
+          ansible.builtin.find:
+            paths: "{{ rb_oim_host_boot_dir }}"
+            patterns: "bss-*.yaml"
+          register: rb_bss_boot_files
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Display discovered BSS boot parameter files
+          ansible.builtin.debug:
+            verbosity: 1
+            msg: >-
+              Found {{ rb_bss_boot_files.files | default([]) | length }} BSS boot parameter files:
+              {{ rb_bss_boot_files.files | default([]) | map(attribute='path') | map('basename') | list }}
+
+        - name: Skip if no BSS boot parameter files found
+          ansible.builtin.debug:
+            msg: >-
+              No bss-*.yaml files found in {{ rb_oim_host_boot_dir }}.
+              BSS boot parameters will remain empty. Nodes will not PXE boot
+              until boot parameters are configured.
+          when: (rb_bss_boot_files.files | default([]) | length) == 0
+
+        # ── Reload each BSS boot parameter file ────────────────────────
+        - name: Reload BSS boot parameters from backup files
+          ansible.builtin.command: >
+            /usr/bin/ochami bss boot params set -f yaml
+            -d @{{ item.path }}
+          environment: "{{ rb_bss_ochami_env }}"
+          loop: "{{ rb_bss_boot_files.files | default([]) }}"
+          loop_control:
+            label: "{{ item.path | basename }}"
+          changed_when: true
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        # ── Verify boot params loaded ───────────────────────────────────
+        - name: Verify BSS boot params loaded
+          ansible.builtin.command: /usr/bin/ochami bss boot params get -F yaml
+          environment: "{{ rb_bss_ochami_env }}"
+          changed_when: false
+          failed_when: false
+          register: rb_bss_verify_result
+          delegate_to: oim
+          delegate_facts: true
+          connection: ssh
+
+        - name: Display BSS boot params reload summary
+          ansible.builtin.debug:
+            msg:
+              - "BSS boot parameters reloaded from backup after rollback."
+              - "Files loaded: {{ rb_bss_boot_files.files | default([]) | map(attribute='path') | map('basename') | list }}"
+              - "Boot params verification: {{ 'OK' if rb_bss_verify_result.rc == 0 else 'FAILED (rc=' ~ rb_bss_verify_result.rc ~ ')' }}"
+
+  rescue:
+    - name: BSS boot params reload failed (non-fatal for rollback)
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: BSS boot parameter reload failed after rollback.
+          Nodes will not PXE boot until boot parameters are configured.
+          Manual fix: ochami bss boot params set -f yaml -d @<bss-group.yaml>


### PR DESCRIPTION
## Problem

During rollback (PG 17→11), the PostgreSQL data volume is cleared and restored from `pg_dump`. The backup only contains the `hmsds` (SMD) database, **not** BSS boot parameters. When `bss-init` starts against fresh tables it creates empty BSS state, causing PXE boot failures — the bootscript redirects to a malformed URL (`https:///apis/bss/boot/v1/bootscript` with empty hostname).

Additionally, after an `openchami.target` restart, services may not be fully ready before subsequent tasks attempt to interact with them, leading to intermittent failures.

## Changes

### 1. Reload BSS boot parameters after PG restore (rollback)
- New task file `reload_bss_boot_params.yml` for the `rollback_openchami` role
- Discovers `bss-*.yaml` files from the backup workdir and reloads them into BSS via `ochami bss boot params set`
- Integrated into `main.yml` task flow after cloud-init reload

### 2. OpenCHAMI stabilization wait (prepare_oim)
- Added 60-second pause after `openchami.target` restart in `verify.yml` to prevent race conditions where services are not yet ready
- Configurable via `openchami_stabilization_wait_time` variable

## Files Changed
| File | Change |
|---|---|
| `prepare_oim/.../verify.yml` | 60s pause after openchami.target restart |
| `prepare_oim/.../vars/main.yml` | `openchami_stabilization_wait_time` variable |
| `rollback/.../main.yml` | Include BSS reload step |
| `rollback/.../reload_bss_boot_params.yml` | **New** — BSS reload for rollback |

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>