### PR TITLE
fix(utils): domain alignment compliance - Galaxy structure, role documentation, and status integration

### DIFF
--- a/src/utils/containers/README.md
+++ b/src/utils/containers/README.md
@@ -1,0 +1,40 @@
+# Containers
+
+This directory is reserved for container-related assets used by the utils domain.
+
+## Purpose
+
+The utils domain may use container images for log collection, ISO building, or other utility operations in the future. This directory provides a standardized location for:
+
+- Containerfiles (Dockerfile/Podmanfile)
+- Container build scripts
+- Container configuration files
+- Container-related documentation
+
+## Structure
+
+```
+containers/
+├── README.md
+└── <container_name>/
+    ├── Containerfile.<os_version>
+    ├── requirements.txt
+    ├── build.sh
+    └── README.md
+```
+
+## Current State
+
+The utils domain currently does not build or use custom containers. All operations are performed directly on the host system or through standard Ansible modules. This directory is provided for future extensibility and Galaxy collection compliance.
+
+## Future Use Cases
+
+Potential container use cases for the utils domain:
+
+- **Log Collection**: Containerized log aggregation tools
+- **ISO Building**: Containerized image build environments
+- **Validation**: Containerized configuration validation tools
+
+## License
+
+Apache License, Version 2.0

--- a/src/utils/playbooks/cleanup/cleanup_install_os.yml
+++ b/src/utils/playbooks/cleanup/cleanup_install_os.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,12 @@
 - name: Cleanup OS installation artifacts
   hosts: localhost
   connection: local
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Record execution start time
+      ansible.builtin.set_fact:
+        utils_execution_start_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
   tasks:
     - name: Set OMNIA_DATA_PATH fact
       ansible.builtin.set_fact:
@@ -123,3 +128,15 @@
           - "Temporary NFS mount removed: /tmp/install_os_nfs"
           - "Credentials removed: {{ 'Yes' if (cleanup_credentials | bool and credentials_stat.stat.exists) else 'No (preserved)' }}"
           - "=========================================="
+  post_tasks:
+    - name: Record execution end time
+      ansible.builtin.set_fact:
+        utils_execution_end_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
+
+    - name: Write execution status
+      ansible.builtin.include_role:
+        name: utils_status_writer
+      vars:
+        utils_domain_status: "{{ 'success' if ansible_failed_result is not defined else 'failure' }}"
+        utils_playbook_name: "cleanup_install_os.yml"

--- a/src/utils/playbooks/cleanup/cleanup_logs.yml
+++ b/src/utils/playbooks/cleanup/cleanup_logs.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,12 @@
 - name: Cleanup log collection artifacts
   hosts: localhost
   connection: local
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Record execution start time
+      ansible.builtin.set_fact:
+        utils_execution_start_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
   tasks:
     - name: Set OMNIA_DATA_PATH fact
       ansible.builtin.set_fact:
@@ -94,3 +99,15 @@
           - "Old bundles removed: {{ old_logs.files | default([]) | length }}"
           - "Retention period: {{ log_retention_days }} days"
           - "=========================================="
+  post_tasks:
+    - name: Record execution end time
+      ansible.builtin.set_fact:
+        utils_execution_end_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
+
+    - name: Write execution status
+      ansible.builtin.include_role:
+        name: utils_status_writer
+      vars:
+        utils_domain_status: "{{ 'success' if ansible_failed_result is not defined else 'failure' }}"
+        utils_playbook_name: "cleanup_logs.yml"

--- a/src/utils/playbooks/collect.yml
+++ b/src/utils/playbooks/collect.yml
@@ -15,9 +15,14 @@
 
 - name: Stage globals
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   tags:
     - setup
+  pre_tasks:
+    - name: Record execution start time
+      ansible.builtin.set_fact:
+        utils_execution_start_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
   roles:
     - role: log_collector
       stage: setup
@@ -93,9 +98,21 @@
 
 - name: Bundle collected logs and publish summary
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   tags:
     - bundle
   roles:
     - role: log_collector
       stage: bundle
+  post_tasks:
+    - name: Record execution end time
+      ansible.builtin.set_fact:
+        utils_execution_end_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
+
+    - name: Write execution status
+      ansible.builtin.include_role:
+        name: utils_status_writer
+      vars:
+        utils_domain_status: "{{ 'success' if ansible_failed_result is not defined else 'failure' }}"
+        utils_playbook_name: "collect.yml"

--- a/src/utils/playbooks/install_os.yml
+++ b/src/utils/playbooks/install_os.yml
@@ -46,6 +46,11 @@
   connection: local
   gather_facts: true
   tags: [install_os, build_iso, deploy, generate_ks]
+  pre_tasks:
+    - name: Record execution start time
+      ansible.builtin.set_fact:
+        utils_execution_start_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
   roles:
     - role: validate_install_os_config
 
@@ -227,3 +232,15 @@
         dest: "{{ _status_dir }}/install_os_status.yml"
         mode: "0644"
       failed_when: false
+
+    - name: Record execution end time
+      ansible.builtin.set_fact:
+        utils_execution_end_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
+
+    - name: Write domain execution status
+      ansible.builtin.include_role:
+        name: utils_status_writer
+      vars:
+        utils_domain_status: "{{ 'success' if ansible_failed_result is not defined else 'failure' }}"
+        utils_playbook_name: "install_os.yml"

--- a/src/utils/playbooks/precheck/precheck_environment.yml
+++ b/src/utils/playbooks/precheck/precheck_environment.yml
@@ -23,6 +23,23 @@
 - name: Precheck utils environment
   hosts: localhost
   connection: local
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Record execution start time
+      ansible.builtin.set_fact:
+        utils_execution_start_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
   roles:
     - precheck_environment
+  post_tasks:
+    - name: Record execution end time
+      ansible.builtin.set_fact:
+        utils_execution_end_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
+
+    - name: Write execution status
+      ansible.builtin.include_role:
+        name: utils_status_writer
+      vars:
+        utils_domain_status: "{{ 'success' if ansible_failed_result is not defined else 'failure' }}"
+        utils_playbook_name: "precheck_environment.yml"

--- a/src/utils/playbooks/utils.yml
+++ b/src/utils/playbooks/utils.yml
@@ -38,6 +38,13 @@
 #   cleanup_install_os - Cleanup OS installation artifacts only
 #   upgrade           - Upgrade flow (placeholder)
 #   rollback          - Rollback flow (placeholder)
+#
+# NOTE: This utils domain does not support the following standard lifecycle tags
+# as it is a utility domain rather than a full deployment domain:
+#   - validate        (not applicable - utilities have their own validation)
+#   - credentials     (not applicable - utilities handle credentials internally)
+#   - prepare         (not applicable - utilities don't require infrastructure setup)
+#   - execute         (not applicable - utilities run directly without orchestration)
 
 # =========================================================================
 # Step 0: Setup - load env vars (omnia.env), validate host
@@ -47,6 +54,11 @@
   connection: local
   gather_facts: true
   tags: always
+  pre_tasks:
+    - name: Record execution start time
+      ansible.builtin.set_fact:
+        utils_execution_start_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
   roles:
     - utils_setup
 
@@ -123,3 +135,24 @@
     - name: Rollback placeholder
       ansible.builtin.debug:
         msg: "Utils rollback - not implemented yet"
+
+# =========================================================================
+# Step 9: Write domain status file (runs after all flows)
+# =========================================================================
+- name: Write utils domain status
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  tags: always
+  post_tasks:
+    - name: Record execution end time
+      ansible.builtin.set_fact:
+        utils_execution_end_time: "{{ ansible_date_time.iso8601 }}"
+        cacheable: true
+
+    - name: Write execution status
+      ansible.builtin.include_role:
+        name: utils_status_writer
+      vars:
+        utils_domain_status: "{{ 'success' if ansible_failed_result is not defined else 'failure' }}"
+        utils_playbook_name: "utils.yml"

--- a/src/utils/plugins/module_utils/README.md
+++ b/src/utils/plugins/module_utils/README.md
@@ -1,0 +1,32 @@
+# Module Utils
+
+This directory contains shared Python utility modules for Ansible modules in the utils domain.
+
+## Purpose
+
+Module utils provide reusable Python functions and classes that can be imported by multiple Ansible modules. This promotes code reuse and maintainability across the domain.
+
+## Structure
+
+```
+plugins/module_utils/
+├── README.md
+└── <utility_modules>/
+```
+
+## Usage
+
+To use a module util in an Ansible module:
+
+```python
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.omnia.utils.plugins.module_utils.<utility_name> import <function>
+```
+
+## Current State
+
+The utils domain currently does not require custom module utilities as all functionality is implemented through standard Ansible modules and roles. This directory is provided for future extensibility and Galaxy collection compliance.
+
+## License
+
+Apache License, Version 2.0

--- a/src/utils/roles/collect_install_os_credentials/README.md
+++ b/src/utils/roles/collect_install_os_credentials/README.md
@@ -1,0 +1,85 @@
+# collect_install_os_credentials
+
+Collects and manages credentials for OS installation via iDRAC virtual media.
+
+## Description
+
+This role handles the complete credential lifecycle for OS installation operations, including:
+
+- Validation of existing credential files
+- Creation of credential files from templates
+- Vault encryption/decryption of sensitive credentials
+- Interactive prompting for mandatory credential fields
+- Generation of password hashes for kickstart files
+- SSH public key injection for kickstart
+
+The role is idempotent and will skip credential collection if credentials are already loaded in the current Ansible run.
+
+## Requirements
+
+- Ansible Vault for credential encryption
+- Sufficient permissions to create/manage credential files
+- SSH public key for kickstart injection (optional but recommended)
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `vars/main.yml`):
+
+```yaml
+# Credential file configuration
+install_os_credential_file:
+  file_path: "/path/to/install_os_credentials.yml"
+  vault_path: "/path/to/install_os_vault_key"
+  template: "templates/install_os_credentials.j2"
+  file_mode: "0600"
+
+# Mandatory credential fields to prompt for
+install_os_cred_config:
+  mandatory:
+    - bmc_username
+    - bmc_password
+    - os_root_password
+
+# SSH public key path for kickstart injection
+ssh_public_key_path: "/root/.ssh/id_rsa.pub"
+```
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- name: Collect OS installation credentials
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - role: collect_install_os_credentials
+```
+
+## Credential Flow
+
+1. **Validate**: Check if credential file and vault key exist
+2. **Create**: Generate credential file from template if missing
+3. **Encrypt**: Apply Ansible Vault encryption to credential file
+4. **Load**: Decrypt and load credentials into Ansible variables
+5. **Prompt**: Interactively prompt for any missing mandatory fields
+6. **Process**: Generate password hashes and prepare SSH keys
+7. **Secure**: Re-encrypt credential file and mark as loaded
+
+## Security Notes
+
+- All credentials are stored encrypted using Ansible Vault
+- Vault keys are protected with restrictive file permissions (0600)
+- Sensitive operations use `no_log: true` to prevent credential leakage
+- The role automatically encrypts plaintext credential files
+
+## License
+
+Apache 2.0
+
+## Author Information
+
+Dell Technologies Omnia Team

--- a/src/utils/roles/utils_status_writer/defaults/main.yml
+++ b/src/utils/roles/utils_status_writer/defaults/main.yml
@@ -12,4 +12,5 @@ utils_execution_warnings: []
 
 # Status file location
 omnia_data_path: "{{ lookup('env', 'OMNIA_DATA_PATH') | default('/opt/omnia', true) }}"
-utils_status_file_path: "{{ omnia_data_path }}/utils/utils_status.yml"
+omnia_project_name: "{{ lookup('env', 'OMNIA_PROJECT_NAME') | default('project_default', true) }}"
+utils_status_file_path: "{{ omnia_data_path }}/utils/output/{{ omnia_project_name }}/utils_status.yml"

--- a/src/utils/roles/utils_status_writer/tasks/validate_status_file.yml
+++ b/src/utils/roles/utils_status_writer/tasks/validate_status_file.yml
@@ -23,8 +23,8 @@
 - name: Verify required status fields
   ansible.builtin.assert:
     that:
-      - utils_status_content.domain is defined
-      - utils_status_content.status is defined
+      - utils_status_content.utility is defined
+      - utils_status_content.overall_status is defined
       - utils_status_content.version is defined
     fail_msg: "Status file missing required fields"
     success_msg: "Status file contains all required fields"

--- a/src/utils/roles/utils_status_writer/tasks/write_status_file.yml
+++ b/src/utils/roles/utils_status_writer/tasks/write_status_file.yml
@@ -9,8 +9,8 @@
   ansible.builtin.copy:
     content: |
       ---
-      domain: utils
-      status: {{ utils_domain_status }}
+      utility: utils
+      overall_status: {{ utils_domain_status }}
       playbook: {{ utils_playbook_name | default('unknown') }}
       version: "2.2.0"
       started_at: {{ utils_execution_start_time | default(ansible_date_time.iso8601) | quote }}

--- a/src/utils/roles/validate_install_os_config/README.md
+++ b/src/utils/roles/validate_install_os_config/README.md
@@ -1,0 +1,160 @@
+# validate_install_os_config
+
+Validates configuration parameters for OS installation operations based on execution mode.
+
+## Description
+
+This role performs comprehensive validation of `install_os_config.yml` parameters, ensuring that all required fields are present and correctly formatted based on the active execution mode. It supports multiple execution modes with different validation requirements:
+
+- **build_iso**: Validates ISO building parameters (source ISO, custom ISO path)
+- **deploy**: Validates deployment parameters (custom ISO, target BMC, target admin IP)
+- **generate_ks**: Validates kickstart generation parameters (source ISO for arch detection)
+- **credentials_only**: Skips config validation (credential collection only)
+- **default**: Validates all parameters for end-to-end execution
+
+## Requirements
+
+- Valid `install_os_config.yml` file in the project input directory
+- SSH public key for kickstart injection (required for build/generate modes)
+- NFS server access for custom ISO storage
+
+## Role Variables
+
+The role loads configuration from `install_os_config.yml` and sets the following variables:
+
+### Input Configuration (from install_os_config.yml)
+
+```yaml
+# ISO paths
+source_iso_path: "/path/to/source.iso"
+source_iso_checksum: "sha256:checksum"
+custom_iso_path: "nfs-server:/path/to/custom.iso"
+
+# Kickstart configuration
+kickstart_delivery_method: "embedded"  # or "nfs"
+kickstart_file: "/path/to/kickstart.ks"
+kickstart_template: "rhel10"
+
+# Target node configuration
+target_bmc_ip: "192.168.1.100"
+target_hostname: "node01"
+target_admin_ip: "192.168.1.101"
+target_architecture: "x86_64"  # or "aarch64"
+
+# Network configuration
+network_device: "eth0"
+netmask: "255.255.255.0"
+gateway: "192.168.1.1"
+dns_server: "192.168.1.1"
+
+# Installation parameters
+install_disk: "sda"
+timezone: "UTC"
+
+# Build options
+rebuild_iso: false
+force_reinstall: false
+
+# SSH verification
+ssh_verify_enabled: true
+ssh_verify_retries: 60
+ssh_verify_delay: 30
+
+# SSH key path
+ssh_public_key_path: "/root/.ssh/id_rsa.pub"
+```
+
+### Output Variables (set by this role)
+
+```yaml
+# Resolved paths and components
+_nfs_server: "nfs-server"
+_nfs_dir: "/path/to"
+_nfs_iso_filename: "custom.iso"
+_local_iso_path: "/local/mount/path/custom.iso"
+
+# Architecture detection
+os_arch: "x86_64"  # auto-detected from ISO filename
+
+# Kickstart variables
+ks_hostname: "node01"
+ks_static_ip: "192.168.1.101"
+ks_netmask: "255.255.255.0"
+ks_gateway: "192.168.1.1"
+ks_dns: "192.168.1.1"
+ks_network_device: "eth0"
+ks_timezone: "UTC"
+ks_install_disk: "sda"
+```
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- name: Validate OS installation configuration
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  tags: [build_iso, deploy, generate_ks]
+  roles:
+    - role: validate_install_os_config
+```
+
+## Validation Logic
+
+The role determines execution mode from Ansible tags and validates accordingly:
+
+### Build ISO Mode
+- Requires: `source_iso_path`, `custom_iso_path`
+- Validates: ISO file accessibility, SSH public key
+- Auto-detects: Architecture from ISO filename
+
+### Deploy Mode
+- Requires: `custom_iso_path`, `target_bmc_ip`, `target_admin_ip`
+- Validates: NFS URI format, BMC IP connectivity
+- Resolves: Local mount path from NFS mounts
+
+### Generate Kickstart Mode
+- Requires: `source_iso_path`
+- Validates: SSH public key availability
+- Auto-detects: Architecture for kickstart template
+
+### Credentials Only Mode
+- Skips: All configuration validation
+- Purpose: Credential collection without config validation
+
+## Error Messages
+
+The role provides descriptive error messages for common validation failures:
+
+- Missing configuration file
+- Invalid kickstart delivery method
+- Malformed NFS URI in custom_iso_path
+- Missing source ISO for build operations
+- Missing target BMC/admin IP for deploy operations
+- Invalid architecture (must be x86_64 or aarch64)
+- Missing SSH public key
+
+## NFS Path Handling
+
+The role automatically resolves NFS paths to local mount points:
+
+1. Parses `custom_iso_path` into server and path components
+2. Queries system mount table for existing NFS mounts
+3. Maps remote NFS export to local mount directory
+4. Resolves full local path for ISO access
+
+## Architecture Detection
+
+If `target_architecture` is not specified, the role auto-detects architecture from the source ISO filename using pattern matching for `x86_64` or `aarch64`.
+
+## License
+
+Apache 2.0
+
+## Author Information
+
+Dell Technologies Omnia Team

--- a/src/utils/vars/README.md
+++ b/src/utils/vars/README.md
@@ -1,0 +1,39 @@
+# Domain Variables
+
+This directory contains domain-level variable files for the utils domain.
+
+## Purpose
+
+Domain variables provide constants and configuration values that are used across multiple roles and playbooks within the utils domain. These are distinct from role-specific variables (which live in `roles/<role_name>/vars/`) and input configuration (which lives in `input/`).
+
+## Structure
+
+```
+vars/
+├── README.md
+└── <domain_vars>.yml
+```
+
+## Usage
+
+Domain variables can be included in playbooks using:
+
+```yaml
+- name: Load domain variables
+  ansible.builtin.include_vars:
+    file: vars/domain_vars.yml
+```
+
+## Variable Types
+
+- **Constants**: Fixed values that should not be modified by users
+- **Domain configuration**: Settings that apply across the entire domain
+- **Shared defaults**: Common default values used by multiple roles
+
+## Current State
+
+The utils domain currently uses role-specific variables and input configuration files. Domain-level variables are provided for future extensibility and Galaxy collection compliance.
+
+## License
+
+Apache License, Version 2.0


### PR DESCRIPTION
## PR Description

### Description of the Solution

**Summary**: Improves utils domain compliance with Galaxy collection standards by adding missing directory structure, role documentation, and domain status writer integration across all playbooks. This addresses key findings from the domain alignment report.

### Changes

#### Galaxy Structure
- Added `plugins/module_utils/README.md` - Documentation for future module utilities
- Added `containers/README.md` - Documentation for future container assets  
- Added `vars/README.md` - Documentation for domain-level variables

#### Role Documentation
- Added `roles/collect_install_os_credentials/README.md` - Documents credential collection lifecycle, security features, and usage
- Added `roles/validate_install_os_config/README.md` - Documents configuration validation logic, execution modes, and NFS path handling

#### Domain Integration
- Integrated `utils_status_writer` role across all 6 playbooks for domain-level status tracking
- Added execution start/end time tracking to all playbooks
- Fixed status writer conditional logic to handle successful playbook execution
- Added comment in `utils.yml` explaining utils domain does not support standard lifecycle tags (validate, credentials, prepare, execute) as it's a utility domain rather than deployment domain

