### PR TITLE
feat(catalog): Add catalog schema transform (1.0→2.0) and group optimization

### DIFF
--- a/src/repo_manager/playbooks/repo_manager.yml
+++ b/src/repo_manager/playbooks/repo_manager.yml
@@ -66,6 +66,8 @@
 #   ansible-playbook repo_manager.yml --tags catalog_add -e "input_file=input/additions.txt"
 #   ansible-playbook repo_manager.yml --tags catalog_delete -e "input_file=input/removals.txt"
 #   ansible-playbook repo_manager.yml --tags catalog_validate
+#   ansible-playbook repo_manager.yml --tags catalog_transform -e "input_file=input/catalog_1.0.json"
+#   ansible-playbook repo_manager.yml --tags catalog_optimize
 # =============================================================================
 
 # -------------------------------------------------------------------------
@@ -197,3 +199,5 @@
     - catalog_add
     - catalog_delete
     - catalog_validate
+    - catalog_transform
+    - catalog_optimize

--- a/src/repo_manager/plugins/module_utils/catalog/catalog_manager.py
+++ b/src/repo_manager/plugins/module_utils/catalog/catalog_manager.py
@@ -34,6 +34,8 @@ from catalog.parser import parse_input_file, parse_delete_file
 from catalog.catalog_io import read_catalog, write_catalog, new_catalog, catalog_exists
 from catalog.mutator import upsert_packages, delete_packages
 from catalog.validator import validate_catalog, format_issues
+from catalog.transformer import detect_schema_version, transform, write_keymap
+from catalog.optimizer import optimize
 
 
 def setup_logging(log_dir=None, log_file='catalog_manager.log'):
@@ -189,6 +191,186 @@ def cmd_validate(args):
     return 1 if errors else 0
 
 
+def cmd_transform(args):
+    """Transform catalog from 1.0 to 2.0 format."""
+    logger = logging.getLogger(__name__)
+    
+    # Check if output file exists
+    output_file = args.output
+    if catalog_exists(output_file) and not args.force:
+        logger.error("Output file '%s' already exists. Use --force to overwrite.", output_file)
+        return 1
+    
+    # Read input file
+    try:
+        with open(args.input, 'r', encoding='utf-8') as f:
+            import json
+            data = json.load(f)
+    except FileNotFoundError:
+        logger.error("Input file '%s' not found", args.input)
+        return 1
+    except json.JSONDecodeError as e:
+        logger.error("Failed to parse input JSON: %s", e)
+        return 1
+    
+    # Detect schema version
+    try:
+        version = detect_schema_version(data)
+    except ValueError as e:
+        logger.error(str(e))
+        return 1
+    
+    if version == '2.0':
+        logger.warning("Input catalog is already Schema 2.0 - no transformation needed")
+        return 0
+    
+    # Transform
+    print("═══ Catalog Transform: 1.0 → 2.0 ═══")
+    print(f"Input:   {args.input}  (Schema {version} detected)")
+    print(f"Output:  {output_file}")
+    
+    old_catalog = data['Catalog']
+    new_catalog, key_map, warnings = transform(old_catalog)
+    
+    # Write output
+    write_catalog(new_catalog, output_file)
+    
+    # Write keymap
+    keymap_path = output_file + ".keymap.json"
+    total_groups = len(new_catalog['catalog']['groups'])
+    total_layers = len(new_catalog['catalog']['functionallayer'])
+    write_keymap(key_map, args.input, output_file, keymap_path, total_groups, total_layers)
+    print(f"Keymap:  {keymap_path}")
+    
+    # Print package transformation report
+    print("\n── Package Transformation ──")
+    total_packages = len(new_catalog['catalog']['packages'])
+    print(f"  Total packages: {total_packages}")
+    
+    # Count by type
+    type_counters = {}
+    for pkg in new_catalog['catalog']['packages'].values():
+        ptype = pkg['packagetype']
+        type_counters[ptype] = type_counters.get(ptype, 0) + 1
+    
+    for ptype in sorted(type_counters.keys()):
+        print(f"  {ptype:12s}: {type_counters[ptype]}")
+    
+    # Print group creation report
+    print("\n── Group Creation ──")
+    baseos_groups = [k for k, v in new_catalog['catalog']['groups'].items() if v['type'] == 'base_os']
+    other_groups = [k for k, v in new_catalog['catalog']['groups'].items() if v['type'] != 'base_os']
+    print(f"  BaseOS groups:          {len(baseos_groups)} ({', '.join(baseos_groups)})")
+    print(f"  FunctionalLayer groups: {len(other_groups)}")
+    
+    # Print functional layer rewiring
+    print("\n── FunctionalLayer Rewiring ──")
+    print(f"  Layers rewired: {total_layers}")
+    if baseos_groups:
+        print(f"  Each layer includes: {', '.join(baseos_groups)} + layer-specific group")
+    
+    # Print warnings
+    print(f"\n── Warnings ──")
+    if warnings:
+        print(f"  {len(warnings)} warning(s)")
+        for w in warnings[:10]:  # Limit to first 10
+            print(f"  - {w}")
+        if len(warnings) > 10:
+            print(f"  ... and {len(warnings) - 10} more (see log)")
+    else:
+        print("  No warnings")
+    
+    # Auto-validate if schema provided
+    print("\n── Post-Transform Validation ──")
+    if args.schema:
+        issues = validate_catalog(new_catalog, args.schema)
+        errors = [i for i in issues if i['severity'] == 'error']
+        if errors:
+            print(f"  ⚠ Validation found {len(errors)} error(s) - review recommended")
+            for issue in errors[:5]:
+                print(f"    - {issue['message']}")
+            if len(errors) > 5:
+                print(f"    ... and {len(errors) - 5} more")
+        else:
+            print("  ✔ Validation passed")
+    else:
+        print("  (skipped - no schema provided)")
+    
+    print("\n✔ Transform complete")
+    return 0
+
+
+def cmd_optimize(args):
+    """Optimize catalog by extracting common packages."""
+    logger = logging.getLogger(__name__)
+    
+    # Read catalog
+    try:
+        catalog = read_catalog(args.catalog)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error("Failed to read catalog: %s", e)
+        return 1
+    
+    # Verify 2.0 format
+    try:
+        version = detect_schema_version(catalog)
+        if version != '2.0':
+            logger.error("Optimize requires a Schema 2.0 catalog (found %s)", version)
+            return 1
+    except ValueError as e:
+        logger.error(str(e))
+        return 1
+    
+    print("═══ Catalog Optimize ═══")
+    print(f"Input:   {args.catalog}")
+    print(f"Output:  {args.output}")
+    print(f"Threshold: {args.threshold} common packages\n")
+    
+    # Optimize
+    optimized_catalog, summary = optimize(catalog, args.threshold)
+    
+    # Check if any changes were made
+    if summary.get('message') and 'nothing to optimize' in summary['message'].lower():
+        print(summary['message'])
+        # Write unchanged catalog to output
+        if args.output != args.catalog:
+            write_catalog(catalog, args.output)
+        return 0
+    
+    if summary.get('message') and ('already exists' in summary['message'] or 'already covers' in summary['message']):
+        print(summary['message'])
+        # Write unchanged catalog to output
+        if args.output != args.catalog:
+            write_catalog(catalog, args.output)
+        return 0
+    
+    # Write optimized catalog
+    write_catalog(optimized_catalog, args.output)
+    
+    # Print detailed report
+    print("── Optimization Summary ──")
+    print(f"  Iterations: {summary['iterations']}")
+    print(f"  Shared groups created: {len(summary['shared_groups_created'])}")
+    for sg in summary['shared_groups_created']:
+        print(f"    - {sg}")
+    
+    print(f"\n── Common Packages ──")
+    print(f"  Total unique common packages extracted: {summary['total_common_packages']}")
+    
+    print(f"\n── Group Refactoring ──")
+    print(f"  Groups refactored: {summary['groups_refactored']}")
+    if summary['groups_removed']:
+        print(f"  Groups removed (empty): {len(summary['groups_removed'])} ({', '.join(summary['groups_removed'])})")
+    
+    print(f"\n── Duplication Reduction ──")
+    print(f"  Component references before: {summary['before_refs']}")
+    print(f"  Component references after:  {summary['after_refs']}")
+    print(f"  Reduction: {summary['reduction_pct']}%")
+    
+    print("\n✔ Optimization complete")
+    return 0
+
+
 def main():
     """Main entry point."""
     # Get CATALOG_FILE_PATH environment variable as default
@@ -248,6 +430,22 @@ def main():
                             help=f'Catalog file to validate (default: $CATALOG_FILE_PATH={catalog_file_path})')
     val_parser.add_argument('--schema', '-s', help='JSON schema file')
     val_parser.set_defaults(func=cmd_validate)
+    
+    # Transform command
+    trans_parser = subparsers.add_parser('transform', help='Transform catalog from 1.0 to 2.0 format')
+    trans_parser.add_argument('--input', '-i', required=True, help='Input 1.0 catalog file')
+    trans_parser.add_argument('--output', '-o', required=True, help='Output 2.0 catalog file')
+    trans_parser.add_argument('--schema', '-s', help='Schema file for post-transform validation')
+    trans_parser.add_argument('--force', '-f', action='store_true', help='Overwrite existing output file')
+    trans_parser.set_defaults(func=cmd_transform)
+    
+    # Optimize command
+    opt_parser = subparsers.add_parser('optimize', help='Optimize catalog by extracting common packages')
+    opt_parser.add_argument('--catalog', '-c', required=True, help='Input 2.0 catalog file')
+    opt_parser.add_argument('--output', '-o', required=True, help='Output optimized catalog file')
+    opt_parser.add_argument('--threshold', '-t', type=int, default=10, 
+                           help='Minimum number of common packages to extract (default: 10)')
+    opt_parser.set_defaults(func=cmd_optimize)
 
     args = parser.parse_args()
     

--- a/src/repo_manager/plugins/module_utils/catalog/catalog_manager.py
+++ b/src/repo_manager/plugins/module_utils/catalog/catalog_manager.py
@@ -23,6 +23,7 @@ Usage:
 """
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -30,8 +31,11 @@ import sys
 # Add parent directory to path for module imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# pylint: disable=wrong-import-position
 from catalog.parser import parse_input_file, parse_delete_file
-from catalog.catalog_io import read_catalog, write_catalog, new_catalog, catalog_exists
+from catalog.catalog_io import (
+    read_catalog, write_catalog, new_catalog as create_new_catalog, catalog_exists
+)
 from catalog.mutator import upsert_packages, delete_packages
 from catalog.validator import validate_catalog, format_issues
 from catalog.transformer import detect_schema_version, transform, write_keymap
@@ -83,7 +87,7 @@ def cmd_generate(args):
         logger.error("Failed to parse input file: %s", e)
         return 1
 
-    catalog = new_catalog(
+    catalog = create_new_catalog(
         args.name,
         parsed['groups'],
         parsed['packages'],
@@ -103,7 +107,8 @@ def cmd_generate(args):
     fl_count = len(parsed.get('functional_layers', []))
     group_count = len(parsed['groups'])
     pkg_count = len(parsed['packages'])
-    print(f"Catalog generated: {fl_count} functional layers, {group_count} groups, {pkg_count} packages -> {args.output}")
+    print(f"Catalog generated: {fl_count} functional layers, {group_count} groups, "
+          f"{pkg_count} packages -> {args.output}")
     return 0
 
 
@@ -191,20 +196,20 @@ def cmd_validate(args):
     return 1 if errors else 0
 
 
-def cmd_transform(args):
+def cmd_transform(args):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """Transform catalog from 1.0 to 2.0 format."""
     logger = logging.getLogger(__name__)
-    
+
     # Check if output file exists
     output_file = args.output
     if catalog_exists(output_file) and not args.force:
-        logger.error("Output file '%s' already exists. Use --force to overwrite.", output_file)
+        logger.error("Output file '%s' already exists. Use --force to overwrite.",
+                     output_file)
         return 1
-    
+
     # Read input file
     try:
         with open(args.input, 'r', encoding='utf-8') as f:
-            import json
             data = json.load(f)
     except FileNotFoundError:
         logger.error("Input file '%s' not found", args.input)
@@ -212,65 +217,70 @@ def cmd_transform(args):
     except json.JSONDecodeError as e:
         logger.error("Failed to parse input JSON: %s", e)
         return 1
-    
+
     # Detect schema version
     try:
         version = detect_schema_version(data)
     except ValueError as e:
         logger.error(str(e))
         return 1
-    
+
     if version == '2.0':
         logger.warning("Input catalog is already Schema 2.0 - no transformation needed")
         return 0
-    
+
     # Transform
     print("═══ Catalog Transform: 1.0 → 2.0 ═══")
     print(f"Input:   {args.input}  (Schema {version} detected)")
     print(f"Output:  {output_file}")
-    
+
     old_catalog = data['Catalog']
-    new_catalog, key_map, warnings = transform(old_catalog)
-    
+    catalog_data, key_map, warnings = transform(old_catalog)
+
     # Write output
-    write_catalog(new_catalog, output_file)
-    
+    write_catalog(catalog_data, output_file)
+
     # Write keymap
     keymap_path = output_file + ".keymap.json"
-    total_groups = len(new_catalog['catalog']['groups'])
-    total_layers = len(new_catalog['catalog']['functionallayer'])
-    write_keymap(key_map, args.input, output_file, keymap_path, total_groups, total_layers)
+    total_groups = len(catalog_data['catalog']['groups'])
+    total_layers = len(catalog_data['catalog']['functionallayer'])
+    write_keymap(key_map, args.input, output_file, keymap_path,
+                 total_groups, total_layers)
     print(f"Keymap:  {keymap_path}")
-    
+
     # Print package transformation report
     print("\n── Package Transformation ──")
-    total_packages = len(new_catalog['catalog']['packages'])
+    total_packages = len(catalog_data['catalog']['packages'])
     print(f"  Total packages: {total_packages}")
-    
+
     # Count by type
     type_counters = {}
-    for pkg in new_catalog['catalog']['packages'].values():
+    for pkg in catalog_data['catalog']['packages'].values():
         ptype = pkg['packagetype']
         type_counters[ptype] = type_counters.get(ptype, 0) + 1
-    
+
     for ptype in sorted(type_counters.keys()):
         print(f"  {ptype:12s}: {type_counters[ptype]}")
-    
+
     # Print group creation report
     print("\n── Group Creation ──")
-    baseos_groups = [k for k, v in new_catalog['catalog']['groups'].items() if v['type'] == 'base_os']
-    other_groups = [k for k, v in new_catalog['catalog']['groups'].items() if v['type'] != 'base_os']
-    print(f"  BaseOS groups:          {len(baseos_groups)} ({', '.join(baseos_groups)})")
+    baseos_groups = [k for k, v in catalog_data['catalog']['groups'].items()
+                     if v['type'] == 'base_os']
+    other_groups = [k for k, v in catalog_data['catalog']['groups'].items()
+                    if v['type'] != 'base_os']
+    print(f"  BaseOS groups:          {len(baseos_groups)} "
+          f"({', '.join(baseos_groups)})")
     print(f"  FunctionalLayer groups: {len(other_groups)}")
-    
+
     # Print functional layer rewiring
     print("\n── FunctionalLayer Rewiring ──")
     print(f"  Layers rewired: {total_layers}")
     if baseos_groups:
-        print(f"  Each layer includes: {', '.join(baseos_groups)} + layer-specific group")
-    
+        print(f"  Each layer includes: {', '.join(baseos_groups)} + "
+              "layer-specific group")
+
     # Print warnings
-    print(f"\n── Warnings ──")
+    print("\n── Warnings ──")
     if warnings:
         print(f"  {len(warnings)} warning(s)")
         for w in warnings[:10]:  # Limit to first 10
@@ -279,11 +289,11 @@ def cmd_transform(args):
             print(f"  ... and {len(warnings) - 10} more (see log)")
     else:
         print("  No warnings")
-    
+
     # Auto-validate if schema provided
     print("\n── Post-Transform Validation ──")
     if args.schema:
-        issues = validate_catalog(new_catalog, args.schema)
+        issues = validate_catalog(catalog_data, args.schema)
         errors = [i for i in issues if i['severity'] == 'error']
         if errors:
             print(f"  ⚠ Validation found {len(errors)} error(s) - review recommended")
@@ -295,22 +305,22 @@ def cmd_transform(args):
             print("  ✔ Validation passed")
     else:
         print("  (skipped - no schema provided)")
-    
+
     print("\n✔ Transform complete")
     return 0
 
 
-def cmd_optimize(args):
+def cmd_optimize(args):  # pylint: disable=too-many-statements
     """Optimize catalog by extracting common packages."""
     logger = logging.getLogger(__name__)
-    
+
     # Read catalog
     try:
         catalog = read_catalog(args.catalog)
     except (FileNotFoundError, ValueError) as e:
         logger.error("Failed to read catalog: %s", e)
         return 1
-    
+
     # Verify 2.0 format
     try:
         version = detect_schema_version(catalog)
@@ -320,15 +330,15 @@ def cmd_optimize(args):
     except ValueError as e:
         logger.error(str(e))
         return 1
-    
+
     print("═══ Catalog Optimize ═══")
     print(f"Input:   {args.catalog}")
     print(f"Output:  {args.output}")
     print(f"Threshold: {args.threshold} common packages\n")
-    
+
     # Optimize
     optimized_catalog, summary = optimize(catalog, args.threshold)
-    
+
     # Check if any changes were made
     if summary.get('message') and 'nothing to optimize' in summary['message'].lower():
         print(summary['message'])
@@ -336,37 +346,41 @@ def cmd_optimize(args):
         if args.output != args.catalog:
             write_catalog(catalog, args.output)
         return 0
-    
-    if summary.get('message') and ('already exists' in summary['message'] or 'already covers' in summary['message']):
+
+    msg = summary.get('message', '')
+    if msg and ('already exists' in msg or 'already covers' in msg):
         print(summary['message'])
         # Write unchanged catalog to output
         if args.output != args.catalog:
             write_catalog(catalog, args.output)
         return 0
-    
+
     # Write optimized catalog
     write_catalog(optimized_catalog, args.output)
-    
+
     # Print detailed report
     print("── Optimization Summary ──")
     print(f"  Iterations: {summary['iterations']}")
     print(f"  Shared groups created: {len(summary['shared_groups_created'])}")
     for sg in summary['shared_groups_created']:
         print(f"    - {sg}")
-    
-    print(f"\n── Common Packages ──")
-    print(f"  Total unique common packages extracted: {summary['total_common_packages']}")
-    
-    print(f"\n── Group Refactoring ──")
+
+    print("\n── Common Packages ──")
+    print(f"  Total unique common packages extracted: "
+          f"{summary['total_common_packages']}")
+
+    print("\n── Group Refactoring ──")
     print(f"  Groups refactored: {summary['groups_refactored']}")
     if summary['groups_removed']:
-        print(f"  Groups removed (empty): {len(summary['groups_removed'])} ({', '.join(summary['groups_removed'])})")
-    
-    print(f"\n── Duplication Reduction ──")
+        removed_groups = ', '.join(summary['groups_removed'])
+        print(f"  Groups removed (empty): {len(summary['groups_removed'])} "
+              f"({removed_groups})")
+
+    print("\n── Duplication Reduction ──")
     print(f"  Component references before: {summary['before_refs']}")
     print(f"  Component references after:  {summary['after_refs']}")
     print(f"  Reduction: {summary['reduction_pct']}%")
-    
+
     print("\n✔ Optimization complete")
     return 0
 
@@ -385,40 +399,54 @@ def main():
     subparsers = parser.add_subparsers(dest='command', required=True)
 
     # Generate command
-    gen_parser = subparsers.add_parser('generate', help='Generate new catalog from input file')
+    gen_parser = subparsers.add_parser('generate',
+                                       help='Generate new catalog from input file')
     gen_parser.add_argument('--input', '-i', help='Input file path')
-    gen_parser.add_argument('--output', '-o', default=catalog_file_path, 
-                            help=f'Output catalog file path (default: $CATALOG_FILE_PATH={catalog_file_path})')
+    gen_parser.add_argument('--output', '-o', default=catalog_file_path,
+                            help=f'Output catalog file path '
+                                 f'(default: $CATALOG_FILE_PATH={catalog_file_path})')
     gen_parser.add_argument('--name', '-n', default='default', help='Catalog name')
-    gen_parser.add_argument('--force', '-f', action='store_true', help='Overwrite existing file')
-    gen_parser.add_argument('--default-arch', default='x86_64', help='Default architecture')
+    gen_parser.add_argument('--force', '-f', action='store_true',
+                            help='Overwrite existing file')
+    gen_parser.add_argument('--default-arch', default='x86_64',
+                            help='Default architecture')
     gen_parser.add_argument('--default-os', default='rhel', help='Default OS')
-    gen_parser.add_argument('--default-os-version', default='10.0', help='Default OS version')
+    gen_parser.add_argument('--default-os-version', default='10.0',
+                            help='Default OS version')
     gen_parser.add_argument('--schema', help='Schema file for validation')
     gen_parser.add_argument('--validate', action='store_true', default=True,
                             help='Validate after generation')
     gen_parser.set_defaults(func=cmd_generate)
 
     # Add command
-    add_parser = subparsers.add_parser('add', help='Add packages to existing catalog')
+    add_parser = subparsers.add_parser('add',
+                                       help='Add packages to existing catalog')
     add_parser.add_argument('--input', '-i', help='Input file with packages to add')
     add_parser.add_argument('--catalog', '-c', default=catalog_file_path,
-                            help=f'Existing catalog file (default: $CATALOG_FILE_PATH={catalog_file_path})')
-    add_parser.add_argument('--output', '-o', help='Output file (default: overwrite catalog)')
-    add_parser.add_argument('--default-arch', default='x86_64', help='Default architecture')
+                            help=f'Existing catalog file '
+                                 f'(default: $CATALOG_FILE_PATH={catalog_file_path})')
+    add_parser.add_argument('--output', '-o',
+                            help='Output file (default: overwrite catalog)')
+    add_parser.add_argument('--default-arch', default='x86_64',
+                            help='Default architecture')
     add_parser.add_argument('--default-os', default='rhel', help='Default OS')
-    add_parser.add_argument('--default-os-version', default='10.0', help='Default OS version')
+    add_parser.add_argument('--default-os-version', default='10.0',
+                            help='Default OS version')
     add_parser.add_argument('--schema', help='Schema file for validation')
     add_parser.add_argument('--validate', action='store_true', default=True,
                             help='Validate after add')
     add_parser.set_defaults(func=cmd_add)
 
     # Delete command
-    del_parser = subparsers.add_parser('delete', help='Delete packages from catalog')
-    del_parser.add_argument('--input', '-i', help='Input file with packages to delete')
+    del_parser = subparsers.add_parser('delete',
+                                       help='Delete packages from catalog')
+    del_parser.add_argument('--input', '-i',
+                            help='Input file with packages to delete')
     del_parser.add_argument('--catalog', '-c', default=catalog_file_path,
-                            help=f'Existing catalog file (default: $CATALOG_FILE_PATH={catalog_file_path})')
-    del_parser.add_argument('--output', '-o', help='Output file (default: overwrite catalog)')
+                            help=f'Existing catalog file '
+                                 f'(default: $CATALOG_FILE_PATH={catalog_file_path})')
+    del_parser.add_argument('--output', '-o',
+                            help='Output file (default: overwrite catalog)')
     del_parser.add_argument('--schema', help='Schema file for validation')
     del_parser.add_argument('--validate', action='store_true', default=True,
                             help='Validate after delete')
@@ -427,43 +455,56 @@ def main():
     # Validate command
     val_parser = subparsers.add_parser('validate', help='Validate a catalog')
     val_parser.add_argument('--catalog', '-c', default=catalog_file_path,
-                            help=f'Catalog file to validate (default: $CATALOG_FILE_PATH={catalog_file_path})')
+                            help=f'Catalog file to validate '
+                                 f'(default: $CATALOG_FILE_PATH={catalog_file_path})')
     val_parser.add_argument('--schema', '-s', help='JSON schema file')
     val_parser.set_defaults(func=cmd_validate)
-    
+
     # Transform command
-    trans_parser = subparsers.add_parser('transform', help='Transform catalog from 1.0 to 2.0 format')
-    trans_parser.add_argument('--input', '-i', required=True, help='Input 1.0 catalog file')
-    trans_parser.add_argument('--output', '-o', required=True, help='Output 2.0 catalog file')
-    trans_parser.add_argument('--schema', '-s', help='Schema file for post-transform validation')
-    trans_parser.add_argument('--force', '-f', action='store_true', help='Overwrite existing output file')
+    trans_parser = subparsers.add_parser('transform',
+                                         help='Transform catalog from 1.0 to 2.0 format')
+    trans_parser.add_argument('--input', '-i', required=True,
+                              help='Input 1.0 catalog file')
+    trans_parser.add_argument('--output', '-o', required=True,
+                              help='Output 2.0 catalog file')
+    trans_parser.add_argument('--schema', '-s',
+                              help='Schema file for post-transform validation')
+    trans_parser.add_argument('--force', '-f', action='store_true',
+                              help='Overwrite existing output file')
     trans_parser.set_defaults(func=cmd_transform)
-    
+
     # Optimize command
-    opt_parser = subparsers.add_parser('optimize', help='Optimize catalog by extracting common packages')
-    opt_parser.add_argument('--catalog', '-c', required=True, help='Input 2.0 catalog file')
-    opt_parser.add_argument('--output', '-o', required=True, help='Output optimized catalog file')
-    opt_parser.add_argument('--threshold', '-t', type=int, default=10, 
-                           help='Minimum number of common packages to extract (default: 10)')
+    opt_parser = subparsers.add_parser('optimize',
+                                       help='Optimize catalog by extracting common packages')
+    opt_parser.add_argument('--catalog', '-c', required=True,
+                            help='Input 2.0 catalog file')
+    opt_parser.add_argument('--output', '-o', required=True,
+                            help='Output optimized catalog file')
+    opt_parser.add_argument('--threshold', '-t', type=int, default=10,
+                            help='Minimum number of common packages to extract '
+                                 '(default: 10)')
     opt_parser.set_defaults(func=cmd_optimize)
 
     args = parser.parse_args()
-    
+
     # Validate required arguments
     if args.command == 'generate':
         if not args.input:
             parser.error("generate: --input is required")
         if not args.output:
-            parser.error("generate: --output is required (set CATALOG_FILE_PATH or use -o)")
+            parser.error("generate: --output is required "
+                         "(set CATALOG_FILE_PATH or use -o)")
     elif args.command in ('add', 'delete'):
         if not args.input:
             parser.error(f"{args.command}: --input is required")
         if not args.catalog:
-            parser.error(f"{args.command}: --catalog is required (set CATALOG_FILE_PATH or use -c)")
+            parser.error(f"{args.command}: --catalog is required "
+                         "(set CATALOG_FILE_PATH or use -c)")
     elif args.command == 'validate':
         if not args.catalog:
-            parser.error("validate: --catalog is required (set CATALOG_FILE_PATH or use -c)")
-    
+            parser.error("validate: --catalog is required "
+                         "(set CATALOG_FILE_PATH or use -c)")
+
     setup_logging(args.log_dir)
 
     return args.func(args)

--- a/src/repo_manager/plugins/module_utils/catalog/optimizer.py
+++ b/src/repo_manager/plugins/module_utils/catalog/optimizer.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Catalog Optimizer - Extract common packages across functional layer groups.
+
+This module provides functions to:
+- Identify common packages across functional layer groups
+- Create shared groups for common packages
+- Refactor existing groups to remove duplicated packages
+- Optimize catalog structure to reduce duplication
+"""
+
+from typing import Tuple, Dict, List, Set
+from itertools import combinations
+
+
+def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
+    """
+    Extract common packages across functional layer groups into shared groups.
+    
+    This optimization iteratively:
+    1. Identifies candidate groups (non-baseos groups in functional layers)
+    2. Finds the largest subset of groups with intersection >= threshold
+    3. Creates a shared group with common packages
+    4. Removes common packages from original groups
+    5. Rewires functional layers to include the shared group
+    6. Repeats until no more common sets >= threshold exist
+    
+    Args:
+        catalog: 2.0 format catalog dictionary
+        threshold: Minimum number of common packages required (default: 10)
+        
+    Returns:
+        Tuple of (modified_catalog, summary_dict)
+        
+    Summary dict contains:
+        - iterations: Number of optimization iterations performed
+        - shared_groups_created: List of shared group keys created
+        - total_common_packages: Total unique common packages extracted
+        - groups_refactored: Number of groups refactored
+        - groups_removed: List of empty groups removed
+        - before_refs: Total component references before
+        - after_refs: Total component references after
+        
+    Raises:
+        ValueError: If not a 2.0 catalog (missing lowercase 'catalog' key)
+    """
+    # Validate 2.0 catalog
+    if 'catalog' not in catalog:
+        raise ValueError("Not a 2.0 catalog - root key 'catalog' not found")
+    
+    cat = catalog['catalog']
+    
+    # Track overall statistics
+    iterations = 0
+    shared_groups_created = []
+    all_refactored_groups = set()
+    all_removed_groups = []
+    count_before_refs = sum(len(g['components']) for g in cat['groups'].values() if g['type'] != 'base_os')
+    
+    # Iteratively extract common packages
+    while True:
+        # Step 1: Identify candidate groups
+        layer_to_groups = {}  # layer_name -> [group_keys]
+        group_to_layers = {}  # group_key -> [layer_names]
+        
+        for layer in cat.get('functionallayer', []):
+            non_baseos_group_keys = []
+            for group_key in layer['components']:
+                if group_key in cat['groups']:
+                    group = cat['groups'][group_key]
+                    # Skip baseos and already-created shared groups
+                    if group['type'] != 'base_os' and 'common_shared_group' not in group_key:
+                        non_baseos_group_keys.append(group_key)
+                        if group_key not in group_to_layers:
+                            group_to_layers[group_key] = []
+                        group_to_layers[group_key].append(layer['name'])
+            layer_to_groups[layer['name']] = non_baseos_group_keys
+        
+        # Collect all unique non-baseos, non-shared group keys
+        candidate_group_keys = list(group_to_layers.keys())
+        
+        if len(candidate_group_keys) < 2:
+            break  # No more groups to optimize
+        
+        # Step 2: Find the best subset with largest common intersection
+        best_subset = None
+        best_intersection = set()
+        best_intersection_size = 0
+        
+        # Try all possible subsets of groups (starting from largest)
+        for subset_size in range(len(candidate_group_keys), 1, -1):
+            for subset in combinations(candidate_group_keys, subset_size):
+                # Compute intersection
+                group_sets = [set(cat['groups'][gk]['components']) for gk in subset]
+                intersection = set.intersection(*group_sets)
+                
+                if len(intersection) >= threshold and len(intersection) > best_intersection_size:
+                    best_intersection_size = len(intersection)
+                    best_intersection = intersection
+                    best_subset = subset
+            
+            # If we found a good subset, stop searching smaller subsets
+            if best_subset:
+                break
+        
+        # If no subset found with intersection >= threshold, we're done
+        if not best_subset or best_intersection_size < threshold:
+            break
+        
+        iterations += 1
+        participating_group_keys = list(best_subset)
+        common_packages = sorted(list(best_intersection))
+        
+        # Step 3: Create shared group
+        shared_group_key = "common_shared_group"
+        if iterations > 1:
+            shared_group_key = f"common_shared_group_{iterations}"
+        counter = 1
+        while shared_group_key in cat['groups']:
+            shared_group_key = f"common_shared_group_{iterations}_{counter}"
+            counter += 1
+        
+        # Determine which layers participate
+        participating_layer_names = []
+        for gk in participating_group_keys:
+            participating_layer_names.extend(group_to_layers[gk])
+        participating_layer_names = sorted(set(participating_layer_names))
+        
+        cat['groups'][shared_group_key] = {
+            "name": shared_group_key,
+            "type": "group",
+            "description": f"Auto-extracted: {len(common_packages)} common packages shared across {len(participating_layer_names)} functional layers ({', '.join(participating_layer_names)})",
+            "components": common_packages
+        }
+        shared_groups_created.append(shared_group_key)
+        
+        # Step 4: Refactor participating groups
+        groups_removed_this_iter = []
+        
+        for gk in participating_group_keys:
+            old_components = cat['groups'][gk]['components']
+            
+            # Remove common packages from this group
+            new_components = [c for c in old_components if c not in common_packages]
+            
+            if len(new_components) == 0:
+                # Group is now empty - mark for removal
+                groups_removed_this_iter.append(gk)
+                all_removed_groups.append(gk)
+                del cat['groups'][gk]
+            else:
+                cat['groups'][gk]['components'] = new_components
+                desc = cat['groups'][gk].get('description', '')
+                if 'layer-specific after optimization' not in desc:
+                    cat['groups'][gk]['description'] = desc + " (layer-specific after optimization)" if desc else "Layer-specific after optimization"
+                all_refactored_groups.add(gk)
+        
+        # Step 5: Rewire functional layers
+        for layer in cat['functionallayer']:
+            # Check if any of this layer's group references are in participating_group_keys
+            layer_has_participating = False
+            for comp in layer['components']:
+                if comp in participating_group_keys:
+                    layer_has_participating = True
+                    break
+            
+            if layer_has_participating:
+                # Insert shared_group_key after baseos groups, before layer-specific groups
+                new_components = []
+                shared_added = False
+                
+                for comp in layer['components']:
+                    # Check if this is a baseos group
+                    is_baseos = False
+                    if comp in cat['groups'] and cat['groups'][comp]['type'] == 'base_os':
+                        is_baseos = True
+                    
+                    new_components.append(comp)
+                    
+                    # After the last baseos group, insert the shared group
+                    if is_baseos and not shared_added:
+                        # Check if next component is also baseos
+                        next_idx = layer['components'].index(comp) + 1
+                        next_is_baseos = False
+                        if next_idx < len(layer['components']):
+                            next_comp = layer['components'][next_idx]
+                            if next_comp in cat['groups'] and cat['groups'][next_comp]['type'] == 'base_os':
+                                next_is_baseos = True
+                        
+                        # Insert after last baseos
+                        if not next_is_baseos:
+                            new_components.append(shared_group_key)
+                            shared_added = True
+                
+                # If no baseos was found, just prepend at position 0
+                if not shared_added:
+                    new_components.insert(0, shared_group_key)
+                
+                # Remove groups that were deleted (empty after extraction)
+                new_components = [c for c in new_components if c not in groups_removed_this_iter]
+                
+                # Deduplicate while preserving order
+                seen = set()
+                deduplicated = []
+                for item in new_components:
+                    if item not in seen:
+                        seen.add(item)
+                        deduplicated.append(item)
+                
+                layer['components'] = deduplicated
+    
+    # If no iterations performed, nothing to optimize
+    if iterations == 0:
+        summary = {
+            'iterations': 0,
+            'shared_groups_created': [],
+            'total_common_packages': 0,
+            'groups_refactored': 0,
+            'groups_removed': [],
+            'before_refs': 0,
+            'after_refs': 0,
+            'message': f'No common sets >= {threshold} found across layer groups - nothing to optimize'
+        }
+        return catalog, summary
+    
+    # Build summary
+    count_after_refs = sum(len(g['components']) for g in cat['groups'].values() if g['type'] != 'base_os')
+    
+    reduction_pct = 0
+    if count_before_refs > 0:
+        reduction_pct = round(((count_before_refs - count_after_refs) / count_before_refs) * 100, 1)
+    
+    # Count total unique common packages
+    total_common_packages = set()
+    for sg in shared_groups_created:
+        if sg in cat['groups']:
+            total_common_packages.update(cat['groups'][sg]['components'])
+    
+    summary = {
+        'iterations': iterations,
+        'shared_groups_created': shared_groups_created,
+        'total_common_packages': len(total_common_packages),
+        'groups_refactored': len(all_refactored_groups),
+        'groups_removed': all_removed_groups,
+        'before_refs': count_before_refs,
+        'after_refs': count_after_refs,
+        'reduction_pct': reduction_pct,
+        'message': 'Optimization complete'
+    }
+    
+    return catalog, summary

--- a/src/repo_manager/plugins/module_utils/catalog/optimizer.py
+++ b/src/repo_manager/plugins/module_utils/catalog/optimizer.py
@@ -22,14 +22,14 @@ This module provides functions to:
 - Optimize catalog structure to reduce duplication
 """
 
-from typing import Tuple, Dict, List, Set
+from typing import Tuple
 from itertools import combinations
 
 
-def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
+def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """
     Extract common packages across functional layer groups into shared groups.
-    
+
     This optimization iteratively:
     1. Identifies candidate groups (non-baseos groups in functional layers)
     2. Finds the largest subset of groups with intersection >= threshold
@@ -37,14 +37,14 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
     4. Removes common packages from original groups
     5. Rewires functional layers to include the shared group
     6. Repeats until no more common sets >= threshold exist
-    
+
     Args:
         catalog: 2.0 format catalog dictionary
         threshold: Minimum number of common packages required (default: 10)
-        
+
     Returns:
         Tuple of (modified_catalog, summary_dict)
-        
+
     Summary dict contains:
         - iterations: Number of optimization iterations performed
         - shared_groups_created: List of shared group keys created
@@ -53,77 +53,80 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
         - groups_removed: List of empty groups removed
         - before_refs: Total component references before
         - after_refs: Total component references after
-        
+
     Raises:
         ValueError: If not a 2.0 catalog (missing lowercase 'catalog' key)
     """
     # Validate 2.0 catalog
     if 'catalog' not in catalog:
         raise ValueError("Not a 2.0 catalog - root key 'catalog' not found")
-    
+
     cat = catalog['catalog']
-    
+
     # Track overall statistics
     iterations = 0
     shared_groups_created = []
     all_refactored_groups = set()
     all_removed_groups = []
-    count_before_refs = sum(len(g['components']) for g in cat['groups'].values() if g['type'] != 'base_os')
-    
+    count_before_refs = sum(len(g['components']) for g in cat['groups'].values()
+                            if g['type'] != 'base_os')
+
     # Iteratively extract common packages
-    while True:
+    while True:  # pylint: disable=too-many-nested-blocks
         # Step 1: Identify candidate groups
         layer_to_groups = {}  # layer_name -> [group_keys]
         group_to_layers = {}  # group_key -> [layer_names]
-        
+
         for layer in cat.get('functionallayer', []):
             non_baseos_group_keys = []
             for group_key in layer['components']:
                 if group_key in cat['groups']:
                     group = cat['groups'][group_key]
                     # Skip baseos and already-created shared groups
-                    if group['type'] != 'base_os' and 'common_shared_group' not in group_key:
+                    if (group['type'] != 'base_os' and
+                            'common_shared_group' not in group_key):
                         non_baseos_group_keys.append(group_key)
                         if group_key not in group_to_layers:
                             group_to_layers[group_key] = []
                         group_to_layers[group_key].append(layer['name'])
             layer_to_groups[layer['name']] = non_baseos_group_keys
-        
+
         # Collect all unique non-baseos, non-shared group keys
         candidate_group_keys = list(group_to_layers.keys())
-        
+
         if len(candidate_group_keys) < 2:
             break  # No more groups to optimize
-        
+
         # Step 2: Find the best subset with largest common intersection
         best_subset = None
         best_intersection = set()
         best_intersection_size = 0
-        
+
         # Try all possible subsets of groups (starting from largest)
         for subset_size in range(len(candidate_group_keys), 1, -1):
             for subset in combinations(candidate_group_keys, subset_size):
                 # Compute intersection
                 group_sets = [set(cat['groups'][gk]['components']) for gk in subset]
                 intersection = set.intersection(*group_sets)
-                
-                if len(intersection) >= threshold and len(intersection) > best_intersection_size:
+
+                if (len(intersection) >= threshold and
+                        len(intersection) > best_intersection_size):
                     best_intersection_size = len(intersection)
                     best_intersection = intersection
                     best_subset = subset
-            
+
             # If we found a good subset, stop searching smaller subsets
             if best_subset:
                 break
-        
+
         # If no subset found with intersection >= threshold, we're done
         if not best_subset or best_intersection_size < threshold:
             break
-        
+
         iterations += 1
         participating_group_keys = list(best_subset)
         common_packages = sorted(list(best_intersection))
-        
+
         # Step 3: Create shared group
         shared_group_key = "common_shared_group"
         if iterations > 1:
@@ -132,30 +135,33 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
         while shared_group_key in cat['groups']:
             shared_group_key = f"common_shared_group_{iterations}_{counter}"
             counter += 1
-        
+
         # Determine which layers participate
         participating_layer_names = []
         for gk in participating_group_keys:
             participating_layer_names.extend(group_to_layers[gk])
         participating_layer_names = sorted(set(participating_layer_names))
-        
+
+        layer_list = ', '.join(participating_layer_names)
         cat['groups'][shared_group_key] = {
             "name": shared_group_key,
             "type": "group",
-            "description": f"Auto-extracted: {len(common_packages)} common packages shared across {len(participating_layer_names)} functional layers ({', '.join(participating_layer_names)})",
+            "description": (f"Auto-extracted: {len(common_packages)} common packages "
+                            f"shared across {len(participating_layer_names)} functional "
+                            f"layers ({layer_list})"),
             "components": common_packages
         }
         shared_groups_created.append(shared_group_key)
-        
+
         # Step 4: Refactor participating groups
         groups_removed_this_iter = []
-        
+
         for gk in participating_group_keys:
             old_components = cat['groups'][gk]['components']
-            
+
             # Remove common packages from this group
             new_components = [c for c in old_components if c not in common_packages]
-            
+
             if len(new_components) == 0:
                 # Group is now empty - mark for removal
                 groups_removed_this_iter.append(gk)
@@ -165,9 +171,11 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
                 cat['groups'][gk]['components'] = new_components
                 desc = cat['groups'][gk].get('description', '')
                 if 'layer-specific after optimization' not in desc:
-                    cat['groups'][gk]['description'] = desc + " (layer-specific after optimization)" if desc else "Layer-specific after optimization"
+                    suffix = " (layer-specific after optimization)"
+                    cat['groups'][gk]['description'] = (desc + suffix if desc
+                                                        else "Layer-specific after optimization")
                 all_refactored_groups.add(gk)
-        
+
         # Step 5: Rewire functional layers
         for layer in cat['functionallayer']:
             # Check if any of this layer's group references are in participating_group_keys
@@ -176,20 +184,20 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
                 if comp in participating_group_keys:
                     layer_has_participating = True
                     break
-            
+
             if layer_has_participating:
                 # Insert shared_group_key after baseos groups, before layer-specific groups
                 new_components = []
                 shared_added = False
-                
+
                 for comp in layer['components']:
                     # Check if this is a baseos group
                     is_baseos = False
                     if comp in cat['groups'] and cat['groups'][comp]['type'] == 'base_os':
                         is_baseos = True
-                    
+
                     new_components.append(comp)
-                    
+
                     # After the last baseos group, insert the shared group
                     if is_baseos and not shared_added:
                         # Check if next component is also baseos
@@ -197,21 +205,23 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
                         next_is_baseos = False
                         if next_idx < len(layer['components']):
                             next_comp = layer['components'][next_idx]
-                            if next_comp in cat['groups'] and cat['groups'][next_comp]['type'] == 'base_os':
+                            if (next_comp in cat['groups'] and
+                                    cat['groups'][next_comp]['type'] == 'base_os'):
                                 next_is_baseos = True
-                        
+
                         # Insert after last baseos
                         if not next_is_baseos:
                             new_components.append(shared_group_key)
                             shared_added = True
-                
+
                 # If no baseos was found, just prepend at position 0
                 if not shared_added:
                     new_components.insert(0, shared_group_key)
-                
+
                 # Remove groups that were deleted (empty after extraction)
-                new_components = [c for c in new_components if c not in groups_removed_this_iter]
-                
+                new_components = [c for c in new_components
+                                  if c not in groups_removed_this_iter]
+
                 # Deduplicate while preserving order
                 seen = set()
                 deduplicated = []
@@ -219,9 +229,9 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
                     if item not in seen:
                         seen.add(item)
                         deduplicated.append(item)
-                
+
                 layer['components'] = deduplicated
-    
+
     # If no iterations performed, nothing to optimize
     if iterations == 0:
         summary = {
@@ -232,23 +242,26 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
             'groups_removed': [],
             'before_refs': 0,
             'after_refs': 0,
-            'message': f'No common sets >= {threshold} found across layer groups - nothing to optimize'
+            'message': (f'No common sets >= {threshold} found across layer groups - '
+                        'nothing to optimize')
         }
         return catalog, summary
-    
+
     # Build summary
-    count_after_refs = sum(len(g['components']) for g in cat['groups'].values() if g['type'] != 'base_os')
-    
+    count_after_refs = sum(len(g['components']) for g in cat['groups'].values()
+                           if g['type'] != 'base_os')
+
     reduction_pct = 0
     if count_before_refs > 0:
-        reduction_pct = round(((count_before_refs - count_after_refs) / count_before_refs) * 100, 1)
-    
+        reduction_pct = round(((count_before_refs - count_after_refs) /
+                               count_before_refs) * 100, 1)
+
     # Count total unique common packages
     total_common_packages = set()
     for sg in shared_groups_created:
         if sg in cat['groups']:
             total_common_packages.update(cat['groups'][sg]['components'])
-    
+
     summary = {
         'iterations': iterations,
         'shared_groups_created': shared_groups_created,
@@ -260,5 +273,5 @@ def optimize(catalog: dict, threshold: int = 10) -> Tuple[dict, dict]:
         'reduction_pct': reduction_pct,
         'message': 'Optimization complete'
     }
-    
+
     return catalog, summary

--- a/src/repo_manager/plugins/module_utils/catalog/transformer.py
+++ b/src/repo_manager/plugins/module_utils/catalog/transformer.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Catalog Transformer - Transform Schema 1.0 catalogs to Schema 2.0.
+
+This module provides functions to:
+- Detect catalog schema version
+- Transform 1.0 format (PascalCase "Catalog" root key) to 2.0 format (lowercase "catalog")
+- Slugify package keys according to transformation rules
+- Extract registry from image names
+- Generate unique keys for packages
+- Transform source arrays
+- Write keymap sidecar files
+"""
+
+import re
+import json
+from datetime import datetime
+from typing import Tuple, Dict, List, Set, Optional
+
+
+def detect_schema_version(catalog_data: dict) -> str:
+    """
+    Detect the schema version of a catalog.
+    
+    Args:
+        catalog_data: The catalog dictionary
+        
+    Returns:
+        '1.0' if root key is 'Catalog' (PascalCase)
+        '2.0' if root key is 'catalog' (lowercase)
+        
+    Raises:
+        ValueError: If neither key is found
+    """
+    if 'Catalog' in catalog_data:
+        return '1.0'
+    elif 'catalog' in catalog_data:
+        return '2.0'
+    else:
+        raise ValueError("Unrecognized catalog format - expected root key 'Catalog' or 'catalog'")
+
+
+def slugify(text: str) -> str:
+    """
+    Core slugification function.
+    
+    Rules:
+    1. Lowercase the entire string
+    2. Replace all `-`, `.`, `/`, `@`, `:` with `_`
+    3. Collapse consecutive `_` into a single `_`
+    4. Strip leading and trailing `_`
+    
+    Special cases:
+    - 'gcc-c++' -> 'gcc_cpp'
+    - Handle + by replacing with 'p' or removing
+    
+    Args:
+        text: String to slugify
+        
+    Returns:
+        Slugified string
+    """
+    if not text:
+        return text
+        
+    # Lowercase
+    result = text.lower()
+    
+    # Special handling for C++
+    result = result.replace('c++', 'cpp')
+    result = result.replace('++', 'pp')
+    result = result.replace('+', 'p')
+    
+    # Replace special characters with underscore
+    result = re.sub(r'[-./\@:]', '_', result)
+    
+    # Collapse consecutive underscores
+    result = re.sub(r'_+', '_', result)
+    
+    # Strip leading/trailing underscores
+    result = result.strip('_')
+    
+    return result
+
+
+def extract_registry(image_name: str) -> str:
+    """
+    Extract registry domain from image path.
+    
+    Examples:
+        "docker.io/calico/cni" -> "docker.io"
+        "registry.k8s.io/etcd" -> "registry.k8s.io"
+        "nvcr.io/nvidia/hpc-benchmarks" -> "nvcr.io"
+        "quay.io/strimzi/kafka" -> "quay.io"
+        "simple-image" -> "docker.io" (default)
+        
+    Args:
+        image_name: Full image name/path
+        
+    Returns:
+        Registry domain or "docker.io" as default
+    """
+    parts = image_name.split('/')
+    
+    # Check if first part looks like a registry (contains . or :)
+    if len(parts) >= 2 and ('.' in parts[0] or ':' in parts[0]):
+        return parts[0]
+    
+    # Default to Docker Hub
+    return "docker.io"
+
+
+def generate_unique_key(old_key: str, pkg_type: str, tag: Optional[str], 
+                       existing_keys: Set[str]) -> str:
+    """
+    Generate a unique slugified key for a package.
+    
+    Rules by package type:
+    - rpm, rpm_repo, tarball, pip_module, git, manifest: slugify(old_key)
+    - image: slugify(last_path_segment + "_" + tag)
+    
+    If collision occurs, append _1, _2, etc.
+    
+    Args:
+        old_key: Original package key from 1.0 catalog
+        pkg_type: Package type (rpm, image, tarball, etc.)
+        tag: Image tag (only for image types)
+        existing_keys: Set of already generated keys for collision detection
+        
+    Returns:
+        Unique slugified key
+    """
+    if pkg_type == "image":
+        # Extract last segment from image path
+        last_segment = old_key.split('/')[-1]
+        tag_slug = slugify(tag) if tag else "notag"
+        slug_base = slugify(last_segment) + "_" + tag_slug
+    else:
+        slug_base = slugify(old_key)
+    
+    # Handle collisions
+    candidate = slug_base
+    counter = 1
+    
+    while candidate in existing_keys:
+        candidate = f"{slug_base}_{counter}"
+        counter += 1
+    
+    existing_keys.add(candidate)
+    return candidate
+
+
+def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List[dict]:
+    """
+    Transform 1.0 Sources array to 2.0 sources array.
+    
+    Args:
+        old_pkg: Original package dictionary
+        pkg_type: Package type
+        warnings: List to append warnings to
+        
+    Returns:
+        List of transformed source dictionaries
+    """
+    old_key = old_pkg.get('Name', 'unknown')
+    
+    # Extract OS info from SupportedOS
+    supported_os = old_pkg.get('SupportedOS', [])
+    if supported_os:
+        os_name = supported_os[0]['Name'].lower()
+        os_versions = list(set(entry['Version'] for entry in supported_os))
+    else:
+        os_name = "rhel"
+        os_versions = ["10.0"]
+        warnings.append(f"Package '{old_key}' has no SupportedOS - using defaults")
+    
+    old_sources = old_pkg.get('Sources', [])
+    new_sources = []
+    
+    if pkg_type in ["rpm", "rpm_repo"]:
+        if old_sources:
+            for src in old_sources:
+                new_sources.append({
+                    "architecture": src['Architecture'].lower(),
+                    "reponame": src['RepoName'],
+                    "name": os_name,
+                    "version": os_versions
+                })
+        else:
+            # Synthesize from Architecture array
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                new_sources.append({
+                    "architecture": arch.lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+                warnings.append(f"No Sources[] for {pkg_type} package '{old_key}' - synthesized")
+    
+    elif pkg_type == "tarball":
+        if old_sources:
+            for src in old_sources:
+                entry = {
+                    "architecture": src['Architecture'].lower(),
+                    "name": os_name,
+                    "version": os_versions,
+                    "url": src['Uri']
+                }
+                new_sources.append(entry)
+        else:
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                new_sources.append({
+                    "architecture": arch.lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+                warnings.append(f"No Sources[] for tarball '{old_key}' - synthesized without URL")
+    
+    elif pkg_type == "git":
+        if old_sources:
+            for src in old_sources:
+                new_sources.append({
+                    "architecture": src['Architecture'].lower(),
+                    "url": src['Uri'],
+                    "name": os_name,
+                    "version": os_versions
+                })
+        else:
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                new_sources.append({
+                    "architecture": arch.lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+                warnings.append(f"No Sources[] for git package '{old_key}' - synthesized")
+    
+    elif pkg_type == "manifest":
+        if old_sources:
+            for src in old_sources:
+                entry = {
+                    "architecture": src['Architecture'].lower(),
+                    "name": os_name,
+                    "version": os_versions
+                }
+                if 'Uri' in src:
+                    entry['url'] = src['Uri']
+                new_sources.append(entry)
+        else:
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                new_sources.append({
+                    "architecture": arch.lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+                warnings.append(f"No Sources[] for manifest '{old_key}' - synthesized")
+    
+    elif pkg_type == "image":
+        registry = extract_registry(old_pkg['Name'])
+        
+        if old_sources:
+            for src in old_sources:
+                entry = {
+                    "architecture": src['Architecture'].lower(),
+                    "registry": src.get('Registry', registry)
+                }
+                if supported_os:
+                    entry['name'] = os_name
+                    entry['version'] = os_versions
+                new_sources.append(entry)
+        else:
+            # Many image packages have NO Sources[] at all
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                entry = {
+                    "architecture": arch.lower(),
+                    "registry": registry
+                }
+                if supported_os:
+                    entry['name'] = os_name
+                    entry['version'] = os_versions
+                new_sources.append(entry)
+                warnings.append(f"No Sources[] for image '{old_key}' - synthesized from Architecture + SupportedOS")
+    
+    elif pkg_type == "pip_module":
+        if old_sources:
+            for src in old_sources:
+                new_sources.append({
+                    "architecture": src['Architecture'].lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+        else:
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                new_sources.append({
+                    "architecture": arch.lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+    
+    else:
+        warnings.append(f"Unknown package type '{pkg_type}' for '{old_key}' - treated as tarball")
+        # Handle same as tarball
+        if old_sources:
+            for src in old_sources:
+                entry = {
+                    "architecture": src['Architecture'].lower(),
+                    "name": os_name,
+                    "version": os_versions
+                }
+                if 'Uri' in src:
+                    entry['url'] = src['Uri']
+                new_sources.append(entry)
+        else:
+            for arch in old_pkg.get('Architecture', ['x86_64']):
+                new_sources.append({
+                    "architecture": arch.lower(),
+                    "name": os_name,
+                    "version": os_versions
+                })
+    
+    return new_sources
+
+
+def deduplicate_preserve_order(items: List[str]) -> List[str]:
+    """
+    Remove duplicates from list while preserving first-occurrence order.
+    
+    Args:
+        items: List of strings
+        
+    Returns:
+        Deduplicated list
+    """
+    seen = set()
+    result = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:
+    """
+    Transform a 1.0 catalog to 2.0 format.
+    
+    Args:
+        old_catalog: The "Catalog" section from 1.0 format
+        
+    Returns:
+        Tuple of (new_catalog_dict, key_map_dict, warnings_list)
+    """
+    warnings = []
+    
+    # Extract catalog metadata
+    catalog_name = old_catalog.get('Name', '')
+    catalog_version = old_catalog.get('Version', '1.0')
+    catalog_identifier = old_catalog.get('Identifier', slugify(catalog_name))
+    
+    base_os_list = old_catalog.get('BaseOS', [])
+    layers = old_catalog.get('FunctionalLayer', [])
+    infrastructure = old_catalog.get('Infrastructure', [])
+    
+    # Merge all package dictionaries from different sections
+    # In 1.0 catalogs, packages can be in Packages, FunctionalPackages, OSPackages, 
+    # DriverPackages, or InfrastructurePackages
+    old_packages = {}
+    for pkg_key in ['Packages', 'FunctionalPackages', 'OSPackages', 'DriverPackages', 'InfrastructurePackages']:
+        pkg_dict = old_catalog.get(pkg_key, {})
+        if pkg_dict:
+            old_packages.update(pkg_dict)
+    
+    # Phase 1: Transform all packages
+    new_packages = {}
+    key_map = {}
+    all_new_keys = set()
+    type_counters = {}
+    
+    for old_key, old_pkg in old_packages.items():
+        pkg_type = old_pkg.get('Type', 'rpm').lower()
+        tag = old_pkg.get('Tag', None)
+        
+        # Generate new key
+        new_key = generate_unique_key(old_key, pkg_type, tag, all_new_keys)
+        key_map[old_key] = new_key
+        
+        # Build new package dict
+        new_pkg = {
+            "name": old_pkg.get('Name', old_key),
+            "packagetype": pkg_type
+        }
+        
+        # Preserve version if present and non-empty
+        if 'Version' in old_pkg and old_pkg['Version']:
+            new_pkg['version'] = old_pkg['Version']
+        
+        # Preserve tag for images
+        if tag:
+            new_pkg['tag'] = tag
+        
+        # Preserve supported_functions (git/CSI packages)
+        if 'SupportedFunctions' in old_pkg and old_pkg['SupportedFunctions']:
+            new_pkg['supported_functions'] = [
+                sf['Name'] for sf in old_pkg['SupportedFunctions']
+            ]
+        
+        # Transform sources
+        new_pkg['sources'] = transform_sources(old_pkg, pkg_type, warnings)
+        
+        new_packages[new_key] = new_pkg
+        
+        # Track type counters
+        type_counters[pkg_type] = type_counters.get(pkg_type, 0) + 1
+    
+    # Phase 2: Build BaseOS groups
+    new_groups = {}
+    baseos_group_keys = []
+    
+    for base_os_entry in base_os_list:
+        os_name = base_os_entry['Name'].lower()
+        os_version = base_os_entry['Version']
+        os_packages = base_os_entry.get('osPackages', [])
+        
+        group_key = f"baseos_{os_name}_{os_version}"
+        
+        # Slugify each BaseOS package name to match its new key in new_packages
+        components = []
+        for old_pkg_name in os_packages:
+            if old_pkg_name in key_map:
+                components.append(key_map[old_pkg_name])
+            else:
+                # Package exists in BaseOS list but not in Packages{} - warn
+                slug = slugify(old_pkg_name)
+                components.append(slug)
+                warnings.append(f"BaseOS package '{old_pkg_name}' not found in Packages - added as '{slug}'")
+        
+        new_groups[group_key] = {
+            "name": group_key,
+            "type": "base_os",
+            "os": os_name,
+            "os_version": os_version,
+            "description": f"Base OS packages for {base_os_entry['Name']} {os_version} - auto-generated from BaseOS",
+            "components": deduplicate_preserve_order(components)
+        }
+        
+        baseos_group_keys.append(group_key)
+    
+    # Phase 3: Build Functional Layer groups
+    new_functionallayers = []
+    
+    for layer in layers:
+        layer_name = layer['Name']
+        old_pkg_refs = layer.get('FunctionalPackages', [])
+        
+        # Create a group for this layer
+        group_key = slugify(layer_name) + "_group"
+        
+        # Remap old package names -> new keys
+        group_components = []
+        for old_pkg_name in old_pkg_refs:
+            if old_pkg_name in key_map:
+                group_components.append(key_map[old_pkg_name])
+            else:
+                slug = slugify(old_pkg_name)
+                group_components.append(slug)
+                warnings.append(f"FunctionalLayer '{layer_name}' references unknown package '{old_pkg_name}' - mapped to '{slug}'")
+        
+        new_groups[group_key] = {
+            "name": group_key,
+            "type": "group",
+            "description": f"Auto-generated from FunctionalLayer: {layer_name}",
+            "components": deduplicate_preserve_order(group_components)
+        }
+        
+        # Create functionallayer entry
+        # Each functionallayer includes ALL baseos groups FIRST, then its own group
+        fl_components = baseos_group_keys.copy()
+        fl_components.append(group_key)
+        
+        new_functionallayers.append({
+            "name": layer_name,
+            "components": fl_components
+        })
+    
+    # Phase 4: Build Infrastructure groups (groups only - NO functionallayer entry)
+    for infra in infrastructure:
+        infra_name = infra['Name']
+        old_pkg_refs = infra.get('InfrastructurePackages', [])
+        
+        group_key = slugify(infra_name) + "_group"
+        
+        group_components = []
+        for old_pkg_name in old_pkg_refs:
+            if old_pkg_name in key_map:
+                group_components.append(key_map[old_pkg_name])
+            else:
+                slug = slugify(old_pkg_name)
+                group_components.append(slug)
+                warnings.append(f"Infrastructure '{infra_name}' references unknown package '{old_pkg_name}' - mapped to '{slug}'")
+        
+        new_groups[group_key] = {
+            "name": group_key,
+            "type": "group",
+            "description": f"Auto-generated from Infrastructure: {infra_name}",
+            "components": deduplicate_preserve_order(group_components)
+        }
+    
+    # Phase 5: Assemble 2.0 catalog
+    new_catalog = {
+        "catalog": {
+            "name": catalog_name,
+            "version": catalog_version,
+            "identifier": catalog_identifier,
+            "description": "Transformed from Schema 1.0 by catalog_transform",
+            "functionallayer": new_functionallayers,
+            "groups": new_groups,
+            "packages": new_packages
+        }
+    }
+    
+    return new_catalog, key_map, warnings
+
+
+def write_keymap(key_map: dict, source_path: str, target_path: str, 
+                 output_path: str, total_groups: int, total_layers: int) -> None:
+    """
+    Write the sidecar keymap JSON file.
+    
+    Args:
+        key_map: Dictionary mapping old keys to new keys
+        source_path: Input file path
+        target_path: Output file path
+        output_path: Keymap file path
+        total_groups: Total groups created
+        total_layers: Total functional layers
+    """
+    keymap_data = {
+        "_meta": {
+            "source": source_path,
+            "target": target_path,
+            "transformed_at": datetime.utcnow().isoformat() + "Z",
+            "total_package_mappings": len(key_map),
+            "total_groups_created": total_groups,
+            "total_layers": total_layers
+        },
+        "packages": key_map
+    }
+    
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(keymap_data, f, indent=2, ensure_ascii=False)

--- a/src/repo_manager/plugins/module_utils/catalog/transformer.py
+++ b/src/repo_manager/plugins/module_utils/catalog/transformer.py
@@ -28,118 +28,117 @@ This module provides functions to:
 import re
 import json
 from datetime import datetime
-from typing import Tuple, Dict, List, Set, Optional
+from typing import Tuple, List, Set, Optional
 
 
 def detect_schema_version(catalog_data: dict) -> str:
     """
     Detect the schema version of a catalog.
-    
+
     Args:
         catalog_data: The catalog dictionary
-        
+
     Returns:
         '1.0' if root key is 'Catalog' (PascalCase)
         '2.0' if root key is 'catalog' (lowercase)
-        
+
     Raises:
         ValueError: If neither key is found
     """
     if 'Catalog' in catalog_data:
         return '1.0'
-    elif 'catalog' in catalog_data:
+    if 'catalog' in catalog_data:
         return '2.0'
-    else:
-        raise ValueError("Unrecognized catalog format - expected root key 'Catalog' or 'catalog'")
+    raise ValueError("Unrecognized catalog format - expected root key 'Catalog' or 'catalog'")
 
 
 def slugify(text: str) -> str:
     """
     Core slugification function.
-    
+
     Rules:
     1. Lowercase the entire string
     2. Replace all `-`, `.`, `/`, `@`, `:` with `_`
     3. Collapse consecutive `_` into a single `_`
     4. Strip leading and trailing `_`
-    
+
     Special cases:
     - 'gcc-c++' -> 'gcc_cpp'
     - Handle + by replacing with 'p' or removing
-    
+
     Args:
         text: String to slugify
-        
+
     Returns:
         Slugified string
     """
     if not text:
         return text
-        
+
     # Lowercase
     result = text.lower()
-    
+
     # Special handling for C++
     result = result.replace('c++', 'cpp')
     result = result.replace('++', 'pp')
     result = result.replace('+', 'p')
-    
+
     # Replace special characters with underscore
     result = re.sub(r'[-./\@:]', '_', result)
-    
+
     # Collapse consecutive underscores
     result = re.sub(r'_+', '_', result)
-    
+
     # Strip leading/trailing underscores
     result = result.strip('_')
-    
+
     return result
 
 
 def extract_registry(image_name: str) -> str:
     """
     Extract registry domain from image path.
-    
+
     Examples:
         "docker.io/calico/cni" -> "docker.io"
         "registry.k8s.io/etcd" -> "registry.k8s.io"
         "nvcr.io/nvidia/hpc-benchmarks" -> "nvcr.io"
         "quay.io/strimzi/kafka" -> "quay.io"
         "simple-image" -> "docker.io" (default)
-        
+
     Args:
         image_name: Full image name/path
-        
+
     Returns:
         Registry domain or "docker.io" as default
     """
     parts = image_name.split('/')
-    
+
     # Check if first part looks like a registry (contains . or :)
     if len(parts) >= 2 and ('.' in parts[0] or ':' in parts[0]):
         return parts[0]
-    
+
     # Default to Docker Hub
     return "docker.io"
 
 
-def generate_unique_key(old_key: str, pkg_type: str, tag: Optional[str], 
-                       existing_keys: Set[str]) -> str:
+def generate_unique_key(old_key: str, pkg_type: str, tag: Optional[str],
+                        existing_keys: Set[str]) -> str:
     """
     Generate a unique slugified key for a package.
-    
+
     Rules by package type:
     - rpm, rpm_repo, tarball, pip_module, git, manifest: slugify(old_key)
     - image: slugify(last_path_segment + "_" + tag)
-    
+
     If collision occurs, append _1, _2, etc.
-    
+
     Args:
         old_key: Original package key from 1.0 catalog
         pkg_type: Package type (rpm, image, tarball, etc.)
         tag: Image tag (only for image types)
         existing_keys: Set of already generated keys for collision detection
-        
+
     Returns:
         Unique slugified key
     """
@@ -150,33 +149,34 @@ def generate_unique_key(old_key: str, pkg_type: str, tag: Optional[str],
         slug_base = slugify(last_segment) + "_" + tag_slug
     else:
         slug_base = slugify(old_key)
-    
+
     # Handle collisions
     candidate = slug_base
     counter = 1
-    
+
     while candidate in existing_keys:
         candidate = f"{slug_base}_{counter}"
         counter += 1
-    
+
     existing_keys.add(candidate)
     return candidate
 
 
-def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List[dict]:
+def transform_sources(old_pkg: dict, pkg_type: str,
+                      warnings: List[str]) -> List[dict]:  # pylint: disable=too-many-branches,too-many-statements
     """
     Transform 1.0 Sources array to 2.0 sources array.
-    
+
     Args:
         old_pkg: Original package dictionary
         pkg_type: Package type
         warnings: List to append warnings to
-        
+
     Returns:
         List of transformed source dictionaries
     """
     old_key = old_pkg.get('Name', 'unknown')
-    
+
     # Extract OS info from SupportedOS
     supported_os = old_pkg.get('SupportedOS', [])
     if supported_os:
@@ -186,10 +186,10 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
         os_name = "rhel"
         os_versions = ["10.0"]
         warnings.append(f"Package '{old_key}' has no SupportedOS - using defaults")
-    
+
     old_sources = old_pkg.get('Sources', [])
     new_sources = []
-    
+
     if pkg_type in ["rpm", "rpm_repo"]:
         if old_sources:
             for src in old_sources:
@@ -207,8 +207,9 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     "name": os_name,
                     "version": os_versions
                 })
-                warnings.append(f"No Sources[] for {pkg_type} package '{old_key}' - synthesized")
-    
+                warnings.append(f"No Sources[] for {pkg_type} package "
+                                f"'{old_key}' - synthesized")
+
     elif pkg_type == "tarball":
         if old_sources:
             for src in old_sources:
@@ -226,8 +227,9 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     "name": os_name,
                     "version": os_versions
                 })
-                warnings.append(f"No Sources[] for tarball '{old_key}' - synthesized without URL")
-    
+                warnings.append(f"No Sources[] for tarball '{old_key}' - "
+                                "synthesized without URL")
+
     elif pkg_type == "git":
         if old_sources:
             for src in old_sources:
@@ -245,7 +247,7 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     "version": os_versions
                 })
                 warnings.append(f"No Sources[] for git package '{old_key}' - synthesized")
-    
+
     elif pkg_type == "manifest":
         if old_sources:
             for src in old_sources:
@@ -265,10 +267,10 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     "version": os_versions
                 })
                 warnings.append(f"No Sources[] for manifest '{old_key}' - synthesized")
-    
+
     elif pkg_type == "image":
         registry = extract_registry(old_pkg['Name'])
-        
+
         if old_sources:
             for src in old_sources:
                 entry = {
@@ -290,8 +292,9 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     entry['name'] = os_name
                     entry['version'] = os_versions
                 new_sources.append(entry)
-                warnings.append(f"No Sources[] for image '{old_key}' - synthesized from Architecture + SupportedOS")
-    
+                warnings.append(f"No Sources[] for image '{old_key}' - "
+                                "synthesized from Architecture + SupportedOS")
+
     elif pkg_type == "pip_module":
         if old_sources:
             for src in old_sources:
@@ -307,9 +310,10 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     "name": os_name,
                     "version": os_versions
                 })
-    
+
     else:
-        warnings.append(f"Unknown package type '{pkg_type}' for '{old_key}' - treated as tarball")
+        warnings.append(f"Unknown package type '{pkg_type}' for '{old_key}' - "
+                        "treated as tarball")
         # Handle same as tarball
         if old_sources:
             for src in old_sources:
@@ -328,17 +332,17 @@ def transform_sources(old_pkg: dict, pkg_type: str, warnings: List[str]) -> List
                     "name": os_name,
                     "version": os_versions
                 })
-    
+
     return new_sources
 
 
 def deduplicate_preserve_order(items: List[str]) -> List[str]:
     """
     Remove duplicates from list while preserving first-occurrence order.
-    
+
     Args:
         items: List of strings
-        
+
     Returns:
         Deduplicated list
     """
@@ -351,89 +355,91 @@ def deduplicate_preserve_order(items: List[str]) -> List[str]:
     return result
 
 
-def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:
+def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """
     Transform a 1.0 catalog to 2.0 format.
-    
+
     Args:
         old_catalog: The "Catalog" section from 1.0 format
-        
+
     Returns:
         Tuple of (new_catalog_dict, key_map_dict, warnings_list)
     """
     warnings = []
-    
+
     # Extract catalog metadata
     catalog_name = old_catalog.get('Name', '')
     catalog_version = old_catalog.get('Version', '1.0')
     catalog_identifier = old_catalog.get('Identifier', slugify(catalog_name))
-    
+
     base_os_list = old_catalog.get('BaseOS', [])
     layers = old_catalog.get('FunctionalLayer', [])
     infrastructure = old_catalog.get('Infrastructure', [])
-    
+
     # Merge all package dictionaries from different sections
-    # In 1.0 catalogs, packages can be in Packages, FunctionalPackages, OSPackages, 
+    # In 1.0 catalogs, packages can be in Packages, FunctionalPackages, OSPackages,
     # DriverPackages, or InfrastructurePackages
     old_packages = {}
-    for pkg_key in ['Packages', 'FunctionalPackages', 'OSPackages', 'DriverPackages', 'InfrastructurePackages']:
+    pkg_keys = ['Packages', 'FunctionalPackages', 'OSPackages',
+                'DriverPackages', 'InfrastructurePackages']
+    for pkg_key in pkg_keys:
         pkg_dict = old_catalog.get(pkg_key, {})
         if pkg_dict:
             old_packages.update(pkg_dict)
-    
+
     # Phase 1: Transform all packages
     new_packages = {}
     key_map = {}
     all_new_keys = set()
     type_counters = {}
-    
+
     for old_key, old_pkg in old_packages.items():
         pkg_type = old_pkg.get('Type', 'rpm').lower()
         tag = old_pkg.get('Tag', None)
-        
+
         # Generate new key
         new_key = generate_unique_key(old_key, pkg_type, tag, all_new_keys)
         key_map[old_key] = new_key
-        
+
         # Build new package dict
         new_pkg = {
             "name": old_pkg.get('Name', old_key),
             "packagetype": pkg_type
         }
-        
+
         # Preserve version if present and non-empty
         if 'Version' in old_pkg and old_pkg['Version']:
             new_pkg['version'] = old_pkg['Version']
-        
+
         # Preserve tag for images
         if tag:
             new_pkg['tag'] = tag
-        
+
         # Preserve supported_functions (git/CSI packages)
         if 'SupportedFunctions' in old_pkg and old_pkg['SupportedFunctions']:
             new_pkg['supported_functions'] = [
                 sf['Name'] for sf in old_pkg['SupportedFunctions']
             ]
-        
+
         # Transform sources
         new_pkg['sources'] = transform_sources(old_pkg, pkg_type, warnings)
-        
+
         new_packages[new_key] = new_pkg
-        
+
         # Track type counters
         type_counters[pkg_type] = type_counters.get(pkg_type, 0) + 1
-    
+
     # Phase 2: Build BaseOS groups
     new_groups = {}
     baseos_group_keys = []
-    
+
     for base_os_entry in base_os_list:
         os_name = base_os_entry['Name'].lower()
         os_version = base_os_entry['Version']
         os_packages = base_os_entry.get('osPackages', [])
-        
+
         group_key = f"baseos_{os_name}_{os_version}"
-        
+
         # Slugify each BaseOS package name to match its new key in new_packages
         components = []
         for old_pkg_name in os_packages:
@@ -443,29 +449,32 @@ def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:
                 # Package exists in BaseOS list but not in Packages{} - warn
                 slug = slugify(old_pkg_name)
                 components.append(slug)
-                warnings.append(f"BaseOS package '{old_pkg_name}' not found in Packages - added as '{slug}'")
-        
+                warnings.append(f"BaseOS package '{old_pkg_name}' not found in "
+                                f"Packages - added as '{slug}'")
+
+        desc = (f"Base OS packages for {base_os_entry['Name']} {os_version} - "
+                "auto-generated from BaseOS")
         new_groups[group_key] = {
             "name": group_key,
             "type": "base_os",
             "os": os_name,
             "os_version": os_version,
-            "description": f"Base OS packages for {base_os_entry['Name']} {os_version} - auto-generated from BaseOS",
+            "description": desc,
             "components": deduplicate_preserve_order(components)
         }
-        
+
         baseos_group_keys.append(group_key)
-    
+
     # Phase 3: Build Functional Layer groups
     new_functionallayers = []
-    
+
     for layer in layers:
         layer_name = layer['Name']
         old_pkg_refs = layer.get('FunctionalPackages', [])
-        
+
         # Create a group for this layer
         group_key = slugify(layer_name) + "_group"
-        
+
         # Remap old package names -> new keys
         group_components = []
         for old_pkg_name in old_pkg_refs:
@@ -474,32 +483,33 @@ def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:
             else:
                 slug = slugify(old_pkg_name)
                 group_components.append(slug)
-                warnings.append(f"FunctionalLayer '{layer_name}' references unknown package '{old_pkg_name}' - mapped to '{slug}'")
-        
+                warnings.append(f"FunctionalLayer '{layer_name}' references unknown "
+                                f"package '{old_pkg_name}' - mapped to '{slug}'")
+
         new_groups[group_key] = {
             "name": group_key,
             "type": "group",
             "description": f"Auto-generated from FunctionalLayer: {layer_name}",
             "components": deduplicate_preserve_order(group_components)
         }
-        
+
         # Create functionallayer entry
         # Each functionallayer includes ALL baseos groups FIRST, then its own group
         fl_components = baseos_group_keys.copy()
         fl_components.append(group_key)
-        
+
         new_functionallayers.append({
             "name": layer_name,
             "components": fl_components
         })
-    
+
     # Phase 4: Build Infrastructure groups (groups only - NO functionallayer entry)
     for infra in infrastructure:
         infra_name = infra['Name']
         old_pkg_refs = infra.get('InfrastructurePackages', [])
-        
+
         group_key = slugify(infra_name) + "_group"
-        
+
         group_components = []
         for old_pkg_name in old_pkg_refs:
             if old_pkg_name in key_map:
@@ -507,15 +517,16 @@ def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:
             else:
                 slug = slugify(old_pkg_name)
                 group_components.append(slug)
-                warnings.append(f"Infrastructure '{infra_name}' references unknown package '{old_pkg_name}' - mapped to '{slug}'")
-        
+                warnings.append(f"Infrastructure '{infra_name}' references unknown "
+                                f"package '{old_pkg_name}' - mapped to '{slug}'")
+
         new_groups[group_key] = {
             "name": group_key,
             "type": "group",
             "description": f"Auto-generated from Infrastructure: {infra_name}",
             "components": deduplicate_preserve_order(group_components)
         }
-    
+
     # Phase 5: Assemble 2.0 catalog
     new_catalog = {
         "catalog": {
@@ -528,15 +539,16 @@ def transform(old_catalog: dict) -> Tuple[dict, dict, List[str]]:
             "packages": new_packages
         }
     }
-    
+
     return new_catalog, key_map, warnings
 
 
-def write_keymap(key_map: dict, source_path: str, target_path: str, 
-                 output_path: str, total_groups: int, total_layers: int) -> None:
+def write_keymap(key_map: dict, source_path: str, target_path: str,
+                 output_path: str, total_groups: int,
+                 total_layers: int) -> None:  # pylint: disable=too-many-arguments,too-many-positional-arguments
     """
     Write the sidecar keymap JSON file.
-    
+
     Args:
         key_map: Dictionary mapping old keys to new keys
         source_path: Input file path
@@ -556,6 +568,6 @@ def write_keymap(key_map: dict, source_path: str, target_path: str,
         },
         "packages": key_map
     }
-    
+
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(keymap_data, f, indent=2, ensure_ascii=False)

--- a/src/repo_manager/plugins/module_utils/catalog/validator.py
+++ b/src/repo_manager/plugins/module_utils/catalog/validator.py
@@ -21,7 +21,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-VALID_PACKAGE_TYPES = {'rpm', 'tarball', 'image', 'rpm_repo'}
+VALID_PACKAGE_TYPES = {'rpm', 'tarball', 'image', 'rpm_repo', 'git', 'manifest', 'pip_module'}
 
 
 def _validate_schema(catalog, schema):
@@ -212,6 +212,22 @@ def _validate_business_rules(catalog):
                     issues.append({
                         'severity': 'error',
                         'message': f"Package '{pkg_key}' (image) source missing 'registry'"
+                    })
+
+        if pkg_type == 'git':
+            for src in sources:
+                if not src.get('url'):
+                    issues.append({
+                        'severity': 'error',
+                        'message': f"Package '{pkg_key}' (git) source missing 'url'"
+                    })
+
+        if pkg_type == 'manifest':
+            for src in sources:
+                if not src.get('url'):
+                    issues.append({
+                        'severity': 'error',
+                        'message': f"Package '{pkg_key}' (manifest) source missing 'url'"
                     })
 
     # Check for orphan packages (in packages{} but unreferenced by any group)

--- a/src/repo_manager/roles/catalog/defaults/main.yml
+++ b/src/repo_manager/roles/catalog/defaults/main.yml
@@ -34,3 +34,9 @@ default_os_version: "10.0"
 
 # ── Post-operation validation ──
 validate_after: true
+
+# ── Transform defaults ──
+# (force is already defined above)
+
+# ── Optimize defaults ──
+common_threshold: 10

--- a/src/repo_manager/roles/catalog/tasks/main.yml
+++ b/src/repo_manager/roles/catalog/tasks/main.yml
@@ -34,3 +34,11 @@
 - name: Include catalog validate tasks
   ansible.builtin.include_tasks: validate.yml
   when: "'catalog_validate' in ansible_run_tags"
+
+- name: Include catalog transform tasks
+  ansible.builtin.include_tasks: transform.yml
+  when: "'catalog_transform' in ansible_run_tags"
+
+- name: Include catalog optimize tasks
+  ansible.builtin.include_tasks: optimize.yml
+  when: "'catalog_optimize' in ansible_run_tags"

--- a/src/repo_manager/roles/catalog/tasks/optimize.yml
+++ b/src/repo_manager/roles/catalog/tasks/optimize.yml
@@ -1,0 +1,31 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# =============================================================================
+# CATALOG OPTIMIZE - Extract common packages into shared groups
+# =============================================================================
+
+- name: "Optimize catalog — extract common packages"
+  ansible.builtin.command:
+    cmd: >-
+      python3 {{ catalog_scripts_dir }}/catalog_manager.py optimize
+      --catalog {{ catalog_file }}
+      --output {{ output_file | default(catalog_file) }}
+      --threshold {{ common_threshold }}
+  register: optimize_result
+  changed_when: optimize_result.rc == 0
+
+- name: "Show optimize result"
+  ansible.builtin.debug:
+    msg: "{{ optimize_result.stdout_lines }}"

--- a/src/repo_manager/roles/catalog/tasks/transform.yml
+++ b/src/repo_manager/roles/catalog/tasks/transform.yml
@@ -1,0 +1,39 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# =============================================================================
+# CATALOG TRANSFORM - Transform catalog from Schema 1.0 to 2.0
+# =============================================================================
+
+- name: "Assert input_file is provided for transform"
+  ansible.builtin.assert:
+    that:
+      - input_file is defined
+      - input_file | length > 0
+    fail_msg: "Required: -e \"input_file=input/catalog_1.0.json\""
+
+- name: "Transform catalog from 1.0 to 2.0"
+  ansible.builtin.command:
+    cmd: >-
+      python3 {{ catalog_scripts_dir }}/catalog_manager.py transform
+      --input {{ input_file }}
+      --output {{ output_file | default(catalog_file) }}
+      --schema {{ schema_file }}
+      {{ '--force' if force | bool else '' }}
+  register: transform_result
+  changed_when: transform_result.rc == 0
+
+- name: "Show transform result"
+  ansible.builtin.debug:
+    msg: "{{ transform_result.stdout_lines }}"

--- a/src/repo_manager/schemas/catalog_schema.json
+++ b/src/repo_manager/schemas/catalog_schema.json
@@ -82,8 +82,20 @@
       "additionalProperties": false,
       "properties": {
         "name": { "type": "string", "minLength": 1 },
-        "packagetype": { "type": "string", "enum": ["rpm", "tarball", "image", "rpm_repo"] },
+        "packagetype": { 
+          "type": "string", 
+          "enum": ["rpm", "tarball", "image", "rpm_repo", "git", "manifest", "pip_module"] 
+        },
+        "version": {
+          "type": "string",
+          "description": "Package version preserved from 1.0 schema or package-specific version"
+        },
         "tag": { "type": "string" },
+        "supported_functions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Functional roles this package supports (e.g., csi)"
+        },
         "sources": {
           "type": "array",
           "minItems": 1,


### PR DESCRIPTION
Adds catalog_transform to convert Schema 1.0 catalogs to the 2.0 format — handling field casing, package key slugification, source restructuring, BaseOS-to-group conversion, and FunctionalLayer rewiring. 
Also adds catalog_optimize as a standalone opt-in operation that extracts common packages shared across functional layer groups into a dedicated shared group, reducing component duplication. 
Extends the 2.0 JSON schema with version, supported_functions fields and git/manifest/pip_module package types. 
Catalog_validate runs automatically after transform.