### PR TITLE
refactor(discovery,orchestrator): replace FQCN with short role/module names

### DIFF
--- a/src/discovery/playbooks/ansible.cfg
+++ b/src/discovery/playbooks/ansible.cfg
@@ -21,7 +21,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.discovery.omnia_default
+stdout_callback = omnia_default
 collections_path = ..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/discovery/playbooks/credentials/ansible.cfg
+++ b/src/discovery/playbooks/credentials/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.discovery.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/discovery/playbooks/credentials/discovery_credentials.yml
+++ b/src/discovery/playbooks/credentials/discovery_credentials.yml
@@ -21,7 +21,7 @@
   connection: local
   gather_facts: false
   roles:
-    - omnia.discovery.discovery_setup
+    - discovery_setup
   tags: always
 
 - name: Create and update credential config files
@@ -29,5 +29,5 @@
   connection: local
   gather_facts: false
   roles:
-    - omnia.discovery.discovery_credentials
+    - discovery_credentials
   tags: always

--- a/src/discovery/playbooks/discovery.yml
+++ b/src/discovery/playbooks/discovery.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tags: always
   roles:
-    - omnia.discovery.discovery_setup
+    - discovery_setup
 
 # Step 1: Validate discovery input (L1 schema + L2 logic)
 - name: Validate discovery input configuration
@@ -44,7 +44,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.discovery.validate_discovery_input
+    - role: validate_discovery_input
       when: not config_file_status | default(false) | bool
   tags: always
 
@@ -54,7 +54,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.discovery.discovery_credentials
+    - role: discovery_credentials
       when:
         - not config_file_status | default(false) | bool
         - (omnia_run_tags | default([]) | intersect(skip_credential_tags | default([])) | length == 0)
@@ -129,4 +129,4 @@
 
         - name: Include OME discovery role
           ansible.builtin.include_role:
-            name: omnia.discovery.ome_discovery
+            name: ome_discovery

--- a/src/discovery/playbooks/validate/ansible.cfg
+++ b/src/discovery/playbooks/validate/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.discovery.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/discovery/playbooks/validate/validate_discovery.yml
+++ b/src/discovery/playbooks/validate/validate_discovery.yml
@@ -21,7 +21,7 @@
   connection: local
   gather_facts: false
   roles:
-    - omnia.discovery.discovery_setup
+    - discovery_setup
   tags: always
 
 - name: Validate discovery input configuration
@@ -29,5 +29,5 @@
   connection: local
   gather_facts: false
   roles:
-    - omnia.discovery.validate_discovery_input
+    - validate_discovery_input
   tags: always

--- a/src/discovery/plugins/callback/omnia_default.py
+++ b/src/discovery/plugins/callback/omnia_default.py
@@ -24,7 +24,7 @@ etc.) is unchanged.
 Usage — add to every ``ansible.cfg``::
 
     [defaults]
-    stdout_callback = omnia.discovery.omnia_default
+    stdout_callback = omnia_default
 """
 from __future__ import annotations
 

--- a/src/discovery/plugins/modules/validate_credentials.py
+++ b/src/discovery/plugins/modules/validate_credentials.py
@@ -48,7 +48,7 @@ options:
 
 EXAMPLES = r'''
 - name: Validate a credential field
-  omnia.discovery.validate_credentials:
+  validate_credentials:
     credential_field: ome_password
     credential_input: "{{ ome_password }}"
     module_utils_path: "{{ role_path }}/../../plugins/module_utils"

--- a/src/discovery/plugins/modules/validate_discovery_config.py
+++ b/src/discovery/plugins/modules/validate_discovery_config.py
@@ -34,7 +34,7 @@ import os
 
 import yaml
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.omnia.discovery.plugins.module_utils.discovery_validation.discovery_validation_flow import (
+from ansible.module_utils.discovery_validation.discovery_validation_flow import (
     validate_discovery_config,
 )
 
@@ -58,7 +58,7 @@ options:
 
 EXAMPLES = r'''
 - name: Validate discovery configuration files
-  omnia.discovery.validate_discovery_config:
+  validate_discovery_config:
     input_project_dir: /opt/omnia/input/project_default
     schema_dir: "{{ role_path }}/../../plugins/module_utils/discovery_validation/schema"
   register: validation_result

--- a/src/discovery/roles/discovery_common/tasks/main.yml
+++ b/src/discovery/roles/discovery_common/tasks/main.yml
@@ -18,7 +18,7 @@
 # Instead, individual task files are included via:
 #
 #   ansible.builtin.include_role:
-#     name: omnia.discovery.discovery_common
+#     name: discovery_common
 #     tasks_from: <task_file>.yml
 #
 # Available task files:
@@ -26,4 +26,4 @@
 
 - name: Discovery_common is a task library — use tasks_from to include specific tasks
   ansible.builtin.debug:
-    msg: "Use 'include_role: name=omnia.discovery.discovery_common tasks_from=<file>.yml' to include specific tasks"
+    msg: "Use 'include_role: name=discovery_common tasks_from=<file>.yml' to include specific tasks"

--- a/src/discovery/roles/discovery_credentials/tasks/create_credentials.yml
+++ b/src/discovery/roles/discovery_credentials/tasks/create_credentials.yml
@@ -17,7 +17,7 @@
 
 - name: Decrypt and include vars for existing credential file
   ansible.builtin.include_role:
-    name: omnia.discovery.discovery_common
+    name: discovery_common
     tasks_from: decrypt_include_encrypt.yml
   vars:
     credential_file_path: "{{ credential_file.file_path }}"
@@ -60,7 +60,7 @@
 
     - name: Include vars from new credential file
       ansible.builtin.include_role:
-        name: omnia.discovery.discovery_common
+        name: discovery_common
         tasks_from: decrypt_include_encrypt.yml
       vars:
         credential_file_path: "{{ credential_file.file_path }}"

--- a/src/discovery/roles/discovery_credentials/tasks/update_credentials.yml
+++ b/src/discovery/roles/discovery_credentials/tasks/update_credentials.yml
@@ -45,7 +45,7 @@
         - ome_username_input.user_input | length == 0
 
     - name: Validate OME username format
-      omnia.discovery.validate_credentials:
+      validate_credentials:
         credential_field: "ome_username"
         credential_input: "{{ ome_username_input.user_input }}"
         module_utils_path: "{{ module_utils_path }}"

--- a/src/discovery/roles/ome_discovery/tasks/collect_inventory.yml
+++ b/src/discovery/roles/ome_discovery/tasks/collect_inventory.yml
@@ -30,7 +30,7 @@
           is correct and that the OME appliance is powered on and network-accessible.
 
 - name: Collect OME server inventory
-  omnia.discovery.ome_server_inventory:
+  ome_server_inventory:
     ome_ip: "{{ ome_ip }}"
     ome_username: "{{ ome_username }}"
     ome_password: "{{ ome_password }}"

--- a/src/discovery/roles/ome_discovery/tasks/generate_discovery_report.yml
+++ b/src/discovery/roles/ome_discovery/tasks/generate_discovery_report.yml
@@ -24,7 +24,7 @@
     discovery_report_output_file: "{{ discovery_output_dir }}/bmc_discovery_report_{{ pxe_mapping_timestamp }}.csv"
 
 - name: Generate BMC discovery report
-  omnia.discovery.generate_discovery_report:
+  generate_discovery_report:
     servers: "{{ discovered_servers }}"
     output_file: "{{ discovery_report_output_file }}"
   register: discovery_report_result

--- a/src/discovery/roles/ome_discovery/tasks/generate_pxe_mapping.yml
+++ b/src/discovery/roles/ome_discovery/tasks/generate_pxe_mapping.yml
@@ -45,7 +45,7 @@
     mode: '0755'
 
 - name: Generate PXE mapping file
-  omnia.discovery.generate_pxe_mapping:
+  generate_pxe_mapping:
     servers: "{{ discovered_servers }}"
     output_file: "{{ pxe_mapping_output_file }}"
     functional_group: "{{ default_functional_group }}"

--- a/src/discovery/roles/validate_discovery_input/tasks/main.yml
+++ b/src/discovery/roles/validate_discovery_input/tasks/main.yml
@@ -37,7 +37,7 @@
 
 # Run the validate_discovery_config module (L1 + L2)
 - name: Run discovery configuration validation
-  omnia.discovery.validate_discovery_config:
+  validate_discovery_config:
     input_project_dir: "{{ input_project_dir }}"
     schema_dir: "{{ discovery_schema_dir }}"
   register: discovery_validation_result

--- a/src/orchestrator/playbooks/ansible.cfg
+++ b/src/orchestrator/playbooks/ansible.cfg
@@ -22,7 +22,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/cleanup/ansible.cfg
+++ b/src/orchestrator/playbooks/cleanup/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/cleanup/cleanup_orchestrator.yml
+++ b/src/orchestrator/playbooks/cleanup/cleanup_orchestrator.yml
@@ -29,7 +29,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true

--- a/src/orchestrator/playbooks/credentials/ansible.cfg
+++ b/src/orchestrator/playbooks/credentials/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/credentials/orchestrator_credentials.yml
+++ b/src/orchestrator/playbooks/credentials/orchestrator_credentials.yml
@@ -21,7 +21,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -32,5 +32,5 @@
   connection: local
   gather_facts: false
   roles:
-    - omnia.orchestrator.orchestrator_credentials
+    - orchestrator_credentials
   tags: always

--- a/src/orchestrator/playbooks/deploy/ansible.cfg
+++ b/src/orchestrator/playbooks/deploy/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/deploy/deploy_openchami.yml
+++ b/src/orchestrator/playbooks/deploy/deploy_openchami.yml
@@ -25,7 +25,7 @@
   tasks:
     - name: Include S3 access configuration
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: configure_s3_access.yml
 
 - name: Deploy OpenCHAMI containers on OIM
@@ -33,4 +33,4 @@
   connection: ssh
   gather_facts: true
   roles:
-    - omnia.orchestrator.deploy_openchami
+    - deploy_openchami

--- a/src/orchestrator/playbooks/deploy/deploy_openldap.yml
+++ b/src/orchestrator/playbooks/deploy/deploy_openldap.yml
@@ -23,4 +23,4 @@
   connection: ssh
   gather_facts: false
   roles:
-    - omnia.orchestrator.deploy_openldap
+    - deploy_openldap

--- a/src/orchestrator/playbooks/prepare/ansible.cfg
+++ b/src/orchestrator/playbooks/prepare/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/prepare/prepare_orchestrator.yml
+++ b/src/orchestrator/playbooks/prepare/prepare_orchestrator.yml
@@ -33,7 +33,7 @@
   gather_facts: false
   tags: always
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -45,7 +45,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.validate_orchestrator_input
+    - role: validate_orchestrator_input
       when: not config_file_status | default(false) | bool
 
 # Step 3: Credential management (prompt, encrypt, vault)
@@ -54,7 +54,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.orchestrator_credentials
+    - role: orchestrator_credentials
       when:
         - not config_file_status | default(false) | bool
         - (omnia_run_tags | default([]) | intersect(skip_credential_tags | default([])) | length == 0)
@@ -67,14 +67,14 @@
   gather_facts: false
   tags: always
   roles:
-    - omnia.orchestrator.orchestrator_functional_groups
+    - orchestrator_functional_groups
 
 # Step 5: Validate orchestrator parameters (mapping, software config, telemetry)
 - name: Validate orchestrator parameters
   hosts: localhost
   connection: local
   roles:
-    - omnia.orchestrator.orchestrator_validations
+    - orchestrator_validations
 
 # Step 6: Validate OIM timezone
 - name: Validate OIM timezone
@@ -83,7 +83,7 @@
   tasks:
     - name: Validate OIM timezone has not changed
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_validations
+        name: orchestrator_validations
         tasks_from: validate_oim_timezone.yml
 
 # Step 7: Validate boot images in S3 for each functional group
@@ -93,7 +93,7 @@
   tasks:
     - name: Image validation
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_validations
+        name: orchestrator_validations
         tasks_from: validate_image.yml
       with_items: "{{ hostvars['localhost']['functional_groups'] | map(attribute='name') | list }}"
 

--- a/src/orchestrator/playbooks/provision/ansible.cfg
+++ b/src/orchestrator/playbooks/provision/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/provision/provision_custom.yml
+++ b/src/orchestrator/playbooks/provision/provision_custom.yml
@@ -57,5 +57,5 @@
       when: target_functional_groups | length == 0
 
   roles:
-    - role: omnia.orchestrator.provision_common
+    - role: provision_common
       when: target_functional_groups | length > 0

--- a/src/orchestrator/playbooks/provision/provision_kubernetes.yml
+++ b/src/orchestrator/playbooks/provision/provision_kubernetes.yml
@@ -50,7 +50,7 @@
       when: target_functional_groups | length == 0
 
   roles:
-    - role: omnia.orchestrator.provision_common
+    - role: provision_common
       when: target_functional_groups | length > 0
 
   tasks:
@@ -67,18 +67,18 @@
 
         - name: Configure mounts
           ansible.builtin.include_role:
-            name: omnia.orchestrator.mount_config
+            name: mount_config
           when: "'mount_config' in category_bolt_ons"
 
         - name: Configure Kubernetes
           ansible.builtin.include_role:
-            name: omnia.orchestrator.k8s_config
+            name: k8s_config
           when: "'k8s_config' in category_bolt_ons"
 
 
         - name: Configure OpenLDAP
           ansible.builtin.include_role:
-            name: omnia.orchestrator.openldap
+            name: openldap
           when:
             - "'openldap' in category_bolt_ons"
             - openldap_support | default(false) | bool

--- a/src/orchestrator/playbooks/provision/provision_os.yml
+++ b/src/orchestrator/playbooks/provision/provision_os.yml
@@ -50,5 +50,5 @@
       when: target_functional_groups | length == 0
 
   roles:
-    - role: omnia.orchestrator.provision_common
+    - role: provision_common
       when: target_functional_groups | length > 0

--- a/src/orchestrator/playbooks/provision/provision_preamble.yml
+++ b/src/orchestrator/playbooks/provision/provision_preamble.yml
@@ -27,7 +27,7 @@
   gather_facts: false
   tags: always
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -38,14 +38,14 @@
   hosts: localhost
   connection: local
   roles:
-    - omnia.orchestrator.passwordless_ssh
+    - passwordless_ssh
 
 # Step 3: Configure OIM SSH access
 - name: Configure OIM SSH from cluster host lists
   hosts: oim
   connection: ssh
   roles:
-    - omnia.orchestrator.passwordless_ssh
+    - passwordless_ssh
 
 # Step 4: Authenticate with OpenCHAMI (token stored as fact)
 - name: Authenticate with OpenCHAMI
@@ -54,7 +54,7 @@
   tasks:
     - name: OpenCHAMI cluster authentication
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
       vars:
         oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"

--- a/src/orchestrator/playbooks/provision/provision_slurm.yml
+++ b/src/orchestrator/playbooks/provision/provision_slurm.yml
@@ -55,7 +55,7 @@
       when: target_functional_groups | length == 0
 
   roles:
-    - role: omnia.orchestrator.provision_common
+    - role: provision_common
       when: target_functional_groups | length > 0
 
   tasks:
@@ -72,17 +72,17 @@
 
         - name: Configure mounts
           ansible.builtin.include_role:
-            name: omnia.orchestrator.mount_config
+            name: mount_config
           when: "'mount_config' in category_bolt_ons"
 
         - name: Configure Slurm
           ansible.builtin.include_role:
-            name: omnia.orchestrator.slurm_config
+            name: slurm_config
           when: "'slurm_config' in category_bolt_ons"
 
         - name: Configure OpenLDAP
           ansible.builtin.include_role:
-            name: omnia.orchestrator.openldap
+            name: openldap
           when:
             - "'openldap' in category_bolt_ons"
             - openldap_support | default(false) | bool

--- a/src/orchestrator/playbooks/rollback/ansible.cfg
+++ b/src/orchestrator/playbooks/rollback/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/rollback/rollback_orchestrator.yml
+++ b/src/orchestrator/playbooks/rollback/rollback_orchestrator.yml
@@ -28,7 +28,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -113,7 +113,7 @@
   tasks:
     - name: Authenticate to OpenCHAMI
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
 
     - name: Check if SMD components backup exists
@@ -152,7 +152,7 @@
   tasks:
     - name: Authenticate to OpenCHAMI
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
 
     - name: Verify openchami.target is active

--- a/src/orchestrator/playbooks/upgrade/ansible.cfg
+++ b/src/orchestrator/playbooks/upgrade/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/upgrade/upgrade_orchestrator.yml
+++ b/src/orchestrator/playbooks/upgrade/upgrade_orchestrator.yml
@@ -29,7 +29,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -62,7 +62,7 @@
   tasks:
     - name: Authenticate to OpenCHAMI
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
 
     - name: Create backup directory structure
@@ -188,7 +188,7 @@
   tasks:
     - name: Authenticate to OpenCHAMI
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
 
     - name: Verify openchami.target is active

--- a/src/orchestrator/playbooks/validate/ansible.cfg
+++ b/src/orchestrator/playbooks/validate/ansible.cfg
@@ -18,7 +18,7 @@ executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
 show_task_path_on_failure = false
-stdout_callback = omnia.orchestrator.omnia_default
+stdout_callback = omnia_default
 collections_path = ../..:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/playbooks/validate/validate_openchami.yml
+++ b/src/orchestrator/playbooks/validate/validate_openchami.yml
@@ -25,7 +25,7 @@
   gather_facts: false
   tags: always
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -37,7 +37,7 @@
   tasks:
     - name: OpenCHAMI authentication
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
       vars:
         oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
@@ -46,4 +46,4 @@
   hosts: oim
   connection: ssh
   roles:
-    - omnia.orchestrator.validate_openchami
+    - validate_openchami

--- a/src/orchestrator/playbooks/validate/validate_openldap.yml
+++ b/src/orchestrator/playbooks/validate/validate_openldap.yml
@@ -26,6 +26,6 @@
   tasks:
     - name: Validate OpenLDAP container is running
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_validations
+        name: orchestrator_validations
         tasks_from: validate_openldap_container.yml
       when: hostvars['localhost']['openldap_support'] | default(false) | bool

--- a/src/orchestrator/playbooks/validate/validate_orchestrator.yml
+++ b/src/orchestrator/playbooks/validate/validate_orchestrator.yml
@@ -21,7 +21,7 @@
   connection: local
   gather_facts: false
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -32,5 +32,5 @@
   connection: local
   gather_facts: false
   roles:
-    - omnia.orchestrator.validate_orchestrator_input
+    - validate_orchestrator_input
   tags: always

--- a/src/orchestrator/playbooks/validate/validate_provisioning.yml
+++ b/src/orchestrator/playbooks/validate/validate_provisioning.yml
@@ -28,7 +28,7 @@
   gather_facts: false
   tags: always
   roles:
-    - role: omnia.orchestrator.orchestrator_setup
+    - role: orchestrator_setup
       vars:
         openchami_vars_support: true
         omnia_metadata_support: true
@@ -40,7 +40,7 @@
   tasks:
     - name: OpenCHAMI cluster authentication
       ansible.builtin.include_role:
-        name: omnia.orchestrator.orchestrator_common
+        name: orchestrator_common
         tasks_from: openchami_auth.yml
       vars:
         oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
@@ -49,8 +49,8 @@
   hosts: oim
   connection: ssh
   roles:
-    - omnia.orchestrator.generate_inventories
-    - omnia.orchestrator.validate_provisioning
+    - generate_inventories
+    - validate_provisioning
 
 - name: Read nodes.yaml and derive Omnia node facts
   hosts: oim
@@ -58,5 +58,5 @@
   tasks:
     - name: Read nodes.yaml and derive Omnia node facts
       ansible.builtin.include_role:
-        name: omnia.orchestrator.passwordless_ssh
+        name: passwordless_ssh
         tasks_from: read_nodes_yaml.yml

--- a/src/orchestrator/plugins/callback/omnia_default.py
+++ b/src/orchestrator/plugins/callback/omnia_default.py
@@ -24,7 +24,7 @@ etc.) is unchanged.
 Usage — add to every ``ansible.cfg``::
 
     [defaults]
-    stdout_callback = omnia.orchestrator.omnia_default
+    stdout_callback = omnia_default
 """
 from __future__ import annotations
 

--- a/src/orchestrator/plugins/modules/fetch_credential_rule.py
+++ b/src/orchestrator/plugins/modules/fetch_credential_rule.py
@@ -41,7 +41,7 @@ options:
 
 EXAMPLES = r'''
 - name: Fetch credential rule for admin password
-  omnia.orchestrator.fetch_credential_rule:
+  fetch_credential_rule:
     credential_field: admin_password
     module_utils_path: "{{ role_path }}/../../plugins/module_utils"
   register: rule_result

--- a/src/orchestrator/plugins/modules/generate_argon2_password.py
+++ b/src/orchestrator/plugins/modules/generate_argon2_password.py
@@ -48,7 +48,7 @@ options:
 
 EXAMPLES = r'''
 - name: Generate argon2 hash for a password
-  omnia.orchestrator.generate_argon2_password:
+  generate_argon2_password:
     password: "{{ admin_password }}"
   register: hash_result
   no_log: true

--- a/src/orchestrator/plugins/modules/generate_functional_groups.py
+++ b/src/orchestrator/plugins/modules/generate_functional_groups.py
@@ -41,7 +41,7 @@ options:
 
 EXAMPLES = r'''
 - name: Generate functional groups from mapping file
-  omnia.orchestrator.generate_functional_groups:
+  generate_functional_groups:
     mapping_file_path: /opt/omnia/input/project_default/pxe_mapping_file.csv
     functional_groups_file_path: /opt/omnia/.data/functional_groups_config.yml
     omnia_config_path: /opt/omnia/input/project_default/omnia_config.yml

--- a/src/orchestrator/plugins/modules/generate_xname_in_mapping_file.py
+++ b/src/orchestrator/plugins/modules/generate_xname_in_mapping_file.py
@@ -33,7 +33,7 @@ options:
 
 EXAMPLES = r'''
 - name: Generate xnames in mapping file
-  omnia.orchestrator.generate_xname_in_mapping_file:
+  generate_xname_in_mapping_file:
     mapping_file_path: /opt/omnia/input/project_default/pxe_mapping_file.csv
 '''
 

--- a/src/orchestrator/plugins/modules/slurm_conf.py
+++ b/src/orchestrator/plugins/modules/slurm_conf.py
@@ -16,7 +16,7 @@
 import os
 from collections import OrderedDict
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.omnia.orchestrator.plugins.module_utils.slurm.slurm_conf_utils import (
+from ansible.module_utils.slurm.slurm_conf_utils import (
     SlurmParserEnum,
     all_confs,
     parse_slurm_conf

--- a/src/orchestrator/plugins/modules/validate_credentials.py
+++ b/src/orchestrator/plugins/modules/validate_credentials.py
@@ -48,7 +48,7 @@ options:
 
 EXAMPLES = r'''
 - name: Validate a credential field
-  omnia.orchestrator.validate_credentials:
+  validate_credentials:
     credential_field: admin_password
     credential_input: "{{ admin_password }}"
     module_utils_path: "{{ role_path }}/../../plugins/module_utils"

--- a/src/orchestrator/plugins/modules/validate_orchestrator_config.py
+++ b/src/orchestrator/plugins/modules/validate_orchestrator_config.py
@@ -35,7 +35,7 @@ import os
 
 import yaml
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.omnia.orchestrator.plugins.module_utils.orchestrator_validation.orchestrator_validation_flow import (
+from ansible.module_utils.orchestrator_validation.orchestrator_validation_flow import (
     validate_orchestrator_config_l2,
     validate_network_spec,
 )
@@ -60,7 +60,7 @@ options:
 
 EXAMPLES = r'''
 - name: Validate orchestrator configuration files
-  omnia.orchestrator.validate_orchestrator_config:
+  validate_orchestrator_config:
     input_project_dir: /opt/omnia/input/project_default
     schema_dir: "{{ role_path }}/../../plugins/module_utils/input_validation/schema"
   register: validation_result

--- a/src/orchestrator/roles/configure_ochami/tasks/main.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Refresh SMD access token before ochami operations
   ansible.builtin.include_role:
-    name: omnia.orchestrator.orchestrator_common
+    name: orchestrator_common
     tasks_from: openchami_auth.yml
   vars:
     oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"

--- a/src/orchestrator/roles/deploy_openchami/tasks/verify_openchami.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/verify_openchami.yml
@@ -19,7 +19,7 @@
 
 - name: Openchami cluster authentication
   ansible.builtin.include_role:
-    name: omnia.orchestrator.orchestrator_common
+    name: orchestrator_common
     tasks_from: openchami_auth.yml
   vars:
     oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"

--- a/src/orchestrator/roles/deploy_openldap/tasks/main.yml
+++ b/src/orchestrator/roles/deploy_openldap/tasks/main.yml
@@ -32,7 +32,7 @@
       block:
         - name: Load OpenLDAP credentials
           ansible.builtin.include_role:
-            name: omnia.orchestrator.orchestrator_common
+            name: orchestrator_common
             tasks_from: decrypt_include_encrypt.yml
           vars:
             credential_file_path: "{{ hostvars['localhost']['input_project_dir'] }}/omnia_config_credentials.yml"

--- a/src/orchestrator/roles/orchestrator_common/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_common/tasks/main.yml
@@ -18,7 +18,7 @@
 # Instead, individual task files are included via:
 #
 #   ansible.builtin.include_role:
-#     name: omnia.orchestrator.orchestrator_common
+#     name: orchestrator_common
 #     tasks_from: <task_file>.yml
 #
 # Available task files:
@@ -29,4 +29,4 @@
 
 - name: Orchestrator_common is a task library — use tasks_from to include specific tasks
   ansible.builtin.debug:
-    msg: "Use 'include_role: name=omnia.orchestrator.orchestrator_common tasks_from=<file>.yml' to include specific tasks"
+    msg: "Use 'include_role: name=orchestrator_common tasks_from=<file>.yml' to include specific tasks"

--- a/src/orchestrator/roles/orchestrator_credentials/tasks/create_credentials.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/tasks/create_credentials.yml
@@ -16,7 +16,7 @@
 # Decrypt and include vars for existing credential files
 - name: Include vars for encrypted credentials
   ansible.builtin.include_role:
-    name: omnia.orchestrator.orchestrator_common
+    name: orchestrator_common
     tasks_from: decrypt_include_encrypt.yml
   loop: "{{ credential_files }}"
   loop_control:

--- a/src/orchestrator/roles/orchestrator_credentials/tasks/prompt_password.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/tasks/prompt_password.yml
@@ -18,7 +18,7 @@
   when: password_status
   block:
     - name: Fetch credential rule for "{{ field.password | default('Password') }}" # noqa name[template]
-      omnia.orchestrator.fetch_credential_rule:
+      fetch_credential_rule:
         credential_field: "{{ field.password }}"
         module_utils_path: "{{ module_utils_path }}"
       register: credential_rule
@@ -38,7 +38,7 @@
         - password_input.user_input | length == 0
 
     - name: Validate input credential - "{{ field.password | default('Password') }}" # noqa name[template]
-      omnia.orchestrator.validate_credentials:
+      validate_credentials:
         credential_field: "{{ field.password }}"
         credential_input: "{{ password_input.user_input }}"
         module_utils_path: "{{ module_utils_path }}"

--- a/src/orchestrator/roles/orchestrator_credentials/tasks/prompt_username.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/tasks/prompt_username.yml
@@ -18,7 +18,7 @@
   when: username_status
   block:
     - name: Fetch credential rule for "{{ field.username | default('Username') }}" # noqa name[template]
-      omnia.orchestrator.fetch_credential_rule:
+      fetch_credential_rule:
         credential_field: "{{ field.username }}"
         module_utils_path: "{{ module_utils_path }}"
       register: credential_rule
@@ -50,7 +50,7 @@
         - username_input.user_input | length == 0
 
     - name: Validate input credential - "{{ field.username | default('Username') }}" # noqa name[template]
-      omnia.orchestrator.validate_credentials:
+      validate_credentials:
         credential_field: "{{ field.username }}"
         credential_input: "{{ username_input.user_input }}"
         module_utils_path: "{{ module_utils_path }}"

--- a/src/orchestrator/roles/orchestrator_credentials/tasks/update_credentials_main.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/tasks/update_credentials_main.yml
@@ -27,7 +27,7 @@
 # Re-include updated credentials
 - name: Include updated credentials
   ansible.builtin.include_role:
-    name: omnia.orchestrator.orchestrator_common
+    name: orchestrator_common
     tasks_from: decrypt_include_encrypt.yml
   loop: "{{ credential_files }}"
   loop_control:

--- a/src/orchestrator/roles/orchestrator_functional_groups/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_functional_groups/tasks/main.yml
@@ -22,7 +22,7 @@
     functional_groups_config_path: "{{ functional_groups_config_path }}"
 
 - name: Generate functional groups from mapping.csv
-  omnia.orchestrator.generate_functional_groups:
+  generate_functional_groups:
     mapping_file_path: "{{ pxe_mapping_file_path }}"
     functional_groups_file_path: "{{ functional_groups_config_path }}"
     omnia_config_path: "{{ omnia_config_dir }}/{{ omnia_config_file }}"

--- a/src/orchestrator/roles/orchestrator_validations/tasks/validate_mapping_file.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/validate_mapping_file.yml
@@ -60,7 +60,7 @@
     mode: "0644"
 
 - name: Generate xnames in temporary mapping file
-  omnia.orchestrator.generate_xname_in_mapping_file:
+  generate_xname_in_mapping_file:
     mapping_file_path: "{{ temp_pxe_file_path }}"
 
 - name: Read host mapping file from CSV file and return a dictionary

--- a/src/orchestrator/roles/slurm_config/tasks/confs.yml
+++ b/src/orchestrator/roles/slurm_config/tasks/confs.yml
@@ -159,7 +159,7 @@
   register: ctld_conf_files
 
 - name: Parse configs_input files from localhost (if they are paths)
-  omnia.orchestrator.slurm_conf:
+  slurm_conf:
     op: parse
     conf_name: "{{ item.key }}"
     path: "{{ item.value }}"
@@ -227,7 +227,7 @@
   no_log: "{{ _no_log }}"
 
 - name: Merge the confs
-  omnia.orchestrator.slurm_conf:
+  slurm_conf:
     op: merge
     conf_sources: "{{ item.value }}"
     conf_name: "{{ item.key }}"

--- a/src/orchestrator/roles/slurm_config/tasks/handle_extra_confs.yml
+++ b/src/orchestrator/roles/slurm_config/tasks/handle_extra_confs.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 - name: Add extra confs which are not handled
-  omnia.orchestrator.slurm_conf:
+  slurm_conf:
     op: merge
     conf_sources: "{{ [configs_input[extra_conf]] }}"
     conf_name: "{{ extra_conf }}"

--- a/src/orchestrator/roles/slurm_config/tasks/remove_node.yml
+++ b/src/orchestrator/roles/slurm_config/tasks/remove_node.yml
@@ -75,7 +75,7 @@
     - updated_partitions is defined
 
 - name: Convert slurm conf to ini
-  omnia.orchestrator.slurm_conf:
+  slurm_conf:
     op: render
     conf_name: slurm
     conf_map: "{{ slurm_conf_dict }}"

--- a/src/orchestrator/roles/validate_orchestrator_input/tasks/main.yml
+++ b/src/orchestrator/roles/validate_orchestrator_input/tasks/main.yml
@@ -50,7 +50,7 @@
 
 # Run the validate_orchestrator_config module (L1 + L2)
 - name: Run orchestrator configuration validation
-  omnia.orchestrator.validate_orchestrator_config:
+  validate_orchestrator_config:
     input_project_dir: "{{ input_dir }}"
     schema_dir: "{{ orchestrator_schema_dir }}"
   register: orchestrator_validation_result


### PR DESCRIPTION
## Summary

Replace all fully-qualified collection names (`omnia.orchestrator.*` and `omnia.discovery.*`) with short names across playbooks, roles, plugins, and `ansible.cfg` files. This aligns both domains with the `image_build_manager` pattern where roles are resolved via `roles_path` and modules via `library`/`module_utils` settings in `ansible.cfg`, **eliminating the need for Galaxy collection installation or symlinks**.

### Changes (63 files)

- **Playbook role references**: `omnia.<domain>.<role>` → `<role>`
- **Role `include_role` references**: `name: omnia.<domain>.<role>` → `<role>`
- **Custom module calls**: `omnia.<domain>.<module>:` → `<module>:`
- **Python `module_utils` imports**: `ansible_collections.omnia.<domain>.plugins.module_utils.*` → `ansible.module_utils.*`
- **Callback plugin references**: `omnia.<domain>.omnia_default` → `omnia_default`
- **DOCUMENTATION strings**: Updated FQCN examples to short names for consistency

### Why

Previously, running `ansible-playbook orchestrator.yml` or `discovery.yml` failed with:
```
[ERROR]: The role 'omnia.orchestrator.orchestrator_setup' was not found
```
This required manually creating Galaxy collection symlinks (`~/.ansible/collections/ansible_collections/omnia/<domain> → src/<domain>`). The `image_build_manager` domain already used short names and worked without this workaround.

### Test Plan

- [x] `ansible-playbook discovery.yml -e discovery_mechanism=ome` — passes (exit 0, 60 ok)
- [x] `ansible-playbook orchestrator.yml` — passes (exit 0, 253+408 ok)
- [x] Both tested **without** any Galaxy collection symlinks installed
- [x] No remaining `omnia.orchestrator.` or `omnia.discovery.` FQCN references (verified via grep, excluding `galaxy.yml`)