### PR TITLE
Fix: Change extra_vars from string to dict in discovery test playbooks

### DIFF
--- a/test/discovery/fvt/discovery/test_playbook.py
+++ b/test/discovery/fvt/discovery/test_playbook.py
@@ -38,7 +38,7 @@ def test_deploy_discovery(host):
         "TC_DS_000",
     )
     result = run_playbook(
-        extra_vars="discovery_mechanism=ome",
+        extra_vars={"discovery_mechanism": "ome"},
         timeout=3600,
     )
 

--- a/test/discovery/fvt/validate/test_playbook.py
+++ b/test/discovery/fvt/validate/test_playbook.py
@@ -37,7 +37,7 @@ def test_deploy_validate(host):
         TEST_NAMES["deploy_validate"], "TC_VL_000"
     )
     result = run_playbook(
-        extra_vars="discovery_mechanism=ome",
+        extra_vars={"discovery_mechanism": "ome"},
     )
 
     if result["success"]:


### PR DESCRIPTION
The run_playbook function expects extra_vars as a dictionary, but the
discovery test playbooks were passing it as a string ("discovery_mechanism=ome").
This caused an AttributeError when the function tried to call .items() on the string.

Fixed by changing:
- extra_vars="discovery_mechanism=ome"
+ extra_vars={"discovery_mechanism": "ome"}

This fix applies to:
- test/discovery/fvt/discovery/test_playbook.py
- test/discovery/fvt/validate/test_playbook.py