### PR TITLE
Fix: Prevent credential exposure &  Update `omnia_auth` to `1.2`

### DIFF
--- a/src/orchestrator/containers/build_images.sh
+++ b/src/orchestrator/containers/build_images.sh
@@ -27,7 +27,7 @@
 #   ./build_images.sh registry=myregistry.io/myrepo           # Custom registry
 #
 # Parameters:
-#   auth_tag=<tag>             Image tag (default: 1.1)
+#   auth_tag=<tag>             Image tag (default: 1.2)
 #   build_tool=<tool>          podman | docker (default: podman)
 #   build_action=<action>      load | push (default: load)
 #   registry=<url>             Registry URL (default: docker.io/dellhpcomniaaisolution)
@@ -56,7 +56,7 @@ show_help() {
     echo "  ./build_images.sh [parameters]"
     echo ""
     echo -e "${BLUE}PARAMETERS (key=value format):${NC}"
-    echo "  auth_tag=<tag>             Image tag (default: 1.1)"
+    echo "  auth_tag=<tag>             Image tag (default: 1.2)"
     echo "  build_tool=<tool>          podman | docker (default: podman)"
     echo "  build_action=<action>      load | push (default: load)"
     echo "  registry=<url>             Registry URL (default: docker.io/dellhpcomniaaisolution)"
@@ -81,7 +81,7 @@ show_help() {
 BUILD_TOOL="podman"
 BUILD_ACTION="load"
 OMNIA_DOCKER_REGISTERY="docker.io/dellhpcomniaaisolution"
-AUTH_TAG="1.1"
+AUTH_TAG="1.2"
 
 # =============================================================================
 # Parse command-line parameters (key=value format)

--- a/src/orchestrator/playbooks/upgrade/upgrade_openldap.yml
+++ b/src/orchestrator/playbooks/upgrade/upgrade_openldap.yml
@@ -13,18 +13,18 @@
 # limitations under the License.
 ---
 
-# Upgrade OpenLDAP --- Upgrade auth container from Fedora-based to Wolfi-based
+# Upgrade OpenLDAP --- Upgrade auth container from Wolfi-based 1.1 to 1.2
 # Can be run standalone or imported by orchestrator.yml
 #
 # Logic:
 #   1. Detect active container image
-#   2. If Fedora-based image (tag 1.0) is running:
+#   2. If Wolfi-based image (tag 1.1) is running:
 #      a. Stop container
-#      b. Pull Wolfi-based image (tag 1.1)
+#      b. Pull Wolfi-based image (tag 1.2)
 #      c. Start Wolfi container
 #      d. Reapply configuration
 #      e. Validate functionality
-#   3. If already running Wolfi image (tag 1.1): exit successfully
+#   3. If already running Wolfi image (tag 1.2): exit successfully
 #   4. If not deployed: skip upgrade
 #
 # Idempotent and re-runnable.
@@ -36,8 +36,8 @@
   vars:
     auth_container_name: omnia_auth
     auth_image: "docker.io/dellhpcomniaaisolution/omnia_auth"
-    auth_target_tag: "1.1"
-    auth_previous_tag: "1.0"
+    auth_target_tag: "1.2"
+    auth_previous_tag: "1.1"
   tasks:
     - name: Check if OpenLDAP container exists
       containers.podman.podman_container_info:

--- a/src/orchestrator/roles/deploy_openchami/tasks/configs/verify_ochami.yml
+++ b/src/orchestrator/roles/deploy_openchami/tasks/configs/verify_ochami.yml
@@ -29,10 +29,12 @@
   delay: "{{ max_delay }}"
   until: access_token_result.rc == 0
   changed_when: false
+  no_log: true
 
 - name: Set ochami_env
   ansible.builtin.set_fact:
     ochami_env: "{{ {cluster_env_key: access_token_result.stdout} }}"
+  no_log: true
 
 - name: Verify ochami installation
   environment: "{{ ochami_env }}"

--- a/src/orchestrator/roles/deploy_openldap/vars/main.yml
+++ b/src/orchestrator/roles/deploy_openldap/vars/main.yml
@@ -15,7 +15,7 @@
 
 # Container image
 omnia_auth_image: "docker.io/dellhpcomniaaisolution/omnia_auth"
-omnia_auth_tag: "1.1"
+omnia_auth_tag: "1.2"
 omnia_auth_container_name: "omnia_auth"
 
 # Directory paths

--- a/src/orchestrator/roles/orchestrator_common/tasks/openchami_auth.yml
+++ b/src/orchestrator/roles/orchestrator_common/tasks/openchami_auth.yml
@@ -27,12 +27,14 @@
   retries: "{{ openchami_auth_retries }}"
   delay: "{{ openchami_auth_delay }}"
   until: access_token_result.rc == 0 and access_token_result.stdout not in ["", "null"]
+  no_log: true
 
 - name: Set ochami_env
   ansible.builtin.set_fact:
     ochami_env: "{{ {cluster_env_key: access_token_result.stdout} }}"
     openchami_access_token: "{{ access_token_result.stdout }}"
   when: access_token_result.rc == 0
+  no_log: true
 
 - name: Check ochami smd status
   ansible.builtin.command: ochami smd service status

--- a/src/orchestrator/roles/orchestrator_validations/tasks/validate_mapping_file.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/validate_mapping_file.yml
@@ -40,6 +40,7 @@
   ansible.builtin.slurp:
     path: "{{ temp_pxe_file_path }}"
   register: mapping_file_raw
+  no_log: true
 
 - name: Replace only the first occurrence of service_kube_control_plane_<arch> with _first_<arch>
   ansible.builtin.set_fact:
@@ -52,12 +53,14 @@
             count=1
           )
       }}
+  no_log: true
 
 - name: Write updated mapping file back to disk
   ansible.builtin.copy:
     content: "{{ modified_mapping_file }}"
     dest: "{{ temp_pxe_file_path }}"
     mode: "0644"
+  no_log: true
 
 - name: Generate xnames in temporary mapping file
   generate_xname_in_mapping_file:
@@ -68,6 +71,7 @@
     path: "{{ temp_pxe_file_path }}"
     key: "{{ mapping_file_key }}"
   register: read_mapping_file
+  no_log: true
 
 - name: Initialize count variables
   ansible.builtin.set_fact:

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -338,6 +338,7 @@
   register: _existing_fg_groups
   failed_when: false
   when: not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
+  no_log: true
 
 - name: Delete existing metadata-service group entries for {{ fg_name }}
   ansible.builtin.uri:

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc_common.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc_common.yml
@@ -66,6 +66,7 @@
   register: _existing_common_groups
   failed_when: false
   when: not (hostvars['localhost']['upgrade_mode'] | default(false) | bool)
+  no_log: true
 
 - name: Delete existing metadata-service common group entries
   ansible.builtin.uri:

--- a/src/orchestrator/roles/provision_common/tasks/delete_smd_endpoints.yml
+++ b/src/orchestrator/roles/provision_common/tasks/delete_smd_endpoints.yml
@@ -91,6 +91,7 @@
     return_content: true
   register: existing_groups
   failed_when: false
+  no_log: true
 
 - name: Delete existing metadata-service groups
   ansible.builtin.uri:


### PR DESCRIPTION
This PR addresses a security vulnerability where sensitive credentials (access tokens, SSH keys, passwords) were exposed in logs during high-verbosity playbook execution, and updates the omnia_auth container tag from 1.1 to 1.2.

### Security Fix:
Added no_log: true to tasks handling sensitive data:
- Access token generation in deploy_openchami and orchestrator_common roles
- Metadata-service group fetching (SSH keys, hashed passwords)
- Mapping file processing (infrastructure-sensitive data)

### Version Update:
Updated omnia_auth container tag from 1.1 to 1.2 across deployment and upgrade playbooks.