### PR TITLE
Migrate `omnia_auth` to Wolfi and Validate Openldap Authentication

### DIFF
--- a/src/orchestrator/containers/omnia_auth/Containerfile
+++ b/src/orchestrator/containers/omnia_auth/Containerfile
@@ -18,10 +18,13 @@
 
 FROM cgr.dev/chainguard/wolfi-base
 
-# Install OpenLDAP 2.7 server, MDB backend, clients, and matching library
+# Install OpenLDAP 2.7 server, backends (MDB + LDAP + Meta for proxy),
+# clients, and matching library
 RUN apk update && apk add --no-cache \
     openldap \
     openldap-back-mdb \
+    openldap-back-ldap \
+    openldap-back-meta \
     openldap-clients \
     libldap-2.7 \
     ca-certificates-bundle

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -205,11 +205,12 @@
           chattr +i /etc/resolv.conf || true
 {% endif %}
         - /usr/local/bin/configure_vast_installation.sh
-        # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh
+        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mkdir -p {{ slurm_slurmd_log_dir_effective }} {{ slurm_slurmd_pid_dir_effective }} {{ slurm_slurmd_spool_dir_effective }} {{ slurm_epilog_dirs_all | join(' ') }} /etc/munge /cert /var/log/track /var/lib/packages
         - echo "{{ metadata_svc_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -av
+        - rm -f /etc/slurm/slurm.conf /etc/slurm/slurm.conf.example
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
         # DOCA and IB configuration - now ready before vendor_data mounts
@@ -271,13 +272,6 @@
 {% if login_compiler_node_present %}
         - /usr/local/bin/generate_install_uuid.sh
         - /usr/local/bin/install_cuda_toolkit.sh
-{% endif %}
-
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
-        # Add NFS entry and mount
-        - mkdir -pv {{ client_mount_path }}
-        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -av
 {% endif %}
 
         # UCX and OpenMPI auto-compilation disabled

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -205,11 +205,12 @@
           chattr +i /etc/resolv.conf || true
 {% endif %}
         - /usr/local/bin/configure_vast_installation.sh
-        # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh
+        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mkdir -p {{ slurm_slurmd_log_dir_effective }} {{ slurm_slurmd_pid_dir_effective }} {{ slurm_slurmd_spool_dir_effective }} {{ slurm_epilog_dirs_all | join(' ') }} /etc/munge /cert /var/log/track /var/lib/packages
         - echo "{{ metadata_svc_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -av
+        - rm -f /etc/slurm/slurm.conf /etc/slurm/slurm.conf.example
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
         # DOCA and IB configuration - now ready before vendor_data mounts
@@ -272,13 +273,6 @@
 {% if login_compiler_node_present %}
         - /usr/local/bin/generate_install_uuid.sh
         - /usr/local/bin/install_cuda_toolkit.sh
-{% endif %}
-
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
-        # Add NFS entry and mount
-        - mkdir -p {{ client_mount_path }}
-        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -a
 {% endif %}
 
         # UCX and OpenMPI auto-compilation disabled

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -161,11 +161,12 @@
           chattr +i /etc/resolv.conf || true
 {% endif %}
         - /usr/local/bin/configure_vast_installation.sh
-        # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh
+        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mkdir -p {{ slurm_slurmd_log_dir_effective }} {{ slurm_slurmd_pid_dir_effective }} {{ slurm_slurmd_spool_dir_effective }} {{ slurm_epilog_dirs_all | join(' ') }} /etc/munge /cert /var/log/track /var/lib/packages
         - echo "{{ metadata_svc_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -av
+        - rm -f /etc/slurm/slurm.conf /etc/slurm/slurm.conf.example
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
         # DOCA and IB configuration - now ready before vendor_data mounts

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -160,11 +160,12 @@
           chattr +i /etc/resolv.conf || true
 {% endif %}
         - /usr/local/bin/configure_vast_installation.sh
-        # DOCA prerequisites - mount /cert and prepare for DOCA installation
         - mkdir -p {{ client_mount_path }}/slurm/ssh
+        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mkdir -p {{ slurm_slurmd_log_dir_effective }} {{ slurm_slurmd_pid_dir_effective }} {{ slurm_slurmd_spool_dir_effective }} {{ slurm_epilog_dirs_all | join(' ') }} /etc/munge /cert /var/log/track /var/lib/packages
         - echo "{{ metadata_svc_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -av
+        - rm -f /etc/slurm/slurm.conf /etc/slurm/slurm.conf.example
         - cp /cert/pulp_webserver.crt /etc/pki/ca-trust/source/anchors && update-ca-trust
         - sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/dnf/dnf.conf
         # DOCA and IB configuration - now ready before vendor_data mounts

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
@@ -164,7 +164,8 @@
             echo "[INFO] Creating base directories for Slurm and Munge"
             mkdir -pv {{ slurm_slurmd_log_dir_effective }} {{ slurm_slurmd_pid_dir_effective }} {{ slurm_slurmd_spool_dir_effective }} {{ slurm_epilog_dirs_all | join(' ') }} /etc/munge /cert /var/log/track /var/lib/packages
 
-            echo "[INFO] Updating /etc/fstab with NFS entries for Pulp cert, Slurm and Munge paths"
+            echo "[INFO] Updating /etc/fstab with NFS entries for shared storage, Pulp cert, Slurm and Munge paths"
+            echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ metadata_svc_nfs_path }}/$(hostname -s)/var/log/slurm  {{ slurm_slurmd_log_dir_effective }}   nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ metadata_svc_nfs_path }}/$(hostname -s)/var/spool/slurmd      {{ slurm_slurmd_spool_dir_effective }}       nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ metadata_svc_nfs_path }}/$(hostname -s)/etc/slurm/epilog.d     /etc/slurm/epilog.d      nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -178,6 +179,9 @@
 
             echo "[INFO] Mounting all NFS entries from /etc/fstab"
             mount -av
+
+            echo "[INFO] Removing stale slurm.conf (compute nodes use configless mode)"
+            rm -f /etc/slurm/slurm.conf /etc/slurm/slurm.conf.example
             mkdir -p /etc/containers/registries.conf.d
             mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
@@ -504,12 +508,6 @@
 
 {% endif %}
 
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
-        # Add NFS entry and mount
-        - mkdir -pv {{ client_mount_path }}
-        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -av
-{% endif %}
         # UCX and OpenMPI auto-compilation disabled
         # DOCA UCX 1.20.0 and OpenMPI 4.1.9a1 configured by default
 {% if hostvars['localhost']['ucx_support'] %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
@@ -196,7 +196,8 @@
             echo "[INFO] Creating base directories for Pulp cert, Slurm and Munge"
             mkdir -pv {{ slurm_slurmd_log_dir_effective }} {{ slurm_slurmd_pid_dir_effective }} {{ slurm_slurmd_spool_dir_effective }} {{ slurm_epilog_dirs_all | join(' ') }} /etc/munge /cert /var/log/track /var/lib/packages
 
-            echo "[INFO] Updating /etc/fstab with NFS entries for Pulp cert, Slurm and Munge paths"
+            echo "[INFO] Updating /etc/fstab with NFS entries for shared storage, Pulp cert, Slurm and Munge paths"
+            echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ metadata_svc_nfs_path }}/cert  /cert   nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ metadata_svc_nfs_path }}/$(hostname -s)/var/log/slurm  {{ slurm_slurmd_log_dir_effective }}   nfs defaults,_netdev 0 0" >> /etc/fstab
             echo "{{ metadata_svc_nfs_path }}/$(hostname -s)/var/spool/slurmd      {{ slurm_slurmd_spool_dir_effective }}       nfs defaults,_netdev 0 0" >> /etc/fstab
@@ -209,6 +210,12 @@
 
             echo "[INFO] Mounting all NFS entries from /etc/fstab"
             mount -av
+
+            # Remove stale slurm.conf from OS image — compute nodes use configless mode
+            # (slurmd --conf-server). The local file has SlurmctldHost=localhost which
+            # breaks CLI tools (sinfo, srun, sbatch).
+            echo "[INFO] Removing stale slurm.conf (compute nodes use configless mode)"
+            rm -f /etc/slurm/slurm.conf /etc/slurm/slurm.conf.example
             mkdir -p /etc/containers/registries.conf.d
             mv /tmp/apptainer_mirror.conf /etc/containers/registries.conf.d/apptainer_mirror.conf
 
@@ -506,12 +513,6 @@
         - systemctl restart sshd
 {% endif %}
 
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
-        # Add NFS entry and mount
-        - mkdir -p {{ client_mount_path }}
-        - echo "{{ metadata_svc_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -av
-{% endif %}
         # UCX and OpenMPI auto-compilation disabled
         # DOCA UCX 1.20.0 and OpenMPI 4.1.9a1 configured by default
 {% if hostvars['localhost']['ucx_support'] %}


### PR DESCRIPTION
### Summary:
Migrate the omnia_auth OpenLDAP container from Fedora to Wolfi base image. 
The Wolfi-based container supports both internal MDB mode and external proxy mode.

### Validation
Comprehensive end-to-end testing was performed for both OpenLDAP modes:

1. Internal Mode (MDB Backend)
- Verified container health, Wolfi base, MDB backend
- Created test users (testuser1, testuser2) via ldapadd + ldappasswd
- Verified SSH login on login node (nid004) and controller (nid001)
- Tested Slurm job submission: srun, sbatch, multi-node srun --nodes=2, sinfo, sacct


2. External Mode (Meta Backend)
- Verified proxy backend modules (back_ldap.so, back_meta.so) loaded
- Confirmed proxy forwards to external LDAP at 100.98.68.17:1389
- Confirmed external user (ldapuser1, UID 2000) resolves on all nodes
- Verified SSH login 
- Verified Slurm job submission from login and controller nodes
