### PR TITLE
fix(orchestrator): make rollback tag a reserved placeholder

### DIFF
--- a/src/orchestrator/playbooks/orchestrator.yml
+++ b/src/orchestrator/playbooks/orchestrator.yml
@@ -31,7 +31,7 @@
 #   ansible-playbook playbooks/orchestrator.yml --tags pxeboot         # PXE boot on iDRAC nodes (requires enable_pxe_boot: true)
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup         # Remove OpenCHAMI + OpenLDAP services + artifacts
 #   ansible-playbook playbooks/orchestrator.yml --tags upgrade         # In-place upgrade OpenCHAMI + OpenLDAP
-#   ansible-playbook playbooks/orchestrator.yml --tags rollback        # Revert OpenCHAMI + OpenLDAP to previous state
+#   ansible-playbook playbooks/orchestrator.yml --tags rollback        # Reserved for future use (not supported in this release)
 #
 # Tags (mutually exclusive — pick ONE):
 #   (none)       — Default flow: precheck + prepare + execute
@@ -46,7 +46,7 @@
 #   pxeboot      — PXE boot on iDRAC nodes (controlled by enable_pxe_boot in orchestrator_config.yml)
 #   cleanup      — Remove OpenCHAMI + OpenLDAP services, containers, artifacts (opt-in only)
 #   upgrade      — In-place upgrade of OpenCHAMI + OpenLDAP (opt-in only)
-#   rollback     — Revert OpenCHAMI + OpenLDAP to previous state from backup (opt-in only)
+#   rollback     — Reserved for future use (upgrade from v0.1.7-1 to v0.2.0 is one-way)
 #
 # Tag Validation:
 #   - Invalid tags will fail with error message
@@ -94,7 +94,7 @@
 #               + pxeboot/pxeboot.yml (when enable_pxe_boot: true)
 #   cleanup   -> cleanup_openchami.yml   + cleanup_openldap.yml
 #   upgrade   -> upgrade_openchami.yml   + upgrade_openldap.yml
-#   rollback  -> rollback_openchami.yml  + rollback_openldap.yml
+#   rollback  -> rollback_openchami.yml  + rollback_openldap.yml  (reserved — not supported)
 #
 # Inputs:  /opt/omnia/orchestrator/input/project_default/
 # Outputs: /opt/omnia/orchestrator/output/project_default/
@@ -300,19 +300,19 @@
     - upgrade
 
 # =========================================================================
-# FLOW: rollback — Revert OpenCHAMI + OpenLDAP to previous state
-# OpenCHAMI: 0.2.0 -> 0.1.7-1 (restore from backup)
-# OpenLDAP:  Wolfi-based -> Fedora-based container image
+# FLOW: rollback — Reserved for future use
+# The OpenCHAMI v0.1.7-1 to v0.2.0 upgrade is a one-way migration.
+# Rollback is not supported in this release.
 # =========================================================================
 
-# Rollback OpenCHAMI (version detection, backup restore, restart, verify)
+# Rollback OpenCHAMI (not supported — fails with informational message)
 - name: Rollback OpenCHAMI
   ansible.builtin.import_playbook: rollback/rollback_openchami.yml
   tags:
     - never
     - rollback
 
-# Rollback OpenLDAP (Wolfi -> Fedora container rollback)
+# Rollback OpenLDAP (not supported — fails with informational message)
 - name: Rollback OpenLDAP
   ansible.builtin.import_playbook: rollback/rollback_openldap.yml
   tags:

--- a/src/orchestrator/playbooks/rollback/rollback_openchami.yml
+++ b/src/orchestrator/playbooks/rollback/rollback_openchami.yml
@@ -13,231 +13,35 @@
 # limitations under the License.
 ---
 
-# Rollback OpenCHAMI --- Revert from 0.2.0 to 0.1.7-1
-# Can be run standalone or imported by orchestrator.yml
+# Rollback OpenCHAMI -- Reserved for future use.
 #
-# Logic:
-#   1. Detect currently installed OpenCHAMI version
-#   2. If current version is 0.2.0:
-#      a. Stop services
-#      b. Locate latest backup
-#      c. Restore configuration and workdir from backup
-#      d. Restore SMD state from backup
-#      e. Start services with restored configuration
-#      f. Verify service health
-#   3. If already on 0.1.7-1: log informational message and exit
+# OpenCHAMI upgrade from v0.1.7-1 to v0.2.0 is a one-way migration.
+# Rolling back to v0.1.7-1 after upgrading to v0.2.0 is not supported
+# due to breaking schema and configuration changes.
 #
-# Idempotent and re-runnable.
+# This tag is reserved for future releases where rollback between
+# compatible versions may be supported.
 
-# Version detection
-- name: Detect OpenCHAMI version for rollback
-  hosts: oim
-  connection: ssh
-  gather_facts: true
-  tasks:
-    - name: Gather installed package facts
-      ansible.builtin.package_facts:
-        manager: rpm
-
-    - name: Set current OpenCHAMI version fact
-      ansible.builtin.set_fact:
-        openchami_current_version: >-
-          {{ (ansible_facts.packages['openchami'][0].version ~ '-' ~ ansible_facts.packages['openchami'][0].release)
-             if 'openchami' in (ansible_facts.packages | default({}))
-             else 'unknown' }}
-        openchami_rollback_target: "0.1.7-1"
-        cacheable: true
-
-    - name: Display current version
-      ansible.builtin.debug:
-        msg: "OpenCHAMI current version: {{ openchami_current_version }}"
-
-    - name: Already on rollback target version
-      ansible.builtin.debug:
-        msg: >-
-          OpenCHAMI is already at version {{ openchami_rollback_target }}.
-          No rollback needed.
-      when: openchami_current_version == openchami_rollback_target
-
-# Locate backup and restore
-- name: Locate latest backup and stop services
-  hosts: oim
-  connection: ssh
-  gather_facts: true
-  vars:
-    openchami_backup_base: /opt/omnia/openchami/backups
-    openchami_config_dir: /etc/openchami/configs
-    openchami_work_dir: "{{ hostvars['localhost']['oim_shared_path'] | default('/opt/omnia') }}/omnia/openchami/workdir"
-  tasks:
-    - name: Skip if already at rollback target
-      ansible.builtin.meta: end_play
-      when: openchami_current_version == openchami_rollback_target
-
-    - name: Find most recent backup directory
-      ansible.builtin.find:
-        paths: "{{ openchami_backup_base }}"
-        file_type: directory
-        patterns: "pre_upgrade_*"
-      register: backup_dirs
-
-    - name: Fail if no backup found
-      ansible.builtin.fail:
-        msg: >-
-          No backup directory found under {{ openchami_backup_base }}.
-          Cannot rollback without a prior upgrade backup.
-      when: backup_dirs.files | length == 0
-
-    - name: Set latest backup path
-      ansible.builtin.set_fact:
-        rollback_backup_dir: "{{ (backup_dirs.files | sort(attribute='mtime', reverse=true) | first).path }}"
-
-    - name: Display rollback source
-      ansible.builtin.debug:
-        msg: "Rolling back from backup {{ rollback_backup_dir }}"
-
-    - name: Stop OpenCHAMI services
-      ansible.builtin.systemd:
-        name: openchami.target
-        state: stopped
-      failed_when: false
-
-    - name: Wait for services to stop
-      ansible.builtin.pause:
-        seconds: 10
-        prompt: "Waiting for OpenCHAMI services to stop..."
-
-    - name: Restore OpenCHAMI config directory from backup
-      ansible.builtin.copy:
-        src: "{{ rollback_backup_dir }}/configs/"
-        dest: "{{ openchami_config_dir }}/"
-        remote_src: true
-        mode: preserve
-      when: rollback_backup_dir is defined
-
-    - name: Restore workdir from backup
-      ansible.builtin.copy:
-        src: "{{ rollback_backup_dir }}/workdir/"
-        dest: "{{ openchami_work_dir }}/"
-        remote_src: true
-        mode: preserve
-      when: rollback_backup_dir is defined
-      failed_when: false
-
-    - name: Start OpenCHAMI services with restored configuration
-      ansible.builtin.systemd:
-        name: openchami.target
-        state: started
-        daemon_reload: true
-
-    - name: Wait for services to stabilize
-      ansible.builtin.pause:
-        seconds: 30
-        prompt: "Waiting for OpenCHAMI services to stabilize after rollback..."
-
-# Restore SMD state
-- name: Restore SMD state from backup
-  hosts: oim
-  connection: ssh
-  gather_facts: false
-  tasks:
-    - name: Skip if already at rollback target
-      ansible.builtin.meta: end_play
-      when: openchami_current_version == openchami_rollback_target
-
-    - name: Authenticate to OpenCHAMI
-      ansible.builtin.include_role:
-        name: orchestrator_common
-        tasks_from: openchami_auth.yml
-
-    - name: Check if SMD components backup exists
-      ansible.builtin.stat:
-        path: "{{ rollback_backup_dir }}/smd/components.json"
-      register: smd_components_backup
-
-    - name: Restore SMD components from backup
-      ansible.builtin.shell: |
-        set -o pipefail
-        ochami smd component add --payload "{{ rollback_backup_dir }}/smd/components.json" --force
-      environment: "{{ ochami_env | default({}) }}"
-      when: smd_components_backup.stat.exists
-      changed_when: true
-      failed_when: false
-
-    - name: Check if SMD groups backup exists
-      ansible.builtin.stat:
-        path: "{{ rollback_backup_dir }}/smd/groups.json"
-      register: smd_groups_backup
-
-    - name: Restore SMD groups from backup
-      ansible.builtin.shell: |
-        set -o pipefail
-        ochami smd group add --payload "{{ rollback_backup_dir }}/smd/groups.json" --force
-      environment: "{{ ochami_env | default({}) }}"
-      when: smd_groups_backup.stat.exists
-      changed_when: true
-      failed_when: false
-
-# Post-rollback verification
-- name: Verify OpenCHAMI health post-rollback
-  hosts: oim
-  connection: ssh
-  gather_facts: false
-  tasks:
-    - name: Skip if already at rollback target (no rollback performed)
-      ansible.builtin.meta: end_play
-      when: openchami_current_version == openchami_rollback_target
-
-    - name: Authenticate to OpenCHAMI
-      ansible.builtin.include_role:
-        name: orchestrator_common
-        tasks_from: openchami_auth.yml
-
-    - name: Verify openchami.target is active
-      ansible.builtin.systemd:
-        name: openchami.target
-      register: openchami_target_post
-      failed_when: openchami_target_post.status.ActiveState != "active"
-
-    - name: Verify SMD API health
-      ansible.builtin.command: ochami smd service status
-      environment: "{{ ochami_env | default({}) }}"
-      register: smd_post_status
-      retries: 5
-      delay: 10
-      until: smd_post_status.rc == 0
-      changed_when: false
-
-    - name: Verify boot-service health
-      ansible.builtin.systemd:
-        name: boot-service.service
-      register: boot_service_post_status
-      retries: 5
-      delay: 10
-      until: boot_service_post_status.status.ActiveState == "active"
-      changed_when: false
-
-    - name: Post-rollback health summary
-      ansible.builtin.debug:
-        msg: >-
-          OpenCHAMI rollback health check passed.
-          openchami.target={{ openchami_target_post.status.ActiveState }},
-          SMD={{ 'OK' if smd_post_status.rc == 0 else 'FAIL' }},
-          Boot-Service={{ 'OK' if boot_service_post_status.status.ActiveState == 'active' else 'FAIL' }}.
-          Restored from {{ rollback_backup_dir }}.
-
-# Finalize
-- name: Finalize OpenCHAMI rollback
+- name: Rollback OpenCHAMI (reserved for future use)
   hosts: localhost
   connection: local
   gather_facts: false
   tasks:
-    - name: Remove upgrade lock file if present
-      ansible.builtin.file:
-        path: "/opt/omnia/.data/upgrade_in_progress.lock"
-        state: absent
+    - name: Rollback not supported
+      ansible.builtin.fail:
+        msg: |
+          ============================================================
+          ROLLBACK NOT SUPPORTED
+          ============================================================
+          OpenCHAMI rollback is not supported in this release.
 
-    - name: OpenCHAMI rollback completed
-      ansible.builtin.debug:
-        msg: >-
-          OpenCHAMI rollback completed. Services restored from backup.
-          Re-run provisioning playbooks if node configuration needs refreshing.
+          The upgrade from v0.1.7-1 to v0.2.0 is a one-way migration
+          with breaking schema and configuration changes. Rolling back
+          to v0.1.7-1 after upgrading is not possible.
+
+          If you need to restore a previous state, please use a full
+          system backup taken before the upgrade.
+
+          This tag is reserved for future releases where rollback
+          between compatible versions may be supported.
+          ============================================================

--- a/src/orchestrator/playbooks/rollback/rollback_openldap.yml
+++ b/src/orchestrator/playbooks/rollback/rollback_openldap.yml
@@ -13,109 +13,36 @@
 # limitations under the License.
 ---
 
-# Rollback OpenLDAP --- Revert auth container from Wolfi-based to Fedora-based
-# Can be run standalone or imported by orchestrator.yml
+# Rollback OpenLDAP -- Reserved for future use.
 #
-# Logic:
-#   1. Detect running auth container image
-#   2. If Wolfi-based auth container is running (tag 1.1):
-#      a. Stop container
-#      b. Remove Wolfi container
-#      c. Pull Fedora image (tag 1.0)
-#      d. Deploy Fedora auth container
-#      e. Reapply configuration
-#      f. Validate service health
-#   3. If Fedora container is already active (tag 1.0): exit successfully
-#   4. If not deployed: skip rollback
+# OpenLDAP rollback is not supported in this release.
+# The container migration from Fedora-based to Wolfi-based is tied
+# to the OpenCHAMI v0.1.7-1 to v0.2.0 upgrade, which is a one-way
+# migration.
 #
-# Idempotent and re-runnable.
+# This tag is reserved for future releases where rollback between
+# compatible versions may be supported.
 
-- name: Rollback OpenLDAP container
-  hosts: oim
-  connection: ssh
+- name: Rollback OpenLDAP (reserved for future use)
+  hosts: localhost
+  connection: local
   gather_facts: false
-  vars:
-    auth_container_name: omnia_auth
-    auth_image: "docker.io/dellhpcomniaaisolution/omnia_auth"
-    auth_rollback_tag: "1.0"
-    auth_current_tag: "1.1"
   tasks:
-    - name: Check if OpenLDAP container exists
-      containers.podman.podman_container_info:
-        name: "{{ auth_container_name }}"
-      register: auth_rollback_check
-      failed_when: false
+    - name: Rollback not supported
+      ansible.builtin.fail:
+        msg: |
+          ============================================================
+          ROLLBACK NOT SUPPORTED
+          ============================================================
+          OpenLDAP rollback is not supported in this release.
 
-    - name: Skip rollback when not deployed
-      ansible.builtin.debug:
-        msg: "OpenLDAP (omnia_auth) not deployed. Skipping rollback."
-      when: auth_rollback_check.containers | default([]) | length == 0
+          The container migration from Fedora-based to Wolfi-based
+          image is tied to the OpenCHAMI v0.1.7-1 to v0.2.0 upgrade,
+          which is a one-way migration.
 
-    - name: Rollback OpenLDAP when present
-      when:
-        - auth_rollback_check.containers | default([]) | length > 0
-      block:
-        - name: Detect current container image tag
-          ansible.builtin.set_fact:
-            auth_current_image: "{{ auth_rollback_check.containers[0].ImageName | default('') }}"
+          If you need to restore a previous state, please use a full
+          system backup taken before the upgrade.
 
-        - name: Already on rollback target image
-          ansible.builtin.debug:
-            msg: >-
-              OpenLDAP is already running the Fedora-based image
-              ({{ auth_image }}:{{ auth_rollback_tag }}). No rollback needed.
-          when: auth_rollback_tag in auth_current_image
-
-        - name: Perform Wolfi-to-Fedora rollback
-          when: auth_rollback_tag not in auth_current_image
-          block:
-            - name: Stop OpenLDAP service
-              ansible.builtin.systemd:
-                name: omnia_auth
-                state: stopped
-              failed_when: false
-
-            - name: Remove Wolfi-based container
-              ansible.builtin.command: "podman rm -f {{ auth_container_name }}"
-              changed_when: true
-              failed_when: false
-
-            - name: Pull Fedora-based OpenLDAP image
-              ansible.builtin.command: "podman pull {{ auth_image }}:{{ auth_rollback_tag }}"
-              register: auth_pull_result
-              retries: 3
-              delay: 10
-              until: auth_pull_result.rc == 0
-              changed_when: "'Pulling' in auth_pull_result.stdout or 'Copying' in auth_pull_result.stderr"
-
-            - name: Start OpenLDAP service with Fedora image
-              ansible.builtin.systemd:
-                name: omnia_auth
-                state: started
-                daemon_reload: true
-
-            - name: Wait for OpenLDAP to be healthy
-              containers.podman.podman_container_info:
-                name: "{{ auth_container_name }}"
-              register: auth_rollback_health
-              retries: 10
-              delay: 5
-              until: >-
-                (auth_rollback_health.containers | default([]) | length > 0) and
-                (auth_rollback_health.containers[0].State.Status == 'running')
-
-            - name: Verify LDAP service responds
-              ansible.builtin.command: >
-                podman exec {{ auth_container_name }} ldapsearch -x -H ldap://localhost -b "" -s base namingContexts
-              register: ldap_verify
-              retries: 5
-              delay: 5
-              until: ldap_verify.rc == 0
-              changed_when: false
-              failed_when: false
-
-            - name: OpenLDAP rollback completed
-              ansible.builtin.debug:
-                msg: >-
-                  OpenLDAP (omnia_auth) successfully rolled back from Wolfi-based
-                  to Fedora-based image ({{ auth_image }}:{{ auth_rollback_tag }}).
+          This tag is reserved for future releases where rollback
+          between compatible versions may be supported.
+          ============================================================

--- a/test/orchestrator/fvt/TEST_CASES.md
+++ b/test/orchestrator/fvt/TEST_CASES.md
@@ -166,9 +166,21 @@
 
 ---
 
+## Rollback Scenario (`fvt/rollback/`)
+
+> Rollback is **not supported** in this release. The OpenCHAMI upgrade from
+> v0.1.7-1 to v0.2.0 is a one-way migration. The rollback tag is reserved
+> for future releases.
+
+|| TC ID | Test Function | Description | Marker |
+||-------|---------------|-------------|--------|
+|| TC_RB_000 | `test_deploy_rollback_not_supported` | Verify rollback fails with 'not supported' message | deploy, sanity |
+
+---
+
 ## Test Summary
 
-**Total Test Cases: 76**
+**Total Test Cases: 73**
 
 | Category | Count |
 |----------|-------|
@@ -183,7 +195,8 @@
 | Prepare Tests | 8 |
 | Provision Tests | 2 |
 | Cleanup Tests | 4 |
+| Rollback Tests | 1 |
 | DCGM Tests | 3 |
-| **Total** | **72** |
+| **Total** | **73** |
 
 **Note**: Some test IDs may be reused across different test files (e.g., TC_SL_001 appears in both status and infrastructure tests). This is intentional as they test different aspects of the same functionality.

--- a/test/orchestrator/fvt/rollback/test_playbook.py
+++ b/test/orchestrator/fvt/rollback/test_playbook.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Orchestrator Rollback -- Deploy (reserved placeholder).
+
+TC_RB_000: Verify orchestrator.yml --tags rollback fails with
+           'not supported' message (rollback is reserved for future use).
+"""
+
+import pytest
+
+from library.functions import TestLogger, run_playbook
+from library.messages import (
+    TEST_NAMES,
+    TEST_LOG_MSGS as LOG,
+)
+
+
+@pytest.mark.deploy
+@pytest.mark.sanity
+@pytest.mark.order(0)
+def test_deploy_rollback_not_supported(host):
+    """TC_RB_000: Verify rollback tag fails with 'not supported' message."""
+    tl = TestLogger(
+        TEST_NAMES["deploy_rollback"], "TC_RB_000"
+    )
+    result = run_playbook(tag="rollback")
+
+    # Rollback is expected to FAIL — it is a reserved placeholder.
+    # The playbook should exit non-zero with "ROLLBACK NOT SUPPORTED".
+    if not result["success"]:
+        output = result.get("output", "") + result.get("error", "")
+        if "ROLLBACK NOT SUPPORTED" in output:
+            tl.passed(LOG["rollback_not_supported"])
+            return
+        tl.failed(
+            LOG["playbook_failed"].format(
+                rc=result["rc"], duration=result["duration"],
+            ),
+            "Rollback failed but without the expected 'ROLLBACK NOT SUPPORTED' message",
+        )
+        pytest.fail(
+            "Rollback failed but did not produce the expected "
+            "'ROLLBACK NOT SUPPORTED' message. Got: " + output[:500]
+        )
+
+    # If it succeeds, that is unexpected — rollback should always fail.
+    tl.failed(
+        LOG["playbook_success"].format(duration=result["duration"]),
+        "Rollback should fail with 'ROLLBACK NOT SUPPORTED' but succeeded",
+    )
+    pytest.fail(
+        "Rollback tag should fail with 'ROLLBACK NOT SUPPORTED' "
+        "but the playbook succeeded (rc=0). Rollback is not supported "
+        "in this release."
+    )

--- a/test/orchestrator/library/messages/orchestrator_msgs.py
+++ b/test/orchestrator/library/messages/orchestrator_msgs.py
@@ -96,6 +96,11 @@ TEST_NAMES: Dict[str, str] = {
         "Verify firewall ports closed after cleanup"
     ),
 
+    # Rollback (reserved)
+    "deploy_rollback": (
+        "Deploy: orchestrator.yml --tags rollback (reserved — not supported)"
+    ),
+
     # Clone / sync
     "clone_status": (
         "Verify repository is cloned and synced on target"
@@ -168,6 +173,11 @@ TEST_LOG_MSGS: Dict[str, str] = {
     ),
     "playbook_failed": (
         "Playbook failed (rc={rc}, duration={duration:.1f}s)"
+    ),
+
+    # Rollback (reserved)
+    "rollback_not_supported": (
+        "Rollback correctly rejected — reserved for future use"
     ),
 
     # Clone

--- a/test/orchestrator/library/vars/domain_vars.py
+++ b/test/orchestrator/library/vars/domain_vars.py
@@ -39,6 +39,7 @@ FVT_TAGS: List[str] = [
     "prepare",
     "provision",
     "cleanup",
+    "rollback",
     "modules",
     "roles",
     "playbooks",
@@ -66,6 +67,7 @@ SUITES: Dict[str, List[str]] = {
     "prepare": ["openchami"],
     "provision": ["slurm"],
     "cleanup": ["status"],
+    "rollback": [],
     "modules": [],
     "roles": [],
     "playbooks": [],
@@ -78,4 +80,5 @@ SUITES: Dict[str, List[str]] = {
 
 EXCLUDE_TAGS: List[str] = [
     "cleanup",
+    "rollback",
 ]


### PR DESCRIPTION
## Summary
OpenCHAMI upgrade from v0.1.7-1 to v0.2.0 is a one-way migration with
breaking schema and configuration changes. Rollback is not supported
for either OpenCHAMI or OpenLDAP.

Replace rollback playbooks with dummy stubs that fail with an
informational message explaining why rollback is not possible and that
the tag is reserved for future releases.

### Changes
- Replace `rollback_openchami.yml` with stub that fails with "ROLLBACK NOT SUPPORTED"
- Replace `rollback_openldap.yml` with stub that fails with "ROLLBACK NOT SUPPORTED"
- Update `orchestrator.yml` header comments to indicate rollback is reserved

### Test automation updates
- Add `fvt/rollback/test_playbook.py` (TC_RB_000) — verifies rollback correctly fails
- Add `rollback` to FVT_TAGS, SUITES, and EXCLUDE_TAGS in domain_vars.py
- Add `deploy_rollback` and `rollback_not_supported` messages in orchestrator_msgs.py
- Update TEST_CASES.md with Rollback Scenario section

#### Test plan
- [x] Syntax check passes for rollback tag
- [x] Test verifies rollback fails with expected message