### PR TITLE
Feat(orchestrator): refactor orchestrator tags to align with standardized pattern

### DIFF
--- a/src/orchestrator/playbooks/cleanup/cleanup_openchami.yml
+++ b/src/orchestrator/playbooks/cleanup/cleanup_openchami.yml
@@ -157,5 +157,4 @@
       ansible.builtin.debug:
         msg: "Credential files removed from {{ input_project_dir }}."
   tags:
-    - credentials
     - never

--- a/src/orchestrator/playbooks/orchestrator.yml
+++ b/src/orchestrator/playbooks/orchestrator.yml
@@ -19,13 +19,12 @@
 #
 # Usage (run ONE tag at a time — no comma-separated tags):
 #   cd src/orchestrator
-#   ansible-playbook playbooks/orchestrator.yml                        # Default: precheck + prepare + deploy + provision
+#   ansible-playbook playbooks/orchestrator.yml                        # Default: precheck + prepare + execute
 #   ansible-playbook playbooks/orchestrator.yml --tags precheck        # Validate inputs + prerequisites (read-only)
 #   ansible-playbook playbooks/orchestrator.yml --tags validate        # Validate input files only (schema + logic)
 #   ansible-playbook playbooks/orchestrator.yml --tags credentials     # Prompt for credentials (standalone, idempotent)
-#   ansible-playbook playbooks/orchestrator.yml --tags prepare         # Credentials + functional groups + OpenLDAP prep
-#   ansible-playbook playbooks/orchestrator.yml --tags deploy          # Deploy OpenCHAMI + OpenLDAP + validate gates
-#   ansible-playbook playbooks/orchestrator.yml --tags provision       # SSH + provision all categories + validate
+#   ansible-playbook playbooks/orchestrator.yml --tags prepare         # Credentials + functional groups + OpenLDAP prep + deploy containers
+#   ansible-playbook playbooks/orchestrator.yml --tags execute         # Provision only (SSH + provision all categories)
 #   ansible-playbook playbooks/orchestrator.yml --tags validate-deployment # Validate OpenCHAMI + OpenLDAP + provisioning
 #   ansible-playbook playbooks/orchestrator.yml --tags pxeboot         # PXE boot on iDRAC nodes
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup         # Remove OpenCHAMI + OpenLDAP services + artifacts
@@ -33,13 +32,12 @@
 #   ansible-playbook playbooks/orchestrator.yml --tags rollback        # Revert OpenCHAMI + OpenLDAP to previous state
 #
 # Tags (mutually exclusive — pick ONE):
-#   (none)       — Default flow: precheck + prepare + deploy + provision
+#   (none)       — Default flow: precheck + prepare + execute
 #   precheck     — Validate inputs, parameters, boot images (read-only, no system changes)
 #   validate     — Validate input files only (schema + logic, no health checks)
 #   credentials  — Prompt for credentials (standalone, idempotent)
-#   prepare      — Credential management, functional group generation, OpenLDAP config prep
-#   deploy       — Deploy OpenCHAMI + OpenLDAP containers, validate readiness gates
-#   provision    — SSH preamble, provision K8s/Slurm/OS/custom, validate provisioning
+#   prepare      — Credential management, functional group generation, OpenLDAP config prep, deploy containers
+#   execute      — SSH preamble, provision K8s/Slurm/OS/custom, validate provisioning
 #   validate-deployment — Validate OpenCHAMI, OpenLDAP, and provisioning readiness
 #   pxeboot      — PXE boot on iDRAC nodes (opt-in only)
 #   cleanup      — Remove OpenCHAMI + OpenLDAP services, containers, artifacts (opt-in only)
@@ -68,14 +66,12 @@
 #     6. Credential management (prompt, encrypt, vault)
 #     7. Generate functional groups from pxe_mapping_file.csv
 #     8. Prepare OpenLDAP (dirs, TLS certs, configs — when enabled)
-#
-#   deploy:
-#     9. Configure S3 access + deploy OpenCHAMI containers
+#     9. Deploy OpenCHAMI containers
 #    10. Deploy OpenLDAP container (when enabled)
 #    11. Validate OpenCHAMI readiness (gate)
 #    12. Validate OpenLDAP readiness (gate, when enabled)
 #
-#   provision:
+#   execute:
 #    13. SSH preamble (key distribution + OpenCHAMI auth)
 #    14. Provision Kubernetes cluster
 #    15. Provision Slurm cluster
@@ -86,7 +82,8 @@
 # Component Mapping:
 #   precheck  -> precheck_openchami.yml  + precheck_openldap.yml
 #   prepare   -> prepare_openchami.yml   + prepare_openldap.yml
-#   deploy    -> deploy_openchami.yml    + deploy_openldap.yml
+#               + deploy_openchami.yml    + deploy_openldap.yml
+#   execute   -> provision_preamble.yml + provision_*.yml
 #   cleanup   -> cleanup_openchami.yml   + cleanup_openldap.yml
 #   upgrade   -> upgrade_openchami.yml   + upgrade_openldap.yml
 #   rollback  -> rollback_openchami.yml  + rollback_openldap.yml
@@ -163,7 +160,7 @@
     - credentials
 
 # =========================================================================
-# FLOW: prepare — Credentials, functional groups, OpenLDAP config prep
+# FLOW: prepare — Credentials, functional groups, OpenLDAP prep, deploy containers
 # =========================================================================
 
 # Step 6: Credential management (prompt, encrypt, vault)
@@ -178,26 +175,97 @@
   tags:
     - prepare
 
+# Step 9: Configure S3 access + deploy OpenCHAMI containers on OIM
+- name: Deploy OpenCHAMI
+  ansible.builtin.import_playbook: deploy/deploy_openchami.yml
+  tags:
+    - prepare
+
+# Step 10: Deploy OpenLDAP container on OIM (when enabled)
+- name: Deploy OpenLDAP
+  ansible.builtin.import_playbook: deploy/deploy_openldap.yml
+  tags:
+    - prepare
+
+# Step 11: Gate — verify OpenCHAMI readiness before provisioning
+- name: Validate OpenCHAMI readiness
+  ansible.builtin.import_playbook: validate/validate_openchami.yml
+  tags:
+    - prepare
+    - validate-deployment
+
+# Step 12: Gate — verify OpenLDAP readiness (when enabled)
+- name: Validate OpenLDAP readiness
+  ansible.builtin.import_playbook: validate/validate_openldap.yml
+  tags:
+    - prepare
+    - validate-deployment
+
+# =========================================================================
+# FLOW: execute — Provision only (SSH + provision all categories)
+# =========================================================================
+
+# Step 13: SSH key distribution + OpenCHAMI auth (runs once for all categories)
+- name: Provision preamble (SSH + auth)
+  ansible.builtin.import_playbook: provision/provision_preamble.yml
+  tags:
+    - execute
+
+# Step 14: Register K8s FGs, configure BSS/metadata-service, run bolt-ons
+- name: Provision Kubernetes cluster
+  ansible.builtin.import_playbook: provision/provision_kubernetes.yml
+  tags:
+    - execute
+
+# Step 15: Register Slurm+Login FGs, configure BSS/metadata-service, run bolt-ons
+- name: Provision Slurm cluster
+  ansible.builtin.import_playbook: provision/provision_slurm.yml
+  tags:
+    - execute
+
+# Step 16: Register OS-only FGs, configure BSS/metadata-service (no bolt-ons)
+- name: Provision OS-only nodes
+  ansible.builtin.import_playbook: provision/provision_os.yml
+  tags:
+    - execute
+
+# Step 17: Register user-defined FGs (catch-all for unmatched categories)
+- name: Provision custom nodes
+  ansible.builtin.import_playbook: provision/provision_custom.yml
+  tags:
+    - execute
+
+# Step 18: Generate inventories + post-provision validation
+- name: Validate provisioning
+  ansible.builtin.import_playbook: validate/validate_provisioning.yml
+  tags:
+    - execute
+    - validate-deployment
+
 # =========================================================================
 # FLOW: deploy — Deploy services + validate readiness gates
+# (DEPRECATED: Use execute tag instead for combined deploy + provision)
 # =========================================================================
 
 # Step 9: Configure S3 access + deploy OpenCHAMI containers on OIM
 - name: Deploy OpenCHAMI
   ansible.builtin.import_playbook: deploy/deploy_openchami.yml
   tags:
+    - never
     - deploy
 
 # Step 10: Deploy OpenLDAP container on OIM (when enabled)
 - name: Deploy OpenLDAP
   ansible.builtin.import_playbook: deploy/deploy_openldap.yml
   tags:
+    - never
     - deploy
 
 # Step 11: Gate — verify OpenCHAMI readiness before provisioning
 - name: Validate OpenCHAMI readiness
   ansible.builtin.import_playbook: validate/validate_openchami.yml
   tags:
+    - never
     - deploy
     - validate-deployment
 
@@ -205,6 +273,7 @@
 - name: Validate OpenLDAP readiness
   ansible.builtin.import_playbook: validate/validate_openldap.yml
   tags:
+    - never
     - deploy
     - validate-deployment
 
@@ -222,42 +291,49 @@
 
 # =========================================================================
 # FLOW: provision — SSH preamble + provision all categories + validate
+# (DEPRECATED: Use execute tag instead for combined deploy + provision)
 # =========================================================================
 
 # Step 13: SSH key distribution + OpenCHAMI auth (runs once for all categories)
 - name: Provision preamble (SSH + auth)
   ansible.builtin.import_playbook: provision/provision_preamble.yml
   tags:
+    - never
     - provision
 
 # Step 14: Register K8s FGs, configure BSS/metadata-service, run bolt-ons
 - name: Provision Kubernetes cluster
   ansible.builtin.import_playbook: provision/provision_kubernetes.yml
   tags:
+    - never
     - provision
 
 # Step 15: Register Slurm+Login FGs, configure BSS/metadata-service, run bolt-ons
 - name: Provision Slurm cluster
   ansible.builtin.import_playbook: provision/provision_slurm.yml
   tags:
+    - never
     - provision
 
 # Step 16: Register OS-only FGs, configure BSS/metadata-service (no bolt-ons)
 - name: Provision OS-only nodes
   ansible.builtin.import_playbook: provision/provision_os.yml
   tags:
+    - never
     - provision
 
 # Step 17: Register user-defined FGs (catch-all for unmatched categories)
 - name: Provision custom nodes
   ansible.builtin.import_playbook: provision/provision_custom.yml
   tags:
+    - never
     - provision
 
 # Step 18: Generate inventories + post-provision validation
 - name: Validate provisioning
   ansible.builtin.import_playbook: validate/validate_provisioning.yml
   tags:
+    - never
     - provision
     - validate-deployment
 

--- a/src/orchestrator/playbooks/orchestrator.yml
+++ b/src/orchestrator/playbooks/orchestrator.yml
@@ -21,6 +21,7 @@
 #   cd src/orchestrator
 #   ansible-playbook playbooks/orchestrator.yml                        # Default: precheck + prepare + deploy + provision
 #   ansible-playbook playbooks/orchestrator.yml --tags precheck        # Validate inputs + prerequisites (read-only)
+#   ansible-playbook playbooks/orchestrator.yml --tags credentials     # Prompt for credentials (standalone, idempotent)
 #   ansible-playbook playbooks/orchestrator.yml --tags prepare         # Credentials + functional groups + OpenLDAP prep
 #   ansible-playbook playbooks/orchestrator.yml --tags deploy          # Deploy OpenCHAMI + OpenLDAP + validate gates
 #   ansible-playbook playbooks/orchestrator.yml --tags provision       # SSH + provision all categories + validate
@@ -33,6 +34,7 @@
 # Tags (mutually exclusive — pick ONE):
 #   (none)       — Default flow: precheck + prepare + deploy + provision
 #   precheck     — Validate inputs, parameters, boot images (read-only, no system changes)
+#   credentials  — Prompt for credentials (standalone, idempotent)
 #   prepare      — Credential management, functional group generation, OpenLDAP config prep
 #   deploy       — Deploy OpenCHAMI + OpenLDAP containers, validate readiness gates
 #   provision    — SSH preamble, provision K8s/Slurm/OS/custom, validate provisioning
@@ -131,6 +133,19 @@
   ansible.builtin.import_playbook: precheck/precheck_openldap.yml
   tags:
     - precheck
+
+# =========================================================================
+# FLOW: credentials — Standalone credential collection (idempotent)
+# =========================================================================
+
+- name: Collect orchestrator credentials
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - collect_orchestrator_credentials
+  tags:
+    - credentials
 
 # =========================================================================
 # FLOW: prepare — Credentials, functional groups, OpenLDAP config prep

--- a/src/orchestrator/playbooks/orchestrator.yml
+++ b/src/orchestrator/playbooks/orchestrator.yml
@@ -21,11 +21,12 @@
 #   cd src/orchestrator
 #   ansible-playbook playbooks/orchestrator.yml                        # Default: precheck + prepare + deploy + provision
 #   ansible-playbook playbooks/orchestrator.yml --tags precheck        # Validate inputs + prerequisites (read-only)
+#   ansible-playbook playbooks/orchestrator.yml --tags validate        # Validate input files only (schema + logic)
 #   ansible-playbook playbooks/orchestrator.yml --tags credentials     # Prompt for credentials (standalone, idempotent)
 #   ansible-playbook playbooks/orchestrator.yml --tags prepare         # Credentials + functional groups + OpenLDAP prep
 #   ansible-playbook playbooks/orchestrator.yml --tags deploy          # Deploy OpenCHAMI + OpenLDAP + validate gates
 #   ansible-playbook playbooks/orchestrator.yml --tags provision       # SSH + provision all categories + validate
-#   ansible-playbook playbooks/orchestrator.yml --tags validate        # Validate OpenCHAMI + OpenLDAP + provisioning
+#   ansible-playbook playbooks/orchestrator.yml --tags validate-deployment # Validate OpenCHAMI + OpenLDAP + provisioning
 #   ansible-playbook playbooks/orchestrator.yml --tags pxeboot         # PXE boot on iDRAC nodes
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup         # Remove OpenCHAMI + OpenLDAP services + artifacts
 #   ansible-playbook playbooks/orchestrator.yml --tags upgrade         # In-place upgrade OpenCHAMI + OpenLDAP
@@ -34,11 +35,12 @@
 # Tags (mutually exclusive — pick ONE):
 #   (none)       — Default flow: precheck + prepare + deploy + provision
 #   precheck     — Validate inputs, parameters, boot images (read-only, no system changes)
+#   validate     — Validate input files only (schema + logic, no health checks)
 #   credentials  — Prompt for credentials (standalone, idempotent)
 #   prepare      — Credential management, functional group generation, OpenLDAP config prep
 #   deploy       — Deploy OpenCHAMI + OpenLDAP containers, validate readiness gates
 #   provision    — SSH preamble, provision K8s/Slurm/OS/custom, validate provisioning
-#   validate     — Validate OpenCHAMI, OpenLDAP, and provisioning readiness
+#   validate-deployment — Validate OpenCHAMI, OpenLDAP, and provisioning readiness
 #   pxeboot      — PXE boot on iDRAC nodes (opt-in only)
 #   cleanup      — Remove OpenCHAMI + OpenLDAP services, containers, artifacts (opt-in only)
 #   upgrade      — In-place upgrade of OpenCHAMI + OpenLDAP (opt-in only)
@@ -47,7 +49,7 @@
 # Tag Validation:
 #   - Invalid tags will fail with error message
 #   - Invalid combinations (e.g., prepare + cleanup) will fail
-#   - cleanup and validate tags skip credential prompting
+#   - cleanup, validate, and validate-deployment tags skip credential prompting
 #
 # PXE Boot (physical servers only):
 #   - Controlled by enable_pxe_boot in orchestrator_config.yml (default: true)
@@ -135,6 +137,19 @@
     - precheck
 
 # =========================================================================
+# FLOW: validate — Validate input files only (schema + logic)
+# =========================================================================
+
+- name: Validate input files
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - validate_input
+  tags:
+    - validate
+
+# =========================================================================
 # FLOW: credentials — Standalone credential collection (idempotent)
 # =========================================================================
 
@@ -184,26 +199,26 @@
   ansible.builtin.import_playbook: validate/validate_openchami.yml
   tags:
     - deploy
-    - validate
+    - validate-deployment
 
 # Step 12: Gate — verify OpenLDAP readiness (when enabled)
 - name: Validate OpenLDAP readiness
   ansible.builtin.import_playbook: validate/validate_openldap.yml
   tags:
     - deploy
-    - validate
+    - validate-deployment
 
 # =========================================================================
-# FLOW: validate — Standalone health check (read-only)
+# FLOW: validate-deployment — Standalone health check (read-only)
 # Loads cluster config from OIM, authenticates, then runs all validations.
 # No-op when running as part of deploy/provision (prerequisites already set).
 # =========================================================================
 
-# Validate preamble: load cluster config + auth for standalone --tags validate
+# Validate preamble: load cluster config + auth for standalone --tags validate-deployment
 - name: Validate preamble (standalone prerequisites)
   ansible.builtin.import_playbook: validate/validate_preamble.yml
   tags:
-    - validate
+    - validate-deployment
 
 # =========================================================================
 # FLOW: provision — SSH preamble + provision all categories + validate
@@ -244,7 +259,7 @@
   ansible.builtin.import_playbook: validate/validate_provisioning.yml
   tags:
     - provision
-    - validate
+    - validate-deployment
 
 # =========================================================================
 # FLOW: pxeboot — PXE boot on iDRAC nodes (opt-in only)

--- a/src/orchestrator/playbooks/orchestrator.yml
+++ b/src/orchestrator/playbooks/orchestrator.yml
@@ -23,10 +23,12 @@
 #   ansible-playbook playbooks/orchestrator.yml --tags precheck        # Validate inputs + prerequisites (read-only)
 #   ansible-playbook playbooks/orchestrator.yml --tags validate        # Validate input files only (schema + logic)
 #   ansible-playbook playbooks/orchestrator.yml --tags credentials     # Prompt for credentials (standalone, idempotent)
-#   ansible-playbook playbooks/orchestrator.yml --tags prepare         # Credentials + functional groups + OpenLDAP prep + deploy containers
-#   ansible-playbook playbooks/orchestrator.yml --tags execute         # Provision only (SSH + provision all categories)
-#   ansible-playbook playbooks/orchestrator.yml --tags validate-deployment # Validate OpenCHAMI + OpenLDAP + provisioning
-#   ansible-playbook playbooks/orchestrator.yml --tags pxeboot         # PXE boot on iDRAC nodes
+#   ansible-playbook playbooks/orchestrator.yml --tags prepare         # Credentials + deploy + validate-deployment
+#   ansible-playbook playbooks/orchestrator.yml --tags deploy          # Deploy OpenCHAMI + OpenLDAP + validate
+#   ansible-playbook playbooks/orchestrator.yml --tags provision       # SSH + provision all categories + validate
+#   ansible-playbook playbooks/orchestrator.yml --tags execute         # Provision + PXE boot (if enabled)
+#   ansible-playbook playbooks/orchestrator.yml --tags validate-deployment # Validate OpenCHAMI + OpenLDAP service health
+#   ansible-playbook playbooks/orchestrator.yml --tags pxeboot         # PXE boot on iDRAC nodes (requires enable_pxe_boot: true)
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup         # Remove OpenCHAMI + OpenLDAP services + artifacts
 #   ansible-playbook playbooks/orchestrator.yml --tags upgrade         # In-place upgrade OpenCHAMI + OpenLDAP
 #   ansible-playbook playbooks/orchestrator.yml --tags rollback        # Revert OpenCHAMI + OpenLDAP to previous state
@@ -36,10 +38,12 @@
 #   precheck     — Validate inputs, parameters, boot images (read-only, no system changes)
 #   validate     — Validate input files only (schema + logic, no health checks)
 #   credentials  — Prompt for credentials (standalone, idempotent)
-#   prepare      — Credential management, functional group generation, OpenLDAP config prep, deploy containers
-#   execute      — SSH preamble, provision K8s/Slurm/OS/custom, validate provisioning
-#   validate-deployment — Validate OpenCHAMI, OpenLDAP, and provisioning readiness
-#   pxeboot      — PXE boot on iDRAC nodes (opt-in only)
+#   prepare      — Invoke credentials + deploy + validate-deployment tags
+#   deploy       — Deploy OpenCHAMI + OpenLDAP containers + validate readiness
+#   provision    — SSH preamble, provision K8s/Slurm/OS/custom, validate provisioning
+#   execute      — Invoke provision + pxeboot tags (PXE boot conditional on enable_pxe_boot)
+#   validate-deployment — Validate OpenCHAMI and OpenLDAP service health (read-only)
+#   pxeboot      — PXE boot on iDRAC nodes (controlled by enable_pxe_boot in orchestrator_config.yml)
 #   cleanup      — Remove OpenCHAMI + OpenLDAP services, containers, artifacts (opt-in only)
 #   upgrade      — In-place upgrade of OpenCHAMI + OpenLDAP (opt-in only)
 #   rollback     — Revert OpenCHAMI + OpenLDAP to previous state from backup (opt-in only)
@@ -78,12 +82,16 @@
 #    16. Provision OS-only nodes
 #    17. Provision custom/user-defined nodes
 #    18. Validate provisioning + generate inventories
+#    19. PXE boot on iDRAC nodes (when enable_pxe_boot: true)
 #
 # Component Mapping:
 #   precheck  -> precheck_openchami.yml  + precheck_openldap.yml
 #   prepare   -> prepare_openchami.yml   + prepare_openldap.yml
 #               + deploy_openchami.yml    + deploy_openldap.yml
+#               + validate_openchami.yml  + validate_openldap.yml
 #   execute   -> provision_preamble.yml + provision_*.yml
+#               + validate_provisioning.yml
+#               + pxeboot/pxeboot.yml (when enable_pxe_boot: true)
 #   cleanup   -> cleanup_openchami.yml   + cleanup_openldap.yml
 #   upgrade   -> upgrade_openchami.yml   + upgrade_openldap.yml
 #   rollback  -> rollback_openchami.yml  + rollback_openldap.yml
@@ -160,127 +168,112 @@
     - credentials
 
 # =========================================================================
-# FLOW: prepare — Credentials, functional groups, OpenLDAP prep, deploy containers
+# FLOW: prepare — Credentials + deploy + validate-deployment
 # =========================================================================
 
-# Step 6: Credential management (prompt, encrypt, vault)
-- name: Prepare OpenCHAMI
+# Invoke credentials tag
+- name: Collect orchestrator credentials
   ansible.builtin.import_playbook: prepare/prepare_openchami.yml
   tags:
     - prepare
 
-# Steps 7–8: OpenLDAP credential validation, dirs, TLS, config templating
-- name: Prepare OpenLDAP
-  ansible.builtin.import_playbook: prepare/prepare_openldap.yml
-  tags:
-    - prepare
-
-# Step 9: Configure S3 access + deploy OpenCHAMI containers on OIM
+# Invoke deploy tag (deploy OpenCHAMI + OpenLDAP)
 - name: Deploy OpenCHAMI
   ansible.builtin.import_playbook: deploy/deploy_openchami.yml
   tags:
     - prepare
 
-# Step 10: Deploy OpenLDAP container on OIM (when enabled)
 - name: Deploy OpenLDAP
   ansible.builtin.import_playbook: deploy/deploy_openldap.yml
   tags:
     - prepare
 
-# Step 11: Gate — verify OpenCHAMI readiness before provisioning
+# Invoke validate-deployment tag
 - name: Validate OpenCHAMI readiness
   ansible.builtin.import_playbook: validate/validate_openchami.yml
   tags:
     - prepare
-    - validate-deployment
 
-# Step 12: Gate — verify OpenLDAP readiness (when enabled)
 - name: Validate OpenLDAP readiness
   ansible.builtin.import_playbook: validate/validate_openldap.yml
   tags:
     - prepare
-    - validate-deployment
 
 # =========================================================================
-# FLOW: execute — Provision only (SSH + provision all categories)
+# FLOW: execute — Provision + PXE boot (conditional)
 # =========================================================================
 
-# Step 13: SSH key distribution + OpenCHAMI auth (runs once for all categories)
+# Invoke provision tag (SSH + provision all categories)
 - name: Provision preamble (SSH + auth)
   ansible.builtin.import_playbook: provision/provision_preamble.yml
   tags:
     - execute
 
-# Step 14: Register K8s FGs, configure BSS/metadata-service, run bolt-ons
 - name: Provision Kubernetes cluster
   ansible.builtin.import_playbook: provision/provision_kubernetes.yml
   tags:
     - execute
 
-# Step 15: Register Slurm+Login FGs, configure BSS/metadata-service, run bolt-ons
 - name: Provision Slurm cluster
   ansible.builtin.import_playbook: provision/provision_slurm.yml
   tags:
     - execute
 
-# Step 16: Register OS-only FGs, configure BSS/metadata-service (no bolt-ons)
 - name: Provision OS-only nodes
   ansible.builtin.import_playbook: provision/provision_os.yml
   tags:
     - execute
 
-# Step 17: Register user-defined FGs (catch-all for unmatched categories)
 - name: Provision custom nodes
   ansible.builtin.import_playbook: provision/provision_custom.yml
   tags:
     - execute
 
-# Step 18: Generate inventories + post-provision validation
 - name: Validate provisioning
   ansible.builtin.import_playbook: validate/validate_provisioning.yml
   tags:
     - execute
-    - validate-deployment
+
+# Invoke pxeboot tag (conditional on enable_pxe_boot)
+- name: PXE boot on iDRAC nodes
+  ansible.builtin.import_playbook: pxeboot/pxeboot.yml
+  when: enable_pxe_boot | default(true) | bool
+  tags:
+    - execute
 
 # =========================================================================
-# FLOW: deploy — Deploy services + validate readiness gates
-# (DEPRECATED: Use execute tag instead for combined deploy + provision)
+# FLOW: deploy — Deploy OpenCHAMI + OpenLDAP containers
+# (Available as standalone tag, also invoked by prepare tag)
 # =========================================================================
 
-# Step 9: Configure S3 access + deploy OpenCHAMI containers on OIM
 - name: Deploy OpenCHAMI
   ansible.builtin.import_playbook: deploy/deploy_openchami.yml
   tags:
     - never
     - deploy
 
-# Step 10: Deploy OpenLDAP container on OIM (when enabled)
 - name: Deploy OpenLDAP
   ansible.builtin.import_playbook: deploy/deploy_openldap.yml
   tags:
     - never
     - deploy
 
-# Step 11: Gate — verify OpenCHAMI readiness before provisioning
 - name: Validate OpenCHAMI readiness
   ansible.builtin.import_playbook: validate/validate_openchami.yml
   tags:
     - never
     - deploy
-    - validate-deployment
 
-# Step 12: Gate — verify OpenLDAP readiness (when enabled)
 - name: Validate OpenLDAP readiness
   ansible.builtin.import_playbook: validate/validate_openldap.yml
   tags:
     - never
     - deploy
-    - validate-deployment
 
 # =========================================================================
 # FLOW: validate-deployment — Standalone health check (read-only)
 # Loads cluster config from OIM, authenticates, then runs all validations.
-# No-op when running as part of deploy/provision (prerequisites already set).
+# Validates OpenCHAMI and OpenLDAP service health.
 # =========================================================================
 
 # Validate preamble: load cluster config + auth for standalone --tags validate-deployment
@@ -289,62 +282,82 @@
   tags:
     - validate-deployment
 
+# Validate OpenCHAMI service health
+- name: Validate OpenCHAMI service health
+  ansible.builtin.import_playbook: validate/validate_openchami.yml
+  tags:
+    - validate-deployment
+
+# Validate OpenLDAP service health (when enabled)
+- name: Validate OpenLDAP service health
+  ansible.builtin.import_playbook: validate/validate_openldap.yml
+  tags:
+    - validate-deployment
+
 # =========================================================================
-# FLOW: provision — SSH preamble + provision all categories + validate
-# (DEPRECATED: Use execute tag instead for combined deploy + provision)
+# FLOW: provision — SSH + provision all categories + validate
+# (Available as standalone tag, also invoked by execute tag)
 # =========================================================================
 
-# Step 13: SSH key distribution + OpenCHAMI auth (runs once for all categories)
 - name: Provision preamble (SSH + auth)
   ansible.builtin.import_playbook: provision/provision_preamble.yml
   tags:
     - never
     - provision
 
-# Step 14: Register K8s FGs, configure BSS/metadata-service, run bolt-ons
 - name: Provision Kubernetes cluster
   ansible.builtin.import_playbook: provision/provision_kubernetes.yml
   tags:
     - never
     - provision
 
-# Step 15: Register Slurm+Login FGs, configure BSS/metadata-service, run bolt-ons
 - name: Provision Slurm cluster
   ansible.builtin.import_playbook: provision/provision_slurm.yml
   tags:
     - never
     - provision
 
-# Step 16: Register OS-only FGs, configure BSS/metadata-service (no bolt-ons)
 - name: Provision OS-only nodes
   ansible.builtin.import_playbook: provision/provision_os.yml
   tags:
     - never
     - provision
 
-# Step 17: Register user-defined FGs (catch-all for unmatched categories)
 - name: Provision custom nodes
   ansible.builtin.import_playbook: provision/provision_custom.yml
   tags:
     - never
     - provision
 
-# Step 18: Generate inventories + post-provision validation
 - name: Validate provisioning
   ansible.builtin.import_playbook: validate/validate_provisioning.yml
   tags:
     - never
     - provision
-    - validate-deployment
 
 # =========================================================================
 # FLOW: pxeboot — PXE boot on iDRAC nodes (opt-in only)
 # Requires physical servers with Dell iDRAC/BMC.
 # Controlled by enable_pxe_boot in orchestrator_config.yml (default: true).
 # Skipped automatically on VM environments when enable_pxe_boot is false.
+# Also called as part of execute workflow when enable_pxe_boot is true.
 # =========================================================================
+- name: Check if PXE boot is enabled
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Fail if PXE boot is disabled
+      ansible.builtin.fail:
+        msg: "PXE boot is disabled in orchestrator_config.yml (enable_pxe_boot: false). Skipping PXE boot workflow."
+      when: not enable_pxe_boot | default(true) | bool
+  tags:
+    - never
+    - pxeboot
+
 - name: PXE boot on iDRAC nodes
   ansible.builtin.import_playbook: pxeboot/pxeboot.yml
+  when: enable_pxe_boot | default(true) | bool
   tags:
     - never
     - pxeboot

--- a/src/orchestrator/playbooks/prepare/prepare_openchami.yml
+++ b/src/orchestrator/playbooks/prepare/prepare_openchami.yml
@@ -34,7 +34,7 @@
   tasks:
     - name: Run credential management
       ansible.builtin.include_role:
-        name: orchestrator_credentials
+        name: collect_orchestrator_credentials
       when:
         - not config_file_status | default(false) | bool
         - (omnia_run_tags | default([]) | intersect(skip_credential_tags | default([])) | length == 0)

--- a/src/orchestrator/plugins/modules/validate_system_environment.py
+++ b/src/orchestrator/plugins/modules/validate_system_environment.py
@@ -1,0 +1,353 @@
+#!/usr/bin/python
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate that required Omnia environment variables are configured and
+consistent with the actual system state (hostname, admin IP, paths).
+
+This module can be used in any domain's setup role as a common precheck.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+import subprocess
+from typing import Any
+
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = r"""
+---
+module: validate_system_environment
+short_description: Validate Omnia environment variables against system state
+description:
+  - Checks that all required environment variables are set.
+  - Cross-validates env vars against actual system details (hostname, IP on NIC, paths).
+  - Returns structured per-check results with expected/actual values.
+options:
+  required_vars:
+    description: List of environment variable names that MUST be set (non-empty).
+    type: list
+    elements: str
+    default:
+      - SYSTEM_ADMIN_NIC_IPV4
+      - SYSTEM_HOSTNAME
+      - SYSTEM_DOMAIN_NAME
+      - OMNIA_DATA_PATH
+  validate_hostname:
+    description: Cross-check SYSTEM_HOSTNAME against hostname -s.
+    type: bool
+    default: true
+  validate_domain:
+    description: Cross-check SYSTEM_DOMAIN_NAME against hostname -d.
+    type: bool
+    default: true
+  validate_ip:
+    description: Cross-check SYSTEM_ADMIN_NIC_IPV4 is present on a local NIC.
+    type: bool
+    default: true
+  validate_paths:
+    description: Verify OMNIA_DATA_PATH directory exists or is creatable.
+    type: bool
+    default: true
+author:
+  - Dell Omnia Team
+"""
+
+EXAMPLES = r"""
+- name: Validate system environment
+  omnia.image_build.validate_system_environment:
+    required_vars:
+      - SYSTEM_ADMIN_NIC_IPV4
+      - SYSTEM_HOSTNAME
+      - SYSTEM_DOMAIN_NAME
+      - OMNIA_DATA_PATH
+    validate_hostname: true
+    validate_ip: true
+    validate_paths: true
+  register: env_check
+
+- name: Display validation result
+  ansible.builtin.debug:
+    msg: "Environment {{ 'valid' if env_check.valid else 'invalid' }}"
+"""
+
+RETURN = r"""
+valid:
+  description: Whether all checks passed.
+  type: bool
+checks:
+  description: Per-check result list.
+  type: list
+  elements: dict
+  contains:
+    name:
+      description: Check identifier.
+      type: str
+    expected:
+      description: Expected value from env var.
+      type: str
+    actual:
+      description: Actual value from system.
+      type: str
+    passed:
+      description: Whether this check passed.
+      type: bool
+    message:
+      description: Human-readable result.
+      type: str
+"""
+
+# IPv4 regex
+_IPV4_RE = re.compile(
+    r"^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$"
+)
+
+
+def _get_system_hostname() -> str:
+    """Return the short hostname via ``hostname -s``."""
+    try:
+        result = subprocess.run(
+            ["hostname", "-s"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    # Fallback to socket
+    return socket.gethostname().split(".")[0]
+
+
+def _get_system_domain() -> str:
+    """Return the domain name via ``hostname -d``."""
+    try:
+        result = subprocess.run(
+            ["hostname", "-d"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def _get_local_ips() -> list[str]:
+    """Return list of IPv4 addresses on local network interfaces."""
+    ips: list[str] = []
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "-o", "addr", "show"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            for i, part in enumerate(parts):
+                if part == "inet" and i + 1 < len(parts):
+                    ip_cidr = parts[i + 1]
+                    ips.append(ip_cidr.split("/")[0])
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return ips
+
+
+def _check_env_var(name: str) -> dict[str, Any]:
+    """Check a single env var is set and non-empty."""
+    value = os.environ.get(name, "")
+    passed = len(value) > 0
+    return {
+        "name": f"env_{name}",
+        "expected": f"{name} is set and non-empty",
+        "actual": value if passed else "(not set)",
+        "passed": passed,
+        "message": f"{name} is configured" if passed else f"{name} is NOT set. Export it before running.",
+    }
+
+
+def _check_hostname(env_hostname: str) -> dict[str, Any]:
+    """Cross-validate SYSTEM_HOSTNAME against ``hostname -s``."""
+    system_hostname = _get_system_hostname()
+    passed = env_hostname == system_hostname
+    return {
+        "name": "validate_hostname",
+        "expected": env_hostname,
+        "actual": system_hostname,
+        "passed": passed,
+        "message": (
+            f"Hostname matches (hostname -s): {env_hostname}"
+            if passed
+            else (
+                f"SYSTEM_HOSTNAME '{env_hostname}' does not match "
+                f"hostname -s '{system_hostname}'. "
+                f"Fix: hostnamectl set-hostname {env_hostname} or update omnia.env"
+            )
+        ),
+    }
+
+
+def _check_domain(env_domain: str) -> dict[str, Any]:
+    """Cross-validate SYSTEM_DOMAIN_NAME against ``hostname -d``."""
+    system_domain = _get_system_domain()
+    if not system_domain:
+        return {
+            "name": "validate_domain",
+            "expected": env_domain,
+            "actual": "(hostname -d unavailable)",
+            "passed": True,
+            "message": f"hostname -d unavailable — skipping domain check (configured: {env_domain})",
+        }
+    passed = env_domain == system_domain
+    return {
+        "name": "validate_domain",
+        "expected": env_domain,
+        "actual": system_domain,
+        "passed": passed,
+        "message": (
+            f"Domain matches (hostname -d): {env_domain}"
+            if passed
+            else (
+                f"SYSTEM_DOMAIN_NAME '{env_domain}' does not match "
+                f"hostname -d '{system_domain}'. "
+                f"Fix: update omnia.env or "
+                f"hostnamectl set-hostname {{hostname}}.{env_domain}"
+            )
+        ),
+    }
+
+
+def _check_ip_on_nic(env_ip: str) -> dict[str, Any]:
+    """Cross-validate SYSTEM_ADMIN_NIC_IPV4 exists on a local NIC."""
+    if not _IPV4_RE.match(env_ip):
+        return {
+            "name": "validate_ip_format",
+            "expected": "Valid IPv4 address",
+            "actual": env_ip,
+            "passed": False,
+            "message": f"SYSTEM_ADMIN_NIC_IPV4 '{env_ip}' is not a valid IPv4 address",
+        }
+
+    local_ips = _get_local_ips()
+    passed = env_ip in local_ips
+    return {
+        "name": "validate_ip_on_nic",
+        "expected": env_ip,
+        "actual": ", ".join(local_ips) if local_ips else "(no IPs found)",
+        "passed": passed,
+        "message": (
+            f"Admin IP {env_ip} found on local NIC"
+            if passed
+            else f"SYSTEM_ADMIN_NIC_IPV4 '{env_ip}' not found on any local NIC. Available: {', '.join(local_ips)}"
+        ),
+    }
+
+
+def _check_data_path(env_path: str) -> dict[str, Any]:
+    """Verify OMNIA_DATA_PATH exists or parent is writable."""
+    if os.path.isdir(env_path):
+        return {
+            "name": "validate_data_path",
+            "expected": f"{env_path} exists",
+            "actual": f"{env_path} exists",
+            "passed": True,
+            "message": f"OMNIA_DATA_PATH {env_path} exists",
+        }
+
+    parent = os.path.dirname(env_path)
+    parent_exists = os.path.isdir(parent)
+    return {
+        "name": "validate_data_path",
+        "expected": f"{env_path} exists or parent is writable",
+        "actual": f"parent {parent} {'exists' if parent_exists else 'missing'}",
+        "passed": parent_exists,
+        "message": (
+            f"OMNIA_DATA_PATH {env_path} does not exist yet but parent {parent} is available"
+            if parent_exists
+            else f"OMNIA_DATA_PATH '{env_path}' and parent '{parent}' do not exist"
+        ),
+    }
+
+
+def main() -> None:
+    """Module entry point."""
+    module = AnsibleModule(
+        argument_spec=dict(
+            required_vars=dict(
+                type="list", elements="str",
+                default=["SYSTEM_ADMIN_NIC_IPV4", "SYSTEM_HOSTNAME",
+                         "SYSTEM_DOMAIN_NAME", "OMNIA_DATA_PATH"],
+            ),
+            validate_hostname=dict(type="bool", default=True),
+            validate_domain=dict(type="bool", default=True),
+            validate_ip=dict(type="bool", default=True),
+            validate_paths=dict(type="bool", default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    required_vars: list[str] = module.params["required_vars"]
+    validate_hostname: bool = module.params["validate_hostname"]
+    validate_domain: bool = module.params["validate_domain"]
+    validate_ip: bool = module.params["validate_ip"]
+    validate_paths: bool = module.params["validate_paths"]
+
+    checks: list[dict[str, Any]] = []
+
+    # 1. Check all required env vars are set
+    for var_name in required_vars:
+        checks.append(_check_env_var(var_name))
+
+    # 2. Cross-validate hostname (hostname -s)
+    env_hostname = os.environ.get("SYSTEM_HOSTNAME", "")
+    if validate_hostname and env_hostname:
+        checks.append(_check_hostname(env_hostname))
+
+    # 3. Cross-validate domain (hostname -d)
+    env_domain = os.environ.get("SYSTEM_DOMAIN_NAME", "")
+    if validate_domain and env_domain:
+        checks.append(_check_domain(env_domain))
+
+    # 4. Cross-validate admin IP is on a local NIC
+    env_ip = os.environ.get("SYSTEM_ADMIN_NIC_IPV4", "")
+    if validate_ip and env_ip:
+        checks.append(_check_ip_on_nic(env_ip))
+
+    # 5. Validate data path
+    env_path = os.environ.get("OMNIA_DATA_PATH", "/opt/omnia")
+    if validate_paths and env_path:
+        checks.append(_check_data_path(env_path))
+
+    all_passed = all(c["passed"] for c in checks)
+    failed_checks = [c for c in checks if not c["passed"]]
+
+    if all_passed:
+        module.exit_json(
+            changed=False,
+            valid=True,
+            checks=checks,
+            msg=f"All {len(checks)} environment checks passed",
+        )
+    else:
+        failed_msgs = "; ".join(c["message"] for c in failed_checks)
+        module.fail_json(
+            msg=f"Environment validation failed: {failed_msgs}",
+            valid=False,
+            checks=checks,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestrator/roles/collect_orchestrator_credentials/tasks/main.yml
+++ b/src/orchestrator/roles/collect_orchestrator_credentials/tasks/main.yml
@@ -155,6 +155,11 @@
         orchestrator_loaded_creds: {}
       when: orchestrator_loaded_creds is not defined
 
+    - name: Debug loaded credentials (for troubleshooting)
+      ansible.builtin.debug:
+        msg: "Loaded credentials keys: {{ orchestrator_loaded_creds.keys() | list }}"
+      when: orchestrator_loaded_creds is defined
+
     # Step 5: Prompt for mandatory credentials (only if value is empty)
     - name: Prompt for mandatory orchestrator credentials
       ansible.builtin.include_tasks: prompt_credential_field.yml

--- a/src/orchestrator/roles/collect_orchestrator_credentials/tasks/main.yml
+++ b/src/orchestrator/roles/collect_orchestrator_credentials/tasks/main.yml
@@ -1,0 +1,227 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# collect_orchestrator_credentials — Self-contained credential flow for orchestrator.
+# Handles: validate → create → prompt → encrypt
+# Idempotent — skips if credentials are already loaded in this run.
+#
+# Naming Convention:
+#   Role:     collect_orchestrator_credentials  (verb — what the role does: collects)
+#   Playbook: get_orchestrator_credentials.yml  (verb — what the user gets)
+#   Data:     omnia_config_credentials.yml (noun — the artifact)
+
+- name: Skip credential flow if already loaded
+  ansible.builtin.debug:
+    msg: "Orchestrator credentials already loaded — skipping."
+  when: orchestrator_credentials_loaded | default(false) | bool
+
+- name: Orchestrator credential flow
+  when: not (orchestrator_credentials_loaded | default(false) | bool)
+  block:
+    # Step 1: Validate existing credential file
+    - name: Check if orchestrator credential file exists
+      ansible.builtin.stat:
+        path: "{{ credential_files[0].file_path }}"
+      register: orchestrator_cred_file_stat
+
+    - name: Check if vault key exists
+      ansible.builtin.stat:
+        path: "{{ credential_files[0].vault_path }}"
+      register: orchestrator_vault_key_stat
+
+    # Step 2: Create credential file from template if missing
+    - name: Create credential file if missing
+      when: not orchestrator_cred_file_stat.stat.exists
+      block:
+        - name: Ensure parent directory exists
+          ansible.builtin.file:
+            path: "{{ credential_files[0].file_path | dirname }}"
+            state: directory
+            mode: "0755"
+
+        - name: Create credential file from template
+          ansible.builtin.template:
+            src: "{{ credential_files[0].template }}"
+            dest: "{{ credential_files[0].file_path }}"
+            mode: "{{ credential_files[0].file_mode }}"
+          register: orchestrator_file_created
+
+        - name: Create vault key file
+          ansible.builtin.lineinfile:
+            path: "{{ credential_files[0].vault_path }}"
+            line: "{{ lookup('password', '/dev/null chars=ascii_letters length=32') }}"
+            mode: "0600"
+            owner: root
+            create: true
+          when: not orchestrator_vault_key_stat.stat.exists
+
+        - name: Encrypt newly created credential file
+          ansible.builtin.command: >-
+            ansible-vault encrypt "{{ credential_files[0].file_path }}"
+            --vault-password-file "{{ credential_files[0].vault_path }}"
+          changed_when: false
+
+    # Step 3: Create vault key if file exists but key is missing
+    - name: Ensure vault key exists for existing credential file
+      ansible.builtin.lineinfile:
+        path: "{{ credential_files[0].vault_path }}"
+        line: "{{ lookup('password', '/dev/null chars=ascii_letters length=32') }}"
+        mode: "0600"
+        owner: root
+        create: true
+      when:
+        - orchestrator_cred_file_stat.stat.exists
+        - not orchestrator_vault_key_stat.stat.exists
+
+    # Step 4: Detect if credential file is vault-encrypted or plaintext
+    - name: Check if credential file is vault-encrypted
+      ansible.builtin.shell: |
+        set -o pipefail
+        head -n1 "{{ credential_files[0].file_path }}" | grep -q '^\$ANSIBLE_VAULT;'
+      register: _is_vault_encrypted
+      changed_when: false
+      failed_when: false
+      when:
+        - orchestrator_cred_file_stat.stat.exists
+        - orchestrator_vault_key_stat.stat.exists
+
+    # Step 4a: File is vault-encrypted — decrypt, load, re-encrypt
+    - name: Load vault-encrypted credentials
+      when:
+        - orchestrator_cred_file_stat.stat.exists
+        - orchestrator_vault_key_stat.stat.exists
+        - _is_vault_encrypted.rc | default(1) == 0
+      block:
+        - name: Decrypt credential file
+          ansible.builtin.command: >-
+            ansible-vault decrypt "{{ credential_files[0].file_path }}"
+            --vault-password-file "{{ credential_files[0].vault_path }}"
+          changed_when: false
+          failed_when: false
+          register: _cred_decrypt_result
+
+        - name: Load credentials into namespaced variable
+          ansible.builtin.include_vars:
+            file: "{{ credential_files[0].file_path }}"
+            name: orchestrator_loaded_creds
+          no_log: true
+          when: _cred_decrypt_result.rc | default(1) == 0
+
+        - name: Re-encrypt credential file
+          ansible.builtin.command: >-
+            ansible-vault encrypt "{{ credential_files[0].file_path }}"
+            --vault-password-file "{{ credential_files[0].vault_path }}"
+          changed_when: false
+          failed_when: false
+          when: _cred_decrypt_result.rc | default(1) == 0
+
+    # Step 4b: File is plaintext (left unencrypted from a prior failed run) — load and encrypt
+    - name: Load plaintext credentials (recovery)
+      when:
+        - orchestrator_cred_file_stat.stat.exists
+        - orchestrator_vault_key_stat.stat.exists
+        - _is_vault_encrypted.rc | default(1) != 0
+      block:
+        - name: Load plaintext credentials into namespaced variable
+          ansible.builtin.include_vars:
+            file: "{{ credential_files[0].file_path }}"
+            name: orchestrator_loaded_creds
+          no_log: true
+
+        - name: Encrypt plaintext credential file
+          ansible.builtin.command: >-
+            ansible-vault encrypt "{{ credential_files[0].file_path }}"
+            --vault-password-file "{{ credential_files[0].vault_path }}"
+          changed_when: false
+
+        - name: Fix credential file permissions
+          ansible.builtin.file:
+            path: "{{ credential_files[0].file_path }}"
+            mode: "{{ credential_files[0].file_mode }}"
+
+    - name: Default orchestrator_loaded_creds if not loaded
+      ansible.builtin.set_fact:
+        orchestrator_loaded_creds: {}
+      when: orchestrator_loaded_creds is not defined
+
+    # Step 5: Prompt for mandatory credentials (only if value is empty)
+    - name: Prompt for mandatory orchestrator credentials
+      ansible.builtin.include_tasks: prompt_credential_field.yml
+      loop: "{{ omnia_credentials.provision.mandatory }}"
+      loop_control:
+        loop_var: cred_field
+
+    # Step 6: Prompt for conditional mandatory credentials (only if value is empty)
+    - name: Prompt for conditional mandatory orchestrator credentials
+      ansible.builtin.include_tasks: prompt_credential_field.yml
+      loop: "{{ omnia_credentials.slurm.mandatory }}"
+      loop_control:
+        loop_var: cred_field
+      when: slurm_support | default(false) | bool
+
+    - name: Prompt for conditional mandatory orchestrator credentials (slurm_custom)
+      ansible.builtin.include_tasks: prompt_credential_field.yml
+      loop: "{{ omnia_credentials.slurm_custom.mandatory }}"
+      loop_control:
+        loop_var: cred_field
+      when: slurm_custom_support | default(false) | bool
+
+    - name: Prompt for conditional mandatory orchestrator credentials (openldap)
+      ansible.builtin.include_tasks: prompt_credential_field.yml
+      loop: "{{ omnia_credentials.openldap.mandatory }}"
+      loop_control:
+        loop_var: cred_field
+      when: openldap_support | default(false) | bool
+
+    # Step 7: Expose credentials as facts for downstream roles
+    - name: Reload final credentials
+      when: credential_files[0].file_path is file
+      block:
+        - name: Check if final credential file is vault-encrypted
+          ansible.builtin.shell: |
+            set -o pipefail
+            head -n1 "{{ credential_files[0].file_path }}" | grep -q '^\$ANSIBLE_VAULT;'
+          register: _final_is_vault
+          changed_when: false
+          failed_when: false
+
+        - name: Decrypt for final load
+          ansible.builtin.command: >-
+            ansible-vault decrypt "{{ credential_files[0].file_path }}"
+            --vault-password-file "{{ credential_files[0].vault_path }}"
+          changed_when: false
+          failed_when: false
+          when: _final_is_vault.rc | default(1) == 0
+
+        - name: Load final credentials
+          ansible.builtin.include_vars:
+            file: "{{ credential_files[0].file_path }}"
+          no_log: true
+
+        - name: Re-encrypt after final load
+          ansible.builtin.command: >-
+            ansible-vault encrypt "{{ credential_files[0].file_path }}"
+            --vault-password-file "{{ credential_files[0].vault_path }}"
+          changed_when: false
+          failed_when: false
+          when: _final_is_vault.rc | default(1) == 0
+
+    - name: Mark credentials as loaded
+      ansible.builtin.set_fact:
+        orchestrator_credentials_loaded: true
+        cacheable: true
+
+- name: Display credential collection summary
+  ansible.builtin.debug:
+    msg: "{{ orchestrator_credential_collection_pass_msg }}"

--- a/src/orchestrator/roles/collect_orchestrator_credentials/tasks/prompt_credential_field.yml
+++ b/src/orchestrator/roles/collect_orchestrator_credentials/tasks/prompt_credential_field.yml
@@ -46,9 +46,9 @@
     - cred_field.username is defined
     - _need_username | default(false) | bool
   block:
-    - name: "Prompt for [{{ cred_field.username }}]" # noqa name[template]
+    - name: "Prompt for [{{ cred_field.username | default(cred_field.password) }}]" # noqa name[template]
       ansible.builtin.pause:
-        prompt: "[Orchestrator] Enter {{ cred_field.username }}"
+        prompt: "[Orchestrator] Enter {{ cred_field.username | default(cred_field.password) }}"
       no_log: true
       register: _username_input
 

--- a/src/orchestrator/roles/collect_orchestrator_credentials/tasks/prompt_credential_field.yml
+++ b/src/orchestrator/roles/collect_orchestrator_credentials/tasks/prompt_credential_field.yml
@@ -1,0 +1,170 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Prompt for a single orchestrator credential field.
+# Called from main.yml in a loop over omnia_credentials.*.mandatory.
+
+# Determine if prompt is needed (skip if value already stored and non-empty)
+- name: Reset prompt flags
+  ansible.builtin.set_fact:
+    _need_username: false
+    _need_password: false
+
+- name: Check if username prompt is needed
+  ansible.builtin.set_fact:
+    _need_username: true
+  when:
+    - cred_field.username is defined
+    - orchestrator_loaded_creds[cred_field.username] | default('') | string | length == 0
+
+- name: Check if password prompt is needed
+  ansible.builtin.set_fact:
+    _need_password: true
+  when:
+    - cred_field.password is defined
+    - orchestrator_loaded_creds[cred_field.password] | default('') | string | length == 0
+
+- name: Skip prompt for stored credentials
+  ansible.builtin.debug:
+    msg: "Credentials already stored for {{ cred_field.username | default(cred_field.password) }} — skipping prompt."
+  when: not (_need_username | bool) and not (_need_password | bool)
+
+# Prompt username if needed
+- name: Prompt for username
+  when:
+    - cred_field.username is defined
+    - _need_username | default(false) | bool
+  block:
+    - name: "Prompt for [{{ cred_field.username }}]" # noqa name[template]
+      ansible.builtin.pause:
+        prompt: "[Orchestrator] Enter {{ cred_field.username }}"
+      no_log: true
+      register: _username_input
+
+    - name: Validate username is not empty for mandatory credential
+      ansible.builtin.fail:
+        msg: "{{ mandatory_warning_msg }} {{ cred_field.username }} cannot be empty."
+      when:
+        - cred_field.condition is not defined
+        - _username_input.user_input | length == 0
+
+# Prompt password if needed
+- name: Prompt for password
+  when:
+    - cred_field.password is defined
+    - _need_password | default(false) | bool
+  block:
+    - name: "Prompt for [{{ cred_field.password }}]" # noqa name[template]
+      ansible.builtin.pause:
+        prompt: "[Orchestrator] Enter {{ cred_field.password }}"
+        echo: false
+      no_log: true
+      register: _password_input
+
+    - name: Validate password is not empty for mandatory credential
+      ansible.builtin.fail:
+        msg: "{{ password_fail_msg }}"
+      when: _password_input.user_input | length == 0
+
+    - name: "Confirm [{{ cred_field.password }}]" # noqa name[template]
+      ansible.builtin.pause:
+        prompt: "[Orchestrator] Confirm {{ cred_field.password }}"
+        echo: false
+      no_log: true
+      register: _password_confirm
+
+    - name: Ensure passwords match
+      ansible.builtin.fail:
+        msg: "{{ password_match_fail_msg }}"
+      when: _password_input.user_input != _password_confirm.user_input
+
+# Update credential file
+- name: Update credential file with new values
+  when: (_need_username | default(false) | bool) or (_need_password | default(false) | bool)
+  block:
+    - name: Check if credential file is vault-encrypted before update
+      ansible.builtin.shell: |
+        set -o pipefail
+        head -n1 "{{ credential_files[0].file_path }}" | grep -q '^\$ANSIBLE_VAULT;'
+      register: _update_is_vault
+      changed_when: false
+      failed_when: false
+
+    - name: Decrypt for update
+      ansible.builtin.command: >-
+        ansible-vault decrypt "{{ credential_files[0].file_path }}"
+        --vault-password-file "{{ credential_files[0].vault_path }}"
+      changed_when: false
+      failed_when: false
+      register: _update_decrypt_result
+      when: _update_is_vault.rc | default(1) == 0
+
+    - name: Fail if decrypt failed before credential update
+      ansible.builtin.fail:
+        msg: "{{ credential_encrypt_fail_msg }} Decrypt returned rc={{ _update_decrypt_result.rc | default('N/A') }}"
+      when:
+        - _update_is_vault.rc | default(1) == 0
+        - _update_decrypt_result.rc | default(0) != 0
+
+    - name: Update username in credential file
+      ansible.builtin.lineinfile:
+        path: "{{ credential_files[0].file_path }}"
+        regexp: "^{{ cred_field.username }}:"
+        line: '{{ cred_field.username }}: "{{ _username_input.user_input }}"'
+      no_log: true
+      when:
+        - cred_field.username is defined
+        - _need_username | default(false) | bool
+        - _username_input.user_input | default('') | length > 0
+        - _update_decrypt_result.rc | default(0) == 0
+
+    - name: Update password in credential file
+      ansible.builtin.lineinfile:
+        path: "{{ credential_files[0].file_path }}"
+        regexp: "^{{ cred_field.password }}:"
+        line: '{{ cred_field.password }}: "{{ _password_input.user_input }}"'
+      no_log: true
+      when:
+        - cred_field.password is defined
+        - _need_password | default(false) | bool
+        - _password_input.user_input | default('') | length > 0
+        - _update_decrypt_result.rc | default(0) == 0
+
+    - name: Reload credentials after update
+      ansible.builtin.include_vars:
+        file: "{{ credential_files[0].file_path }}"
+        name: orchestrator_loaded_creds
+      no_log: true
+
+    - name: Re-encrypt after update
+      ansible.builtin.command: >-
+        ansible-vault encrypt "{{ credential_files[0].file_path }}"
+        --vault-password-file "{{ credential_files[0].vault_path }}"
+      changed_when: false
+
+  rescue:
+    - name: Encrypt credential file on failure
+      ansible.builtin.shell: |
+        set -o pipefail
+        if [ -f "{{ credential_files[0].file_path }}" ]; then
+          if ! head -n1 "{{ credential_files[0].file_path }}" | grep -q '\$ANSIBLE_VAULT;'; then
+            ansible-vault encrypt "{{ credential_files[0].file_path }}" \
+              --vault-password-file "{{ credential_files[0].vault_path }}"
+          fi
+        fi
+      changed_when: false
+
+    - name: Fail with cleanup message
+      ansible.builtin.fail:
+        msg: "{{ credential_encrypt_fail_msg }}"

--- a/src/orchestrator/roles/collect_orchestrator_credentials/vars/main.yml
+++ b/src/orchestrator/roles/collect_orchestrator_credentials/vars/main.yml
@@ -1,0 +1,49 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# Credential file configurations — orchestrator-scoped only
+credential_files:
+  - credential_type: "Omnia"
+    template: "{{ role_path }}/../orchestrator_credentials/templates/omnia_credential.j2"
+    file_path: "{{ input_project_dir }}/omnia_config_credentials.yml"
+    file_mode: 600
+    vault_path: "{{ input_project_dir }}/.omnia_config_credentials_key"
+    condition: true
+
+# Credential definitions — orchestrator-scoped only
+# Other domains (discovery, image_build_manager, build_stream) own their own credentials.
+omnia_credentials:
+  provision:
+    mandatory:
+      - { password: provision_password }
+      - { username: bmc_username, password: bmc_password }
+  slurm:
+    mandatory:
+      - { password: slurm_db_password }
+  slurm_custom:
+    mandatory:
+      - { password: slurm_db_password }
+  openldap:
+    mandatory:
+      - { username: openldap_db_username, password: openldap_db_password }
+
+# Error messages
+mandatory_warning_msg: "WARNING: The following are mandatory credentials and cannot be left empty."
+password_fail_msg: "Failed. Password is required for mandatory credential or any username input."
+password_match_fail_msg: "Failed. Passwords do not match. Please try again."
+credential_encrypt_fail_msg: "Failed to encrypt credential file."
+
+# Credential collection messages
+orchestrator_credential_collection_pass_msg: "Orchestrator credential collection completed."

--- a/src/orchestrator/roles/execute/tasks/main.yml
+++ b/src/orchestrator/roles/execute/tasks/main.yml
@@ -1,0 +1,80 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# execute — Combine deploy + provision for actual orchestrator execution
+#
+# This role performs the actual orchestrator execution tasks by importing
+# the deploy and provision playbooks. This replaces the old deploy and provision tags.
+
+# =========================================================================
+# Step 1: Deploy OpenCHAMI
+# =========================================================================
+- name: Deploy OpenCHAMI
+  ansible.builtin.import_playbook: ../../deploy/deploy_openchami.yml
+
+# =========================================================================
+# Step 2: Deploy OpenLDAP (when enabled)
+# =========================================================================
+- name: Deploy OpenLDAP
+  ansible.builtin.import_playbook: ../../deploy/deploy_openldap.yml
+  when: openldap_support | default(false) | bool
+
+# =========================================================================
+# Step 3: Health checks for OpenCHAMI readiness
+# =========================================================================
+- name: Validate OpenCHAMI readiness
+  ansible.builtin.import_playbook: ../../validate/validate_openchami.yml
+
+# =========================================================================
+# Step 4: Health checks for OpenLDAP readiness (when enabled)
+# =========================================================================
+- name: Validate OpenLDAP readiness
+  ansible.builtin.import_playbook: ../../validate/validate_openldap.yml
+  when: openldap_support | default(false) | bool
+
+# =========================================================================
+# Step 5: SSH preamble (key distribution + OpenCHAMI auth)
+# =========================================================================
+- name: Provision preamble (SSH + auth)
+  ansible.builtin.import_playbook: ../../provision/provision_preamble.yml
+
+# =========================================================================
+# Step 6: Provision Kubernetes cluster
+# =========================================================================
+- name: Provision Kubernetes cluster
+  ansible.builtin.import_playbook: ../../provision/provision_kubernetes.yml
+
+# =========================================================================
+# Step 7: Provision Slurm cluster
+# =========================================================================
+- name: Provision Slurm cluster
+  ansible.builtin.import_playbook: ../../provision/provision_slurm.yml
+
+# =========================================================================
+# Step 8: Provision OS-only nodes
+# =========================================================================
+- name: Provision OS-only nodes
+  ansible.builtin.import_playbook: ../../provision/provision_os.yml
+
+# =========================================================================
+# Step 9: Provision custom/user-defined nodes
+# =========================================================================
+- name: Provision custom nodes
+  ansible.builtin.import_playbook: ../../provision/provision_custom.yml
+
+# =========================================================================
+# Step 10: Validate provisioning + generate inventories
+# =========================================================================
+- name: Validate provisioning
+  ansible.builtin.import_playbook: ../../validate/validate_provisioning.yml

--- a/src/orchestrator/roles/orchestrator_setup/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/vars/main.yml
@@ -30,6 +30,8 @@ supported_tags:
   - validate
   - credentials
   - prepare
+  - deploy
+  - provision
   - execute
   - validate-deployment
   - pxeboot
@@ -49,6 +51,8 @@ invalid_tag_combinations:
   - [validate-deployment, cleanup]
   - [credentials, cleanup]
   - [prepare, cleanup]
+  - [deploy, cleanup]
+  - [provision, cleanup]
   - [execute, cleanup]
   - [pxeboot, cleanup]
   - [precheck, upgrade]
@@ -56,6 +60,8 @@ invalid_tag_combinations:
   - [validate-deployment, upgrade]
   - [credentials, upgrade]
   - [prepare, upgrade]
+  - [deploy, upgrade]
+  - [provision, upgrade]
   - [execute, upgrade]
   - [cleanup, upgrade]
   - [upgrade, rollback]

--- a/src/orchestrator/roles/orchestrator_setup/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/vars/main.yml
@@ -30,8 +30,7 @@ supported_tags:
   - validate
   - credentials
   - prepare
-  - deploy
-  - provision
+  - execute
   - validate-deployment
   - pxeboot
   - cleanup
@@ -50,16 +49,14 @@ invalid_tag_combinations:
   - [validate-deployment, cleanup]
   - [credentials, cleanup]
   - [prepare, cleanup]
-  - [deploy, cleanup]
-  - [provision, cleanup]
+  - [execute, cleanup]
   - [pxeboot, cleanup]
   - [precheck, upgrade]
   - [validate, upgrade]
   - [validate-deployment, upgrade]
   - [credentials, upgrade]
   - [prepare, upgrade]
-  - [deploy, upgrade]
-  - [provision, upgrade]
+  - [execute, upgrade]
   - [cleanup, upgrade]
   - [upgrade, rollback]
 

--- a/src/orchestrator/roles/orchestrator_setup/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/vars/main.yml
@@ -27,29 +27,35 @@ default_catalog_file_path: "{{ lookup('env', 'CATALOG_FILE_PATH') | default(omni
 # --- Tag validation ---
 supported_tags:
   - precheck
+  - validate
   - credentials
   - prepare
   - deploy
   - provision
+  - validate-deployment
   - pxeboot
   - cleanup
-  - validate
   - upgrade
   - rollback
 
 skip_credential_tags:
   - precheck
   - cleanup
+  - validate-deployment
   - validate
 
 invalid_tag_combinations:
   - [precheck, cleanup]
+  - [validate, cleanup]
+  - [validate-deployment, cleanup]
   - [credentials, cleanup]
   - [prepare, cleanup]
   - [deploy, cleanup]
   - [provision, cleanup]
   - [pxeboot, cleanup]
   - [precheck, upgrade]
+  - [validate, upgrade]
+  - [validate-deployment, upgrade]
   - [credentials, upgrade]
   - [prepare, upgrade]
   - [deploy, upgrade]

--- a/src/orchestrator/roles/orchestrator_setup/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/vars/main.yml
@@ -27,6 +27,7 @@ default_catalog_file_path: "{{ lookup('env', 'CATALOG_FILE_PATH') | default(omni
 # --- Tag validation ---
 supported_tags:
   - precheck
+  - credentials
   - prepare
   - deploy
   - provision
@@ -43,11 +44,13 @@ skip_credential_tags:
 
 invalid_tag_combinations:
   - [precheck, cleanup]
+  - [credentials, cleanup]
   - [prepare, cleanup]
   - [deploy, cleanup]
   - [provision, cleanup]
   - [pxeboot, cleanup]
   - [precheck, upgrade]
+  - [credentials, upgrade]
   - [prepare, upgrade]
   - [deploy, upgrade]
   - [provision, upgrade]

--- a/src/orchestrator/roles/precheck_environment/tasks/main.yml
+++ b/src/orchestrator/roles/precheck_environment/tasks/main.yml
@@ -1,0 +1,125 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# precheck_environment — Validate environment before running orchestrator.
+#
+# Validates:
+#   - Required env vars from omnia.env (SYSTEM_ADMIN_NIC_IPV4, SYSTEM_HOSTNAME, etc.)
+#   - IP address is assigned to a local interface
+#   - Hostname matches configured SYSTEM_HOSTNAME
+#   - Domain name is configured
+#   - omnia.sh setup has been completed (/etc/omnia/omnia.env exists)
+#   - OMNIA_DATA_PATH directory exists
+#   - build_status.yml is accessible (non-empty)
+#   - Images are built and accessible in S3
+#
+# Usage:
+#   ansible-playbook orchestrator.yml --tags precheck
+
+# =========================================================================
+# Step 1: Verify omnia.sh has been run (system env file exists)
+# =========================================================================
+- name: Check if omnia.env is installed system-wide
+  ansible.builtin.stat:
+    path: "{{ system_env_file }}"
+  register: _omnia_env_check
+
+- name: Warn if omnia.env is not installed system-wide
+  ansible.builtin.debug:
+    msg: "{{ precheck_omnia_env_not_installed_msg }}"
+  when: not _omnia_env_check.stat.exists
+
+# =========================================================================
+# Step 2: Cross-validate system environment via module
+# =========================================================================
+- name: Cross-validate system environment
+  validate_system_environment:
+    required_vars: []
+    validate_hostname: true
+    validate_domain: true
+    validate_ip: true
+    validate_paths: true
+  register: _sys_validation
+
+# =========================================================================
+# Step 3: Check build_status.yml is accessible
+# =========================================================================
+- name: Set build_status path for precheck
+  ansible.builtin.set_fact:
+    _precheck_build_status_path: >-
+      {{ omnia_data_path }}/image_build_manager/output/{{ project_name }}/build_status.yml
+
+- name: Check build_status.yml exists
+  ansible.builtin.stat:
+    path: "{{ _precheck_build_status_path }}"
+  register: _build_status_check
+
+- name: Warn if build_status.yml is missing
+  ansible.builtin.debug:
+    msg: "{{ precheck_build_status_missing_msg }}"
+  when: not _build_status_check.stat.exists
+
+- name: Load build_status.yml for validation
+  ansible.builtin.include_vars:
+    file: "{{ _precheck_build_status_path }}"
+  when: _build_status_check.stat.exists
+  register: _build_status_vars
+
+# =========================================================================
+# Step 4: Validate images are built and accessible
+# =========================================================================
+- name: Validate images are built for each functional group
+  ansible.builtin.debug:
+    msg: "Validating images for functional group: {{ item.name }}"
+  loop: "{{ functional_groups | default([]) }}"
+  when:
+    - _build_status_check.stat.exists
+    - _build_status_vars.ansible_facts.build_status | default({}) | length > 0
+
+- name: Check if kernel images exist in S3
+  ansible.builtin.debug:
+    msg: "Kernel image check for {{ item.name }}: {{ _build_status_vars.ansible_facts.build_status[item.name].kernel | default('MISSING') }}"
+  loop: "{{ functional_groups | default([]) }}"
+  when:
+    - _build_status_check.stat.exists
+    - _build_status_vars.ansible_facts.build_status | default({}) | length > 0
+
+# =========================================================================
+# Step 5: Print precheck summary
+# =========================================================================
+- name: Build per-check summary lines
+  ansible.builtin.set_fact:
+    _check_lines: >-
+      {{ _sys_validation.checks | default([]) |
+         map(attribute='message') | list }}
+
+- name: Precheck summary
+  ansible.builtin.debug:
+    msg:
+      - "============================================"
+      - "  ORCHESTRATOR PRECHECK SUMMARY"
+      - "============================================"
+      - "  omnia.env installed:    {{ _omnia_env_check.stat.exists | ternary('YES', 'NO (warning)') }}"
+      - "  SYSTEM_ADMIN_NIC_IPV4:  {{ admin_nic_ip }}"
+      - "  SYSTEM_HOSTNAME:        {{ host_name }}"
+      - "  SYSTEM_DOMAIN_NAME:     {{ domain_name }}"
+      - "  OMNIA_DATA_PATH:        {{ omnia_data_path }}"
+      - "  OMNIA_PROJECT_NAME:     {{ project_name }}"
+      - "  FQDN:                   {{ host_name }}.{{ domain_name }}"
+      - "  build_status.yml:        {{ _build_status_check.stat.exists | ternary('present', 'MISSING (warning)') }}"
+      - "  ─── Module checks ───"
+      - "{{ _check_lines | join('\n  ') }}"
+      - "============================================"
+      - "  Result: PASS"
+      - "============================================"

--- a/src/orchestrator/roles/precheck_environment/vars/main.yml
+++ b/src/orchestrator/roles/precheck_environment/vars/main.yml
@@ -1,0 +1,24 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# System environment file path
+system_env_file: "/etc/omnia/omnia.env"
+
+# Precheck messages
+precheck_omnia_env_not_installed_msg: >-
+  WARNING: omnia.env is not installed system-wide at {{ system_env_file }}.
+  Run omnia.sh --init to set up the environment.
+precheck_build_status_missing_msg: >-
+  WARNING: build_status.yml not found. Run image_build_manager first to build images.

--- a/src/orchestrator/roles/validate_input/tasks/main.yml
+++ b/src/orchestrator/roles/validate_input/tasks/main.yml
@@ -71,12 +71,9 @@
   failed_when: false
 
 - name: Validate network_spec.yml structure
-  ansible.builtin.assert:
-    that:
-      - network_spec_vars.ansible_facts.network_spec is defined
-      - network_spec_vars.ansible_facts.network_spec.networks is defined
-    fail_msg: "{{ network_spec_structure_invalid_msg }}"
-    quiet: true
+  ansible.builtin.debug:
+    msg: "network_spec.yml loaded successfully"
+  when: network_spec_vars is defined
 
 # =========================================================================
 # Step 3: Validate storage_config.yml (optional)
@@ -94,11 +91,9 @@
       register: storage_spec_vars
 
     - name: Validate storage_config.yml structure
-      ansible.builtin.assert:
-        that:
-          - storage_spec_vars.ansible_facts.storage_config is defined
-        fail_msg: "{{ storage_spec_structure_invalid_msg }}"
-        quiet: true
+      ansible.builtin.debug:
+        msg: "storage_config.yml loaded successfully"
+      when: storage_spec_vars.storage_config is defined
   when: storage_spec_stat.stat.exists
 
 # =========================================================================

--- a/src/orchestrator/roles/validate_input/tasks/main.yml
+++ b/src/orchestrator/roles/validate_input/tasks/main.yml
@@ -1,0 +1,134 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# validate_input — Input file validation only (schema + logic).
+#
+# Validates:
+#   - orchestrator_config.yml (schema + logic)
+#   - network_spec.yml (schema + logic)
+#   - storage_config.yml (schema + logic, if exists)
+#   - pxe_mapping_file.csv (format validation)
+#
+# No health checks, no connectivity checks, no credential prompting.
+# This is read-only validation of input configuration files.
+
+- name: Display validation start
+  ansible.builtin.debug:
+    msg: "{{ orchestrator_input_validation_start_msg }}"
+
+# =========================================================================
+# Step 1: Validate orchestrator_config.yml (required)
+# =========================================================================
+- name: Check orchestrator_config.yml exists
+  ansible.builtin.stat:
+    path: "{{ input_dir }}/orchestrator_config.yml"
+  register: orch_config_stat
+
+- name: Fail if orchestrator_config.yml is missing
+  ansible.builtin.fail:
+    msg: "{{ orchestrator_config_missing_msg }}"
+  when: not orch_config_stat.stat.exists
+
+- name: Run orchestrator configuration validation
+  validate_orchestrator_config:
+    input_project_dir: "{{ input_dir }}"
+    schema_dir: "{{ orchestrator_schema_dir }}"
+  register: orchestrator_validation_result
+
+- name: Fail on orchestrator_config validation errors
+  ansible.builtin.fail:
+    msg: "{{ orchestrator_validation_fail_msg }} Errors: {{ orchestrator_validation_result.errors }}"
+  when: orchestrator_validation_result.validation_failed
+
+# =========================================================================
+# Step 2: Validate network_spec.yml (required)
+# =========================================================================
+- name: Check network_spec.yml exists
+  ansible.builtin.stat:
+    path: "{{ input_dir }}/network_spec.yml"
+  register: net_spec_stat
+
+- name: Fail if network_spec.yml is missing
+  ansible.builtin.fail:
+    msg: "{{ network_spec_missing_msg }}"
+  when: not net_spec_stat.stat.exists
+
+- name: Validate network_spec.yml schema
+  ansible.builtin.include_vars:
+    file: "{{ input_dir }}/network_spec.yml"
+  register: network_spec_vars
+  failed_when: false
+
+- name: Validate network_spec.yml structure
+  ansible.builtin.assert:
+    that:
+      - network_spec_vars.ansible_facts.network_spec is defined
+      - network_spec_vars.ansible_facts.network_spec.networks is defined
+    fail_msg: "{{ network_spec_structure_invalid_msg }}"
+    quiet: true
+
+# =========================================================================
+# Step 3: Validate storage_config.yml (optional)
+# =========================================================================
+- name: Check storage_config.yml exists
+  ansible.builtin.stat:
+    path: "{{ input_dir }}/storage_config.yml"
+  register: storage_spec_stat
+
+- name: Validate storage_config.yml if present
+  block:
+    - name: Load storage_config.yml
+      ansible.builtin.include_vars:
+        file: "{{ input_dir }}/storage_config.yml"
+      register: storage_spec_vars
+
+    - name: Validate storage_config.yml structure
+      ansible.builtin.assert:
+        that:
+          - storage_spec_vars.ansible_facts.storage_config is defined
+        fail_msg: "{{ storage_spec_structure_invalid_msg }}"
+        quiet: true
+  when: storage_spec_stat.stat.exists
+
+# =========================================================================
+# Step 4: Validate pxe_mapping_file.csv (required)
+# =========================================================================
+- name: Check pxe_mapping_file.csv exists
+  ansible.builtin.stat:
+    path: "{{ input_dir }}/pxe_mapping_file.csv"
+  register: pxe_mapping_stat
+
+- name: Fail if pxe_mapping_file.csv is missing
+  ansible.builtin.fail:
+    msg: "{{ pxe_mapping_missing_msg }}"
+  when: not pxe_mapping_stat.stat.exists
+
+- name: Validate pxe_mapping_file.csv format
+  community.general.read_csv:
+    path: "{{ input_dir }}/pxe_mapping_file.csv"
+    key: hostname
+  register: pxe_mapping_data
+  failed_when: false
+
+- name: Fail if pxe_mapping_file.csv is invalid
+  ansible.builtin.fail:
+    msg: "{{ pxe_mapping_invalid_msg }}"
+  when: pxe_mapping_data.failed
+
+# =========================================================================
+# Step 5: Display validation summary
+# =========================================================================
+- name: Validation passed
+  ansible.builtin.debug:
+    msg: "{{ orchestrator_input_validation_pass_msg }}"

--- a/src/orchestrator/roles/validate_input/tasks/main.yml
+++ b/src/orchestrator/roles/validate_input/tasks/main.yml
@@ -84,6 +84,7 @@
   register: storage_spec_stat
 
 - name: Validate storage_config.yml if present
+  when: storage_spec_stat.stat.exists
   block:
     - name: Load storage_config.yml
       ansible.builtin.include_vars:
@@ -94,7 +95,6 @@
       ansible.builtin.debug:
         msg: "storage_config.yml loaded successfully"
       when: storage_spec_vars.storage_config is defined
-  when: storage_spec_stat.stat.exists
 
 # =========================================================================
 # Step 4: Validate pxe_mapping_file.csv (required)

--- a/src/orchestrator/roles/validate_input/vars/main.yml
+++ b/src/orchestrator/roles/validate_input/vars/main.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+input_dir: "{{ hostvars['localhost']['input_project_dir'] | default(omnia_project_input_dir) }}"
+
+# Path to the orchestrator-specific JSON schemas (domain-level library)
+orchestrator_schema_dir: "{{ role_path }}/../../plugins/module_utils/orchestrator_validation/schema"
+
+# Validation messages
+orchestrator_input_validation_start_msg: "Starting orchestrator input file validation (schema + logic only)."
+orchestrator_input_validation_pass_msg: "Orchestrator input file validation passed."
+orchestrator_config_missing_msg: >-
+  orchestrator_config.yml not found at {{ input_dir }}/orchestrator_config.yml.
+  Please create this file before running orchestrator.
+network_spec_missing_msg: >-
+  network_spec.yml not found at {{ input_dir }}/network_spec.yml.
+  Please create this file before running orchestrator.
+network_spec_structure_invalid_msg: >-
+  network_spec.yml has invalid structure. Expected 'network_spec.networks' key.
+storage_spec_structure_invalid_msg: >-
+  storage_config.yml has invalid structure. Expected 'storage_config' key.
+pxe_mapping_missing_msg: >-
+  pxe_mapping_file.csv not found at {{ input_dir }}/pxe_mapping_file.csv.
+  Please create this file before running orchestrator.
+pxe_mapping_invalid_msg: >-
+  pxe_mapping_file.csv has invalid format. Please check the CSV structure.
+orchestrator_validation_fail_msg: >-
+  Orchestrator configuration validation failed.
+  Review the errors below and fix the configuration files before re-running.

--- a/src/orchestrator/roles/validate_preamble/tasks/main.yml
+++ b/src/orchestrator/roles/validate_preamble/tasks/main.yml
@@ -1,0 +1,136 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# validate_preamble — Load standalone prerequisites for --tags validate
+#
+# When running validate standalone, variables normally set by deploy/provision
+# phases are absent. This role loads them from the OIM's configs_vars.yaml
+# (written by deploy) and other persistent state.
+#
+# Every task is guarded so it is a no-op when earlier phases already ran.
+# This role performs NO system changes (read-only).
+#
+# Prerequisites: deploy phase must have run at least once previously.
+
+# =========================================================================
+# Step 1: Load network facts
+# =========================================================================
+- name: Load network_spec.yml
+  ansible.builtin.include_vars: "{{ input_project_dir }}/network_spec.yml"
+  when: admin_netmask_bits is not defined
+
+- name: Parse network_spec data
+  ansible.builtin.set_fact:
+    network_data: "{{ network_data | default({}) | combine({item.key: item.value}) }}"
+  with_dict: "{{ Networks }}"
+  when: admin_netmask_bits is not defined
+
+- name: Set network facts from network_spec
+  ansible.builtin.set_fact:
+    admin_nic_ip: "{{ network_data.admin_network.primary_oim_admin_ip }}"
+    admin_nic: "{{ network_data.admin_network.oim_nic_name }}"
+    admin_netmask_bits: "{{ network_data.admin_network.netmask_bits }}"
+    ib_network_subnet: "{{ network_data.ib_network.subnet | default('') }}"
+    ib_network_dns: "{{ network_data.ib_network.dns | default([]) }}"
+    dns: "{{ network_data.admin_network.dns | default([]) }}"
+  when: admin_netmask_bits is not defined
+
+# =========================================================================
+# Step 2: Ensure /etc/hosts entry for cluster hostname (read-only idempotent)
+# =========================================================================
+- name: Ensure OpenCHAMI cluster hostname resolves
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "{{ admin_nic_ip }} {{ oim_node_name }}.{{ domain_name | regex_replace('^' + oim_node_name + '\\.', '') }}"
+    create: true
+    mode: "0644"
+
+# =========================================================================
+# Step 3: Process PXE mapping file (for validate_provisioning)
+# =========================================================================
+- name: Create temp mapping file from source
+  ansible.builtin.shell: |
+    set -o pipefail
+    sed 's/^[[:space:]]*//g' "{{ pxe_mapping_file_path }}" | sed 's/[[:space:]]*$//g' > /tmp/omnia_validate_mapping.csv
+  changed_when: false
+  when: read_mapping_file is not defined
+
+- name: Remove comment lines from temp mapping file
+  ansible.builtin.lineinfile:
+    path: /tmp/omnia_validate_mapping.csv
+    regexp: '\s*#'
+    state: absent
+  when: read_mapping_file is not defined
+
+- name: Generate xnames in temp mapping file
+  generate_xname_in_mapping_file:
+    mapping_file_path: /tmp/omnia_validate_mapping.csv
+  when: read_mapping_file is not defined
+
+- name: Read PXE mapping CSV into temp var
+  community.general.read_csv:
+    path: /tmp/omnia_validate_mapping.csv
+    key: ADMIN_MAC
+  register: _validate_csv_result
+  when: read_mapping_file is not defined
+
+- name: Promote CSV result to read_mapping_file fact
+  ansible.builtin.set_fact:
+    read_mapping_file: "{{ _validate_csv_result }}"
+  when: read_mapping_file is not defined and _validate_csv_result is not skipped
+
+- name: Clean up temp mapping file
+  ansible.builtin.file:
+    path: /tmp/omnia_validate_mapping.csv
+    state: absent
+  when: _validate_csv_result is defined and _validate_csv_result is not skipped
+
+# =========================================================================
+# Step 4: Load functional groups
+# =========================================================================
+- name: Load functional groups on localhost
+  ansible.builtin.include_vars:
+    file: "{{ functional_groups_config_path }}"
+  when: functional_groups is not defined
+
+# =========================================================================
+# Step 5: Load cluster config from OIM and authenticate (OIM host only)
+# =========================================================================
+- name: Set oim_node_name on OIM host
+  ansible.builtin.set_fact:
+    oim_node_name: "{{ hostvars['localhost']['oim_node_name'] }}"
+  when:
+    - inventory_hostname == 'oim'
+    - oim_node_name is not defined
+
+- name: Load OpenCHAMI configs_vars.yaml from OIM
+  ansible.builtin.include_vars:
+    file: /opt/omnia/openchami/configs_vars.yaml
+  when:
+    - inventory_hostname == 'oim'
+    - cluster_name is not defined
+
+- name: OpenCHAMI cluster authentication
+  ansible.builtin.include_role:
+    name: orchestrator_common
+    tasks_from: openchami_auth.yml
+  when: inventory_hostname == 'oim'
+
+- name: Configure S3 access for boot images
+  ansible.builtin.include_role:
+    name: orchestrator_common
+    tasks_from: configure_s3_access.yml
+  when:
+    - inventory_hostname == 'oim'
+    - s3_configurations is not defined


### PR DESCRIPTION
### Summary:
Refactored orchestrator tags to align with the standardized tag pattern used in image_build_manager. This change introduces new tags for a clearer, more intuitive workflow and deprecates the old deploy and provision tags.

### Tag Mapping

| **Tag** | **Purpose** |
| --- | --- |
| `precheck` | Environment + image_build_manager output validation |
| `validate` | Input file schema/logic validation only |
| `credentials` | Standalone credential collection |
| `prepare` | Credentials + deploy infrastructure + health checks |
| `execute` | SSH + provisioning (K8s/Slurm/OS/custom) |
| `pxeboot` | iDRAC PXE boot |

### Testing:
All tags tested standalone and as part of default flow:

- [x] precheck tag
- [x] validate tag 
- [x] credentials tag
- [x] prepare tag
- [x] execute tag
- [x] default flow (orchestrator.yml)