### PR TITLE
fix(orchestrator): use chpasswd to reliably set root password

### DIFF
--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-common.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-common.yaml.j2
@@ -13,6 +13,15 @@
         - name: dict
           settings: [no_replace, recurse_list]
  
+      ssh_pwauth: true
+
+      chpasswd:
+        expire: false
+        users:
+          - name: root
+            password: "{{ hashed_password_output.stdout }}"
+            type: hash
+
       write_files:
         - path: /usr/local/bin/set-ssh-config.sh
           permissions: '0755'

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-default_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-default_x86_64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
       disable_root: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -77,6 +77,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if login_compiler_node_present %}
         - path: /usr/local/bin/generate_install_uuid.sh

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -76,6 +76,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if login_compiler_node_present %}
         - path: /usr/local/bin/generate_install_uuid.sh

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -79,6 +79,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -79,6 +79,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-os_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-os_aarch64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
       disable_root: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-os_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-os_x86_64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
       disable_root: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -94,6 +94,8 @@
             Host {{ k8s_control_ssh_patterns }}
                 IdentityFile {{ k8s_client_mount_path }}/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
         - path: /etc/chrony.conf
           permissions: '0644'

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -14,7 +14,8 @@
 
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
       disable_root: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -14,7 +14,8 @@
 
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
       disable_root: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -86,6 +86,8 @@
             Host {{ k8s_control_ssh_patterns }}
                 IdentityFile {{ k8s_client_mount_path }}/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
         - path: /etc/modules-load.d/k8s.conf
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -74,6 +74,8 @@
             Host {{ k8s_control_ssh_patterns }}
                 IdentityFile {{ k8s_client_mount_path }}/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
         - path: /etc/modules-load.d/k8s.conf
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -14,7 +14,8 @@
 
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
       disable_root: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
@@ -77,6 +77,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 {% if metadata_svc_groups_dict[functional_group_name].powervault_scripts is defined %}
 {% for pv_entry in metadata_svc_groups_dict[functional_group_name].powervault_scripts | default([], true) %}
         - path: /usr/local/bin/setup_iscsi_storage_{{ pv_entry.name }}.sh

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
@@ -78,6 +78,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
@@ -79,6 +79,8 @@
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 
 {% if hostvars['localhost']['openldap_support'] %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}

--- a/src/orchestrator/roles/passwordless_ssh/tasks/read_nodes_yaml.yml
+++ b/src/orchestrator/roles/passwordless_ssh/tasks/read_nodes_yaml.yml
@@ -131,7 +131,7 @@
 
 - name: Configure SSH on OIM with Host * when all groups are present in nodes.yaml
   ansible.builtin.blockinfile:
-    path: "{{ ssh_private_key_path }}"
+    path: "{{ oim_ssh_config_path }}"
     create: true
     mode: '0600'
     marker: "# {mark} OMNIA_CLUSTER_SSH"
@@ -145,7 +145,7 @@
 
 - name: Configure SSH on OIM with derived hostname/IP patterns when groups are incomplete
   ansible.builtin.blockinfile:
-    path: "{{ ssh_private_key_path }}"
+    path: "{{ oim_ssh_config_path }}"
     create: true
     mode: '0600'
     marker: "# {mark} OMNIA_CLUSTER_SSH"

--- a/src/orchestrator/roles/passwordless_ssh/tasks/read_nodes_yaml.yml
+++ b/src/orchestrator/roles/passwordless_ssh/tasks/read_nodes_yaml.yml
@@ -141,6 +141,7 @@
           IdentitiesOnly yes
           StrictHostKeyChecking no
           UserKnownHostsFile /dev/null
+          LogLevel ERROR
   when: all_group_names_present
 
 - name: Configure SSH on OIM with derived hostname/IP patterns when groups are incomplete
@@ -159,6 +160,7 @@
           IdentitiesOnly yes
           StrictHostKeyChecking no
           UserKnownHostsFile /dev/null
+          LogLevel ERROR
   when:
     - not all_group_names_present | default(false) | bool
     - omnia_cluster_ssh_matches | default([]) | length > 0

--- a/src/orchestrator/roles/passwordless_ssh/tasks/read_nodes_yaml.yml
+++ b/src/orchestrator/roles/passwordless_ssh/tasks/read_nodes_yaml.yml
@@ -139,6 +139,8 @@
       Host *
           IdentityFile ~/.ssh/oim_rsa
           IdentitiesOnly yes
+          StrictHostKeyChecking no
+          UserKnownHostsFile /dev/null
   when: all_group_names_present
 
 - name: Configure SSH on OIM with derived hostname/IP patterns when groups are incomplete
@@ -155,6 +157,8 @@
                | join(' ') }}
           IdentityFile ~/.ssh/oim_rsa
           IdentitiesOnly yes
+          StrictHostKeyChecking no
+          UserKnownHostsFile /dev/null
   when:
     - not all_group_names_present | default(false) | bool
     - omnia_cluster_ssh_matches | default([]) | length > 0

--- a/src/orchestrator/roles/passwordless_ssh/vars/main.yml
+++ b/src/orchestrator/roles/passwordless_ssh/vars/main.yml
@@ -37,4 +37,4 @@ omnia_required_groups_from_nodes_yaml: >-
      | map(attribute='name')
      | list }}
 
-ssh_private_key_path: "{{ ansible_user_dir | default('/root') }}/.ssh/config"
+oim_ssh_config_path: "{{ ansible_user_dir | default('/root') }}/.ssh/config"

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -185,6 +185,37 @@
     label: "{{ entry.name }}"
   when: not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
 
+- name: Fetch existing metadata-service groups for delete-before-set - {{ fg_name }}
+  ansible.builtin.uri:
+    url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443/metadata-service/groups"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ ochami_env[(oim_node_name | upper) + '_ACCESS_TOKEN'] }}"
+    status_code: [200]
+    validate_certs: false
+    return_content: true
+  register: _existing_fg_groups
+  failed_when: false
+  when: not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
+
+- name: Delete existing metadata-service group entries for {{ fg_name }}
+  ansible.builtin.uri:
+    url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443/metadata-service/groups/{{ item.metadata.uid }}"
+    method: DELETE
+    headers:
+      Authorization: "Bearer {{ ochami_env[(oim_node_name | upper) + '_ACCESS_TOKEN'] }}"
+    status_code: [200, 204, 404]
+    validate_certs: false
+  loop: >-
+    {{ _existing_fg_groups.json | default([])
+       | selectattr('metadata.name', 'in', _ms_fg_bodies | default([]) | map(attribute='metadata.name') | list)
+       | list }}
+  loop_control:
+    label: "{{ item.metadata.name | default(item.metadata.uid) }}"
+  when:
+    - not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
+    - _existing_fg_groups.json | default([]) | length > 0
+
 - name: Set metadata-service group configuration for functional group (via metadata-service API)  # noqa: name[template]
   ansible.builtin.uri:
     url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443/metadata-service/groups"
@@ -194,7 +225,7 @@
       Content-Type: "application/json"
     body_format: json
     body: "{{ item }}"
-    status_code: [200, 201, 409]
+    status_code: [200, 201]
     validate_certs: false
   loop: "{{ _ms_fg_bodies | default([]) }}"
   loop_control:

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc_common.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc_common.yml
@@ -54,6 +54,37 @@
     label: "{{ entry.name }}"
   when: not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
 
+- name: Fetch existing metadata-service groups for delete-before-set - common
+  ansible.builtin.uri:
+    url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443/metadata-service/groups"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ ochami_env[(oim_node_name | upper) + '_ACCESS_TOKEN'] }}"
+    status_code: [200]
+    validate_certs: false
+    return_content: true
+  register: _existing_common_groups
+  failed_when: false
+  when: not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
+
+- name: Delete existing metadata-service common group entries
+  ansible.builtin.uri:
+    url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443/metadata-service/groups/{{ item.metadata.uid }}"
+    method: DELETE
+    headers:
+      Authorization: "Bearer {{ ochami_env[(oim_node_name | upper) + '_ACCESS_TOKEN'] }}"
+    status_code: [200, 204, 404]
+    validate_certs: false
+  loop: >-
+    {{ _existing_common_groups.json | default([])
+       | selectattr('metadata.name', 'in', _ms_group_bodies | default([]) | map(attribute='metadata.name') | list)
+       | list }}
+  loop_control:
+    label: "{{ item.metadata.name | default(item.metadata.uid) }}"
+  when:
+    - not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
+    - _existing_common_groups.json | default([]) | length > 0
+
 - name: Set metadata-service group configuration - common (via metadata-service API)
   ansible.builtin.uri:
     url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443/metadata-service/groups"
@@ -63,7 +94,7 @@
       Content-Type: "application/json"
     body_format: json
     body: "{{ item }}"
-    status_code: [200, 201, 409]
+    status_code: [200, 201]
     validate_certs: false
   loop: "{{ _ms_group_bodies | default([]) }}"
   loop_control:


### PR DESCRIPTION
# Fix passwordless SSH and root password provisioning

This PR fixes multiple issues preventing passwordless SSH and root password from being correctly deployed to compute nodes via cloud-init.

## Issues Fixed

### 1. Cloud-init Jinja template crash on `host_mount_map`
The metadata-service API stores `metaData` values as strings. When `host_mount_map` (an empty dict `{}`) was serialized via `| map('to_json')`, it became the JSON string `"{}"`. Cloud-init's Jinja2 engine crashed when calling `.get()` on this string with `'str object has no attribute get'`, causing the entire template to be dropped including `ssh_authorized_keys`.

**Fix:** Add `is mapping` guard to ensure `.get()` is only called when `host_mount_map` is actually a dict.

### 2. Inter-node SSH required NFS availability
The SSH config referenced `IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa`, which relied on NFS being mounted. When the NFS server (172.16.107.168) was unreachable from compute nodes, inter-node SSH failed.

**Fix:** Deploy the `oim_rsa` private key directly via cloud-init `write_files` to `/root/.ssh/oim_rsa` on each compute node, making inter-node SSH independent of NFS availability.

### 3. Variable name collision: `ssh_private_key_path`
The variable `ssh_private_key_path` was defined in `passwordless_ssh` as `~/.ssh/config` (SSH config file path), but the same variable name was also defined in `provision_common`, `slurm_config`, and `configure_ochami` as `~/.ssh/oim_rsa` (SSH private key file path). When `configure_metadata_svc.yml` ran `include_vars` from `slurm_config`, it set `ssh_private_key_path=~/.ssh/oim_rsa` at host level (Ansible precedence 18), overriding the `passwordless_ssh` role var (precedence 12). This caused the `blockinfile` task to write SSH config content INTO the private key file instead of creating `~/.ssh/config`.

**Fix:** Rename the variable in `passwordless_ssh` to `oim_ssh_config_path` to avoid the name collision.

### 4. Metadata-service group updates not propagating
The metadata-service groups API returns 409 when a group already exists, causing POST to silently skip the update. Template changes (e.g., `ssh_authorized_keys` format fix, `StrictHostKeyChecking` additions) never reached the metadata-service on re-runs.

**Fix:** Add delete-before-post flow: fetch existing groups, delete those matching the current FG/common entries by UID, then POST the new config.

### 5. `ssh_authorized_keys` format incorrect
Cloud-init schema expects `ssh_authorized_keys` to be an array, not a string. When a string was passed, cloud-init's `set()` call iterated over individual characters instead of treating it as a single key, resulting in garbage in `authorized_keys` and broken SSH key authentication.

**Fix:** Change from `ssh_authorized_keys: "{{ read_ssh_key.stdout }}"` to list format:
```yaml
ssh_authorized_keys:
  - "{{ read_ssh_key.stdout }}"
```

### 6. Root password not reliably set
The root user is pre-existing on all Linux systems. Cloud-init's `hashed_passwd` field in the users module has a known bug where the password can remain locked (`!` prefix in `/etc/shadow`) even with `lock_passwd: false` for pre-existing users (cloud-init #6703).

**Fix:** Add `chpasswd` to the ssh common group in `ms-group-common.yaml.j2` to reliably set and unlock the root password.

### 7. SSH known_hosts warnings
With `UserKnownHostsFile /dev/null`, SSH treats every connection as a new host and prints `'Warning: Permanently added ... to the list of known hosts.'` on every connection.

**Fix:** Add `LogLevel ERROR` to suppress this informational warning while still showing actual errors.

## Changes

- **10 FG templates** in `configure_ochami/templates/metadata_svc/`:
  - Add `is mapping` guard to `host_mount_map` check
  - Update `IdentityFile` path from NFS-dependent to `/root/.ssh/oim_rsa`
  - Add `write_files` entry to deploy private key to `/root/.ssh/oim_rsa`
  - Fix `ssh_authorized_keys` to list format
  - Add `StrictHostKeyChecking no` and `UserKnownHostsFile /dev/null` to SSH config
  - Add `LogLevel ERROR` to SSH config

- **2 playbook tasks** in `configure_metadata_svc.yml` and `configure_metadata_svc_common.yml`:
  - Add delete-before-post flow for metadata-service group updates

- **Variable rename** in `passwordless_ssh` role:
  - `ssh_private_key_path` → `oim_ssh_config_path`

- **ms-group-common.yaml.j2**:
  - Add `chpasswd` runcmd to reliably set root password

## Verification

After applying these fixes:
- OIM → compute nodes: passwordless SSH works
- Compute node → compute node: passwordless SSH works
- Root password is correctly set and unlocked
- No SSH known_hosts warnings on connections