### PR TITLE
fix(orchestrator): add SMD database connection env vars to openchami.env

### DIFF
--- a/src/orchestrator/roles/deploy_openchami/tasks/configs/ochami.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/configs/ochami.yml
@@ -61,6 +61,11 @@
     - { regexp: '^DOCKER_STEPCA_INIT_DNS_NAMES=', line: 'DOCKER_STEPCA_INIT_DNS_NAMES=step-ca,step-ca.{{ cluster_domain }}' }
     - { regexp: '^TOKENSMITH_CLUSTER_ID=', line: 'TOKENSMITH_CLUSTER_ID={{ cluster_name }}-cluster' }
     - { regexp: '^TOKENSMITH_OPENCHAMI_ID=', line: 'TOKENSMITH_OPENCHAMI_ID={{ cluster_name }}-openchami' }
+    - { regexp: '^SMD_DBHOST=', line: 'SMD_DBHOST={{ smd_dbhost }}' }
+    - { regexp: '^SMD_DBPORT=', line: 'SMD_DBPORT={{ smd_dbport }}' }
+    - { regexp: '^SMD_DBNAME=', line: 'SMD_DBNAME={{ smd_dbname }}' }
+    - { regexp: '^SMD_DBUSER=', line: 'SMD_DBUSER={{ smd_dbuser }}' }
+    - { regexp: '^SMD_DBOPTS=', line: 'SMD_DBOPTS={{ smd_dbopts }}' }
   loop_control:
     label: "{{ item.regexp }}"
 

--- a/src/orchestrator/roles/deploy_openchami/tasks/configs/verify.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/configs/verify.yml
@@ -31,8 +31,27 @@
     - name: Verify openchami service
       ansible.builtin.include_tasks: verify_ochami.yml
       vars:
-        max_retries: 1
+        max_retries: 3
   rescue:
+    - name: Collect openchami service statuses before restart # noqa: command-instead-of-module
+      ansible.builtin.shell: |
+        echo "=== systemctl status openchami.target ==="
+        systemctl status openchami.target --no-pager 2>&1 || true
+        echo "=== Failed services ==="
+        systemctl list-dependencies openchami.target --plain 2>/dev/null | while read svc; do
+          state=$(systemctl is-active "$svc" 2>/dev/null)
+          if [ "$state" != "active" ]; then
+            echo "$svc: $state"
+          fi
+        done
+      register: pre_restart_diag
+      changed_when: false
+      failed_when: false
+
+    - name: Display pre-restart diagnostics
+      ansible.builtin.debug:
+        msg: "{{ pre_restart_diag.stdout_lines | default([]) }}"
+
     - name: Restart openchami in case of error
       ansible.builtin.systemd:
         name: openchami.target

--- a/src/orchestrator/roles/deploy_openchami/tasks/configs/verify.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/configs/verify.yml
@@ -34,16 +34,19 @@
         max_retries: 3
   rescue:
     - name: Collect openchami service statuses before restart # noqa: command-instead-of-module
-      ansible.builtin.shell: |
-        echo "=== systemctl status openchami.target ==="
-        systemctl status openchami.target --no-pager 2>&1 || true
-        echo "=== Failed services ==="
-        systemctl list-dependencies openchami.target --plain 2>/dev/null | while read svc; do
-          state=$(systemctl is-active "$svc" 2>/dev/null)
-          if [ "$state" != "active" ]; then
-            echo "$svc: $state"
-          fi
-        done
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          echo "=== systemctl status openchami.target ==="
+          systemctl status openchami.target --no-pager 2>&1 || true
+          echo "=== Failed services ==="
+          systemctl list-dependencies openchami.target --plain 2>/dev/null | while read svc; do
+            state=$(systemctl is-active "$svc" 2>/dev/null)
+            if [ "$state" != "active" ]; then
+              echo "$svc: $state"
+            fi
+          done
+        executable: /bin/bash
       register: pre_restart_diag
       changed_when: false
       failed_when: false

--- a/src/orchestrator/roles/deploy_openchami/tasks/configs/verify_ochami.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/configs/verify_ochami.yml
@@ -39,6 +39,32 @@
       ansible.builtin.debug:
         msg: "{{ openchami_dependencies.stdout_lines }}"
 
+    - name: Verify postgres is active
+      ansible.builtin.systemd:
+        name: postgres.service
+      register: openchami_postgres_status
+      until: openchami_postgres_status.status.ActiveState == "active"
+      retries: "{{ max_retries }}"
+      delay: "{{ max_delay }}"
+      changed_when: false
+      failed_when: false
+
+    - name: Collect postgres container logs on failure
+      ansible.builtin.command: podman logs --tail 30 postgres
+      register: postgres_logs
+      changed_when: false
+      failed_when: false
+      when: openchami_postgres_status.status.ActiveState != "active"
+
+    - name: Fail if postgres is not running
+      ansible.builtin.fail:
+        msg: >-
+          postgres is not running after {{ max_retries }} retries
+          (state={{ openchami_postgres_status.status.ActiveState }}).
+          Logs: {{ postgres_logs.stdout | default('unavailable') }}
+          {{ postgres_logs.stderr | default('') }}
+      when: openchami_postgres_status.status.ActiveState != "active"
+
     - name: Verify boot-service is active
       ansible.builtin.systemd:
         name: boot-service.service
@@ -54,6 +80,32 @@
         msg: "boot-service is not running after {{ max_retries }} retries."
       when: openchami_boot_service_status.status.ActiveState != "active"
 
+    - name: Verify smd systemd service is active
+      ansible.builtin.systemd:
+        name: smd.service
+      register: openchami_smd_service_status
+      until: openchami_smd_service_status.status.ActiveState == "active"
+      retries: "{{ max_retries }}"
+      delay: "{{ max_delay }}"
+      changed_when: false
+      failed_when: false
+
+    - name: Collect smd container logs if service not active
+      ansible.builtin.command: podman logs --tail 50 smd
+      register: smd_container_logs
+      changed_when: false
+      failed_when: false
+      when: openchami_smd_service_status.status.ActiveState != "active"
+
+    - name: Fail if smd systemd service is not running
+      ansible.builtin.fail:
+        msg: >-
+          smd.service is not active after {{ max_retries }} retries
+          (state={{ openchami_smd_service_status.status.ActiveState }}).
+          Container logs: {{ smd_container_logs.stdout | default('unavailable') }}
+          {{ smd_container_logs.stderr | default('') }}
+      when: openchami_smd_service_status.status.ActiveState != "active"
+
     - name: Verify ochami smd status
       ansible.builtin.command:
         ochami smd service status
@@ -64,9 +116,44 @@
       changed_when: false
       failed_when: false
 
+    - name: Collect diagnostic info on smd status failure
+      when: openchami_smd_status.rc != 0
+      block:
+        - name: Collect smd container logs
+          ansible.builtin.command: podman logs --tail 50 smd
+          register: smd_diag_logs
+          changed_when: false
+          failed_when: false
+
+        - name: Collect haproxy container logs
+          ansible.builtin.command: podman logs --tail 30 haproxy
+          register: haproxy_diag_logs
+          changed_when: false
+          failed_when: false
+
+        - name: Collect smd-init service status
+          ansible.builtin.command: journalctl -u smd-init.service --no-pager -n 20
+          register: smd_init_diag_logs
+          changed_when: false
+          failed_when: false
+
+        - name: Display diagnostic info
+          ansible.builtin.debug:
+            msg:
+              - "=== SMD container logs ==="
+              - "{{ smd_diag_logs.stdout_lines | default([]) }}"
+              - "{{ smd_diag_logs.stderr_lines | default([]) }}"
+              - "=== HAProxy container logs ==="
+              - "{{ haproxy_diag_logs.stdout_lines | default([]) }}"
+              - "=== smd-init service journal ==="
+              - "{{ smd_init_diag_logs.stdout_lines | default([]) }}"
+
     - name: Fail if ochami smd status check failed
       ansible.builtin.fail:
-        msg: "ochami smd service is not running after {{ max_retries }} retries. {{ openchami_smd_status.stderr | default('') }}"
+        msg: >-
+          ochami smd service is not running after {{ max_retries }} retries.
+          {{ openchami_smd_status.stderr | default('') }}
+          Run 'podman logs smd' and 'podman logs haproxy' on the OIM host for details.
       when: openchami_smd_status.rc != 0
 
     - name: Openchami smd status output

--- a/src/orchestrator/roles/deploy_openchami/templates/haproxy.cfg.j2
+++ b/src/orchestrator/roles/deploy_openchami/templates/haproxy.cfg.j2
@@ -10,6 +10,8 @@ defaults
   timeout connect 5s
   timeout server 10s
   timeout http-request 10s
+  retries 3
+  option redispatch
   log global
 
 frontend stats

--- a/src/orchestrator/roles/deploy_openchami/vars/main.yml
+++ b/src/orchestrator/roles/deploy_openchami/vars/main.yml
@@ -58,6 +58,16 @@ openchami_images:
 # Usage: verify_openchami.yml
 cluster_env_key: "{{ oim_node_name | upper }}_ACCESS_TOKEN"
 
+# SMD (State Management Database) postgres connection settings
+# These must match the values in smd-init.container from the OpenCHAMI RPM.
+# They are injected into openchami.env so smd.container can reach postgres
+# via the Podman DNS name instead of defaulting to localhost.
+smd_dbhost: postgres
+smd_dbport: 5432
+smd_dbname: hmsds
+smd_dbuser: smd-user
+smd_dbopts: "sslmode=disable"
+
 # --- OpenCHAMI configs role variables ---
 # Directory paths
 ochami_dir: /etc/ochami


### PR DESCRIPTION
The SMD container was failing to connect to PostgreSQL because it lacked database connection environment variables. Without SMD_DBHOST, the SMD binary defaulted to localhost ([::1]), which cannot reach the postgres container running on the Podman network. The smd-init container worked because it has these variables set directly in its quadlet.

This fix injects the 5 required SMD_DB* variables (DBHOST, DBPORT, DBNAME, DBUSER, DBOPTS) into /etc/openchami/configs/openchami.env, which smd.container already loads via EnvironmentFile. The values match those in smd-init.container from the OpenCHAMI RPM.

Also adds diagnostic improvements:
- Pre-checks for postgres.service and smd.service before SMD status
- Enhanced failure diagnostics with container logs
- HAProxy resilience: retries 3 + option redispatch in defaults
- Increased verify retry count with pre-restart diagnostics