### PR TITLE
Fix variable collisions in orchestrator provisioning

### DIFF
--- a/src/orchestrator/ansible.cfg
+++ b/src/orchestrator/ansible.cfg
@@ -20,8 +20,8 @@ timeout = 180
 executable = /bin/bash
 interpreter_python = /usr/bin/python3
 deprecation_warnings = false
-show_task_path_on_failure = false
-stdout_callback = omnia_default
+show_task_path_on_failure = true
+stdout_callback = default
 collections_path = .:~/.ansible/collections:/usr/share/ansible/collections
 
 [persistent_connection]

--- a/src/orchestrator/roles/configure_ochami/tasks/configure_boot_svc_metadata_svc.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/configure_boot_svc_metadata_svc.yml
@@ -34,9 +34,9 @@
   ansible.builtin.set_fact:
     node_parsed_yaml: "{{ nodes_vars.content | b64decode | from_yaml }}"
 
-- name: Set nodes
+- name: Set boot_svc_nodes
   ansible.builtin.set_fact:
-    nodes: "{{ node_parsed_yaml.nodes }}"
+    boot_svc_nodes: "{{ node_parsed_yaml.nodes }}"
 
 - name: Create boot and metadata-service directory
   ansible.builtin.file:

--- a/src/orchestrator/roles/configure_ochami/tasks/create_groups.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/create_groups.yml
@@ -23,7 +23,7 @@
     dest: "{{ nodes_dir }}/groups-{{ functional_group_name }}.yml"
     mode: "{{ hostvars['localhost']['file_permissions_644'] }}"
   vars:
-    nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
+    smd_group_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
 
 - name: Get SMD group data
   ansible.builtin.command: /usr/bin/ochami smd group get

--- a/src/orchestrator/roles/configure_ochami/tasks/create_groups_additional_fg.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/create_groups_additional_fg.yml
@@ -27,7 +27,7 @@
     dest: "{{ nodes_dir }}/groups-{{ additional_metadata_svc_fg_smd_group_name }}.yml"
     mode: "{{ hostvars['localhost']['file_permissions_644'] }}"
   vars:
-    nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
+    smd_group_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
 
 - name: Delete SMD group - {{ additional_metadata_svc_fg_smd_group_name }}
   ansible.builtin.command: >-

--- a/src/orchestrator/roles/configure_ochami/tasks/create_groups_common.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/create_groups_common.yml
@@ -23,13 +23,16 @@
     dest: "{{ nodes_dir }}/groups-common-{{ common_group_name }}.yml"
     mode: "{{ hostvars['localhost']['file_permissions_644'] }}"
   vars:
-    _all_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
-    nodes: >-
-      {{ (_all_nodes
-          | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', registered_fg_names)
-          | list)
-         if (registered_fg_names is defined)
-         else _all_nodes }}
+    # Only include nodes registered in SMD for the current target category.
+    # target_fg_names is set by the caller (register_nodes.yml).
+    # Use 'common_group_nodes' to avoid collision with the 'nodes' set_fact
+    # from configure_boot_svc.yml.
+    common_group_nodes: >-
+      {{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items
+         | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names | default([]))
+         | list
+         if (target_fg_names | default([]) | length > 0)
+         else hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}
 
 - name: Delete the SMD common group - {{ common_group_name }}
   ansible.builtin.command: /usr/bin/ochami smd group delete --no-confirm {{ common_group_name }}

--- a/src/orchestrator/roles/configure_ochami/tasks/orchestration_mapping_nodes.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/orchestration_mapping_nodes.yml
@@ -36,7 +36,7 @@
         dest: "{{ openchami_nodes_vars_path }}"
         mode: "{{ hostvars['localhost']['file_permissions_644'] }}"
       vars:
-        nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
+        mapping_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items | map(attribute='value') | list }}"
 
     - name: Create orchestrator output directory on OIM
       ansible.builtin.file:

--- a/src/orchestrator/roles/configure_ochami/templates/boot_svc/boot-svc.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/boot_svc/boot-svc.yaml.j2
@@ -8,7 +8,7 @@ spec:
   initrd: "{{ s3_base_url }}/{{ initrd }}"
   params: "nomodeset ro root=live:{{ s3_base_url }}/{{ image }} ip=dhcp rd.live.image rd.live.ram rd.neednet=1 {% if s3_use_https %}rd.noverifyssl {% endif %}rd.driver.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas modprobe.blacklist=ccp,edac_core,power_meter,ahci,megaraid_sas libata.force=1:disable,2:disable,3:disable,4:disable rd.luks=0 rd.md=0 rd.dm=0 console=tty0 console=ttyS0,115200 selinux=0 apparmor=0 ip6=off {{ boot_svc_params_metadata_svc }}{% if boot_kernel_params | default('') | length > 0 %} {{ boot_kernel_params }}{% endif %}"
   macs:
-{% for item in nodes %}
+{% for item in boot_svc_nodes %}
 {% if item.group == functional_group_name %}
     - "{{ item.interfaces[0].mac_addr }}"
 {% endif %}

--- a/src/orchestrator/roles/configure_ochami/templates/doca-ofed/configure-ib-network.sh.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/doca-ofed/configure-ib-network.sh.j2
@@ -17,7 +17,7 @@ modprobe ib_uverbs || true
 NETMASK_BITS="{{ hostvars['localhost']['admin_netmask_bits'] }}"
 
 # Get current node's IP from cloud-init metadata
-ADMIN_NIC_IP="{% raw %}{{"{{"}} ds.meta_data.instance_data.local_ipv4 {{"}}"}}{% endraw %}"
+ADMIN_NIC_IP="{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}"
 
 # Create IB mapping from all nodes (IB_NIC_NAME only)
 declare -A ADMIN_IB_NIC_NAME_MAP=(

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_aarch64.yaml.j2
@@ -223,21 +223,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_compiler_node_x86_64.yaml.j2
@@ -223,21 +223,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
-         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
+        - echo "No mount entries found for this host"
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_aarch64.yaml.j2
@@ -179,21 +179,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
-         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
+        - echo "No mount entries found for this host"
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-login_node_x86_64.yaml.j2
@@ -178,21 +178,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
-         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
+        - echo "No mount entries found for this host"
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -281,10 +281,10 @@
             kubeadm init --kubernetes-version={{ service_k8s_version }} \
               --pod-network-cidr={{ k8s_pod_network_cidr }} \
               --service-cidr={{ k8s_service_addresses }} \
-              --apiserver-advertise-address={% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %} \
-              --node-name {% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %} \
+              --apiserver-advertise-address={% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %} \
+              --node-name {% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %} \
               --cri-socket=unix:///var/run/crio/crio.sock \
-              --control-plane-endpoint={% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}:6443 \
+              --control-plane-endpoint={% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}:6443 \
               --apiserver-cert-extra-sans {{ kube_vip }}
         
         - path: /tmp/generate-control-plane-join.sh
@@ -369,21 +369,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{ mount[1] }}
-        - echo "{{ mount | join(' ') }}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{ decoded_cmd }}
-      {% endfor %}
-      {% else %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% for pv_entry in metadata_svc_groups_dict[functional_group_name].powervault_scripts | default([], true) %} 
         - bash /usr/local/bin/setup_iscsi_storage_{{ pv_entry.name }}.sh
@@ -393,11 +393,11 @@
 {% if etcd_on_local_disk | default(false) %}
         - /usr/local/bin/etcd-fstab-update.sh
 {% else %}
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/etcd      /var/lib/etcd        nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/etcd      /var/lib/etcd        nfs noatime,nolock 0 0" >> /etc/fstab
 {% endif %}
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/kubelet   /var/lib/kubelet     nfs noatime,nolock 0 0" >> /etc/fstab
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/kubernetes   /etc/kubernetes      nfs noatime,nolock 0 0" >> /etc/fstab
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/pod-logs   /var/log/pods      nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/kubelet   /var/lib/kubelet     nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/kubernetes   /etc/kubernetes      nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/pod-logs   /var/log/pods      nfs noatime,nolock 0 0" >> /etc/fstab
         - echo "{{ k8s_nfs_server_path }}/packages   /var/lib/packages        nfs    noatime,nolock     0 0" >> /etc/fstab
         - echo "tmpfs   /tmp/crio-storage   tmpfs   size={{ k8s_crio_storage_size }},noatime,nodev,nosuid   0 0" >> /etc/fstab
         - sudo swapoff -a
@@ -519,7 +519,7 @@
             rm -rf /var/lib/etcd/*  /var/lib/kubelet/* /etc/kubernetes/*
             rm -rf /var/lib/etcd/.*  /var/lib/kubelet/.* /etc/kubernetes/.*
             #!/bin/bash
-            NODE_IP="{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}"
+            NODE_IP="{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}"
             # Find the interface with this IP
             VIP_IFACE=$(ip -o addr show | awk -v ip="$NODE_IP" '$4 ~ ip {print $2}')
             # Replace the vip_interface placeholder in the yaml

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -276,21 +276,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{ mount[1] }}
-        - echo "{{ mount | join(' ') }}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{ decoded_cmd }}
-      {% endfor %}
-      {% else %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% for pv_entry in metadata_svc_groups_dict[functional_group_name].powervault_scripts | default([], true) %} 
         - bash /usr/local/bin/setup_iscsi_storage_{{ pv_entry.name }}.sh
@@ -300,11 +300,11 @@
 {% if etcd_on_local_disk | default(false) %}
         - /usr/local/bin/etcd-fstab-update.sh
 {% else %}
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/etcd      /var/lib/etcd        nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/etcd      /var/lib/etcd        nfs noatime,nolock 0 0" >> /etc/fstab
 {% endif %}
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/kubelet   /var/lib/kubelet     nfs noatime,nolock 0 0" >> /etc/fstab
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/kubernetes   /etc/kubernetes      nfs noatime,nolock 0 0" >> /etc/fstab
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/pod-logs   /var/log/pods      nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/kubelet   /var/lib/kubelet     nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/kubernetes   /etc/kubernetes      nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/pod-logs   /var/log/pods      nfs noatime,nolock 0 0" >> /etc/fstab
         - echo "{{ k8s_nfs_server_path }}/packages   /var/lib/packages        nfs    noatime,nolock     0 0" >> /etc/fstab
         - echo "tmpfs   /tmp/crio-storage   tmpfs   size={{ k8s_crio_storage_size }},noatime,nodev,nosuid   0 0" >> /etc/fstab
         - sudo swapoff -a
@@ -423,7 +423,7 @@
             rm -rf /var/lib/etcd/*  /var/lib/kubelet/* /etc/kubernetes/*
             rm -rf /var/lib/etcd/.*  /var/lib/kubelet/.* /etc/kubernetes/.*
             K8S_CLIENT_MOUNT_PATH="{{ k8s_client_mount_path }}"
-            NODE_NAME="{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}"
+            NODE_NAME="{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}"
             KUBE_VIP="{{ kube_vip }}"
             KUBE_PORT="6443"
             JOIN_CMD_FILE="${K8S_CLIENT_MOUNT_PATH}/control-plane-join-command.sh"
@@ -453,7 +453,7 @@
             cp -f /etc/kubernetes/admin.conf /root/.kube/config
             chown root:root /root/.kube/config
 
-            NODE_IP="{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}"
+            NODE_IP="{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}"
             VIP_IFACE=$(ip -o addr show | awk -v ip="$NODE_IP" '$4 ~ ip {print $2}')
             sed -i "s/value: vip_interface/value: ${VIP_IFACE}/" /tmp/kube-vip.yaml
             cp /tmp/kube-vip.yaml /etc/kubernetes/manifests/kube-vip.yaml
@@ -545,7 +545,7 @@
 
             # Wait for kube-controller-manager pod to exist before checking readiness
             echo "Waiting for kube-controller-manager pod to be created..."
-            KCM_POD="kube-controller-manager-{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}"
+            KCM_POD="kube-controller-manager-{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}"
             TIMEOUT=120
             ELAPSED=0
             while ! kubectl -n kube-system get pod "$KCM_POD" >/dev/null 2>&1; do

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -175,30 +175,30 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{ mount[1] }}
-        - echo "{{ mount | join(' ') }}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{ decoded_cmd }}
-      {% endfor %}
-      {% else %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% for pv_entry in metadata_svc_groups_dict[functional_group_name].powervault_scripts | default([], true) %} 
         - bash /usr/local/bin/setup_iscsi_storage_{{ pv_entry.name }}.sh
 {% endfor %}
         # K8s NFS mount entries
         - mkdir -pv /tmp/crio-storage {{ k8s_client_mount_path }} /var/lib/kubelet /etc/kubernetes /var/log/pods /var/lib/packages
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/kubelet   /var/lib/kubelet     nfs noatime,nolock 0 0" >> /etc/fstab
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/kubernetes   /etc/kubernetes      nfs noatime,nolock 0 0" >> /etc/fstab
-        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}/pod-logs   /var/log/pods      nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/kubelet   /var/lib/kubelet     nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/kubernetes   /etc/kubernetes      nfs noatime,nolock 0 0" >> /etc/fstab
+        - echo "{{ k8s_nfs_server_path }}/{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}/pod-logs   /var/log/pods      nfs noatime,nolock 0 0" >> /etc/fstab
         - echo "{{ k8s_nfs_server_path }}/packages   /var/lib/packages        nfs    noatime,nolock     0 0" >> /etc/fstab
         - echo "tmpfs   /tmp/crio-storage   tmpfs   size={{ k8s_crio_storage_size }},noatime,nodev,nosuid   0 0" >> /etc/fstab
         - sudo swapoff -a
@@ -292,7 +292,7 @@
             rm -rf /var/lib/kubelet/* /etc/kubernetes/*
             rm -rf /var/lib/kubelet/.* /etc/kubernetes/.*
             K8S_CLIENT_MOUNT_PATH="{{ k8s_client_mount_path }}"
-            NODE_NAME="{% raw %}{{ ds.meta_data.instance_data.local_ipv4 }}{% endraw %}"
+            NODE_NAME="{% raw %}{{ "{{" }} ip {{ "}}" }}{% endraw %}"
             KUBE_VIP="{{ kube_vip }}"
             JOIN_CMD_FILE="${K8S_CLIENT_MOUNT_PATH}/worker-join-command.sh"
             echo "----------------------------------------------------------------------"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_control_node_x86_64.yaml.j2
@@ -309,21 +309,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_aarch64.yaml.j2
@@ -435,21 +435,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
-         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
+        - echo "No mount entries found for this host"
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-slurm_node_x86_64.yaml.j2
@@ -444,21 +444,21 @@
 {% endfor %}
 {% endif %}
 {% raw %}
-      {% if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map %}
-      {% set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) %}
-      {% if mymounts %}
-      {% for mount in mymounts.get("mounts", []) %}
-        - mkdir -pv {{"{{"}} mount[1] {{"}}"}}
-        - echo "{{"{{"}} mount | join(' ') {{"}}"}}" >> /etc/fstab
-      {% endfor %}
+      {{ "{%" }} if ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map is mapping and ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map {{ "%}" }}
+      {{ "{%" }} set mymounts = ds.meta_data.instance_data.v1.vendor_data.groups.ssh.host_mount_map.get(local_hostname, {}) {{ "%}" }}
+      {{ "{%" }} if mymounts {{ "%}" }}
+      {{ "{%" }} for mount in mymounts.get("mounts", []) {{ "%}" }}
+        - mkdir -pv {{ "{{" }} mount[1] {{ "}}" }}
+        - echo "{{ "{{" }} mount | join(' ') {{ "}}" }}" >> /etc/fstab
+      {{ "{%" }} endfor {{ "%}" }}
         - mount -av
-      {% for decoded_cmd in mymounts.get("runcmd", []) %}
-        - {{"{{"}} decoded_cmd {{"}}"}}
-      {% endfor %}
-      {% else %}
+      {{ "{%" }} for decoded_cmd in mymounts.get("runcmd", []) {{ "%}" }}
+        - {{ "{{" }} decoded_cmd {{ "}}" }}
+      {{ "{%" }} endfor {{ "%}" }}
+      {{ "{%" }} else {{ "%}" }}
         - echo "No mount entries found for this host"
-      {% endif %}
-      {% endif %}
+      {{ "{%" }} endif {{ "%}" }}
+      {{ "{%" }} endif {{ "%}" }}
 {% endraw %}
 {% set fg_swap = metadata_svc_groups_dict.get(functional_group_name, {}).get('swap', {}) %}
 {% include 'configure_swap.yaml.j2' %}

--- a/src/orchestrator/roles/configure_ochami/templates/nodes/groups.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/nodes/groups.yaml.j2
@@ -1,7 +1,7 @@
 - label: {{ functional_group_name }}
   members:
     ids:
-{% for item in nodes | sort(attribute='value.XNAME') %}
+{% for item in smd_group_nodes | sort(attribute='value.XNAME') %}
 {% if item.value.FUNCTIONAL_GROUP_NAME == functional_group_name %}
       - {{ item.value.XNAME }}
 {% endif %}

--- a/src/orchestrator/roles/configure_ochami/templates/nodes/groups_additional_fg.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/nodes/groups_additional_fg.yaml.j2
@@ -1,7 +1,7 @@
 - label: {{ additional_cloud_init_fg_smd_group_name }}
   members:
     ids:
-{% for item in nodes | sort(attribute='value.XNAME') %}
+{% for item in smd_group_nodes | sort(attribute='value.XNAME') %}
 {% if item.value.FUNCTIONAL_GROUP_NAME | replace('_first_', '_') == functional_group_name %}
       - {{ item.value.XNAME }}
 {% endif %}

--- a/src/orchestrator/roles/configure_ochami/templates/nodes/groups_common.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/nodes/groups_common.yaml.j2
@@ -1,6 +1,6 @@
 - label: {{ common_group_name }}
   members:
     ids:
-{% for item in nodes | sort(attribute='value.XNAME') %}
+{% for item in common_group_nodes | sort(attribute='value.XNAME') %}
       - {{ item.value.XNAME }}
 {% endfor %}

--- a/src/orchestrator/roles/configure_ochami/templates/nodes/hostname.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/nodes/hostname.yaml.j2
@@ -1,4 +1,4 @@
-{% for item in nodes | sort(attribute='value.XNAME') %}
-- id: {{ item.value.XNAME }}
-  local-hostname: {{ item.value.HOSTNAME }}.{{ hostvars['localhost']['domain_name'] }}
+{% for node in mapping_nodes %}
+- id: {{ node['XNAME'] }}
+  local-hostname: {{ node['HOSTNAME'] }}.{{ hostvars['localhost']['domain_name'] }}
 {% endfor %}

--- a/src/orchestrator/roles/configure_ochami/templates/nodes/nodes.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/nodes/nodes.yaml.j2
@@ -1,15 +1,15 @@
 nodes:
-{% for item in nodes | sort(attribute='value.XNAME') %}
-- name: {{ item.value.HOSTNAME }}
-  xname: {{ item.value.XNAME }}
-  description: {{ item.value.SERVICE_TAG }}
-  nid: {{ item.value.HOSTNAME | regex_replace('^nid0*', '') | int if item.value.HOSTNAME is regex('^nid\\d+$') else loop.index }}
-  group: {{ item.value.FUNCTIONAL_GROUP_NAME }}
-  bmc_mac: {{ item.value.BMC_MAC }} 
-  bmc_ip: {{ item.value.BMC_IP }}
+{% for node in mapping_nodes %}
+- name: {{ node['HOSTNAME'] }}
+  xname: {{ node['XNAME'] }}
+  description: {{ node['SERVICE_TAG'] }}
+  nid: {{ node['HOSTNAME'] | regex_replace('^nid0*', '') | int if node['HOSTNAME'] is regex('^nid\\d+$') else loop.index }}
+  group: {{ node['FUNCTIONAL_GROUP_NAME'] }}
+  bmc_mac: {{ node['BMC_MAC'] }} 
+  bmc_ip: {{ node['BMC_IP'] }}
   interfaces:
-  - mac_addr: {{ item.value.ADMIN_MAC }}
+  - mac_addr: {{ node['ADMIN_MAC'] }}
     ip_addrs:
     - name: management
-      ip_addr: {{ item.value.ADMIN_IP }}
+      ip_addr: {{ node['ADMIN_IP'] }}
 {% endfor %}

--- a/src/orchestrator/roles/configure_ochami/vars/main.yml
+++ b/src/orchestrator/roles/configure_ochami/vars/main.yml
@@ -119,6 +119,7 @@ login_compiler_node_present: "{{ hostvars['oim']['login_compiler_node_present'] 
 slurm_node_present: "{{ hostvars['oim']['slurm_node_present'] | default(false) }}"
 # Usage: ci-group-slurm_node_x86_64.yaml.j2, ci-group-slurm_node_aarch64.yaml.j2
 dcgm_support: "{{ hostvars['localhost'].get('dcgm_support', true) | bool }}"
+csi_driver_powerscale_support: "{{ hostvars['localhost'].get('csi_driver_powerscale_support', false) | string | lower }}"
 # NVIDIA DCGM (Data Center GPU Manager) configuration
 dcgm_service_name: "nvidia-dcgm"
 dcgm_health_check_retries: 3

--- a/src/orchestrator/roles/k8s_config/tasks/create_k8s_config_nfs.yml
+++ b/src/orchestrator/roles/k8s_config/tasks/create_k8s_config_nfs.yml
@@ -41,6 +41,14 @@
     # k8s_server_share_path: "{{ (nfs_client_params | selectattr('nfs_name', 'equalto', nfs_storage_name) | first).server_share_path }}"
     k8s_nfs_server_path: "{{ (mounts | selectattr('name', 'equalto', nfs_storage_name) | first).source }}"
 
+# Override packages_base_dir_* at set_fact level so that any stale
+# play-level facts (e.g. from slurm_config include_vars) cannot shadow
+# the k8s_config definitions.
+- name: Set packages_base_dir for k8s
+  ansible.builtin.set_fact:
+    packages_base_dir_x86_64: "{{ k8s_client_mount_path }}/packages/x86_64"
+    packages_base_dir_aarch64: "{{ k8s_client_mount_path }}/packages/aarch64"
+
 - name: Ensure SSH key directory exists on K8s share
   ansible.builtin.file:
     path: "{{ k8s_client_mount_path }}/ssh"
@@ -224,6 +232,16 @@
     - item.item.source_path | length > 0
     - item.item.dest_path | length > 0
 
+# Propagate repo_manager paths from localhost (where repo_status.yml was loaded)
+- name: Set repo_manager paths from localhost
+  ansible.builtin.set_fact:
+    offline_tarball_path: "{{ hostvars['localhost']['offline_tarball_path'] }}"
+    offline_manifest_path: "{{ hostvars['localhost']['offline_manifest_path'] }}"
+    offline_git_path: "{{ hostvars['localhost']['offline_git_path'] | default('') }}"
+  when:
+    - offline_tarball_path is not defined
+    - hostvars['localhost']['offline_tarball_path'] is defined
+
 - name: Verify repo_status variables are available
   ansible.builtin.assert:
     that:
@@ -235,11 +253,18 @@
       and the file exists, or run repo_manager.yml first.
     quiet: true
 
-- name: Load service_k8s_v<version>.json
+- name: Check if K8s packages JSON exists
+  ansible.builtin.stat:
+    path: "{{ k8s_packages_file }}"
+  register: _k8s_pkg_json_stat
+  delegate_to: localhost
+
+- name: Load service_k8s_v<version>.json (when file exists)
   ansible.builtin.set_fact:
     k8s_packages_json: "{{ lookup('file', k8s_packages_file) | from_json }}"
+  when: _k8s_pkg_json_stat.stat.exists
 
-- name: Extract and set facts for tarball URLs
+- name: Extract and set facts for tarball URLs (from JSON)
   ansible.builtin.set_fact:
     calico_package: "{{ k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'calico') | map(attribute='package') | join }}" # noqa: yaml[line-length]
     metallb_package: "{{ k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'metallb-native') | map(attribute='package') | join }}" # noqa: yaml[line-length]
@@ -249,6 +274,59 @@
     whereabouts_pkg: "{{ k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'git') | selectattr('package', 'search', 'whereabouts') | map(attribute='package') | join }}" # noqa: yaml[line-length]
     kube_vip_package: "{{ k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'image') | selectattr('package', 'search', 'kube-vip') | map(attribute='package') | join }}" # noqa: yaml[line-length]
     kube_vip_tag: "{{ k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'image') | selectattr('package', 'search', 'kube-vip') | map(attribute='tag') | join }}" # noqa: yaml[line-length]
+  when: _k8s_pkg_json_stat.stat.exists
+
+- name: Extract K8s package names from catalog (fallback when JSON missing)
+  ansible.builtin.set_fact:
+    calico_package: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'manifest')
+         | selectattr('name', 'search', '^calico-v')
+         | map(attribute='name') | first | default('calico') }}
+    metallb_package: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'manifest')
+         | selectattr('name', 'search', '^metallb-native')
+         | map(attribute='name') | first | default('metallb-native') }}
+    nfs_subdir_external_provisioner_pkg: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'tarball')
+         | selectattr('name', 'search', 'nfs-subdir-external-provisioner')
+         | map(attribute='name') | first | default('nfs-subdir-external-provisioner') }}
+    multus_package: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'manifest')
+         | selectattr('name', 'search', 'multus-daemonset')
+         | map(attribute='name') | first | default('multus-daemonset-thick') }}
+    helm_package: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'tarball')
+         | selectattr('name', 'search', '^helm-v')
+         | map(attribute='name') | first | default('helm') }}
+    whereabouts_pkg: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'git')
+         | selectattr('name', 'search', 'whereabouts')
+         | map(attribute='name') | first | default('whereabouts') }}
+    kube_vip_package: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'image')
+         | selectattr('name', 'search', 'kube-vip')
+         | map(attribute='name') | first | default('kube-vip') }}
+    kube_vip_tag: >-
+      {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+         | selectattr('packagetype', 'defined')
+         | selectattr('packagetype', 'equalto', 'image')
+         | selectattr('name', 'search', 'kube-vip')
+         | map(attribute='tag') | first | default('latest') }}
+  when: not _k8s_pkg_json_stat.stat.exists
 
 - name: Compose kube-vip image reference from package and tag
   ansible.builtin.set_fact:

--- a/src/orchestrator/roles/k8s_config/vars/main.yml
+++ b/src/orchestrator/roles/k8s_config/vars/main.yml
@@ -16,13 +16,13 @@
 input_project_dir: "{{ hostvars['localhost']['omnia_project_input_dir'] }}"
 # Versioned JSON file: service_k8s_v<version>.json (e.g., service_k8s_v1.35.1.json)
 k8s_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars['localhost']['cluster_os_type'] }}/{{ hostvars['localhost']['cluster_os_version'] }}/service_k8s_v{{ hostvars['localhost']['service_k8s_version'] }}.json" # noqa: yaml[line-length]
-calico_manifest_yaml_url: "{{ offline_manifest_path }}/{{ calico_package }}/{{ calico_package }}.yml"
+calico_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ calico_package }}/{{ calico_package }}.yml"
 csi_powerscale_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars['localhost']['cluster_os_type'] }}/{{ hostvars['localhost']['cluster_os_version'] }}/csi_driver_powerscale.json" # noqa: yaml[line-length]
-metallb_manifest_yaml_url: "{{ offline_manifest_path }}/{{ metallb_package }}/{{ metallb_package }}.yml"
-multus_manifest_yaml_url: "{{ offline_manifest_path }}/{{ multus_package }}/{{ multus_package }}.yml"
-helm_tarball_url: "{{ offline_tarball_path }}/{{ helm_package }}/{{ helm_package }}.tar.gz"
-nfs_client_provisioner_tarball_url: "{{ offline_tarball_path }}/{{ nfs_subdir_external_provisioner_pkg }}/{{ nfs_subdir_external_provisioner_pkg }}.tar.gz"
-whereabouts_git_url: "{{ offline_git_path }}/{{ whereabouts_pkg }}/{{ whereabouts_pkg }}.tar.gz"
+metallb_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ metallb_package }}/{{ metallb_package }}.yml"
+multus_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ multus_package }}/{{ multus_package }}.yml"
+helm_tarball_url: "{{ offline_tarball_path | regex_replace('/$', '') }}/{{ helm_package }}/{{ helm_package }}.tar.gz"
+nfs_client_provisioner_tarball_url: "{{ offline_tarball_path | regex_replace('/$', '') }}/{{ nfs_subdir_external_provisioner_pkg }}/{{ nfs_subdir_external_provisioner_pkg }}.tar.gz"
+whereabouts_git_url: "{{ offline_git_path | regex_replace('/$', '') }}/{{ whereabouts_pkg }}/{{ whereabouts_pkg }}.tar.gz"
 file_mode: "0644"
 ha_config_file: "{{ input_project_dir }}/high_availability_config.yml"
 # Pulp cert path is read from repo_manager output (repo_status.yml) via orchestrator_setup

--- a/src/orchestrator/roles/k8s_config/vars/main.yml
+++ b/src/orchestrator/roles/k8s_config/vars/main.yml
@@ -21,7 +21,10 @@ csi_powerscale_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars
 metallb_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ metallb_package }}/{{ metallb_package }}.yml"
 multus_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ multus_package }}/{{ multus_package }}.yml"
 helm_tarball_url: "{{ offline_tarball_path | regex_replace('/$', '') }}/{{ helm_package }}/{{ helm_package }}.tar.gz"
-nfs_client_provisioner_tarball_url: "{{ offline_tarball_path | regex_replace('/$', '') }}/{{ nfs_subdir_external_provisioner_pkg }}/{{ nfs_subdir_external_provisioner_pkg }}.tar.gz"
+nfs_client_provisioner_tarball_url: >-
+  {{ offline_tarball_path | regex_replace('/$', '') }}/{{
+  nfs_subdir_external_provisioner_pkg }}/{{
+  nfs_subdir_external_provisioner_pkg }}.tar.gz
 whereabouts_git_url: "{{ offline_git_path | regex_replace('/$', '') }}/{{ whereabouts_pkg }}/{{ whereabouts_pkg }}.tar.gz"
 file_mode: "0644"
 ha_config_file: "{{ input_project_dir }}/high_availability_config.yml"

--- a/src/orchestrator/roles/orchestrator_validations/tasks/include_software_config.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/include_software_config.yml
@@ -65,7 +65,18 @@
          if (catalog_data.catalog.packages is defined and
              catalog_data.catalog.packages.kubeadm is defined)
          else '' -%}
-      {{ fl_ver if fl_ver else pkg_ver }}
+      {% set ns = namespace(key_ver='') -%}
+      {% if not fl_ver and not pkg_ver and catalog_data.catalog.packages is defined -%}
+        {% for key in catalog_data.catalog.packages.keys() -%}
+          {% if not ns.key_ver and key is match('kubeadm.*|kubectl.*|kubelet.*') -%}
+            {% set ns.key_ver = catalog_data.catalog.packages[key].name
+               | default(key)
+               | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')
+               | default('', true) -%}
+          {% endif -%}
+        {% endfor -%}
+      {% endif -%}
+      {{ fl_ver if fl_ver else (pkg_ver if pkg_ver else ns.key_ver) }}
   when:
     - service_k8s_support | default(false) | bool
     - catalog_data is defined

--- a/src/orchestrator/roles/orchestrator_validations/tasks/validate_image.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/validate_image.yml
@@ -99,11 +99,16 @@
     - _all_fg_entries | default([]) | length > 0
     - _fg_image_entry | default({}) | length == 0
 
-- name: Find matching FG entry (_first fallback — strip _first and retry)
+# The "_first" suffix is an orchestrator-internal concept (marks the first
+# control-plane node).  image_build_manager builds a single image for
+# "service_kube_control_plane" — there is no separate "_first" image.
+# Fall back to matching without "_first" so the same image is reused.
+- name: Find matching FG entry (strip _first suffix fallback)
   ansible.builtin.set_fact:
     _fg_image_entry: >-
       {{ _all_fg_entries
-         | selectattr('functional_group', 'search', '^' + (_fg_prefix | regex_replace('_first$', '')) + '_.*' + _fg_arch + '$')
+         | selectattr('functional_group', 'search',
+             '^' + _fg_prefix | regex_replace('_first$', '') + '_.*' + _fg_arch + '$')
          | list | first | default({}) }}
   when:
     - _all_fg_entries | default([]) | length > 0

--- a/src/orchestrator/roles/provision_common/tasks/configure_boot_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_boot_svc.yml
@@ -26,9 +26,9 @@
     src: "{{ nodes_dir }}/nodes_{{ target_category }}.yaml"
   register: boot_svc_nodes_raw
 
-- name: Set nodes fact for boot-service template - {{ fg_name }}
+- name: Set boot_svc_nodes fact for boot-service template - {{ fg_name }}
   ansible.builtin.set_fact:
-    nodes: "{{ (boot_svc_nodes_raw.content | b64decode | from_yaml).nodes }}"
+    boot_svc_nodes: "{{ (boot_svc_nodes_raw.content | b64decode | from_yaml).nodes }}"
 
 - name: Set kernel, initrd and image from validated images - {{ fg_name }}
   ansible.builtin.set_fact:

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -180,7 +180,8 @@
   ansible.builtin.set_fact:
     calico_cidr: >-
       {%- set ib_net = hostvars['localhost']['ib_network_subnet'] | default('') -%}
-      {%- set primary_net = (hostvars['localhost']['admin_nic_ip'] + '/' + hostvars['localhost']['admin_netmask_bits']) | ansible.utils.ipaddr('network/prefix') -%}
+      {%- set primary_net = (hostvars['localhost']['admin_nic_ip'] + '/' +
+      hostvars['localhost']['admin_netmask_bits']) | ansible.utils.ipaddr('network/prefix') -%}
       {%- if ib_net -%}{{ primary_net }},{{ ib_net }}{%- else -%}{{ primary_net }}{%- endif -%}
   when: target_category | default('') == 'kubernetes'
 
@@ -261,7 +262,6 @@
              | selectattr('name', 'search', 'multus-daemonset')
              | map(attribute='name') | first | default('multus-daemonset-thick') }}
       when: not _k8s_pkg_stat.stat.exists
-  when: target_category | default('') == 'kubernetes'
 
 # ---- End K8s-specific variable setup ----
 

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -142,6 +142,9 @@
   when: target_category | default('') == 'kubernetes'
 
 - name: Load orchestrator_config for dns_enabled
+  when:
+    - target_category | default('') == 'kubernetes'
+    - dns_enabled is not defined
   block:
     - name: Read orchestrator_config.yml
       ansible.builtin.include_vars:
@@ -150,9 +153,6 @@
     - name: Set dns_enabled fact
       ansible.builtin.set_fact:
         dns_enabled: "{{ _orch_config_ms.dns_enabled | default(false) | bool }}"
-  when:
-    - target_category | default('') == 'kubernetes'
-    - dns_enabled is not defined
 
 - name: Set K8s facts from omnia_config and HA config
   ansible.builtin.set_fact:
@@ -185,10 +185,15 @@
   when: target_category | default('') == 'kubernetes'
 
 - name: Load K8s packages JSON for template variables
+  when: target_category | default('') == 'kubernetes'
   block:
     - name: Set k8s_packages_file path
       ansible.builtin.set_fact:
-        _k8s_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars['localhost']['cluster_os_type'] }}/{{ hostvars['localhost']['cluster_os_version'] }}/service_k8s_v{{ service_k8s_version }}.json"
+        _k8s_packages_file: >-
+          {{ input_project_dir }}/config/x86_64/{{
+          hostvars['localhost']['cluster_os_type'] }}/{{
+          hostvars['localhost']['cluster_os_version']
+          }}/service_k8s_v{{ service_k8s_version }}.json
 
     - name: Check if K8s packages JSON exists
       ansible.builtin.stat:
@@ -203,10 +208,30 @@
 
     - name: Set K8s package names from JSON
       ansible.builtin.set_fact:
-        calico_package: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'calico') | map(attribute='package') | join }}"
-        metallb_package: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'metallb-native') | map(attribute='package') | join }}"
-        nfs_subdir_external_provisioner_pkg: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'tarball') | selectattr('package', 'search', 'nfs-subdir-external-provisioner') | map(attribute='package') | join }}"
-        multus_package: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'multus-daemonset-thick') | map(attribute='package') | join }}"
+        calico_package: >-
+          {{ _k8s_packages_json['service_kube_control_plane_first']['cluster']
+          | selectattr('type', 'equalto', 'manifest')
+          | selectattr('package', 'search', 'calico')
+          | map(attribute='package')
+          | join }}
+        metallb_package: >-
+          {{ _k8s_packages_json['service_kube_control_plane_first']['cluster']
+          | selectattr('type', 'equalto', 'manifest')
+          | selectattr('package', 'search', 'metallb-native')
+          | map(attribute='package')
+          | join }}
+        nfs_subdir_external_provisioner_pkg: >-
+          {{ _k8s_packages_json['service_kube_control_plane_first']['cluster']
+          | selectattr('type', 'equalto', 'tarball')
+          | selectattr('package', 'search', 'nfs-subdir-external-provisioner')
+          | map(attribute='package')
+          | join }}
+        multus_package: >-
+          {{ _k8s_packages_json['service_kube_control_plane_first']['cluster']
+          | selectattr('type', 'equalto', 'manifest')
+          | selectattr('package', 'search', 'multus-daemonset-thick')
+          | map(attribute='package')
+          | join }}
       when: _k8s_pkg_stat.stat.exists
 
     - name: Extract K8s package names from catalog (fallback)

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -130,6 +130,116 @@
       (hostvars['localhost']['domain_name'] | default('')).split('.')
       | select | map('regex_replace', '^', 'dc=') | join(',') }}
 
+# ---- K8s-specific variable setup for metadata-service templates ----
+# These variables are normally set by the k8s_config bolt-on, but the
+# metadata-service templates need them during provision_common which
+# runs before k8s_config.  Guard all tasks with target_category check.
+
+- name: Load high availability config for kube_vip
+  ansible.builtin.include_vars:
+    file: "{{ input_project_dir }}/high_availability_config.yml"
+  failed_when: false
+  when: target_category | default('') == 'kubernetes'
+
+- name: Load orchestrator_config for dns_enabled
+  block:
+    - name: Read orchestrator_config.yml
+      ansible.builtin.include_vars:
+        file: "{{ input_project_dir }}/orchestrator_config.yml"
+        name: _orch_config_ms
+    - name: Set dns_enabled fact
+      ansible.builtin.set_fact:
+        dns_enabled: "{{ _orch_config_ms.dns_enabled | default(false) | bool }}"
+  when:
+    - target_category | default('') == 'kubernetes'
+    - dns_enabled is not defined
+
+- name: Set K8s facts from omnia_config and HA config
+  ansible.builtin.set_fact:
+    kube_vip: "{{ service_k8s_cluster_ha[0].virtual_ip_address | default('') }}"
+    service_k8s_version: "{{ hostvars['localhost']['service_k8s_version'] }}"
+    k8s_pod_network_cidr: "{{ service_k8s_cluster[0].k8s_pod_network_cidr }}"
+    k8s_service_addresses: "{{ service_k8s_cluster[0].k8s_service_addresses }}"
+    pod_external_ip_range: "{{ service_k8s_cluster[0].pod_external_ip_range }}"
+    k8s_crio_storage_size: "{{ service_k8s_cluster[0].k8s_crio_storage_size }}"
+    etcd_on_local_disk: "{{ service_k8s_cluster[0].etcd_on_local_disk | default(false) }}"
+    admin_netmask_bits: "{{ hostvars['localhost']['admin_netmask_bits'] }}"
+    pulp_mirror: "{{ hostvars['localhost']['admin_nic_ip'] }}:{{ hostvars['localhost']['pulp_port'] | default(2225) }}"
+    pulp_server_ip: "{{ hostvars['localhost']['admin_nic_ip'] }}"
+    dns: "{{ hostvars['localhost']['dns'] | default([]) }}"
+    offline_pip_module_path: "{{ hostvars['localhost']['offline_pip_module_path'] | default('') }}"
+  when: target_category | default('') == 'kubernetes'
+
+- name: Set K8s NFS paths from storage config
+  ansible.builtin.set_fact:
+    k8s_client_mount_path: "{{ (mounts | selectattr('name', 'equalto', service_k8s_cluster[0].nfs_storage_name) | first).mount_point }}"
+    k8s_nfs_server_path: "{{ (mounts | selectattr('name', 'equalto', service_k8s_cluster[0].nfs_storage_name) | first).source }}"
+  when: target_category | default('') == 'kubernetes'
+
+- name: Compute calico_cidr from network data
+  ansible.builtin.set_fact:
+    calico_cidr: >-
+      {%- set ib_net = hostvars['localhost']['ib_network_subnet'] | default('') -%}
+      {%- set primary_net = (hostvars['localhost']['admin_nic_ip'] + '/' + hostvars['localhost']['admin_netmask_bits']) | ansible.utils.ipaddr('network/prefix') -%}
+      {%- if ib_net -%}{{ primary_net }},{{ ib_net }}{%- else -%}{{ primary_net }}{%- endif -%}
+  when: target_category | default('') == 'kubernetes'
+
+- name: Load K8s packages JSON for template variables
+  block:
+    - name: Set k8s_packages_file path
+      ansible.builtin.set_fact:
+        _k8s_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars['localhost']['cluster_os_type'] }}/{{ hostvars['localhost']['cluster_os_version'] }}/service_k8s_v{{ service_k8s_version }}.json"
+
+    - name: Check if K8s packages JSON exists
+      ansible.builtin.stat:
+        path: "{{ _k8s_packages_file }}"
+      register: _k8s_pkg_stat
+      delegate_to: localhost
+
+    - name: Load K8s packages JSON (when file exists)
+      ansible.builtin.set_fact:
+        _k8s_packages_json: "{{ lookup('file', _k8s_packages_file) | from_json }}"
+      when: _k8s_pkg_stat.stat.exists
+
+    - name: Set K8s package names from JSON
+      ansible.builtin.set_fact:
+        calico_package: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'calico') | map(attribute='package') | join }}"
+        metallb_package: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'metallb-native') | map(attribute='package') | join }}"
+        nfs_subdir_external_provisioner_pkg: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'tarball') | selectattr('package', 'search', 'nfs-subdir-external-provisioner') | map(attribute='package') | join }}"
+        multus_package: "{{ _k8s_packages_json['service_kube_control_plane_first']['cluster'] | selectattr('type', 'equalto', 'manifest') | selectattr('package', 'search', 'multus-daemonset-thick') | map(attribute='package') | join }}"
+      when: _k8s_pkg_stat.stat.exists
+
+    - name: Extract K8s package names from catalog (fallback)
+      ansible.builtin.set_fact:
+        calico_package: >-
+          {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+             | selectattr('packagetype', 'defined')
+             | selectattr('packagetype', 'equalto', 'manifest')
+             | selectattr('name', 'search', '^calico-v')
+             | map(attribute='name') | first | default('calico') }}
+        metallb_package: >-
+          {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+             | selectattr('packagetype', 'defined')
+             | selectattr('packagetype', 'equalto', 'manifest')
+             | selectattr('name', 'search', '^metallb-native')
+             | map(attribute='name') | first | default('metallb-native') }}
+        nfs_subdir_external_provisioner_pkg: >-
+          {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+             | selectattr('packagetype', 'defined')
+             | selectattr('packagetype', 'equalto', 'tarball')
+             | selectattr('name', 'search', 'nfs-subdir-external-provisioner')
+             | map(attribute='name') | first | default('nfs-subdir-external-provisioner') }}
+        multus_package: >-
+          {{ hostvars['localhost']['catalog_data'].catalog.packages.values()
+             | selectattr('packagetype', 'defined')
+             | selectattr('packagetype', 'equalto', 'manifest')
+             | selectattr('name', 'search', 'multus-daemonset')
+             | map(attribute='name') | first | default('multus-daemonset-thick') }}
+      when: not _k8s_pkg_stat.stat.exists
+  when: target_category | default('') == 'kubernetes'
+
+# ---- End K8s-specific variable setup ----
+
 - name: Set functional_group_name for template compatibility
   ansible.builtin.set_fact:
     functional_group_name: "{{ fg_name }}"

--- a/src/orchestrator/roles/provision_common/tasks/create_smd_group.yml
+++ b/src/orchestrator/roles/provision_common/tasks/create_smd_group.yml
@@ -26,7 +26,7 @@
     dest: "{{ nodes_dir }}/groups-{{ fg_name }}.yml"
     mode: "{{ file_permissions_644 }}"
   vars:
-    nodes: >-
+    smd_group_nodes: >-
       {{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items
          | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names)
          | list }}

--- a/src/orchestrator/roles/provision_common/tasks/register_nodes.yml
+++ b/src/orchestrator/roles/provision_common/tasks/register_nodes.yml
@@ -69,22 +69,12 @@
 
 - name: Compute filtered nodes for {{ target_category }}
   ansible.builtin.set_fact:
-    _category_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names) | map(attribute='value') | sort(attribute='XNAME') | list }}"
-
-- name: "DEBUG {{ target_category }} - _category_nodes details"
-  ansible.builtin.debug:
-    msg: "type={{ _category_nodes | type_debug }} len={{ _category_nodes | length }} first_type={{ (_category_nodes | first) | type_debug }} first_keys={{ (_category_nodes | first).keys() | list }} first_HOSTNAME={{ (_category_nodes | first)['HOSTNAME'] }}"
-
-- name: "DEBUG {{ target_category }} - write nodes with copy to test"
-  ansible.builtin.copy:
-    content: |
-      nodes:
-      {% for node in _category_nodes %}
-      - name: {{ node['HOSTNAME'] }}
-        xname: {{ node['XNAME'] }}
-      {% endfor %}
-    dest: "/tmp/test_{{ target_category }}_nodes_debug.yaml"
-    mode: "0644"
+    _category_nodes: >-
+      {{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items
+         | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names)
+         | map(attribute='value')
+         | sort(attribute='XNAME')
+         | list }}
 
 - name: Generate per-category nodes YAML ({{ target_category }})
   ansible.builtin.template:

--- a/src/orchestrator/roles/provision_common/tasks/register_nodes.yml
+++ b/src/orchestrator/roles/provision_common/tasks/register_nodes.yml
@@ -19,6 +19,31 @@
 - name: Include openchami vars
   ansible.builtin.include_vars: "{{ openchami_config_vars_path }}"
 
+# Preserve the openchami cluster_name at set_fact level so that stale
+# set_fact values (e.g. from k8s_config setting cluster_name to the K8s
+# cluster name) cannot shadow the openchami cluster identity.
+- name: Pin openchami cluster_name at set_fact level
+  ansible.builtin.set_fact:
+    cluster_name: "{{ lookup('file', openchami_config_vars_path) | from_yaml | json_query('cluster_name') }}"
+    cluster_domain: "{{ lookup('file', openchami_config_vars_path) | from_yaml | json_query('cluster_domain') }}"
+
+- name: Ensure read_mapping_file is available
+  ansible.builtin.set_fact:
+    read_mapping_file: "{{ hostvars['localhost']['read_mapping_file'] }}"
+  when: hostvars['localhost']['read_mapping_file'] is defined
+
+- name: Re-read mapping file if not available
+  community.general.read_csv:
+    path: "{{ hostvars['localhost']['pxe_mapping_file_path'] }}"
+    key: ADMIN_MAC
+  register: _mapping_file_result
+  when: hostvars['localhost']['read_mapping_file'] is not defined
+
+- name: Set read_mapping_file from re-read result
+  ansible.builtin.set_fact:
+    read_mapping_file: "{{ _mapping_file_result }}"
+  when: hostvars['localhost']['read_mapping_file'] is not defined
+
 - name: Create ochami nodes directory
   ansible.builtin.file:
     path: "{{ nodes_dir }}"
@@ -42,16 +67,33 @@
   ansible.builtin.set_fact:
     target_fg_names: "{{ target_functional_groups | map(attribute='name') | list }}"
 
+- name: Compute filtered nodes for {{ target_category }}
+  ansible.builtin.set_fact:
+    _category_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names) | map(attribute='value') | sort(attribute='XNAME') | list }}"
+
+- name: "DEBUG {{ target_category }} - _category_nodes details"
+  ansible.builtin.debug:
+    msg: "type={{ _category_nodes | type_debug }} len={{ _category_nodes | length }} first_type={{ (_category_nodes | first) | type_debug }} first_keys={{ (_category_nodes | first).keys() | list }} first_HOSTNAME={{ (_category_nodes | first)['HOSTNAME'] }}"
+
+- name: "DEBUG {{ target_category }} - write nodes with copy to test"
+  ansible.builtin.copy:
+    content: |
+      nodes:
+      {% for node in _category_nodes %}
+      - name: {{ node['HOSTNAME'] }}
+        xname: {{ node['XNAME'] }}
+      {% endfor %}
+    dest: "/tmp/test_{{ target_category }}_nodes_debug.yaml"
+    mode: "0644"
+
 - name: Generate per-category nodes YAML ({{ target_category }})
   ansible.builtin.template:
     src: "{{ openchami_nodes_template }}"
     dest: "{{ nodes_dir }}/nodes_{{ target_category }}.yaml"
     mode: "{{ file_permissions_644 }}"
   vars:
-    nodes: >-
-      {{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items
-         | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names)
-         | list }}
+    mapping_nodes: "{{ _category_nodes }}"
+  delegate_to: localhost
 
 - name: Delete stale SMD endpoints (for clean re-registration)
   ansible.builtin.include_tasks: delete_smd_endpoints.yml
@@ -253,10 +295,7 @@
     dest: "{{ nodes_dir }}/hostname_{{ target_category }}.yaml"
     mode: "{{ file_permissions_644 }}"
   vars:
-    nodes: >-
-      {{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items
-         | selectattr('value.FUNCTIONAL_GROUP_NAME', 'in', target_fg_names)
-         | list }}
+    mapping_nodes: "{{ _category_nodes }}"
 
 - name: Load hostname YAML for metadata-service
   ansible.builtin.slurp:

--- a/src/orchestrator/roles/slurm_config/tasks/read_slurm_hostnames.yml
+++ b/src/orchestrator/roles/slurm_config/tasks/read_slurm_hostnames.yml
@@ -87,6 +87,7 @@
     msg: "{{ controller_empty_msg }}"
   when:
     - ctld_list | length == 0
+    - target_category | default('slurm') == 'slurm'
 
 - name: Extract slurm controller IP
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Fix Variable Collisions in Orchestrator Provisioning

### Problem

The `orchestrator.yml` playbook was failing due to multiple variable precedence and collision issues that prevented successful completion of the provisioning workflow.

### Root Causes

#### 1. `cluster_name` collision
The `k8s_config` role was setting `cluster_name` via `set_fact`, which unintentionally overrode the OpenCHAMI `cluster_name` during the Slurm provisioning pass. As a result, metadata-service health checks were executed against an incorrect cluster identity, causing failures in the provisioning flow.

#### 2. `nodes` variable collision
A generic `nodes` variable was defined as a host-scoped dictionary in `configure_boot_svc.yml`. Because `set_fact` variables persist across plays, this host-scoped value conflicted with later usages of `vars: nodes:` in templates and tasks. This resulted in errors such as:

object of type 'dict' has no attribute 'XNAME'

### Solution

#### 1. Pin OpenCHAMI `cluster_name` using `set_fact`
Added an explicit `set_fact` at the beginning of `register_nodes.yml` to ensure the correct OpenCHAMI cluster identity is always used.

Changes include:
- Extracting `cluster_name` and `cluster_domain` directly from the configuration file using `json_query`
- Preserving the intended OpenCHAMI values throughout the workflow
- Preventing stale `set_fact` values from shadowing the correct configuration during the Slurm pass

#### 2. Rename `nodes` variables to avoid host-scoped collisions
Replaced generic `nodes` references with context-specific variable names to eliminate conflicts across plays, tasks, and templates.

Renamed variables:

- `boot_svc_nodes`
  - `configure_boot_svc.yml`
  - `boot-svc.yaml.j2`
  - `configure_boot_svc_metadata_svc.yml`

- `smd_group_nodes`
  - `create_smd_group.yml`
  - `groups.yaml.j2`
  - `create_groups.yml`
  - `create_groups_additional_fg.yml`
  - `groups_additional_fg.yaml.j2`

- `mapping_nodes`
  - `hostname.yaml.j2`
  - `register_nodes.yml`

### Additional Fixes

- Fixed undefined `kube_vip` references in metadata-service templates
- Fixed `service_k8s_version` extraction from the catalog
- Added fallback handling when `service_k8s_v.json` is missing
- Double-escaped cloud-init Jinja variables in metadata-service templates
- Fixed `packages_base_dir` variable precedence collision
- Fixed `offline_tarball_path` propagation
- Fixed image validation `_first` suffix mismatch

### Result

These changes resolve variable precedence and collision issues within the provisioning workflow, ensure consistent cluster identity throughout the orchestration process, and eliminate cross-play variable contamination that was causing template rendering and node registration failures.