### PR TITLE
fix(orchestrator): resolve three runtime failures in orchestrator.yml playbook

### DIFF
--- a/src/orchestrator/roles/configure_ochami/vars/main.yml
+++ b/src/orchestrator/roles/configure_ochami/vars/main.yml
@@ -48,14 +48,14 @@ boot_svc_params_opts: 'ip=dhcp rd.live.image rd.live.ram rd.neednet=1 rd.driver.
 image_missing_fail_msg: "Failed to set kernel or initrd. Create the image using build_image.yml and try again."
 
 # Usage: configure_metadata_svc_group.yml, configure_bss_metadata_svc.yml
-ssh_key_path: /root/.ssh/oim_rsa.pub
+ssh_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/oim_rsa.pub"
 ms_defaults_template: metadata_svc/ms-defaults.yaml.j2
 metadata_svc_dir: "{{ openchami_work_dir }}/metadata-service"
 ms_defaults_dest: '{{ metadata_svc_dir }}/ms-defaults.yaml'
 ms_group_load_fail_msg: |
   "Template loading failed. Ensure the template exists in the specified path and is compatible with the defined functional groups."
 default_file_path: "{{ role_path }}/../slurm_config/defaults/main.yml"
-ssh_private_key_path: /root/.ssh/oim_rsa
+ssh_private_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/oim_rsa"
 
 # Usage: configure_metadata_svc_common.yml
 ms_group_common_template: metadata_svc/ms-group-common.yaml.j2

--- a/src/orchestrator/roles/deploy_openchami/tasks/configs/ochami.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/configs/ochami.yml
@@ -31,9 +31,7 @@
 - name: Determine RPM download URL from release assets
   ansible.builtin.set_fact:
     openchami_rpm_url: >-
-      {{ (openchami_release_info.json.assets
-          | selectattr('name', 'match', '.*\\.rpm$')
-          | first).browser_download_url }}
+      https://github.com/{{ openchami_release_repo }}/releases/download/{{ openchami_release_info.json.tag_name }}/{{ openchami_rpm_name }}
   when: not _openchami_rpm_stat.stat.exists
 
 - name: Download the OpenCHAMI RPM from GitHub releases

--- a/src/orchestrator/roles/k8s_config/vars/main.yml
+++ b/src/orchestrator/roles/k8s_config/vars/main.yml
@@ -86,4 +86,4 @@ packages_layout_aarch64:
 print_copy_msg: "Copying {{ item.name }} from {{ item.source_path }} to {{ item.dest_path }}"
 offline_path_x86_64: []
 offline_path_aarch64: []
-ssh_private_key_path: /root/.ssh/oim_rsa
+ssh_private_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/oim_rsa"

--- a/src/orchestrator/roles/passwordless_ssh/tasks/configure_oim_ssh.yml
+++ b/src/orchestrator/roles/passwordless_ssh/tasks/configure_oim_ssh.yml
@@ -14,6 +14,19 @@
 ---
 # tasks/configure_oim_ssh.yml
 
+- name: Ensure .ssh directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_user_dir }}/.ssh"
+    state: directory
+    mode: '0700'
+
+- name: Generate OIM SSH key pair
+  ansible.builtin.command: >-
+    ssh-keygen -t rsa -b 4096
+    -f {{ ansible_user_dir }}/.ssh/oim_rsa -N ""
+  args:
+    creates: "{{ ansible_user_dir }}/.ssh/oim_rsa"
+
 - name: Gather cluster hostnames and IP wildcard patterns from localhost facts
   ansible.builtin.set_fact:
     k8s_cluster_hostnames: "{{ hostvars['localhost']['k8s_cluster_hostnames'] | default([]) }}"

--- a/src/orchestrator/roles/passwordless_ssh/vars/main.yml
+++ b/src/orchestrator/roles/passwordless_ssh/vars/main.yml
@@ -37,4 +37,4 @@ omnia_required_groups_from_nodes_yaml: >-
      | map(attribute='name')
      | list }}
 
-ssh_private_key_path: /root/.ssh/config
+ssh_private_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/config"

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -35,6 +35,11 @@
     apply_config: "{{ __default_config }}"
   when: apply_config is not defined
 
+- name: Initialize slurm_conf_dict from defaults
+  ansible.builtin.set_fact:
+    slurm_conf_dict: "{{ __default_config.slurm }}"
+  when: slurm_conf_dict is not defined
+
 - name: Set nodes_yaml path for slurm_config tasks
   ansible.builtin.set_fact:
     nodes_yaml: "{{ nodes_dir }}/nodes_{{ target_category }}.yaml"

--- a/src/orchestrator/roles/provision_common/vars/main.yml
+++ b/src/orchestrator/roles/provision_common/vars/main.yml
@@ -38,8 +38,8 @@ ms_defaults_dest: "{{ metadata_svc_dir }}/ms-defaults.yaml"
 ms_group_common_dest: "{{ metadata_svc_dir }}/ms-group-common.yaml"
 
 # SSH keys
-ssh_key_path: /root/.ssh/oim_rsa.pub
-ssh_private_key_path: /root/.ssh/oim_rsa
+ssh_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/oim_rsa.pub"
+ssh_private_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/oim_rsa"
 
 # Service retry settings
 service_retries: 16

--- a/src/orchestrator/roles/slurm_config/vars/main.yml
+++ b/src/orchestrator/roles/slurm_config/vars/main.yml
@@ -149,7 +149,7 @@ print_copy_msg: "Copying {{ item.name }} from {{ item.source_path }} to {{ item.
 offline_path_x86_64: []
 offline_path_aarch64: []
 hosts_file_path: "/etc/hosts"
-ssh_private_key_path: /root/.ssh/oim_rsa
+ssh_private_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/oim_rsa"
 
 # NVIDIA HPC SDK vars
 # NOTE: NVHPC is now installed via DNF from Pulp-mirrored NVIDIA repo


### PR DESCRIPTION
## Summary

Fixes three sequential runtime failures encountered when running `ansible-playbook orchestrator.yml`.

## Changes

### 1. Construct OpenCHAMI RPM URL from release tag_name
**File:** `roles/deploy_openchami/tasks/configs/ochami.yml`

The previous approach parsed the GitHub release `assets` array using `selectattr | first` to find the RPM download URL. This fails when the OIM host receives an incomplete API response (rate limiting, proxy interception) resulting in an empty sequence.

Now constructs the URL directly from `tag_name` + `openchami_rpm_name`, which only requires the `tag_name` field in the response.

### 2. Generate OIM SSH key pair and use user-aware paths
**Files:** `roles/passwordless_ssh/tasks/configure_oim_ssh.yml`, `roles/passwordless_ssh/vars/main.yml`, `roles/provision_common/vars/main.yml`, `roles/configure_ochami/vars/main.yml`, `roles/slurm_config/vars/main.yml`, `roles/k8s_config/vars/main.yml`

The `passwordless_ssh` role configured SSH config blocks referencing `~/.ssh/oim_rsa` but never generated the key pair, causing `provision_common` to fail at "Read SSH public key". Added `ssh-keygen` to `configure_oim_ssh.yml` and replaced all hardcoded `/root/.ssh/oim_rsa` paths with `ansible_user_dir` so the playbook works for any user.

### 3. Initialize slurm_conf_dict for login_compiler_node templates
**File:** `roles/provision_common/tasks/configure_metadata_svc.yml`

The `login_compiler_node_x86_64` metadata-service template references `slurm_conf_dict.SrunPortRange` and `slurm_conf_dict.SlurmdPort`, but this variable is only set by `slurm_config/confs.yml` which is not called during provisioning. Added initialization from `__default_config.slurm` defaults.

## Testing

All three fixes verified by running `ansible-playbook orchestrator.yml` end-to-end successfully (exit code 0).

Signed-off-by: Sujit Jadhav <sujit.jadhav@dell.com>