### PR TITLE
fix(discovery): restore ansible.cfg paths after merge

### DIFF
--- a/src/discovery/playbooks/ansible.cfg
+++ b/src/discovery/playbooks/ansible.cfg
@@ -9,10 +9,10 @@
 
 [defaults]
 log_path = /var/log/omnia/discovery/discovery.log
-roles_path = roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-library = plugins/modules
-module_utils = plugins/module_utils
-callback_plugins = plugins/callback
+roles_path = ../roles:roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+library = ../plugins/modules:plugins/modules
+module_utils = ../plugins/module_utils:plugins/module_utils
+callback_plugins = ../plugins/callback:plugins/callback
 remote_tmp = /tmp/.ansible/tmp/
 host_key_checking = false
 forks = 5


### PR DESCRIPTION
## Summary
The PR merge overwrote the ansible.cfg fix that allowed playbooks
to run from both src/discovery/ and src/discovery/playbooks/.
Restored the relative path prefixes (../) to find roles and plugins
from the playbooks subdirectory.

#### Test plan
- [x] Syntax check passes from src/discovery/playbooks/
- [x] Syntax check passes from src/discovery/