### PR TITLE
Fix: Passwordless SSH

### DIFF
--- a/src/orchestrator/containers/omnia_auth/Containerfile
+++ b/src/orchestrator/containers/omnia_auth/Containerfile
@@ -30,14 +30,20 @@ RUN apk update && apk add --no-cache \
 # BusyBox syntax: addgroup/adduser (not groupadd/useradd)
 RUN addgroup -S ldap && adduser -S -D -H -G ldap ldap
 
-RUN mkdir -p /var/lib/openldap/openldap-data && \
-    chown -R ldap:ldap /var/lib/openldap
+# Pre-create data directory and runtime directory for slapd PID file
+RUN mkdir -p /var/lib/openldap/openldap-data /run/openldap && \
+    chown -R ldap:ldap /var/lib/openldap /run/openldap
+
+VOLUME /var/lib/openldap/openldap-data
 
 EXPOSE 389 636
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD ldapwhoami -x -H ldap://localhost || exit 1
+
 CMD ["/bin/sh", "-c", "\
-  mkdir -p /var/lib/openldap/openldap-data && \
-  chown ldap:ldap /var/lib/openldap/openldap-data; \
+  mkdir -p /var/lib/openldap/openldap-data /run/openldap && \
+  chown ldap:ldap /var/lib/openldap/openldap-data /run/openldap; \
   if [ ! -f /var/lib/openldap/openldap-data/__initialized ]; then \
     slapadd -f /etc/openldap/slapd.conf -l /container-init/bootstrap.ldif && \
     chown -R ldap:ldap /var/lib/openldap && \

--- a/src/orchestrator/containers/omnia_auth/Containerfile
+++ b/src/orchestrator/containers/omnia_auth/Containerfile
@@ -18,29 +18,30 @@
 
 FROM cgr.dev/chainguard/wolfi-base
 
-# Install OpenLDAP server and clients
+# Install OpenLDAP 2.7 server, MDB backend, clients, and matching library
 RUN apk update && apk add --no-cache \
     openldap \
     openldap-back-mdb \
     openldap-clients \
+    libldap-2.7 \
     ca-certificates-bundle
 
 # Create ldap user/group — Wolfi does NOT auto-create this
 # BusyBox syntax: addgroup/adduser (not groupadd/useradd)
 RUN addgroup -S ldap && adduser -S -D -H -G ldap ldap
 
-# Pre-create data directory (runtime re-creates if a volume is mounted over it)
-RUN mkdir -p /var/lib/openldap/openldap-data /run/openldap && \
-    chown -R ldap:ldap /var/lib/openldap /run/openldap
-
-VOLUME /var/lib/openldap/openldap-data
+RUN mkdir -p /var/lib/openldap/openldap-data && \
+    chown -R ldap:ldap /var/lib/openldap
 
 EXPOSE 389 636
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD ldapwhoami -x -H ldap://localhost || exit 1
-
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/bin/sh", "-c", "\
+  mkdir -p /var/lib/openldap/openldap-data && \
+  chown ldap:ldap /var/lib/openldap/openldap-data; \
+  if [ ! -f /var/lib/openldap/openldap-data/__initialized ]; then \
+    slapadd -f /etc/openldap/slapd.conf -l /container-init/bootstrap.ldif && \
+    chown -R ldap:ldap /var/lib/openldap && \
+    touch /var/lib/openldap/openldap-data/__initialized; \
+  fi; \
+  exec /usr/sbin/slapd -f /etc/openldap/slapd.conf -h 'ldap:/// ldaps:///' -d 0 \
+"]

--- a/src/orchestrator/roles/configure_ochami/tasks/configure_boot_svc_metadata_svc.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/configure_boot_svc_metadata_svc.yml
@@ -103,6 +103,10 @@
   register: read_ssh_key
   no_log: true
 
+# NOTE: The private key is embedded into cloud-init write_files so that
+# nodes can perform passwordless SSH without depending on an NFS mount.
+# The metadata-service endpoint is HTTP-only on the admin network;
+# ensure the admin network is trusted and not exposed externally.
 - name: Read the ssh private key
   ansible.builtin.command: cat {{ ssh_private_key_path }}
   changed_when: false

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-common.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-common.yaml.j2
@@ -1,7 +1,7 @@
 - name: ssh
   description: "ssh config"
   meta-data:
-    host_mount_map: {{ host_mount_map | default({}) }}
+    host_mount_map: {{ host_mount_map | default({}) | to_json }}
   file:
     encoding: plain
     content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -12,8 +12,7 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys:
-            - "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -71,14 +70,16 @@
                 done
             fi
 
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
-                StrictHostKeyChecking no
-                UserKnownHostsFile /dev/null
 
 {% if login_compiler_node_present %}
         - path: /usr/local/bin/generate_install_uuid.sh
@@ -217,7 +218,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}
@@ -306,11 +307,44 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - firewall-cmd --permanent --add-service=ssh
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
-        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+
+            # Default values in case parsing slurm.conf fails
+            DEFAULT_SRUN_RANGE="60001-63000"
+            DEFAULT_SLURMD_PORT="6818"
+
+            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
+            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
+
+            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
+            mkdir -p "$CTLD_SLURM_DIR_MNT"
+            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
+              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            }
+
+            if [ -f "$SLURM_CONF_PATH" ]; then
+              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
+
+              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
+              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
+
+              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
+              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
+            else
+              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            fi
+
+            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
+
+            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
+            firewall-cmd --permanent --add-service=ssh
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
 
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -74,12 +75,15 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if login_compiler_node_present %}
         - path: /usr/local/bin/generate_install_uuid.sh
@@ -307,7 +311,7 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-
+        - |
             # Default values in case parsing slurm.conf fails
             DEFAULT_SRUN_RANGE="60001-63000"
             DEFAULT_SLURMD_PORT="6818"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -311,44 +311,11 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - |
-            # Default values in case parsing slurm.conf fails
-            DEFAULT_SRUN_RANGE="60001-63000"
-            DEFAULT_SLURMD_PORT="6818"
-
-            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
-            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
-
-            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
-            mkdir -p "$CTLD_SLURM_DIR_MNT"
-            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
-              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            }
-
-            if [ -f "$SLURM_CONF_PATH" ]; then
-              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
-
-              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
-              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
-
-              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
-              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
-            else
-              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            fi
-
-            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
-
-            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
-            firewall-cmd --permanent --add-service=ssh
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
+        - firewall-cmd --permanent --add-service=ssh
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
+        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
 
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -312,44 +312,11 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - |
-            # Default values in case parsing slurm.conf fails
-            DEFAULT_SRUN_RANGE="60001-63000"
-            DEFAULT_SLURMD_PORT="6818"
-
-            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
-            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
-
-            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
-            mkdir -p "$CTLD_SLURM_DIR_MNT"
-            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
-              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            }
-
-            if [ -f "$SLURM_CONF_PATH" ]; then
-              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
-
-              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
-              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
-
-              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
-              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
-            else
-              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            fi
-
-            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
-
-            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
-            firewall-cmd --permanent --add-service=ssh
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
+        - firewall-cmd --permanent --add-service=ssh
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
+        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
         
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -12,7 +12,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -73,12 +74,15 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if login_compiler_node_present %}
         - path: /usr/local/bin/generate_install_uuid.sh
@@ -308,7 +312,7 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-
+        - |
             # Default values in case parsing slurm.conf fails
             DEFAULT_SRUN_RANGE="60001-63000"
             DEFAULT_SLURMD_PORT="6818"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -12,8 +12,7 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys:
-            - "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -70,14 +69,16 @@
                 done
             fi
         
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
-                StrictHostKeyChecking no
-                UserKnownHostsFile /dev/null
 
 {% if login_compiler_node_present %}
         - path: /usr/local/bin/generate_install_uuid.sh
@@ -217,7 +218,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}
@@ -307,11 +308,44 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - firewall-cmd --permanent --add-service=ssh
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
-        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+
+            # Default values in case parsing slurm.conf fails
+            DEFAULT_SRUN_RANGE="60001-63000"
+            DEFAULT_SLURMD_PORT="6818"
+
+            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
+            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
+
+            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
+            mkdir -p "$CTLD_SLURM_DIR_MNT"
+            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
+              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            }
+
+            if [ -f "$SLURM_CONF_PATH" ]; then
+              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
+
+              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
+              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
+
+              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
+              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
+            else
+              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            fi
+
+            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
+
+            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
+            firewall-cmd --permanent --add-service=ssh
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
         
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -242,44 +242,11 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - |
-            # Default values in case parsing slurm.conf fails
-            DEFAULT_SRUN_RANGE="60001-63000"
-            DEFAULT_SLURMD_PORT="6818"
-
-            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
-            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
-
-            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
-            mkdir -p "$CTLD_SLURM_DIR_MNT"
-            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
-              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            }
-
-            if [ -f "$SLURM_CONF_PATH" ]; then
-              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
-
-              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
-              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
-
-              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
-              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
-            else
-              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            fi
-
-            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
-
-            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
-            firewall-cmd --permanent --add-service=ssh
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
+        - firewall-cmd --permanent --add-service=ssh
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
+        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
         
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -76,12 +77,15 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf
@@ -238,7 +242,7 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-
+        - |
             # Default values in case parsing slurm.conf fails
             DEFAULT_SRUN_RANGE="60001-63000"
             DEFAULT_SLURMD_PORT="6818"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -13,8 +13,7 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys:
-            - "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -73,14 +72,16 @@
                 done
             fi
 
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
-                StrictHostKeyChecking no
-                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf
@@ -173,7 +174,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}
@@ -237,11 +238,44 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - firewall-cmd --permanent --add-service=ssh
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
-        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+
+            # Default values in case parsing slurm.conf fails
+            DEFAULT_SRUN_RANGE="60001-63000"
+            DEFAULT_SLURMD_PORT="6818"
+
+            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
+            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
+
+            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
+            mkdir -p "$CTLD_SLURM_DIR_MNT"
+            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
+              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            }
+
+            if [ -f "$SLURM_CONF_PATH" ]; then
+              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
+
+              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
+              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
+
+              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
+              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
+            else
+              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            fi
+
+            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
+
+            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
+            firewall-cmd --permanent --add-service=ssh
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
         
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -13,7 +13,8 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys:
+            - "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -76,12 +77,15 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
                 IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf
@@ -235,7 +239,7 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-
+        - |
             # Default values in case parsing slurm.conf fails
             DEFAULT_SRUN_RANGE="60001-63000"
             DEFAULT_SLURMD_PORT="6818"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -13,8 +13,7 @@
         settings: [no_replace, recurse_list]
       users:
         - name: root
-          ssh_authorized_keys:
-            - "{{ read_ssh_key.stdout }}"
+          ssh_authorized_keys: "{{ read_ssh_key.stdout }}"
           lock_passwd: false
           hashed_passwd: "{{ hashed_password_output.stdout }}"
         - name: {{ slurm_user }}
@@ -73,14 +72,16 @@
                 done
             fi
         
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
-                StrictHostKeyChecking no
-                UserKnownHostsFile /dev/null
 
 {% if hostvars['localhost']['openldap_support'] %}
         - path: /etc/sssd/sssd.conf
@@ -172,7 +173,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}
@@ -234,11 +235,44 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - firewall-cmd --permanent --add-service=ssh
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
-        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
-        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
+
+            # Default values in case parsing slurm.conf fails
+            DEFAULT_SRUN_RANGE="60001-63000"
+            DEFAULT_SLURMD_PORT="6818"
+
+            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
+            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
+
+            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
+            mkdir -p "$CTLD_SLURM_DIR_MNT"
+            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
+              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            }
+
+            if [ -f "$SLURM_CONF_PATH" ]; then
+              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
+
+              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
+              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
+
+              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
+              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
+            else
+              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
+              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
+              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
+            fi
+
+            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
+
+            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
+            firewall-cmd --permanent --add-service=ssh
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
+            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
+            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
         
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -239,44 +239,11 @@
         - setenforce 0
         - systemctl enable firewalld
         - systemctl start firewalld
-        - |
-            # Default values in case parsing slurm.conf fails
-            DEFAULT_SRUN_RANGE="60001-63000"
-            DEFAULT_SLURMD_PORT="6818"
-
-            CTLD_SLURM_DIR_MNT="/mnt/slurm_ctld_etc_slurm"
-            SLURM_CONF_PATH="$CTLD_SLURM_DIR_MNT/slurm.conf"
-
-            echo "[INFO] Mounting controller slurm.conf from NFS: {{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm -> $CTLD_SLURM_DIR_MNT"
-            mkdir -p "$CTLD_SLURM_DIR_MNT"
-            mount -t nfs "{{ metadata_svc_nfs_path }}/{{ ctld_list[0] }}/etc/slurm" "$CTLD_SLURM_DIR_MNT" || {
-              echo "[WARN] Failed to mount controller slurm.conf directory, falling back to defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            }
-
-            if [ -f "$SLURM_CONF_PATH" ]; then
-              echo "[INFO] Parsing SlurmdPort and SrunPortRange from $SLURM_CONF_PATH"
-
-              SLURMD_PORT=$(grep -iE '^SlurmdPort=' "$SLURM_CONF_PATH" | sed -E 's/^SlurmdPort=//; s/#.*//; s/\s+$//')
-              SRUN_RANGE=$(grep -iE '^SrunPortRange=' "$SLURM_CONF_PATH" | sed -E 's/^SrunPortRange=//; s/#.*//; s/\s+$//')
-
-              [ -z "$SLURMD_PORT" ] && SLURMD_PORT="$DEFAULT_SLURMD_PORT" && echo "[WARN] SlurmdPort not found in slurm.conf, using default $SLURMD_PORT"
-              [ -z "$SRUN_RANGE" ] && SRUN_RANGE="$DEFAULT_SRUN_RANGE" && echo "[WARN] SrunPortRange not found in slurm.conf, using default $SRUN_RANGE"
-            else
-              echo "[WARN] slurm.conf not found at $SLURM_CONF_PATH, using defaults."
-              SRUN_RANGE="$DEFAULT_SRUN_RANGE"
-              SLURMD_PORT="$DEFAULT_SLURMD_PORT"
-            fi
-
-            echo "[INFO] Using SlurmdPort=$SLURMD_PORT and SrunPortRange=$SRUN_RANGE for firewall configuration"
-
-            echo "[INFO] Configuring firewall rules for SSH and Slurm ports"
-            firewall-cmd --permanent --add-service=ssh
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/tcp
-            firewall-cmd --permanent --add-port="${SRUN_RANGE}"/udp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/tcp
-            firewall-cmd --permanent --add-port="${SLURMD_PORT}"/udp
+        - firewall-cmd --permanent --add-service=ssh
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SrunPortRange }}/udp
+        - firewall-cmd --permanent --add-port={{  slurm_conf_dict.SlurmdPort }}/tcp
+        - firewall-cmd --permanent --add-port={{ slurm_conf_dict.SlurmdPort }}/udp
         
         # Add PXE network to trusted zone for ORTE communication
         - echo "[INFO] Adding PXE network to trusted zone for ORTE communication"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -92,6 +92,7 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -88,11 +88,15 @@
                 done
             fi
         
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ k8s_control_ssh_patterns }}
-                IdentityFile {{ k8s_client_mount_path }}/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
@@ -364,7 +368,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -80,11 +80,15 @@
                 done
             fi
 
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ k8s_control_ssh_patterns }}
-                IdentityFile {{ k8s_client_mount_path }}/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
@@ -271,7 +275,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -84,6 +84,7 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -68,11 +68,15 @@
                 done
             fi
 
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ k8s_control_ssh_patterns }}
-                IdentityFile {{ k8s_client_mount_path }}/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
@@ -170,7 +174,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -72,6 +72,7 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
@@ -71,11 +71,15 @@
                 done
             fi
 
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
@@ -304,7 +308,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
@@ -75,6 +75,7 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
@@ -72,11 +72,15 @@
                 done
             fi
 
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
@@ -426,7 +430,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
@@ -76,6 +76,7 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
@@ -77,6 +77,7 @@
           permissions: '0600'
           content: |
             {{ read_ssh_private_key.stdout | indent(12) }}
+
         - path: /root/.ssh/config
           permissions: '0600'
           content: |

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
@@ -73,11 +73,15 @@
                 done
             fi
         
+        - path: /root/.ssh/oim_rsa
+          permissions: '0600'
+          content: |
+            {{ read_ssh_private_key.stdout | indent(12) }}
         - path: /root/.ssh/config
           permissions: '0600'
           content: |
             Host {{ slurm_control_ssh_patterns }}
-                IdentityFile {{ client_mount_path }}/slurm/ssh/oim_rsa
+                IdentityFile /root/.ssh/oim_rsa
                 IdentitiesOnly yes
                 StrictHostKeyChecking no
                 UserKnownHostsFile /dev/null
@@ -432,7 +436,7 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
+      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
       {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
       {% if mymounts %}
       {% for mount in mymounts.get("mounts", []) %}

--- a/src/orchestrator/roles/deploy_openldap/templates/slapd.conf.j2
+++ b/src/orchestrator/roles/deploy_openldap/templates/slapd.conf.j2
@@ -1,6 +1,10 @@
 # {{ ansible_managed }}
 # slapd.conf — OpenLDAP server configuration for omnia_auth container
 
+# Load MDB backend module (required for Wolfi-based container)
+modulepath /usr/lib/openldap
+moduleload back_mdb.so
+
 include     /etc/openldap/schema/core.schema
 include     /etc/openldap/schema/cosine.schema
 include     /etc/openldap/schema/inetorgperson.schema


### PR DESCRIPTION

### Issue:
The SSH config on nodes references oim_rsa at `{{ client_mount_path }}/slurm/ssh/oim_rsa`, which was supposed to be NFS-mounted from the storage server. When the storage server is unreachable, the mount fails silently and SSH falls back to password.

### Changes:
- Fix node-to-node passwordless SSH by delivering `oim_rsa` private key directly via cloud-init write_files instead of relying on NFS mount from storage server
- Add is mapping guard on `host_mount_map` to prevent cloud-init Jinja crash when metadata-service stores it as string `"{}"`
- Update `omnia_auth` Containerfile and `slapd.conf.j2` for OpenLDAP support

### Fix:
Embed `oim_rsa` directly in cloud-init write_files to `/root/.ssh/oim_rsa` on each node. 
The `read_ssh_private_key` variable was already registered in the orchestrator but never used in any template.