### PR TITLE
fix(orchestrator): add kube_vip group in inventory only when K8s functional groups are defined

### DIFF
--- a/src/orchestrator/roles/generate_inventories/tasks/main.yml
+++ b/src/orchestrator/roles/generate_inventories/tasks/main.yml
@@ -55,24 +55,13 @@
     mapping_group_data: "{{ (lookup('file', hostvars['localhost']['functional_groups_config_path']) | from_yaml).groups }}"
 
 # K8s deployment validation - kube_vip is only added when ALL conditions are met:
-# 1. K8s deployment is enabled in omnia_config.yml (deployment: true)
-# 2. K8s functional groups (service_kube_*) are defined in PXE mapping file
-# 3. high_availability_config.yml exists with valid kube_vip configuration
+# 1. K8s functional groups (service_kube_*) are defined in PXE mapping file
+# 2. high_availability_config.yml exists with valid kube_vip configuration
 - name: Check if high_availability_config.yml exists
   ansible.builtin.stat:
     path: "{{ hostvars['localhost']['input_project_dir'] }}/high_availability_config.yml"
   register: ha_config_stat
   delegate_to: localhost
-
-- name: Load omnia_config.yml to check K8s deployment
-  ansible.builtin.include_vars:
-    file: "{{ hostvars['localhost']['input_project_dir'] }}/omnia_config.yml"
-    name: omnia_config
-  delegate_to: localhost
-
-- name: Check if Service K8s cluster deployment is enabled in omnia_config
-  ansible.builtin.set_fact:
-    k8s_deployment_config_enabled: "{{ omnia_config.service_k8s_cluster | default([]) | selectattr('deployment', 'equalto', true) | list | length > 0 }}"
 
 - name: Check if Service K8s functional groups exist in mapping
   ansible.builtin.set_fact:
@@ -84,10 +73,6 @@
         | length > 0
       }}
 
-- name: Set final K8s deployment flag (both config and mapping must have K8s)
-  ansible.builtin.set_fact:
-    k8s_deployment_enabled: "{{ k8s_deployment_config_enabled | default(false) and k8s_groups_in_mapping | default(false) }}"
-
 - name: Load high_availability_config.yml to get kube_vip
   ansible.builtin.include_vars:
     file: "{{ hostvars['localhost']['input_project_dir'] }}/high_availability_config.yml"
@@ -95,14 +80,14 @@
   delegate_to: localhost
   when:
     - ha_config_stat.stat.exists | default(false)
-    - k8s_deployment_enabled | default(false)
+    - k8s_groups_in_mapping | default(false)
 
 - name: Set kube_vip fact
   ansible.builtin.set_fact:
     kube_vip: "{{ ha_config.service_k8s_cluster_ha[0].virtual_ip_address | default('') }}"
   when:
     - ha_config_stat.stat.exists | default(false)
-    - k8s_deployment_enabled | default(false)
+    - k8s_groups_in_mapping | default(false)
 
 - name: Generate BMC group data file
   ansible.builtin.template:

--- a/src/orchestrator/roles/generate_inventories/tasks/main.yml
+++ b/src/orchestrator/roles/generate_inventories/tasks/main.yml
@@ -28,24 +28,6 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/../../vars/functional_group_classification.yml"
 
-- name: Check if high_availability_config.yml exists
-  ansible.builtin.stat:
-    path: "{{ hostvars['localhost']['input_project_dir'] }}/high_availability_config.yml"
-  register: ha_config_stat
-  delegate_to: localhost
-
-- name: Load high_availability_config.yml to get kube_vip
-  ansible.builtin.include_vars:
-    file: "{{ hostvars['localhost']['input_project_dir'] }}/high_availability_config.yml"
-    name: ha_config
-  delegate_to: localhost
-  when: ha_config_stat.stat.exists | default(false)
-
-- name: Set kube_vip fact
-  ansible.builtin.set_fact:
-    kube_vip: "{{ ha_config.service_k8s_cluster_ha[0].virtual_ip_address | default('') }}"
-  when: ha_config_stat.stat.exists | default(false)
-
 # Inventory templates and output paths (from configure_ochami/vars/main.yml)
 - name: Set inventory variables
   ansible.builtin.set_fact:
@@ -71,6 +53,56 @@
   ansible.builtin.set_fact:
     mapping_nodes: "{{ hostvars['localhost']['read_mapping_file']['dict'] | dict2items }}"
     mapping_group_data: "{{ (lookup('file', hostvars['localhost']['functional_groups_config_path']) | from_yaml).groups }}"
+
+# K8s deployment validation - kube_vip is only added when ALL conditions are met:
+# 1. K8s deployment is enabled in omnia_config.yml (deployment: true)
+# 2. K8s functional groups (service_kube_*) are defined in PXE mapping file
+# 3. high_availability_config.yml exists with valid kube_vip configuration
+- name: Check if high_availability_config.yml exists
+  ansible.builtin.stat:
+    path: "{{ hostvars['localhost']['input_project_dir'] }}/high_availability_config.yml"
+  register: ha_config_stat
+  delegate_to: localhost
+
+- name: Load omnia_config.yml to check K8s deployment
+  ansible.builtin.include_vars:
+    file: "{{ hostvars['localhost']['input_project_dir'] }}/omnia_config.yml"
+    name: omnia_config
+  delegate_to: localhost
+
+- name: Check if Service K8s cluster deployment is enabled in omnia_config
+  ansible.builtin.set_fact:
+    k8s_deployment_config_enabled: "{{ omnia_config.service_k8s_cluster | default([]) | selectattr('deployment', 'equalto', true) | list | length > 0 }}"
+
+- name: Check if Service K8s functional groups exist in mapping
+  ansible.builtin.set_fact:
+    k8s_groups_in_mapping: >-
+      {{
+        (mapping_nodes | map(attribute='value.FUNCTIONAL_GROUP_NAME') | list)
+        | select('match', '^service_kube_')
+        | list
+        | length > 0
+      }}
+
+- name: Set final K8s deployment flag (both config and mapping must have K8s)
+  ansible.builtin.set_fact:
+    k8s_deployment_enabled: "{{ k8s_deployment_config_enabled | default(false) and k8s_groups_in_mapping | default(false) }}"
+
+- name: Load high_availability_config.yml to get kube_vip
+  ansible.builtin.include_vars:
+    file: "{{ hostvars['localhost']['input_project_dir'] }}/high_availability_config.yml"
+    name: ha_config
+  delegate_to: localhost
+  when:
+    - ha_config_stat.stat.exists | default(false)
+    - k8s_deployment_enabled | default(false)
+
+- name: Set kube_vip fact
+  ansible.builtin.set_fact:
+    kube_vip: "{{ ha_config.service_k8s_cluster_ha[0].virtual_ip_address | default('') }}"
+  when:
+    - ha_config_stat.stat.exists | default(false)
+    - k8s_deployment_enabled | default(false)
 
 - name: Generate BMC group data file
   ansible.builtin.template:


### PR DESCRIPTION
### Description of the Solution
 
**Summary**: Fixes kube_vip group being incorrectly added to orchestrator inventory when Kubernetes is not actually deployed. The kube_vip group is now only added when K8s functional groups (service_kube_*) are defined in the PXE mapping file, which is the definitive indicator that K8s should be deployed.
 
### Changes
 
#### generate_inventories role
- Added validation to check if K8s functional groups exist in PXE mapping file before setting kube_vip
- Removed dependency on omnia_config.yml deployment flag for kube_vip determination
- Simplified logic to only check for service_kube_* functional groups in mapping data
- kube_vip is only set when both HA config exists AND K8s groups are present in mapping
 
#### orchestrator_inventory template
- Updated kube_vip_group conditional logic documentation
- Template now correctly handles undefined kube_vip variable
 
### Files Changed
 
| File | Change Type | Description |
|------|------------|-------------|
| `src/orchestrator/roles/generate_inventories/tasks/main.yml` | Modified | Added K8s functional groups validation in mapping, simplified kube_vip conditions |
| `src/orchestrator/roles/configure_ochami/templates/nodes/orchestrator_inventory.yaml.j2` | Modified | Updated conditional logic for kube_vip_group |
 
### Testing
 
- Verified kube_vip group is NOT added when K8s functional groups are absent from PXE mapping
- Verified kube_vip group IS added when service_kube_* groups are present in mapping and HA config exists
- Verified template handles undefined kube_vip variable correctly
 
### Backward Compatibility
 
- No breaking changes - only fixes incorrect behavior where kube_vip was added when it shouldn't be
- Existing deployments with K8s functional groups will continue to work as expected
- Deployments without K8s functional groups will no longer have spurious kube_vip entries
 