### PR TITLE
install_os workflow: auto-mount NFS, SSH key validation, and duplicate ISO build fix

### DIFF
--- a/src/utils/input/install_os_config.yml
+++ b/src/utils/input/install_os_config.yml
@@ -108,6 +108,11 @@ netmask: "255.255.255.0"
 gateway: ""
 dns_server: ""
 
+# SSH public key path for passwordless authentication.
+# This key is injected into the kickstart file and used for post-install verification.
+# If empty, defaults to /root/.ssh/id_rsa.pub
+ssh_public_key_path: ""
+
 # Target install disk (e.g., "sda", "nvme0n1").
 # If empty, defaults to "sda".
 install_disk: "sda"

--- a/src/utils/playbooks/install_os.yml
+++ b/src/utils/playbooks/install_os.yml
@@ -114,9 +114,11 @@
             mode: "0755"
 
         - name: Mount NFS share
-          ansible.builtin.command:
-            cmd: mount -t nfs {{ _nfs_server }}:{{ _nfs_dir | dirname }} /tmp/install_os_nfs
-          changed_when: true
+          ansible.builtin.mount:
+            src: "{{ _nfs_server }}:{{ _nfs_dir | dirname }}"
+            path: /tmp/install_os_nfs
+            fstype: nfs
+            state: mounted
 
         - name: Re-check NFS mounts after auto-mount
           ansible.builtin.shell: |
@@ -124,7 +126,6 @@
             mount | grep '{{ _nfs_server }}:' | awk '{print $1 " " $3}'
           register: _ks_nfs_remount_check
           changed_when: false
-        
         - name: Update _ks_nfs_mounts with remount check
           ansible.builtin.set_fact:
             _ks_nfs_mounts: "{{ _ks_nfs_remount_check }}"

--- a/src/utils/playbooks/install_os.yml
+++ b/src/utils/playbooks/install_os.yml
@@ -56,7 +56,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  tags: [credentials, build_iso, deploy]
+  tags: [credentials, build_iso, deploy, generate_ks]
   roles:
     - role: collect_install_os_credentials
 
@@ -91,7 +91,12 @@
   gather_facts: true
   tags: [generate_ks]
   tasks:
-    - name: Resolve local NFS path for kickstart output
+    - name: Initialize NFS auto-mount flag
+      ansible.builtin.set_fact:
+        _nfs_auto_mounted: false
+        cacheable: false
+
+    - name: Check if NFS is already mounted
       ansible.builtin.shell: |
         set -o pipefail
         mount | grep '{{ _nfs_server }}:' | awk '{print $1 " " $3}'
@@ -99,10 +104,40 @@
       changed_when: false
       failed_when: false
 
+    - name: Auto-mount NFS if not already mounted
+      when: _ks_nfs_mounts.stdout | default('') | trim | length == 0
+      block:
+        - name: Create temporary NFS mount point
+          ansible.builtin.file:
+            path: /tmp/install_os_nfs
+            state: directory
+            mode: "0755"
+
+        - name: Mount NFS share
+          ansible.builtin.command:
+            cmd: mount -t nfs {{ _nfs_server }}:{{ _nfs_dir | dirname }} /tmp/install_os_nfs
+          changed_when: true
+
+        - name: Re-check NFS mounts after auto-mount
+          ansible.builtin.shell: |
+            set -o pipefail
+            mount | grep '{{ _nfs_server }}:' | awk '{print $1 " " $3}'
+          register: _ks_nfs_remount_check
+          changed_when: false
+        
+        - name: Update _ks_nfs_mounts with remount check
+          ansible.builtin.set_fact:
+            _ks_nfs_mounts: "{{ _ks_nfs_remount_check }}"
+
+        - name: Set flag for cleanup
+          ansible.builtin.set_fact:
+            _nfs_auto_mounted: true
+            cacheable: false
+
     - name: Resolve local kickstart output path
       ansible.builtin.set_fact:
         _ks_local_dir: >-
-          {% set mounts = _ks_nfs_mounts.stdout_lines %}
+          {% set mounts = _ks_nfs_mounts.stdout_lines | default([]) %}
           {% set target_nfs_dir = _nfs_dir %}
           {% for line in mounts %}
           {% set parts = line.split() %}
@@ -118,6 +153,11 @@
           {% endif %}
           {% endfor %}
 
+    - name: Fail if path resolution failed
+      ansible.builtin.fail:
+        msg: "Failed to resolve local path for kickstart output. NFS mount may have failed or path is incorrect."
+      when: _ks_local_dir | trim | length == 0
+
     - name: Render Kickstart from template
       ansible.builtin.template:
         src: "{{ role_path | default(playbook_dir + '/../roles/iso_creation') }}/templates/{{ kickstart_template }}.ks.j2"
@@ -128,6 +168,13 @@
     - name: Log kickstart generation
       ansible.builtin.debug:
         msg: "Kickstart file generated at {{ _ks_local_dir | trim }}/kickstart.ks"
+
+    - name: Unmount auto-mounted NFS
+      ansible.builtin.command:
+        cmd: umount /tmp/install_os_nfs
+      when: _nfs_auto_mounted | default(false) | bool
+      changed_when: true
+      failed_when: false
 
 # ─────────────────────────────────────────────────────────────────────────
 # Play 6: Deploy ISO via iDRAC virtual media

--- a/src/utils/plugins/callback/omnia_default.py
+++ b/src/utils/plugins/callback/omnia_default.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Custom Ansible stdout callback plugin for Omnia.
+
+Extends the built-in ``default`` callback to suppress the ``[ERROR]``
+source-context block introduced in ansible-core 2.19/2.20 (Data Tagging).
+Renders multiline ``msg`` fields with real newlines on failure.
+All other output (task banners, ok/changed/skipped lines, play recaps,
+etc.) is unchanged.
+
+Usage — add to every ``ansible.cfg``::
+
+    [defaults]
+    stdout_callback = omnia_default
+    callback_plugins = <relative-path-to>/common/callback_plugins
+"""
+from __future__ import annotations
+
+import json
+import re
+
+from ansible import constants as C  # pylint: disable=no-name-in-module
+from ansible.plugins.callback.default import CallbackModule as DefaultCallback
+
+DOCUMENTATION = r"""
+    name: omnia_default
+    type: stdout
+    short_description: Omnia default stdout callback
+    version_added: "2.1"
+    description:
+        - Inherits every behaviour of the built-in C(default) callback.
+        - Suppresses the C([ERROR]) source-context block added in
+          ansible-core 2.19/2.20.
+        - Renders multiline C(msg) fields with real newlines on failure.
+        - Produces only the classic single-line C(fatal:) output.
+    extends_documentation_fragment:
+        - default_callback
+"""
+
+# Pattern to detect the 2.19/2.20 [ERROR] task-failure context block
+_ERROR_CONTEXT_PATTERN = re.compile(
+    r"\[ERROR\]:\s*Task failed:|"
+    r"\[ERROR\]:\s*Action failed:|"
+    r"Origin:\s+\S+\.ya?ml:\d+:\d+|"
+    r"\s+\^\s+column\s+\d+"
+)
+
+
+class CallbackModule(DefaultCallback):  # pylint: disable=too-many-ancestors
+    """
+    Omnia stdout callback plugin.
+
+    Extends the built-in default callback to suppress the ``[ERROR]``
+    source-context block introduced in ansible-core 2.19/2.20 and
+    renders multiline failure messages with real newlines.
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = "stdout"
+    CALLBACK_NAME = "omnia_default"
+
+    def __init__(self):
+        super().__init__()
+        self._patched = False
+
+    def _patch_display(self):
+        """Monkey-patch Display.display to drop [ERROR] context blocks."""
+        if self._patched:
+            return
+        self._patched = True
+
+        original_display = self._display.display
+
+        def filtered_display(msg, *args, **kwargs):
+            msg_str = str(msg)
+            if _ERROR_CONTEXT_PATTERN.search(msg_str):
+                return
+            original_display(msg, *args, **kwargs)
+
+        self._display.display = filtered_display
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        """Load options and apply the display patch."""
+        super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+        self._patch_display()
+
+    def v2_playbook_on_play_start(self, play):
+        """Ensure patch is active before the first play."""
+        self._patch_display()
+        super().v2_playbook_on_play_start(play)
+
+    def _format_result_msg(self, result_dict):
+        """
+        Format result dict for display.
+
+        If ``msg`` contains newlines, display them as real line breaks
+        instead of escaped ``\\n`` characters.
+        """
+        msg = result_dict.get("msg", "")
+        if isinstance(msg, str) and "\n" in msg:
+            filtered = {k: v for k, v in result_dict.items() if k != "msg"}
+            return f"{json.dumps(filtered, sort_keys=True)}\nmsg: |-\n  {msg.replace(chr(10), chr(10) + '  ')}"
+        return self._dump_results(result_dict)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        """
+        Render task failures as the classic single-line ``fatal:`` message.
+
+        The ``[ERROR]`` block is suppressed by the ``Display.display`` patch.
+        Multiline ``msg`` values are rendered with real newlines.
+        """
+        # pylint: disable=protected-access
+        self._patch_display()
+        delegated_vars = result._result.get("_ansible_delegated_vars", None)
+        self._clean_results(result._result, result._task.action)
+
+        if self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        self._handle_exception(
+            result._result,
+            use_stderr=self.get_option("display_failed_stderr"),
+        )
+        self._handle_warnings(result._result)
+
+        if result._task.loop and "results" in result._result:
+            self._process_items(result)
+        else:
+            formatted = self._format_result_msg(result._result)
+            host_name = result._host.get_name()
+            stderr_opt = self.get_option("display_failed_stderr")
+            color = getattr(C, "COLOR_ERROR", "red")
+
+            if delegated_vars:
+                self._display.display(
+                    f"fatal: [{host_name} -> {delegated_vars['ansible_host']}]: FAILED! => {formatted}",
+                    color=color,
+                    stderr=stderr_opt,
+                )
+            else:
+                self._display.display(
+                    f"fatal: [{host_name}]: FAILED! => {formatted}",
+                    color=color,
+                    stderr=stderr_opt,
+                )
+
+        if ignore_errors:
+            color_skip = getattr(C, "COLOR_SKIP", "cyan")
+            self._display.display("...ignoring", color=color_skip)
+        # pylint: enable=protected-access
+
+    def v2_playbook_on_stats(self, stats):
+        """Ensure patch is active during PLAY RECAP to suppress replayed errors."""
+        self._patch_display()
+        super().v2_playbook_on_stats(stats)
+
+    def _display_error_context(self, *args, **kwargs):
+        """Intentionally suppressed — prevents [ERROR] source-context rendering."""

--- a/src/utils/roles/collect_install_os_credentials/tasks/main.yml
+++ b/src/utils/roles/collect_install_os_credentials/tasks/main.yml
@@ -209,7 +209,7 @@
     # Step 8: Read SSH public key for kickstart injection
     - name: Read OIM SSH public key
       ansible.builtin.slurp:
-        src: /root/.ssh/id_rsa.pub
+        src: "{{ ssh_public_key_path | default('/root/.ssh/id_rsa.pub') }}"
       register: _ssh_pub_key
       failed_when: false
 

--- a/src/utils/roles/collect_install_os_credentials/tasks/prompt_credential_field.yml
+++ b/src/utils/roles/collect_install_os_credentials/tasks/prompt_credential_field.yml
@@ -36,7 +36,7 @@
 
 - name: Skip prompt for stored credentials
   ansible.builtin.debug:
-    msg: "Credentials already stored for {{ cred_field.username | default(cred_field.password) }} — skipping prompt."
+    msg: "Credentials already stored for {{ cred_field.username | default(cred_field.password | default('credential')) }} — skipping prompt."
   when: not (_need_username | bool) and not (_need_password | bool)
 
 # Prompt username if needed
@@ -45,7 +45,7 @@
     - cred_field.username is defined
     - _need_username | default(false) | bool
   block:
-    - name: "Prompt for [{{ cred_field.username }}]" # noqa name[template]
+    - name: "Prompt for username" # noqa name[template]
       ansible.builtin.pause:
         prompt: "[OS Install] Enter {{ cred_field.username }}"
       no_log: true
@@ -62,7 +62,7 @@
     - cred_field.password is defined
     - _need_password | default(false) | bool
   block:
-    - name: "Prompt for [{{ cred_field.password }}]" # noqa name[template]
+    - name: "Prompt for password" # noqa name[template]
       ansible.builtin.pause:
         prompt: "[OS Install] Enter {{ cred_field.password }}"
         echo: false
@@ -74,7 +74,7 @@
         msg: "{{ install_os_password_fail_msg }}"
       when: _password_input.user_input | length == 0
 
-    - name: "Confirm [{{ cred_field.password }}]" # noqa name[template]
+    - name: "Confirm password" # noqa name[template]
       ansible.builtin.pause:
         prompt: "[OS Install] Confirm {{ cred_field.password }}"
         echo: false

--- a/src/utils/roles/iso_creation/tasks/main.yml
+++ b/src/utils/roles/iso_creation/tasks/main.yml
@@ -14,7 +14,12 @@
 ---
 
 # Step 1: Resolve NFS path to local mount point
-- name: Find local mount point for NFS server
+- name: Initialize NFS auto-mount flag
+  ansible.builtin.set_fact:
+    _nfs_auto_mounted: false
+    cacheable: false
+
+- name: Check if NFS is already mounted
   ansible.builtin.shell: |
     set -o pipefail
     mount | grep '{{ _nfs_server }}:' | awk '{print $1 " " $3}'
@@ -22,15 +27,47 @@
   changed_when: false
   failed_when: false
 
-- name: Fail if NFS mount not found
+- name: Auto-mount NFS if not already mounted
+  when: _nfs_mounts.stdout | default('') | trim | length == 0
+  block:
+    - name: Create temporary NFS mount point
+      ansible.builtin.file:
+        path: /tmp/install_os_nfs
+        state: directory
+        mode: "0755"
+
+    - name: Mount NFS share
+      ansible.builtin.command:
+        cmd: mount -t nfs {{ _nfs_server }}:{{ _nfs_dir | dirname }} /tmp/install_os_nfs
+      changed_when: true
+
+    - name: Re-check NFS mounts after auto-mount
+      ansible.builtin.shell: |
+        set -o pipefail
+        mount | grep '{{ _nfs_server }}:' | awk '{print $1 " " $3}'
+      register: _nfs_remount_check
+      changed_when: false
+    
+    - name: Update _nfs_mounts with remount check
+      ansible.builtin.set_fact:
+        _nfs_mounts: "{{ _nfs_remount_check }}"
+
+    - name: Set flag for cleanup
+      ansible.builtin.set_fact:
+        _nfs_auto_mounted: true
+        cacheable: false
+
+- name: Fail if NFS mount still not found
   ansible.builtin.fail:
     msg: "{{ nfs_mount_not_found_msg }}"
-  when: _nfs_mounts.stdout | trim | length == 0
+  when:
+    - _nfs_mounts.stdout is defined
+    - _nfs_mounts.stdout | trim | length == 0
 
 - name: Resolve local path from NFS mount
   ansible.builtin.set_fact:
     _local_iso_dir: >-
-      {% set mounts = _nfs_mounts.stdout_lines %}
+      {% set mounts = _nfs_mounts.stdout_lines | default([]) %}
       {% set target_nfs_dir = _nfs_dir %}
       {% set result = '' %}
       {% for line in mounts %}
@@ -47,6 +84,11 @@
       {% endif %}
       {% endfor %}
     cacheable: true
+
+- name: Validate path resolution succeeded
+  ansible.builtin.fail:
+    msg: "Failed to resolve local NFS path. NFS server {{ _nfs_server }} may not be mounted or path {{ _nfs_dir }} doesn't match any mounted export."
+  when: _local_iso_dir | trim | length == 0
 
 - name: Clean up local ISO directory path
   ansible.builtin.set_fact:
@@ -112,3 +154,11 @@
   when:
     - not _custom_iso_stat.stat.exists or rebuild_iso | bool
     - kickstart_delivery_method | default('embedded') == 'nfs'
+
+# Step 5: Cleanup auto-mounted NFS
+- name: Unmount auto-mounted NFS
+  ansible.builtin.command:
+    cmd: umount /tmp/install_os_nfs
+  when: _nfs_auto_mounted | default(false) | bool
+  changed_when: true
+  failed_when: false

--- a/src/utils/roles/iso_creation/tasks/main.yml
+++ b/src/utils/roles/iso_creation/tasks/main.yml
@@ -37,9 +37,11 @@
         mode: "0755"
 
     - name: Mount NFS share
-      ansible.builtin.command:
-        cmd: mount -t nfs {{ _nfs_server }}:{{ _nfs_dir | dirname }} /tmp/install_os_nfs
-      changed_when: true
+      ansible.builtin.mount:
+        src: "{{ _nfs_server }}:{{ _nfs_dir | dirname }}"
+        path: /tmp/install_os_nfs
+        fstype: nfs
+        state: mounted
 
     - name: Re-check NFS mounts after auto-mount
       ansible.builtin.shell: |
@@ -47,7 +49,6 @@
         mount | grep '{{ _nfs_server }}:' | awk '{print $1 " " $3}'
       register: _nfs_remount_check
       changed_when: false
-    
     - name: Update _nfs_mounts with remount check
       ansible.builtin.set_fact:
         _nfs_mounts: "{{ _nfs_remount_check }}"

--- a/src/utils/roles/iso_delivery/meta/main.yml
+++ b/src/utils/roles/iso_delivery/meta/main.yml
@@ -20,5 +20,4 @@ galaxy_info:
     - dell
     - idrac
 
-dependencies:
-  - role: iso_creation
+dependencies: []

--- a/src/utils/roles/validate_install_os_config/tasks/main.yml
+++ b/src/utils/roles/validate_install_os_config/tasks/main.yml
@@ -209,4 +209,5 @@
       Custom ISO: {{ custom_iso_path | default('N/A') }}.
       KS delivery: {{ kickstart_delivery_method | default('embedded') }}.
       Target BMC: {{ target_bmc_ip | default('N/A') }}.
-      SSH key: {{ ssh_public_key_path }} (validated).
+      SSH key: {{ ssh_public_key_path | default('N/A') }} (validated).
+  when: not _mode_credentials_only

--- a/src/utils/roles/validate_install_os_config/tasks/main.yml
+++ b/src/utils/roles/validate_install_os_config/tasks/main.yml
@@ -125,9 +125,12 @@
 
 # Step 8a: Resolve local NFS mount path for deploy mode
 - name: Get NFS mounts for deploy mode
-  ansible.builtin.shell: "mount | grep -E ' type nfs[0-9]?' || true"
+  ansible.builtin.shell: |
+    set -o pipefail
+    mount | grep -E ' type nfs[0-9]?' || true
   register: _deploy_nfs_mounts
   changed_when: false
+  failed_when: false
   when:
     - _mode_deploy | bool
     - custom_iso_path | default('') | length > 0
@@ -137,6 +140,7 @@
     - _mode_deploy | bool
     - custom_iso_path | default('') | length > 0
   ansible.builtin.shell: |
+    set -o pipefail
     mount | grep -E ' type nfs[0-9]?' | while read -r line; do
       nfs_export=$(echo "$line" | awk '{print $1}')
       local_mount=$(echo "$line" | awk '{print $3}')
@@ -226,12 +230,7 @@
 
 - name: Fail if SSH public key not found
   ansible.builtin.fail:
-    msg: >-
-      SSH public key not found at {{ ssh_public_key_path }}.
-      Passwordless SSH verification requires this key for OS installation.
-      Generate an SSH key with the following command:
-      ssh-keygen -t rsa -b 4096 -N "" -f {{ ssh_public_key_path | dirname }}/id_rsa
-      Or specify a different path in install_os_config.yml: ssh_public_key_path
+    msg: "{{ ssh_key_not_found_msg }}"
   when:
     - not (_mode_credentials_only | bool)
     - (_mode_build_iso | bool or _mode_generate_ks | bool or ansible_run_tags | length == 0)
@@ -253,13 +252,5 @@
 
 - name: Log validated configuration summary
   ansible.builtin.debug:
-    msg: >-
-      OS Install config validated.
-      Mode: build={{ _mode_build_iso }}, deploy={{ _mode_deploy }}, generate_ks={{ _mode_generate_ks }}.
-      Arch: {{ os_arch | default('N/A') }}.
-      Source ISO: {{ source_iso_path | default('N/A') }}.
-      Custom ISO: {{ custom_iso_path | default('N/A') }}.
-      KS delivery: {{ kickstart_delivery_method | default('embedded') }}.
-      Target BMC: {{ target_bmc_ip | default('N/A') }}.
-      SSH key: {{ ssh_public_key_path | default('N/A') }} (validated).
+    msg: "{{ config_validated_msg }}"
   when: not _mode_credentials_only

--- a/src/utils/roles/validate_install_os_config/tasks/main.yml
+++ b/src/utils/roles/validate_install_os_config/tasks/main.yml
@@ -123,6 +123,58 @@
     _nfs_iso_filename: "{{ custom_iso_path.split(':')[1] | basename }}"
     cacheable: true
 
+# Step 8a: Resolve local NFS mount path for deploy mode
+- name: Get NFS mounts for deploy mode
+  ansible.builtin.shell: "mount | grep -E ' type nfs[0-9]?' || true"
+  register: _deploy_nfs_mounts
+  changed_when: false
+  when:
+    - _mode_deploy | bool
+    - custom_iso_path | default('') | length > 0
+
+- name: Resolve local ISO path from NFS mounts for deploy mode
+  when:
+    - _mode_deploy | bool
+    - custom_iso_path | default('') | length > 0
+  ansible.builtin.shell: |
+    mount | grep -E ' type nfs[0-9]?' | while read -r line; do
+      nfs_export=$(echo "$line" | awk '{print $1}')
+      local_mount=$(echo "$line" | awk '{print $3}')
+      if [[ "$nfs_export" == "{{ _nfs_server }}:"* ]]; then
+        remote_export="${nfs_export#{{ _nfs_server }}:}"
+        if [[ "{{ _nfs_dir }}" == "$remote_export" ]]; then
+          echo "$local_mount"
+          exit 0
+        elif [[ "{{ _nfs_dir }}" == "$remote_export"/* ]]; then
+          rel_path="{{ _nfs_dir }}"
+          rel_path="${rel_path#$remote_export/}"
+          echo "$local_mount/$rel_path"
+          exit 0
+        fi
+      fi
+    done
+  register: _local_iso_dir_result
+  changed_when: false
+  failed_when: false
+
+- name: Set local ISO directory fact for deploy mode
+  when:
+    - _mode_deploy | bool
+    - custom_iso_path | default('') | length > 0
+    - _local_iso_dir_result.stdout | default('') | trim | length > 0
+  ansible.builtin.set_fact:
+    _local_iso_dir: "{{ _local_iso_dir_result.stdout | trim }}"
+    cacheable: true
+
+- name: Set local ISO path for deploy mode
+  when:
+    - _mode_deploy | bool
+    - custom_iso_path | default('') | length > 0
+    - _local_iso_dir | default('') | trim | length > 0
+  ansible.builtin.set_fact:
+    _local_iso_path: "{{ _local_iso_dir | trim }}/{{ _nfs_iso_filename }}"
+    cacheable: true
+
 # Step 9: Validate source_iso_path for build modes
 - name: Validate source_iso_path for build modes
   ansible.builtin.fail:

--- a/src/utils/roles/validate_install_os_config/tasks/main.yml
+++ b/src/utils/roles/validate_install_os_config/tasks/main.yml
@@ -86,6 +86,7 @@
     ssh_verify_enabled: "{{ install_os_config.ssh_verify_enabled | default(true) }}"
     ssh_verify_retries: "{{ install_os_config.ssh_verify_retries | default(60) }}"
     ssh_verify_delay: "{{ install_os_config.ssh_verify_delay | default(30) }}"
+    ssh_public_key_path: "{{ install_os_config.ssh_public_key_path | default('/root/.ssh/id_rsa.pub') }}"
     cacheable: true
 
 # Step 6: Validate kickstart_delivery_method
@@ -143,6 +144,7 @@
   ansible.builtin.fail:
     msg: "{{ invalid_architecture_msg }}"
   when:
+    - not (_mode_credentials_only | bool)
     - _os_arch | default('') | length > 0
     - _os_arch not in ['x86_64', 'aarch64']
 
@@ -161,7 +163,29 @@
     - _mode_deploy | bool
     - target_admin_ip | default('') | length == 0
 
-# Step 12: Set derived variables for downstream roles
+# Step 12: Validate SSH public key availability
+- name: Check if SSH public key exists
+  ansible.builtin.stat:
+    path: "{{ ssh_public_key_path }}"
+  register: _ssh_key_stat
+  when:
+    - not (_mode_credentials_only | bool)
+    - (_mode_build_iso | bool or _mode_generate_ks | bool or ansible_run_tags | length == 0)
+
+- name: Fail if SSH public key not found
+  ansible.builtin.fail:
+    msg: >-
+      SSH public key not found at {{ ssh_public_key_path }}.
+      Passwordless SSH verification requires this key for OS installation.
+      Generate an SSH key with the following command:
+      ssh-keygen -t rsa -b 4096 -N "" -f {{ ssh_public_key_path | dirname }}/id_rsa
+      Or specify a different path in install_os_config.yml: ssh_public_key_path
+  when:
+    - not (_mode_credentials_only | bool)
+    - (_mode_build_iso | bool or _mode_generate_ks | bool or ansible_run_tags | length == 0)
+    - not (_ssh_key_stat.stat.exists | default(false))
+
+# Step 13: Set derived variables for downstream roles
 - name: Set derived variables for downstream roles
   ansible.builtin.set_fact:
     os_arch: "{{ _os_arch }}"
@@ -185,3 +209,4 @@
       Custom ISO: {{ custom_iso_path | default('N/A') }}.
       KS delivery: {{ kickstart_delivery_method | default('embedded') }}.
       Target BMC: {{ target_bmc_ip | default('N/A') }}.
+      SSH key: {{ ssh_public_key_path }} (validated).

--- a/src/utils/roles/validate_install_os_config/vars/main.yml
+++ b/src/utils/roles/validate_install_os_config/vars/main.yml
@@ -36,3 +36,18 @@ invalid_architecture_msg: >-
   'target_architecture' must be 'x86_64' or 'aarch64'. Got: '{{ _os_arch }}'
 invalid_ks_delivery_msg: >-
   'kickstart_delivery_method' must be 'embedded' or 'nfs'. Got: '{{ install_os_config.kickstart_delivery_method | default("") }}'
+ssh_key_not_found_msg: >-
+  SSH public key not found at {{ ssh_public_key_path }}.
+  Passwordless SSH verification requires this key for OS installation.
+  Generate an SSH key with the following command:
+  ssh-keygen -t rsa -b 4096 -N "" -f {{ ssh_public_key_path | dirname }}/id_rsa
+  Or specify a different path in install_os_config.yml: ssh_public_key_path
+config_validated_msg: >-
+  OS Install config validated.
+  Mode: build={{ _mode_build_iso }}, deploy={{ _mode_deploy }}, generate_ks={{ _mode_generate_ks }}.
+  Arch: {{ os_arch | default('N/A') }}.
+  Source ISO: {{ source_iso_path | default('N/A') }}.
+  Custom ISO: {{ custom_iso_path | default('N/A') }}.
+  KS delivery: {{ kickstart_delivery_method | default('embedded') }}.
+  Target BMC: {{ target_bmc_ip | default('N/A') }}.
+  SSH key: {{ ssh_public_key_path | default('N/A') }} (validated).


### PR DESCRIPTION
Added automatic NFS mounting for install_os workflow (no manual mount required)
Added SSH public key validation with configurable path via ssh_public_key_path config parameter
Fixed duplicate ISO creation by removing iso_creation dependency from iso_delivery role
Fixed architecture validation to skip in credentials-only mode
Fixed missing ks_root_password_hash in generate_ks mode by adding generate_ks tag to credentials play
Fixed template errors in credential prompting