### PR TITLE
fix: remove dead imports shadowed by local redefinitions in build_stream

### DIFF
--- a/build_stream/api/build_image/dependencies.py
+++ b/build_stream/api/build_image/dependencies.py
@@ -25,7 +25,6 @@ from api.dependencies import (
     _create_sql_stage_repo,
     _create_sql_audit_repo,
     _create_sql_image_group_repo,
-    _get_container,
     _ENV,
 )
 from core.jobs.value_objects import ClientId, CorrelationId

--- a/build_stream/api/local_repo/dependencies.py
+++ b/build_stream/api/local_repo/dependencies.py
@@ -24,7 +24,6 @@ from api.dependencies import (
     _create_sql_job_repo,
     _create_sql_stage_repo,
     _create_sql_audit_repo,
-    _get_container,
     _ENV,
     verify_token,
 )

--- a/build_stream/api/validate/dependencies.py
+++ b/build_stream/api/validate/dependencies.py
@@ -24,7 +24,6 @@ from api.dependencies import (
     _create_sql_job_repo,
     _create_sql_stage_repo,
     _create_sql_audit_repo,
-    _get_container,
     _ENV,
 )
 from core.jobs.value_objects import CorrelationId

--- a/build_stream/container.py
+++ b/build_stream/container.py
@@ -69,7 +69,6 @@ from core.build_image.services import (
 )
 from core.validate.services import ValidateQueueService
 from core.deploy.services import DeployQueueService
-from core.catalog.adapter_policy import _DEFAULT_POLICY_PATH, _DEFAULT_SCHEMA_PATH
 from core.artifacts.value_objects import SafePath
 from common.config import load_config
 

--- a/build_stream/orchestrator/local_repo/use_cases/create_local_repo.py
+++ b/build_stream/orchestrator/local_repo/use_cases/create_local_repo.py
@@ -161,7 +161,6 @@ class CreateLocalRepoUseCase:
         self, command: CreateLocalRepoCommand
     ) -> None:
         """Verify that generate-input-files stage is COMPLETED."""
-        from core.jobs.value_objects import StageState
         
         prerequisite_stage = self._stage_repo.find_by_job_and_name(
             command.job_id, 
@@ -184,7 +183,6 @@ class CreateLocalRepoUseCase:
 
     def _validate_stage(self, command: CreateLocalRepoCommand) -> Stage:
         """Validate stage exists; reset to PENDING if in a retryable terminal state."""
-        from core.jobs.value_objects import StageState
         
         # Verify upstream stage is completed
         self._verify_upstream_stage_completed(command)


### PR DESCRIPTION
## Summary

Several names in `build_stream/` are imported and then immediately shadowed by local redefinitions (ruff F811), leaving dead imports that contradict the code's own intent:

1. **`api/{build_image,local_repo,validate}/dependencies.py`** — each imports `_get_container` and then redefines it locally with a comment saying the local version exists to *avoid circular imports*. The import in the list re-creates exactly the coupling the comment says it avoids, and the local def wins anyway. Removed `_get_container` from the three import lists.
2. **`container.py`** — imports `_DEFAULT_POLICY_PATH, _DEFAULT_SCHEMA_PATH` from `core.catalog.adapter_policy`, then redefines both from the local resources directory ~40 lines later. The redefinitions win; removed the dead import.
3. **`orchestrator/local_repo/use_cases/create_local_repo.py`** — two method-local `from core.jobs.value_objects import StageState` re-imports that shadow the module-level import of the same name; removed.

## Testing
`python -m py_compile` passes on all five files; `ruff check --select F811` on `build_stream/` (excluding tests) goes clean. No runtime behavior change — every removed name was shadowed before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)