### PR TITLE
Feature/orchestrator tags

### DIFF
--- a/src/orchestrator/playbooks/orchestrator.yml
+++ b/src/orchestrator/playbooks/orchestrator.yml
@@ -179,6 +179,18 @@
     - validate
 
 # =========================================================================
+# FLOW: validate — Standalone health check (read-only)
+# Loads cluster config from OIM, authenticates, then runs all validations.
+# No-op when running as part of deploy/provision (prerequisites already set).
+# =========================================================================
+
+# Validate preamble: load cluster config + auth for standalone --tags validate
+- name: Validate preamble (standalone prerequisites)
+  ansible.builtin.import_playbook: validate/validate_preamble.yml
+  tags:
+    - validate
+
+# =========================================================================
 # FLOW: provision — SSH preamble + provision all categories + validate
 # =========================================================================
 

--- a/src/orchestrator/playbooks/provision/provision_preamble.yml
+++ b/src/orchestrator/playbooks/provision/provision_preamble.yml
@@ -32,28 +32,154 @@
         omnia_metadata_support: true
         oim_group: true
 
-# Step 2: Build cluster host lists from PXE mapping
+# Step 2: Populate standalone prerequisites on localhost
+#   When running --tags provision alone, variables normally set by precheck /
+#   deploy are absent.  This play loads them.  Every task is guarded so it is
+#   a no-op when earlier phases already ran.
+#
+#   IMPORTANT: Never use  register: read_mapping_file  inside a guarded block.
+#   Ansible overwrites the register variable with a "skipped" result even when
+#   the block's `when` is false, destroying the value set by precheck.
+- name: Populate standalone prerequisites on localhost
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    # --- PXE mapping file ---
+    - name: Create temp mapping file from source
+      ansible.builtin.shell: |
+        set -o pipefail
+        sed 's/^[[:space:]]*//g' "{{ pxe_mapping_file_path }}" | sed 's/[[:space:]]*$//g' > /tmp/omnia_provision_mapping.csv
+      changed_when: false
+      when: read_mapping_file is not defined
+
+    - name: Remove comment lines from temp mapping file
+      ansible.builtin.lineinfile:
+        path: /tmp/omnia_provision_mapping.csv
+        regexp: '\s*#'
+        state: absent
+      when: read_mapping_file is not defined
+
+    - name: Generate xnames in temp mapping file
+      generate_xname_in_mapping_file:
+        mapping_file_path: /tmp/omnia_provision_mapping.csv
+      when: read_mapping_file is not defined
+
+    - name: Read PXE mapping CSV into temp var
+      community.general.read_csv:
+        path: /tmp/omnia_provision_mapping.csv
+        key: ADMIN_MAC
+      register: _preamble_csv_result
+      when: read_mapping_file is not defined
+
+    - name: Promote CSV result to read_mapping_file fact
+      ansible.builtin.set_fact:
+        read_mapping_file: "{{ _preamble_csv_result }}"
+      when: read_mapping_file is not defined and _preamble_csv_result is not skipped
+
+    - name: Clean up temp mapping file
+      ansible.builtin.file:
+        path: /tmp/omnia_provision_mapping.csv
+        state: absent
+      when: _preamble_csv_result is not skipped
+
+    # --- Network facts ---
+    - name: Load network_spec.yml
+      ansible.builtin.include_vars: "{{ input_project_dir }}/network_spec.yml"
+      when: admin_netmask_bits is not defined
+
+    - name: Parse network_spec data
+      ansible.builtin.set_fact:
+        network_data: "{{ network_data | default({}) | combine({item.key: item.value}) }}"
+      with_dict: "{{ Networks }}"
+      when: admin_netmask_bits is not defined
+
+    - name: Set network facts from network_spec
+      ansible.builtin.set_fact:
+        admin_nic_ip: "{{ network_data.admin_network.primary_oim_admin_ip }}"
+        admin_nic: "{{ network_data.admin_network.oim_nic_name }}"
+        admin_netmask_bits: "{{ network_data.admin_network.netmask_bits }}"
+        ib_network_subnet: "{{ network_data.ib_network.subnet | default('') }}"
+        ib_network_dns: "{{ network_data.ib_network.dns | default([]) }}"
+        dns: "{{ network_data.admin_network.dns | default([]) }}"
+      when: admin_netmask_bits is not defined
+
+    # --- Functional groups and security config ---
+    - name: Load functional groups on localhost for bolt-on roles
+      ansible.builtin.include_vars:
+        file: "{{ functional_groups_config_path }}"
+      when: functional_groups is not defined
+
+    - name: Load security config on localhost for bolt-on roles
+      ansible.builtin.include_vars:
+        file: "{{ omnia_project_input_dir }}/security_config.yml"
+      when: ldap_connection_type is not defined
+
+    # --- /etc/hosts entry for cluster hostname ---
+    - name: Ensure OpenCHAMI cluster hostname resolves
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ admin_nic_ip }} {{ oim_node_name }}.{{ domain_name | regex_replace('^' + oim_node_name + '\\.', '') }}"
+        create: true
+        mode: "0644"
+
+# Step 3: Load encrypted credentials onto localhost
+- name: Load provision credentials
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Load credentials from encrypted credential store
+      ansible.builtin.include_role:
+        name: orchestrator_common
+        tasks_from: decrypt_include_encrypt.yml
+      vars:
+        credential_file_path: "{{ input_project_dir }}/omnia_config_credentials.yml"
+        vault_password_file: "{{ input_project_dir }}/.omnia_config_credentials_key"
+      when: provision_password is not defined
+
+# Step 4: Build cluster host lists from PXE mapping
 - name: Build cluster host lists from PXE mapping
   hosts: localhost
   connection: local
   roles:
     - passwordless_ssh
 
-# Step 3: Configure OIM SSH access
+# Step 5: Configure OIM SSH access
 - name: Configure OIM SSH from cluster host lists
   hosts: oim
   connection: ssh
   roles:
     - passwordless_ssh
 
-# Step 4: Authenticate with OpenCHAMI (token stored as fact)
+# Step 6: Authenticate with OpenCHAMI (token stored as fact)
 - name: Authenticate with OpenCHAMI
   hosts: oim
   connection: ssh
   tasks:
+    - name: Set oim_node_name on oim host
+      ansible.builtin.set_fact:
+        oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
+
     - name: OpenCHAMI cluster authentication
       ansible.builtin.include_role:
         name: orchestrator_common
         tasks_from: openchami_auth.yml
-      vars:
-        oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
+
+    - name: Configure S3 access for boot images
+      ansible.builtin.include_role:
+        name: orchestrator_common
+        tasks_from: configure_s3_access.yml
+      when: s3_configurations is not defined
+
+    - name: Load functional groups configuration for image validation
+      ansible.builtin.include_vars:
+        file: "{{ hostvars['localhost']['functional_groups_config_path'] }}"
+      when: validated_images is not defined
+
+    - name: Validate boot images for provisioning
+      ansible.builtin.include_role:
+        name: orchestrator_validations
+        tasks_from: validate_image.yml
+      with_items: "{{ functional_groups | map(attribute='name') | list }}"
+      when: validated_images is not defined

--- a/src/orchestrator/playbooks/validate/validate_preamble.yml
+++ b/src/orchestrator/playbooks/validate/validate_preamble.yml
@@ -1,0 +1,144 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# Validate Preamble — Load standalone prerequisites for --tags validate
+# =====================================================================
+# When running validate standalone, variables normally set by deploy/provision
+# phases are absent.  This play loads them from the OIM's configs_vars.yaml
+# (written by deploy) and other persistent state.
+#
+# Every task is guarded so it is a no-op when earlier phases already ran.
+# This playbook performs NO system changes (read-only).
+#
+# Prerequisites: deploy phase must have run at least once previously.
+
+# Step 1: Setup orchestrator vars (needed for standalone runs)
+- name: Setup orchestrator environment
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags: always
+  roles:
+    - role: orchestrator_setup
+      vars:
+        openchami_vars_support: true
+        omnia_metadata_support: true
+        oim_group: true
+
+# Step 2: Load standalone prerequisites on localhost
+- name: Populate standalone prerequisites on localhost
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    # --- Network facts ---
+    - name: Load network_spec.yml
+      ansible.builtin.include_vars: "{{ input_project_dir }}/network_spec.yml"
+      when: admin_netmask_bits is not defined
+
+    - name: Parse network_spec data
+      ansible.builtin.set_fact:
+        network_data: "{{ network_data | default({}) | combine({item.key: item.value}) }}"
+      with_dict: "{{ Networks }}"
+      when: admin_netmask_bits is not defined
+
+    - name: Set network facts from network_spec
+      ansible.builtin.set_fact:
+        admin_nic_ip: "{{ network_data.admin_network.primary_oim_admin_ip }}"
+        admin_nic: "{{ network_data.admin_network.oim_nic_name }}"
+        admin_netmask_bits: "{{ network_data.admin_network.netmask_bits }}"
+        ib_network_subnet: "{{ network_data.ib_network.subnet | default('') }}"
+        ib_network_dns: "{{ network_data.ib_network.dns | default([]) }}"
+        dns: "{{ network_data.admin_network.dns | default([]) }}"
+      when: admin_netmask_bits is not defined
+
+    # --- /etc/hosts entry for cluster hostname (read-only idempotent) ---
+    - name: Ensure OpenCHAMI cluster hostname resolves
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ admin_nic_ip }} {{ oim_node_name }}.{{ domain_name | regex_replace('^' + oim_node_name + '\\.', '') }}"
+        create: true
+        mode: "0644"
+
+    # --- PXE mapping file (for validate_provisioning) ---
+    - name: Create temp mapping file from source
+      ansible.builtin.shell: |
+        set -o pipefail
+        sed 's/^[[:space:]]*//g' "{{ pxe_mapping_file_path }}" | sed 's/[[:space:]]*$//g' > /tmp/omnia_validate_mapping.csv
+      changed_when: false
+      when: read_mapping_file is not defined
+
+    - name: Remove comment lines from temp mapping file
+      ansible.builtin.lineinfile:
+        path: /tmp/omnia_validate_mapping.csv
+        regexp: '\s*#'
+        state: absent
+      when: read_mapping_file is not defined
+
+    - name: Generate xnames in temp mapping file
+      generate_xname_in_mapping_file:
+        mapping_file_path: /tmp/omnia_validate_mapping.csv
+      when: read_mapping_file is not defined
+
+    - name: Read PXE mapping CSV into temp var
+      community.general.read_csv:
+        path: /tmp/omnia_validate_mapping.csv
+        key: ADMIN_MAC
+      register: _validate_csv_result
+      when: read_mapping_file is not defined
+
+    - name: Promote CSV result to read_mapping_file fact
+      ansible.builtin.set_fact:
+        read_mapping_file: "{{ _validate_csv_result }}"
+      when: read_mapping_file is not defined and _validate_csv_result is not skipped
+
+    - name: Clean up temp mapping file
+      ansible.builtin.file:
+        path: /tmp/omnia_validate_mapping.csv
+        state: absent
+      when: _validate_csv_result is defined and _validate_csv_result is not skipped
+
+    # --- Functional groups ---
+    - name: Load functional groups on localhost
+      ansible.builtin.include_vars:
+        file: "{{ functional_groups_config_path }}"
+      when: functional_groups is not defined
+
+# Step 3: Load cluster config from OIM and authenticate
+- name: Load cluster configuration and authenticate
+  hosts: oim
+  connection: ssh
+  gather_facts: false
+  tasks:
+    - name: Set oim_node_name on OIM host
+      ansible.builtin.set_fact:
+        oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
+      when: oim_node_name is not defined
+
+    - name: Load OpenCHAMI configs_vars.yaml from OIM
+      ansible.builtin.include_vars:
+        file: /opt/omnia/openchami/configs_vars.yaml
+      when: cluster_name is not defined
+
+    - name: OpenCHAMI cluster authentication
+      ansible.builtin.include_role:
+        name: orchestrator_common
+        tasks_from: openchami_auth.yml
+
+    - name: Configure S3 access for boot images
+      ansible.builtin.include_role:
+        name: orchestrator_common
+        tasks_from: configure_s3_access.yml
+      when: s3_configurations is not defined

--- a/src/orchestrator/plugins/callback/omnia_default.py
+++ b/src/orchestrator/plugins/callback/omnia_default.py
@@ -50,11 +50,12 @@ DOCUMENTATION = r"""
 """
 
 # Pattern to detect the 2.19/2.20 [ERROR] task-failure context block
+# NOTE: Only suppress [ERROR] blocks that are part of task failure context
+# rendering. Do NOT suppress standalone [ERROR] messages (e.g. module-not-found)
+# which are critical for debugging parser errors (exit code 4).
 _ERROR_CONTEXT_PATTERN = re.compile(
     r"\[ERROR\]:\s*Task failed:|"
-    r"\[ERROR\]:\s*Action failed:|"
-    r"Origin:\s+\S+\.ya?ml:\d+:\d+|"
-    r"\s+\^\s+column\s+\d+"
+    r"\[ERROR\]:\s*Action failed:"
 )
 
 

--- a/src/orchestrator/plugins/modules/bulk_discover_node_specs.py
+++ b/src/orchestrator/plugins/modules/bulk_discover_node_specs.py
@@ -1,0 +1,507 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/python
+# pylint: disable=import-error,no-name-in-module,line-too-long,too-many-locals
+"""
+Ansible module to bulk-discover hardware specs from iDRAC Redfish API
+across multiple nodes in parallel.
+
+Supports two discovery modes:
+
+  Heterogeneous (per-node):  Each compute node is individually queried
+      via its iDRAC.  Use the ``nodes`` parameter.
+
+  Homogeneous (per-group):  For each hardware group one sample node is
+      queried and the discovered specs are replicated to every node in
+      that group.  Use the ``groups`` parameter.
+
+Exactly one of ``nodes`` or ``groups`` must be provided.
+
+Designed for HPC clusters with 500-2000 nodes where serial Ansible
+URI loops are prohibitively slow (50-80 min at 1000 nodes serial
+vs ~4 min at 20 parallel threads).
+
+GPU fallback detection via PCIe device enumeration is included.
+
+Usage in playbook (heterogeneous):
+  bulk_discover_node_specs:
+    nodes: "{{ cmpt_list }}"
+    bmc_ip_map: "{{ bmc_ip_map }}"
+    bmc_username: "{{ bmc_username }}"
+    bmc_password: "{{ bmc_password }}"
+    max_parallel: 20
+    connect_timeout: 60
+    defaults:
+      real_memory: 864
+      corespersocket: 72
+      threadspercore: 1
+  register: bulk_discovery
+
+Usage in playbook (homogeneous group):
+  bulk_discover_node_specs:
+    groups: "{{ sample_idrac_groups }}"
+    bmc_ip_map: "{{ bmc_ip_map }}"
+    bmc_username: "{{ bmc_username }}"
+    bmc_password: "{{ bmc_password }}"
+    max_parallel: 20
+    connect_timeout: 60
+    defaults:
+      real_memory: 864
+      corespersocket: 72
+      threadspercore: 1
+      sockets: 2
+  register: bulk_discovery
+"""
+import json
+import re
+import ssl
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from ansible.module_utils.basic import AnsibleModule
+
+
+# ─── Redfish API helpers ───────────────────────────────────────────────────
+
+def _create_ssl_context():
+    """Create an unverified SSL context for iDRAC self-signed certs."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _redfish_get(bmc_ip, path, username, password, timeout):
+    """Perform a Redfish GET request and return parsed JSON.
+
+    Returns (success, json_data_or_error_string).
+    """
+    url = f"https://{bmc_ip}{path}"
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "OData-Version": "4.0",
+    }
+
+    # Build basic auth header
+    import base64
+    credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+    headers["Authorization"] = f"Basic {credentials}"
+
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    ctx = _create_ssl_context()
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            data = json.loads(resp.read().decode())
+            return (True, data)
+    except urllib.error.HTTPError as exc:
+        return (False, f"HTTP {exc.code}: {exc.reason}")
+    except urllib.error.URLError as exc:
+        return (False, f"URL error: {exc.reason}")
+    except Exception as exc:  # pylint: disable=broad-except
+        return (False, str(exc))
+
+
+# ─── GPU detection ─────────────────────────────────────────────────────────
+
+def _detect_gpus_from_processors(proc_members):
+    """Extract NVIDIA GPUs from Processor members (primary detection)."""
+    gpus = []
+    for member in proc_members:
+        if member.get("ProcessorType") != "GPU":
+            continue
+        manufacturer = member.get("Manufacturer", "")
+        if re.search(r"nvidia", manufacturer, re.IGNORECASE):
+            gpus.append(member)
+    return gpus
+
+
+def _detect_gpus_from_pcie(bmc_ip, username, password, timeout):
+    """Fallback GPU detection via PCIe device enumeration.
+
+    Queries PCIeDevices collection, then individual devices for ClassCode
+    and manufacturer matching.
+    """
+    gpus = []
+
+    # Get PCIe device list
+    ok, data = _redfish_get(
+        bmc_ip,
+        "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices",
+        username, password, timeout,
+    )
+    if not ok or "Members" not in data:
+        return gpus
+
+    device_urls = [
+        m.get("@odata.id", "") for m in data.get("Members", [])
+        if m.get("@odata.id")
+    ]
+
+    # Query each PCIe device for GPU identification
+    for dev_url in device_urls:
+        ok, dev_data = _redfish_get(bmc_ip, dev_url, username, password, timeout)
+        if not ok:
+            continue
+
+        class_code = dev_data.get("ClassCode", "")
+        vendor_id = dev_data.get("VendorId", "")
+        manufacturer = dev_data.get("Manufacturer", "")
+        name = dev_data.get("Name", "")
+
+        # ClassCode 0x0300 = VGA controller, 0x0302 = 3D controller
+        if class_code in ("0x0300", "0x0302") and vendor_id:
+            gpus.append(dev_data)
+        elif (re.search(r"nvidia", manufacturer, re.IGNORECASE)
+              and re.search(r"GPU|RTX|TESLA|A100|H100|L40|GB", name, re.IGNORECASE)):
+            gpus.append(dev_data)
+
+    return gpus
+
+
+# ─── Per-node discovery ────────────────────────────────────────────────────
+
+def _discover_single_node(hostname, bmc_ip, username, password,
+                          timeout, defaults):
+    """Discover hardware specs for a single node via iDRAC Redfish.
+
+    Returns (hostname, node_params_dict, gpu_list, error_string_or_None).
+    """
+    default_memory = defaults.get("real_memory", 864)
+    default_cores = defaults.get("corespersocket", 72)
+    default_threads = defaults.get("threadspercore", 1)
+
+    # ── Step 1: Read Processors ──
+    ok, proc_data = _redfish_get(
+        bmc_ip,
+        "/redfish/v1/Systems/System.Embedded.1/Processors?$expand=*($levels=1)",
+        username, password, timeout,
+    )
+
+    if ok:
+        members = proc_data.get("Members", [])
+        cpus = [m for m in members if m.get("ProcessorType") == "CPU"]
+        gpus = _detect_gpus_from_processors(members)
+    else:
+        cpus = []
+        gpus = []
+
+    # ── Step 2: GPU fallback via PCIe devices ──
+    if not gpus:
+        gpus = _detect_gpus_from_pcie(bmc_ip, username, password, timeout)
+
+    # ── Step 3: Read System info for memory ──
+    ok, sys_data = _redfish_get(
+        bmc_ip,
+        "/redfish/v1/Systems/System.Embedded.1",
+        username, password, timeout,
+    )
+
+    if ok:
+        total_gib = (sys_data
+                     .get("MemorySummary", {})
+                     .get("TotalSystemMemoryGiB", default_memory))
+        total_mb = int(total_gib * 1024)
+        real_memory = int(total_mb * 0.90)
+    else:
+        real_memory = default_memory
+
+    # ── Step 4: Build node_params ──
+    sockets = max(len(cpus), 1)
+    if cpus:
+        cores_per_socket = cpus[0].get("TotalEnabledCores", default_cores)
+        total_threads = cpus[0].get("TotalThreads", default_threads)
+        total_cores = cpus[0].get("TotalCores", 1)
+        threads_per_core = total_threads // max(total_cores, 1)
+    else:
+        cores_per_socket = default_cores
+        threads_per_core = default_threads
+
+    node_params = {
+        "NodeName": hostname,
+        "Sockets": sockets,
+        "CoresPerSocket": cores_per_socket,
+        "ThreadsPerCore": threads_per_core,
+        "RealMemory": real_memory,
+    }
+
+    if gpus:
+        node_params["Gres"] = f"gpu:{len(gpus)}"
+
+    return (hostname, node_params, gpus, None)
+
+
+# ─── Per-group discovery (homogeneous) ────────────────────────────────────
+
+def _discover_group(group_name, group_nodes, bmc_ip_map, username,
+                    password, timeout, defaults):
+    """Discover hardware specs for a homogeneous group via iDRAC Redfish.
+
+    Tries each node in the group sequentially until one iDRAC responds,
+    then replicates the discovered specs to all nodes in the group.
+
+    Returns (group_name, node_params_list, gpu_dict, sample_node_or_None,
+             failed_bool).
+    """
+    default_memory = defaults.get("real_memory", 864)
+    default_cores = defaults.get("corespersocket", 72)
+    default_threads = defaults.get("threadspercore", 1)
+    default_sockets = defaults.get("sockets", 2)
+
+    # Try each node until one responds
+    sample_hostname = None
+    sample_params = None
+    sample_gpus = []
+
+    for hostname in group_nodes:
+        bmc_ip = bmc_ip_map.get(hostname)
+        if not bmc_ip:
+            continue
+        _, params, gpus, error = _discover_single_node(
+            hostname, bmc_ip, username, password, timeout, defaults,
+        )
+        if error is None:
+            sample_hostname = hostname
+            sample_params = params
+            sample_gpus = gpus
+            break
+
+    # Replicate discovered (or default) specs to all nodes in group
+    node_params_list = []
+    gpu_dict = {}
+
+    if sample_params:
+        for hostname in group_nodes:
+            entry = dict(sample_params)
+            entry["NodeName"] = hostname
+            node_params_list.append(entry)
+            if sample_gpus:
+                gpu_dict[hostname] = sample_gpus
+    else:
+        # All iDRACs in group failed — use defaults
+        for hostname in group_nodes:
+            node_params_list.append({
+                "NodeName": hostname,
+                "Sockets": default_sockets,
+                "CoresPerSocket": default_cores,
+                "ThreadsPerCore": default_threads,
+                "RealMemory": default_memory,
+            })
+
+    return (group_name, node_params_list, gpu_dict, sample_hostname,
+            sample_params is None)
+
+
+# ─── Main module ────────────────────────────────────────────────────────────
+
+def run_module():
+    """Ansible module entry point."""
+    module_args = {
+        "nodes": {
+            "type": "list", "required": False, "default": None,
+            "elements": "str",
+        },
+        "groups": {
+            "type": "dict", "required": False, "default": None,
+        },
+        "bmc_ip_map": {"type": "dict", "required": True},
+        "bmc_username": {"type": "str", "required": True, "no_log": True},
+        "bmc_password": {"type": "str", "required": True, "no_log": True},
+        "max_parallel": {
+            "type": "int", "required": False, "default": 20,
+        },
+        "connect_timeout": {
+            "type": "int", "required": False, "default": 60,
+        },
+        "defaults": {
+            "type": "dict", "required": False, "default": {},
+        },
+    }
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        mutually_exclusive=[("nodes", "groups")],
+        required_one_of=[("nodes", "groups")],
+    )
+
+    nodes = module.params["nodes"]
+    groups = module.params["groups"]
+    bmc_ip_map = module.params["bmc_ip_map"]
+    bmc_username = module.params["bmc_username"]
+    bmc_password = module.params["bmc_password"]
+    max_parallel = module.params["max_parallel"]
+    connect_timeout = module.params["connect_timeout"]
+    defaults = module.params["defaults"]
+
+    # Dispatch to per-node or per-group discovery
+    if groups is not None:
+        _run_group_discovery(
+            module, groups, bmc_ip_map, bmc_username, bmc_password,
+            max_parallel, connect_timeout, defaults,
+        )
+    else:
+        _run_node_discovery(
+            module, nodes or [], bmc_ip_map, bmc_username, bmc_password,
+            max_parallel, connect_timeout, defaults,
+        )
+
+
+def _run_node_discovery(module, nodes, bmc_ip_map, bmc_username,
+                        bmc_password, max_parallel, connect_timeout,
+                        defaults):
+    """Heterogeneous mode: discover every node individually in parallel."""
+    result = {
+        "changed": False,
+        "node_params": [],
+        "gpu_params": {},
+        "failed_nodes": [],
+        "total_nodes": len(nodes),
+        "discovered_count": 0,
+    }
+
+    if module.check_mode or not nodes:
+        module.exit_json(**result)
+
+    # Validate that all nodes have BMC IPs
+    missing_bmc = [n for n in nodes if n not in bmc_ip_map]
+    if missing_bmc:
+        module.warn(
+            f"No BMC IP found for {len(missing_bmc)} node(s): "
+            f"{', '.join(missing_bmc[:10])}"
+            f"{'...' if len(missing_bmc) > 10 else ''}"
+        )
+
+    # Parallel iDRAC discovery
+    workers = min(max_parallel, len(nodes))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {}
+        for hostname in nodes:
+            bmc_ip = bmc_ip_map.get(hostname)
+            if not bmc_ip:
+                result["failed_nodes"].append(hostname)
+                continue
+            future = pool.submit(
+                _discover_single_node,
+                hostname, bmc_ip, bmc_username, bmc_password,
+                connect_timeout, defaults,
+            )
+            futures[future] = hostname
+
+        for future in as_completed(futures):
+            hostname = futures[future]
+            try:
+                _, node_params, gpus, error = future.result()
+                if error:
+                    result["failed_nodes"].append(hostname)
+                    module.warn(
+                        f"iDRAC discovery failed for {hostname}: {error}"
+                    )
+                else:
+                    result["node_params"].append(node_params)
+                    if gpus:
+                        result["gpu_params"][hostname] = gpus
+                    result["discovered_count"] += 1
+            except Exception as exc:  # pylint: disable=broad-except
+                result["failed_nodes"].append(hostname)
+                module.warn(
+                    f"iDRAC discovery exception for {hostname}: {exc}"
+                )
+
+    if result["failed_nodes"]:
+        module.warn(
+            f"iDRAC discovery failed for {len(result['failed_nodes'])} of "
+            f"{len(nodes)} node(s)"
+        )
+
+    module.exit_json(**result)
+
+
+def _run_group_discovery(module, groups, bmc_ip_map, bmc_username,
+                         bmc_password, max_parallel, connect_timeout,
+                         defaults):
+    """Homogeneous mode: discover one sample per group in parallel."""
+    all_nodes = [h for hosts in groups.values() for h in hosts]
+    result = {
+        "changed": False,
+        "node_params": [],
+        "gpu_params": {},
+        "failed_nodes": [],
+        "failed_groups": [],
+        "total_nodes": len(all_nodes),
+        "total_groups": len(groups),
+        "discovered_count": 0,
+        "group_sample_nodes": {},
+    }
+
+    if module.check_mode or not groups:
+        module.exit_json(**result)
+
+    # Parallel group discovery — one thread per group
+    workers = min(max_parallel, len(groups))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {}
+        for group_name, group_nodes in groups.items():
+            future = pool.submit(
+                _discover_group,
+                group_name, group_nodes, bmc_ip_map,
+                bmc_username, bmc_password, connect_timeout, defaults,
+            )
+            futures[future] = group_name
+
+        for future in as_completed(futures):
+            group_name = futures[future]
+            try:
+                (_, node_params_list, gpu_dict, sample_node,
+                 failed) = future.result()
+                result["node_params"].extend(node_params_list)
+                result["gpu_params"].update(gpu_dict)
+                if sample_node:
+                    result["group_sample_nodes"][group_name] = sample_node
+                if failed:
+                    result["failed_groups"].append(group_name)
+                    module.warn(
+                        f"All iDRACs failed for group '{group_name}' "
+                        f"({len(groups[group_name])} nodes) — "
+                        f"using defaults"
+                    )
+                else:
+                    result["discovered_count"] += len(
+                        groups[group_name]
+                    )
+            except Exception as exc:  # pylint: disable=broad-except
+                result["failed_groups"].append(group_name)
+                module.warn(
+                    f"Group discovery exception for '{group_name}': "
+                    f"{exc}"
+                )
+
+    if result["failed_groups"]:
+        module.warn(
+            f"iDRAC group discovery failed for "
+            f"{len(result['failed_groups'])} of "
+            f"{len(groups)} group(s)"
+        )
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point."""
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestrator/plugins/modules/bulk_discover_node_specs.py
+++ b/src/orchestrator/plugins/modules/bulk_discover_node_specs.py
@@ -103,7 +103,7 @@ def _redfish_get(bmc_ip, path, username, password, timeout):
     ctx = _create_ssl_context()
 
     try:
-        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:  # nosec B310
             data = json.loads(resp.read().decode())
             return (True, data)
     except urllib.error.HTTPError as exc:

--- a/src/orchestrator/plugins/modules/bulk_update_hosts.py
+++ b/src/orchestrator/plugins/modules/bulk_update_hosts.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/usr/bin/python
+# pylint: disable=import-error,no-name-in-module,line-too-long,too-many-locals
+"""
+Ansible module to bulk-update /etc/hosts across multiple remote hosts
+in parallel via SSH.
+
+Designed for HPC clusters with 500-2000 nodes where serial Ansible
+loops are prohibitively slow.  This module is responsible ONLY for
+/etc/hosts management.  Munge key status is handled separately in
+the calling playbook tasks.
+
+Usage in playbook:
+  bulk_update_hosts:
+    hosts: "{{ reachable_hosts }}"
+    ip_name_map: "{{ ip_name_map }}"
+    ssh_key_path: "/root/.ssh/oim_rsa"
+    nodes_to_remove: []
+    ssh_max_parallel: 20
+    ssh_connect_timeout: 10
+  register: bulk_update_result
+"""
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from ansible.module_utils.basic import AnsibleModule
+
+
+# ─── Hosts-file content generation ──────────────────────────────────────────
+
+def _build_hosts_block(ip_name_map):
+    """Build the OMNIA MANAGED HOSTS block content.
+
+    Returns a string containing the full managed block including markers.
+    Sorted by hostname for deterministic output.
+    """
+    lines = ["# BEGIN OMNIA MANAGED HOSTS"]
+    for hostname in sorted(ip_name_map.keys()):
+        ip_addr = ip_name_map[hostname]
+        lines.append(f"{ip_addr} {hostname}")
+    lines.append("# END OMNIA MANAGED HOSTS")
+    return "\n".join(lines)
+
+
+def _build_cleanup_sed(ip_name_map, nodes_to_remove):
+    """Build sed commands to remove stale /etc/hosts entries.
+
+    Cleans up:
+      - Old managed block markers and content
+      - Unmanaged entries matching Omnia node IPs or hostnames
+      - Entries for explicitly removed nodes
+    """
+    all_ips = list(ip_name_map.values())
+    all_names = list(ip_name_map.keys()) + list(nodes_to_remove or [])
+
+    cmds = [
+        # Remove old managed block markers and content (idempotent)
+        "sed -i '/^# BEGIN OMNIA MANAGED HOSTS$/,/^# END OMNIA MANAGED HOSTS$/d' /etc/hosts 2>/dev/null || true",
+    ]
+    if all_ips:
+        ip_pattern = "|".join(_regex_escape(ip) for ip in all_ips)
+        cmds.append(
+            f"sed -i -E '/^({ip_pattern})[[:space:]]/d' /etc/hosts 2>/dev/null || true"
+        )
+    if all_names:
+        name_pattern = "|".join(all_names)
+        cmds.append(
+            f"sed -i -E '/[[:space:]]({name_pattern})$/d' /etc/hosts 2>/dev/null || true"
+        )
+    return "\n".join(cmds)
+
+
+def _regex_escape(text):
+    """Escape regex special characters in a string for sed patterns."""
+    special = r'\.^$*+?{}[]|()'
+    return "".join(f"\\{c}" if c in special else c for c in text)
+
+
+# ─── Remote execution ──────────────────────────────────────────────────────
+
+def _ssh_run(host, script, ssh_key_path, ssh_connect_timeout):
+    """Execute a script on a remote host via SSH.
+
+    Returns (host, success, stdout, stderr).
+    """
+    cmd = [
+        "ssh",
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", f"ConnectTimeout={ssh_connect_timeout}",
+        "-o", "BatchMode=yes",
+        "-o", "LogLevel=ERROR",
+        "-i", ssh_key_path,
+        f"root@{host}",
+        "bash -s",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            input=script,
+            capture_output=True,
+            text=True,
+            timeout=ssh_connect_timeout + 30,
+            check=False,
+        )
+        return (host, result.returncode == 0, result.stdout, result.stderr)
+    except subprocess.TimeoutExpired:
+        return (host, False, "", f"SSH timeout after {ssh_connect_timeout + 30}s")
+    except Exception as exc:  # pylint: disable=broad-except
+        return (host, False, "", str(exc))
+
+
+def _update_single_host(host, cleanup_sed, hosts_block, ssh_key_path,
+                        ssh_connect_timeout):
+    """Update /etc/hosts on a single remote host.
+
+    Steps:
+      1. Run sed cleanup to remove stale entries
+      2. Append the new managed hosts block
+    """
+    script = f"""set -o pipefail
+{cleanup_sed}
+cat >> /etc/hosts << 'OMNIA_HOSTS_EOF'
+{hosts_block}
+OMNIA_HOSTS_EOF
+"""
+    return _ssh_run(host, script, ssh_key_path, ssh_connect_timeout)
+
+
+# ─── Main module ────────────────────────────────────────────────────────────
+
+def run_module():
+    """Ansible module entry point."""
+    module_args = {
+        "hosts": {"type": "list", "required": True, "elements": "str"},
+        "ip_name_map": {"type": "dict", "required": True},
+        "ssh_key_path": {"type": "str", "required": True},
+        "nodes_to_remove": {
+            "type": "list", "required": False, "default": [],
+            "elements": "str",
+        },
+        "ssh_max_parallel": {
+            "type": "int", "required": False, "default": 20,
+        },
+        "ssh_connect_timeout": {
+            "type": "int", "required": False, "default": 10,
+        },
+    }
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    hosts = module.params["hosts"]
+    ip_name_map = module.params["ip_name_map"]
+    ssh_key_path = module.params["ssh_key_path"]
+    nodes_to_remove = module.params["nodes_to_remove"]
+    ssh_max_parallel = module.params["ssh_max_parallel"]
+    ssh_connect_timeout = module.params["ssh_connect_timeout"]
+
+    result = {
+        "changed": False,
+        "hosts_updated": [],
+        "hosts_failed": [],
+        "total_hosts": len(hosts),
+        "per_host_results": {},
+    }
+
+    if module.check_mode:
+        result["changed"] = len(hosts) > 0
+        module.exit_json(**result)
+
+    if not hosts:
+        module.exit_json(**result)
+
+    # Build content once (same for every node)
+    hosts_block = _build_hosts_block(ip_name_map)
+    cleanup_sed = _build_cleanup_sed(ip_name_map, nodes_to_remove)
+
+    # Parallel SSH execution
+    with ThreadPoolExecutor(max_workers=min(ssh_max_parallel, len(hosts))) as pool:
+        futures = {
+            pool.submit(
+                _update_single_host,
+                host, cleanup_sed, hosts_block,
+                ssh_key_path, ssh_connect_timeout,
+            ): host
+            for host in hosts
+        }
+
+        for future in as_completed(futures):
+            host = futures[future]
+            try:
+                _, success, stdout, stderr = future.result()
+                result["per_host_results"][host] = {
+                    "success": success,
+                    "stdout": stdout.strip() if stdout else "",
+                    "stderr": stderr.strip() if stderr else "",
+                }
+                if success:
+                    result["hosts_updated"].append(host)
+                else:
+                    result["hosts_failed"].append(host)
+            except Exception as exc:  # pylint: disable=broad-except
+                result["per_host_results"][host] = {
+                    "success": False,
+                    "stdout": "",
+                    "stderr": str(exc),
+                }
+                result["hosts_failed"].append(host)
+
+    result["changed"] = len(result["hosts_updated"]) > 0
+
+    if result["hosts_failed"]:
+        module.warn(
+            f"Failed to update /etc/hosts on {len(result['hosts_failed'])} host(s): "
+            f"{', '.join(result['hosts_failed'])}"
+        )
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point."""
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestrator/roles/orchestrator_setup/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/tasks/main.yml
@@ -175,7 +175,7 @@
   ansible.builtin.set_fact:
     image_build_manager_output_path: "{{ _orch_config.image_build_manager_output_path | default(default_build_status_path) }}"
     boot_kernel_params: "{{ _orch_config.boot_kernel_params | default('') }}"
-    pxe_mapping_file_path: "{{ _orch_config.pxe_mapping_file_path | default('') }}"
+    pxe_mapping_file_path: "{{ (_orch_config.pxe_mapping_file_path | default('')) | ternary(_orch_config.pxe_mapping_file_path | default(''), default_pxe_mapping_file_path) }}"
     enable_pxe_boot: "{{ _orch_config.enable_pxe_boot | default(true) | bool }}"
     cacheable: true
 

--- a/src/orchestrator/roles/orchestrator_setup/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/tasks/main.yml
@@ -173,9 +173,14 @@
 
 - name: Set image_build_manager_output_path and boot params on localhost
   ansible.builtin.set_fact:
-    image_build_manager_output_path: "{{ _orch_config.image_build_manager_output_path | default(default_build_status_path) }}"
+    image_build_manager_output_path: >-
+      {{ _orch_config.image_build_manager_output_path | default(default_build_status_path) }}
     boot_kernel_params: "{{ _orch_config.boot_kernel_params | default('') }}"
-    pxe_mapping_file_path: "{{ (_orch_config.pxe_mapping_file_path | default('')) | ternary(_orch_config.pxe_mapping_file_path | default(''), default_pxe_mapping_file_path) }}"
+    pxe_mapping_file_path: >-
+      {{ (_orch_config.pxe_mapping_file_path | default('')) | ternary(
+          _orch_config.pxe_mapping_file_path | default(''),
+          default_pxe_mapping_file_path
+        ) }}
     enable_pxe_boot: "{{ _orch_config.enable_pxe_boot | default(true) | bool }}"
     cacheable: true
 

--- a/src/orchestrator/roles/orchestrator_setup/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/vars/main.yml
@@ -20,6 +20,8 @@ upgrade_lock_file: "{{ omnia_data_path | default('/opt/omnia') }}/.data/upgrade_
 default_build_status_path: >-
   {{ omnia_data_path | default('/opt/omnia') }}/image_build_manager/output/{{ project_name | default('project_default') }}/build_status.yml
 default_repo_status_path: "{{ omnia_data_path | default('/opt/omnia') }}/repo_manager/output/{{ project_name | default('project_default') }}/repo_status.yml"
+default_pxe_mapping_file_path: >-
+  {{ omnia_data_path | default('/opt/omnia') }}/orchestrator/input/{{ project_name | default('project_default') }}/pxe_mapping_file.csv
 default_catalog_file_path: "{{ lookup('env', 'CATALOG_FILE_PATH') | default(omnia_data_path | default('/opt/omnia') + '/catalog/catalog_rhel.json', true) }}"
 
 # --- Tag validation ---

--- a/src/orchestrator/roles/orchestrator_validations/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/main.yml
@@ -45,3 +45,4 @@
 
 - name: Update hosts file
   ansible.builtin.include_tasks: update_hosts.yml
+  when: "'precheck' not in (hostvars['localhost']['omnia_run_tags'] | default([]))"

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -25,6 +25,11 @@
     file: "{{ role_path }}/../slurm_config/vars/main.yml"
   failed_when: false
 
+# Re-load openchami configs_vars to restore cluster_name / cluster_domain
+# which slurm_config/vars/main.yml clobbers with its own cluster_name.
+- name: Reload openchami cluster vars after slurm_config include
+  ansible.builtin.include_vars: "{{ openchami_config_vars_path }}"
+
 - name: Include vars from configure_ochami role
   ansible.builtin.include_vars:
     file: "{{ role_path }}/../configure_ochami/vars/main.yml"

--- a/src/orchestrator/roles/validate_openchami/tasks/main.yml
+++ b/src/orchestrator/roles/validate_openchami/tasks/main.yml
@@ -60,6 +60,56 @@
       delay: 5
       until: tokensmith_health.status.ActiveState == "active"
 
+    - name: Verify metadata-service is reachable
+      ansible.builtin.uri:
+        url: "{{ openchami_base_url }}/metadata-service/health"
+        method: GET
+        status_code: 200
+        validate_certs: "{{ openchami_validate_certs | default(true) }}"
+        headers:
+          Authorization: "Bearer {{ openchami_access_token }}"
+      register: metadata_service_health
+      retries: 3
+      delay: 5
+      until: metadata_service_health.status == 200
+
+    - name: Verify ACME certificate service is active
+      ansible.builtin.systemd:
+        name: acme-deploy.service
+      register: acme_health
+      changed_when: false
+      failed_when: acme_health.status.ActiveState != "active"
+
+    - name: Check HAProxy TLS certificate directory
+      ansible.builtin.stat:
+        path: /etc/haproxy/certs/
+      register: haproxy_cert_dir
+
+    - name: Verify HAProxy TLS certificates are present
+      ansible.builtin.find:
+        paths: /etc/haproxy/certs/
+        patterns: "*.pem"
+      register: haproxy_certs
+      when: haproxy_cert_dir.stat.isdir | default(false)
+
+    - name: Report HAProxy TLS certificate status
+      ansible.builtin.debug:
+        msg: >-
+          HAProxy TLS certificates: {{ 'found' if (haproxy_certs.matched | default(0)) > 0 else 'not found (warning)' }}
+      when: haproxy_cert_dir.stat.isdir | default(false)
+
+    - name: Verify S3 endpoint is reachable
+      ansible.builtin.uri:
+        url: "{{ s3_configurations.endpoint_url }}/minio/health/live"
+        method: GET
+        status_code: 200
+        validate_certs: false
+      register: s3_health
+      retries: 3
+      delay: 5
+      until: s3_health.status == 200
+      when: s3_configurations is defined
+
     - name: Set openchami_ready fact
       ansible.builtin.set_fact:
         openchami_ready: true
@@ -75,4 +125,7 @@
           OpenCHAMI is not ready for provisioning. Check that all services are
           running and accessible. SMD: {{ smd_health.status | default('N/A') }},
           Boot-Service: {{ boot_service_health.status | default('N/A') }},
-          Tokensmith: {{ tokensmith_health.status.ActiveState | default('N/A') }}.
+          Metadata-Service: {{ metadata_service_health.status | default('N/A') }},
+          Tokensmith: {{ tokensmith_health.status.ActiveState | default('N/A') }},
+          ACME: {{ acme_health.status.ActiveState | default('N/A') }},
+          S3: {{ s3_health.status | default('N/A') }}.

--- a/src/orchestrator/roles/validate_openchami/vars/main.yml
+++ b/src/orchestrator/roles/validate_openchami/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 # Variables for validate_openchami role
-# Uses cluster_name and cluster_domain facts set by deploy_openchami/refresh_openchami_configs.yml
-openchami_base_url: "https://{{ cluster_name }}.{{ cluster_domain }}:8443"
+# Derive OpenCHAMI base URL from stable localhost facts (oim_node_name, domain_name)
+# rather than cluster_name which may be overwritten by slurm_config/k8s_config roles.
+openchami_base_url: "https://{{ hostvars['localhost']['oim_node_name'] }}.{{ hostvars['localhost']['domain_name'] | regex_replace('^' + hostvars['localhost']['oim_node_name'] + '\\.', '') }}:8443"
 openchami_validate_certs: false

--- a/src/orchestrator/roles/validate_openchami/vars/main.yml
+++ b/src/orchestrator/roles/validate_openchami/vars/main.yml
@@ -2,5 +2,11 @@
 # Variables for validate_openchami role
 # Derive OpenCHAMI base URL from stable localhost facts (oim_node_name, domain_name)
 # rather than cluster_name which may be overwritten by slurm_config/k8s_config roles.
-openchami_base_url: "https://{{ hostvars['localhost']['oim_node_name'] }}.{{ hostvars['localhost']['domain_name'] | regex_replace('^' + hostvars['localhost']['oim_node_name'] + '\\.', '') }}:8443"
+openchami_base_url: >-
+  https://{{ hostvars['localhost']['oim_node_name'] }}.{{
+    hostvars['localhost']['domain_name'] | regex_replace(
+      '^' + hostvars['localhost']['oim_node_name'] + '\\.',
+      ''
+    )
+  }}:8443
 openchami_validate_certs: false

--- a/src/orchestrator/roles/validate_provisioning/tasks/main.yml
+++ b/src/orchestrator/roles/validate_provisioning/tasks/main.yml
@@ -60,6 +60,92 @@
     - missing_nodes | length > 0
     - strict_validation | default(false) | bool
 
+# --- BSS boot parameter verification ---
+- name: Query boot-service for all boot configurations
+  ansible.builtin.uri:
+    url: "{{ openchami_base_url }}/boot-service/bootconfigurations"
+    method: GET
+    status_code: 200
+    validate_certs: "{{ openchami_validate_certs | default(true) }}"
+    headers:
+      Authorization: "Bearer {{ openchami_access_token }}"
+  register: bss_boot_configs
+
+- name: Build list of functional group names with boot configurations
+  ansible.builtin.set_fact:
+    bss_configured_groups: "{{ bss_boot_configs.json | map(attribute='metadata') | map(attribute='name') | list }}"
+
+- name: Build expected functional group names
+  ansible.builtin.set_fact:
+    expected_fg_names: "{{ fg_config.functional_groups | map(attribute='name') | list }}"
+
+- name: Identify functional groups without boot configurations
+  ansible.builtin.set_fact:
+    fg_missing_bss: "{{ expected_fg_names | difference(bss_configured_groups) }}"
+
+- name: Report functional groups missing BSS boot parameters
+  ansible.builtin.debug:
+    msg: "WARNING: {{ fg_missing_bss | length }} functional groups have no BSS boot configuration: {{ fg_missing_bss }}"
+  when: fg_missing_bss | length > 0
+
+# --- Metadata-service (cloud-init) data verification ---
+- name: Query metadata-service for all group configurations
+  ansible.builtin.uri:
+    url: "{{ openchami_base_url }}/metadata-service/groups"
+    method: GET
+    status_code: 200
+    validate_certs: "{{ openchami_validate_certs | default(true) }}"
+    headers:
+      Authorization: "Bearer {{ openchami_access_token }}"
+  register: ms_groups
+
+- name: Build list of metadata-service configured group names
+  ansible.builtin.set_fact:
+    ms_configured_groups: "{{ ms_groups.json | map(attribute='metadata') | map(attribute='name') | list }}"
+
+- name: Identify functional groups without metadata-service data
+  ansible.builtin.set_fact:
+    fg_missing_metadata: "{{ expected_fg_names | difference(ms_configured_groups) }}"
+
+- name: Report functional groups missing metadata-service data
+  ansible.builtin.debug:
+    msg: "WARNING: {{ fg_missing_metadata | length }} functional groups have no metadata-service configuration: {{ fg_missing_metadata }}"
+  when: fg_missing_metadata | length > 0
+
+# --- Node hostname assignment verification ---
+- name: Query SMD for Ethernet interfaces (hostname assignments)
+  ansible.builtin.uri:
+    url: "{{ openchami_base_url }}/hsm/v2/Inventory/EthernetInterfaces"
+    method: GET
+    status_code: 200
+    validate_certs: "{{ openchami_validate_certs | default(true) }}"
+    headers:
+      Authorization: "Bearer {{ openchami_access_token }}"
+  register: smd_ethernet
+  failed_when: false
+
+- name: Build list of nodes with hostname assignments
+  ansible.builtin.set_fact:
+    nodes_with_hostnames: >-
+      {{ (smd_ethernet.json | default([])) |
+         selectattr('Description', 'defined') |
+         selectattr('Description', 'ne', '') |
+         map(attribute='ComponentID') | unique | list }}
+  when: smd_ethernet.status | default(0) == 200
+
+- name: Identify registered nodes without hostname assignments
+  ansible.builtin.set_fact:
+    nodes_missing_hostnames: "{{ registered_xnames | difference(nodes_with_hostnames | default([])) }}"
+  when: smd_ethernet.status | default(0) == 200
+
+- name: Report nodes without hostname assignments
+  ansible.builtin.debug:
+    msg: "WARNING: {{ nodes_missing_hostnames | length }} registered nodes have no hostname assignment: {{ nodes_missing_hostnames }}"
+  when:
+    - nodes_missing_hostnames is defined
+    - nodes_missing_hostnames | length > 0
+
+# --- Provisioning summary ---
 - name: Generate provisioning summary
   ansible.builtin.set_fact:
     provisioning_summary:
@@ -67,17 +153,24 @@
       total_registered_nodes: "{{ registered_xnames | length }}"
       missing_nodes: "{{ missing_nodes }}"
       functional_groups_count: "{{ fg_config.functional_groups | length }}"
+      fg_with_boot_config: "{{ bss_configured_groups | intersect(expected_fg_names) | length }}"
+      fg_missing_boot_config: "{{ fg_missing_bss }}"
+      fg_with_metadata: "{{ ms_configured_groups | intersect(expected_fg_names) | length }}"
+      fg_missing_metadata: "{{ fg_missing_metadata }}"
+      nodes_missing_hostnames: "{{ nodes_missing_hostnames | default([]) }}"
       timestamp: "{{ ansible_date_time.iso8601 }}"
 
 - name: Display provisioning summary
   ansible.builtin.debug:
     var: provisioning_summary
 
+# Write provisioning report only when called from provision flow (not standalone validate)
 - name: Write provisioning report
   ansible.builtin.copy:
     content: "{{ provisioning_summary | to_nice_yaml }}"
     dest: "{{ orchestrator_output_dir }}/provisioning_report.yml"
     mode: "0644"
+  when: ansible_run_tags | default([]) | intersect(['provision']) | length > 0 or ansible_run_tags | length == 0
 
 # Write orchestrator_status.yml — the canonical status contract consumed by
 # external tools. During the provisioning-only path (no PXE boot) the node
@@ -92,6 +185,7 @@
            'failure_reason': ('' if item in registered_xnames else 'not registered in SMD')}] }}
   loop: "{{ expected_nodes }}"
 
+# Write orchestrator_status.yml only when called from provision flow (not standalone validate)
 - name: Write orchestrator_status.yml (provisioning path)
   ansible.builtin.copy:
     content: "{{ orchestrator_status | to_nice_yaml }}"
@@ -105,3 +199,4 @@
       success_count: "{{ registered_xnames | intersect(expected_nodes) | length }}"
       failure_count: "{{ missing_nodes | length }}"
       nodes: "{{ provisioning_nodes_status | default([]) }}"
+  when: ansible_run_tags | default([]) | intersect(['provision']) | length > 0 or ansible_run_tags | length == 0


### PR DESCRIPTION
### Summary
This PR validates that all orchestrator tags `(precheck, prepare, deploy, provision, validate)` can run successfully both standalone and as part of the full pipeline. 
It includes fixes for standalone execution of precheck, provision, and validate tags, restores missing bulk modules, and ensures read-only compliance for the precheck tag.

### Fixes:
- Restore missing bulk modules: The PR #5076 restructuring silently dropped two modules added in PR #5001: - `bulk_discover_node_specs.py` and `bulk_update_hosts.py`.
- Fix read-only contract: The precheck tag was modifying /etc/hosts via update_hosts.yml, violating the read-only contract. This change gates update_hosts.yml behind a precheck tag check so --tags precheck performs no system changes.
- Fix callback plugin error suppression: The omnia_default.py callback plugin was suppressing [ERROR] messages too aggressively, including module-resolution errors. Updated to only suppress task-failure [ERROR] blocks, not module-not-found errors.
- Enable standalone execution: Added provision_preamble.yml to load variables normally set by precheck/deploy phases when running provision in isolation.
- Fix cluster_name clobbering: The slurm_config/vars/main.yml sets cluster_name: cluster, which overwrites the correct value from configs_vars.yaml. Fixed by reloading OpenCHAMI configs_vars after slurm_config include in configure_metadata_svc.yml.
- Add validate_preamble.yml: Loads cluster config from OIM, authenticates with OpenCHAMI, and ensures network prerequisites for standalone --tags validate execution.
- Enhanced validate_provisioning role with detailed provisioning checks.
