### PR TITLE
feat(image_build): add multi-version repo status contract for RHEL 10.2

### DIFF
--- a/src/image_build_manager/plugins/module_utils/input_validation/schema/catalog.json
+++ b/src/image_build_manager/plugins/module_utils/input_validation/schema/catalog.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "schemaVersion": "1.0",
   "title": "catalog",
   "description": "Schema for catalog JSON consumed by image_build_manager parse_catalog module. Validates the three-level hierarchy: functionallayer -> groups -> packages.",

--- a/src/image_build_manager/plugins/module_utils/input_validation/schema/repo_status.json
+++ b/src/image_build_manager/plugins/module_utils/input_validation/schema/repo_status.json
@@ -7,6 +7,8 @@
         "overall_status",
         "cluster_os_type",
         "repo_config",
+        "execution_contexts",
+        "overall_status_by_version",
         "repo_manager",
         "repositories"
     ],
@@ -15,23 +17,31 @@
             "type": "string",
             "const": "success"
         },
-        "cluster_os_type": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^\\S(?:.*\\S)?$"
+        "cluster_os_type": {"$ref": "#/$defs/nonBlankString"},
+        "repo_config": {"$ref": "#/$defs/nonBlankString"},
+        "execution_contexts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"$ref": "#/$defs/executionContext"}
         },
-        "repo_config": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^\\S(?:.*\\S)?$"
+        "overall_status_by_version": {
+            "type": "object",
+            "minProperties": 1,
+            "patternProperties": {
+                "^[0-9]+(?:\\.[0-9]+)*$": {
+                    "type": "string",
+                    "enum": ["pending", "success", "failed"]
+                }
+            },
+            "additionalProperties": false
         },
         "repo_manager": {
             "type": "object",
-            "description": "Repository service metadata. Values may be empty for internet-hosted repositories, but the structure is always required.",
+            "description": "Repository service metadata. Values may be empty for the internet-only test fixture, but the structure is always required.",
             "required": ["port", "certificates"],
             "properties": {
                 "port": {
-                    "description": "Managed repository service port, or an empty string in internet mode.",
+                    "description": "Managed repository service port, or an empty string in the internet-only test fixture.",
                     "oneOf": [
                         {
                             "type": "integer",
@@ -43,11 +53,10 @@
                 },
                 "certificates": {
                     "type": "object",
-                    "description": "Certificate path structure. Individual paths may be empty in internet mode.",
-                    "required": ["server_crt", "server_key", "certs_dir"],
+                    "description": "Public certificate paths. Private-key paths are intentionally excluded from the output contract.",
+                    "required": ["server_crt", "certs_dir"],
                     "properties": {
                         "server_crt": {"type": "string"},
-                        "server_key": {"type": "string"},
                         "certs_dir": {"type": "string"}
                     },
                     "additionalProperties": false
@@ -59,24 +68,58 @@
             "type": "object",
             "minProperties": 1,
             "patternProperties": {
-                "^[0-9]+(?:\\.[0-9]+)*$": {
-                    "type": "object",
-                    "required": ["x86_64"],
-                    "properties": {
-                        "x86_64": {"$ref": "#/$defs/architectureRepositories"},
-                        "aarch64": {"$ref": "#/$defs/architectureRepositories"}
-                    },
-                    "additionalProperties": false
+                "^[0-9]+(?:\\.[0-9]+)*$": {"$ref": "#/$defs/versionRepositories"}
+            },
+            "additionalProperties": false
+        },
+        "registries": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$": {"$ref": "#/$defs/registry"}
+            },
+            "additionalProperties": false
+        },
+        "file_repos": {
+            "type": "object",
+            "properties": {
+                "x86_64": {"$ref": "#/$defs/fileRepositories"},
+                "aarch64": {"$ref": "#/$defs/fileRepositories"}
+            },
+            "additionalProperties": false
+        }
+    },
+    "$defs": {
+        "nonBlankString": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^\\S(?:.*\\S)?$"
+        },
+        "osVersion": {
+            "type": "string",
+            "pattern": "^[0-9]+(?:\\.[0-9]+)*$"
+        },
+        "executionContext": {
+            "type": "object",
+            "required": ["context_id", "os_type", "os_version", "architectures"],
+            "properties": {
+                "context_id": {"$ref": "#/$defs/nonBlankString"},
+                "os_type": {"$ref": "#/$defs/nonBlankString"},
+                "os_version": {"$ref": "#/$defs/osVersion"},
+                "architectures": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "enum": ["x86_64", "aarch64"]
+                    }
                 }
             },
             "additionalProperties": false
         },
-        "registries": {"type": "object"},
-        "file_repos": {"type": "object"}
-    },
-    "$defs": {
         "repository": {
             "type": "object",
+            "required": ["url"],
             "properties": {
                 "url": {
                     "type": "string",
@@ -96,6 +139,60 @@
             "type": "object",
             "patternProperties": {
                 "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$": {"$ref": "#/$defs/repository"}
+            },
+            "additionalProperties": false
+        },
+        "versionRepositories": {
+            "type": "object",
+            "minProperties": 1,
+            "properties": {
+                "x86_64": {"$ref": "#/$defs/architectureRepositories"},
+                "aarch64": {"$ref": "#/$defs/architectureRepositories"}
+            },
+            "additionalProperties": false
+        },
+        "registry": {
+            "type": "object",
+            "required": ["base_url", "port", "host"],
+            "properties": {
+                "base_url": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^https?://\\S+$",
+                    "format": "uri"
+                },
+                "port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                },
+                "host": {"$ref": "#/$defs/nonBlankString"},
+                "tls": {
+                    "type": "object",
+                    "required": ["insecure"],
+                    "properties": {
+                        "insecure": {"type": "boolean"}
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "fileRepositories": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$": {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^https?://\\S+$",
+                            "format": "uri"
+                        }
+                    },
+                    "additionalProperties": false
+                }
             },
             "additionalProperties": false
         }

--- a/src/image_build_manager/plugins/module_utils/input_validation/validators/repo_status_validator.py
+++ b/src/image_build_manager/plugins/module_utils/input_validation/validators/repo_status_validator.py
@@ -14,33 +14,149 @@
 """Semantic validation for the repo_status.yml input contract."""
 
 
+def _version_keys(mapping):
+    """Return normalized string keys for a version-keyed mapping."""
+    if not isinstance(mapping, dict):
+        return set()
+    return {str(version) for version in mapping}
+
+
+def _validate_contexts(repo_status_data):
+    """Return context errors and the ordered selected OS versions."""
+    errors = []
+    contexts = repo_status_data.get("execution_contexts", [])
+    context_ids = []
+    context_versions = []
+    cluster_os_type = repo_status_data.get("cluster_os_type")
+    if isinstance(contexts, list):
+        for context in contexts:
+            if not isinstance(context, dict):
+                continue
+            context_id = context.get("context_id")
+            version = context.get("os_version")
+            if context_id is not None:
+                context_ids.append(str(context_id))
+            if version is not None:
+                context_versions.append(str(version))
+            if context.get("os_type") != cluster_os_type:
+                errors.append(
+                    "repo_status.yml: every execution context os_type must "
+                    "match cluster_os_type."
+                )
+                break
+
+    if len(context_ids) != len(set(context_ids)):
+        errors.append(
+            "repo_status.yml: execution_contexts contains duplicate context_id values."
+        )
+    if len(context_versions) != len(set(context_versions)):
+        errors.append(
+            "repo_status.yml: execution_contexts contains duplicate OS versions."
+        )
+    return errors, context_versions
+
+
+def _validate_version_maps(context_versions, status_by_version, repositories):
+    """Return errors for mismatched or incomplete version-keyed output."""
+    errors = []
+    selected_versions = set(context_versions)
+    status_versions = _version_keys(status_by_version)
+    repository_versions = _version_keys(repositories)
+    if selected_versions != status_versions:
+        errors.append(
+            "repo_status.yml: overall_status_by_version keys must exactly match "
+            "the execution_contexts OS versions."
+        )
+    if selected_versions != repository_versions:
+        errors.append(
+            "repo_status.yml: repositories keys must exactly match the "
+            "execution_contexts OS versions."
+        )
+
+    if isinstance(status_by_version, dict):
+        incomplete_versions = sorted(
+            str(version)
+            for version, status in status_by_version.items()
+            if status != "success"
+        )
+        if incomplete_versions:
+            errors.append(
+                "repo_status.yml: overall_status_by_version must be 'success' "
+                "for every version; incomplete versions: "
+                + ", ".join(incomplete_versions)
+                + "."
+            )
+    return errors
+
+
+def _validate_architecture_maps(contexts, repositories):
+    """Require each version to expose exactly its selected architectures."""
+    errors = []
+    if not isinstance(contexts, list) or not isinstance(repositories, dict):
+        return errors
+    for context in contexts:
+        if not isinstance(context, dict):
+            continue
+        version = str(context.get("os_version", ""))
+        expected = set(context.get("architectures", []))
+        version_repositories = repositories.get(version, {})
+        actual = (
+            set(version_repositories)
+            if isinstance(version_repositories, dict)
+            else set()
+        )
+        if expected != actual:
+            errors.append(
+                "repo_status.yml: repositories."
+                f"{version} architecture keys must match execution_contexts."
+            )
+    return errors
+
+
+def _has_repository_url(repositories):
+    """Return whether any architecture has a consumable RPM repository URL."""
+    if isinstance(repositories, dict):
+        for version_data in repositories.values():
+            if not isinstance(version_data, dict):
+                continue
+            for arch_repositories in version_data.values():
+                if not isinstance(arch_repositories, dict):
+                    continue
+                for repository in arch_repositories.values():
+                    if not isinstance(repository, dict):
+                        continue
+                    url = repository.get("url")
+                    if isinstance(url, str) and url.strip():
+                        return True
+    return False
+
+
 def validate(repo_status_data, logger=None):
-    """Require a successful contract with at least one usable x86_64 RPM URL."""
+    """Validate cross-field consistency required by image build consumers."""
     errors = []
 
     if repo_status_data.get("overall_status") != "success":
         errors.append("repo_status.yml: overall_status must be 'success'.")
 
-    x86_urls = []
+    context_errors, context_versions = _validate_contexts(repo_status_data)
+    errors.extend(context_errors)
+    status_by_version = repo_status_data.get("overall_status_by_version", {})
     repositories = repo_status_data.get("repositories", {})
-    if isinstance(repositories, dict):
-        for version_data in repositories.values():
-            if not isinstance(version_data, dict):
-                continue
-            arch_repositories = version_data.get("x86_64", {})
-            if not isinstance(arch_repositories, dict):
-                continue
-            for repository in arch_repositories.values():
-                if not isinstance(repository, dict):
-                    continue
-                url = repository.get("url")
-                if isinstance(url, str) and url.strip():
-                    x86_urls.append(url)
+    errors.extend(
+        _validate_version_maps(
+            context_versions, status_by_version, repositories
+        )
+    )
+    errors.extend(
+        _validate_architecture_maps(
+            repo_status_data.get("execution_contexts", []), repositories
+        )
+    )
 
-    if not x86_urls:
+    if not _has_repository_url(repositories):
         errors.append(
             "repo_status.yml: repositories must contain at least one non-empty "
-            "x86_64 repository URL."
+            "repository URL."
         )
 
     if logger:

--- a/src/image_build_manager/plugins/modules/parse_repo_status.py
+++ b/src/image_build_manager/plugins/modules/parse_repo_status.py
@@ -28,11 +28,12 @@ short_description: Parse repo_status.yml and build per-architecture repo lists
 version_added: "2.3.0"
 description:
   - Reads the C(repo_status.yml) file produced by repo_manager.
-  - Extracts C(cluster_os_type) and derives C(cluster_os_version) from
-    the first key in C(repositories).
+  - Extracts C(cluster_os_type) and derives the ordered OS versions from
+    C(execution_contexts).
   - Builds per-architecture repo lists from
     C(repositories.{version}.{arch}.{repo_name}.url).
-  - Extracts C(repo_port) from the first non-empty repo URL.
+  - Reads C(repo_port) from repository service metadata and falls back to the
+    first non-empty repository URL for the internet-only test fixture.
 options:
   repo_status_file:
     description: Absolute path to repo_status.yml.
@@ -65,14 +66,19 @@ cluster_os_type:
   type: str
 cluster_os_version:
   description:
-    - OS version derived from first key of repositories dict.
-    - Example C(10.0), C(10.1).
+    - Primary OS version from the first execution context.
+    - Example C(10.0), C(10.2).
   returned: always
   type: str
+cluster_os_versions:
+  description: Ordered OS versions published by Repo Manager.
+  returned: always
+  type: list
+  elements: str
 repo_port:
   description:
-    - Port number extracted from first non-empty repo URL.
-    - Defaults to 2225 if no URL contains a port.
+    - Port from C(repo_manager.port), or from the first repository URL for
+      the internet-only test fixture.
   returned: always
   type: int
 repo_manager_repos_x86_64:
@@ -146,7 +152,13 @@ def _extract_port(url: str) -> int:
     """
     try:
         parsed = urlparse(url)
-        return parsed.port or 0
+        if parsed.port:
+            return parsed.port
+        if parsed.scheme == "https":
+            return 443
+        if parsed.scheme == "http":
+            return 80
+        return 0
     except (ValueError, AttributeError):
         return 0
 
@@ -158,7 +170,7 @@ def _find_repo_port(version_repos: dict) -> int:
         version_repos: Dict of {arch: {repo_name: {url: ...}}}.
 
     Returns:
-        Port number or DEFAULT_PORT.
+        Port number or 0 when no usable URL exists.
     """
     for arch in SUPPORTED_ARCHS:
         arch_repos = version_repos.get(arch, {})
@@ -172,7 +184,7 @@ def _find_repo_port(version_repos: dict) -> int:
                 port = _extract_port(repo_data["url"])
                 if port > 0:
                     return port
-    return DEFAULT_PORT
+    return 0
 
 
 def _build_repo_list(arch_repos: dict) -> list:
@@ -204,6 +216,34 @@ def _build_repo_list(arch_repos: dict) -> list:
     return result
 
 
+def _ordered_versions(data: dict) -> list[str]:
+    """Return version keys in the producer's execution order."""
+    context_versions = [
+        str(context["os_version"])
+        for context in data.get("execution_contexts", [])
+        if isinstance(context, dict) and context.get("os_version") is not None
+    ]
+    return context_versions or [
+        str(version) for version in data["repositories"]
+    ]
+
+
+def _repo_manager_metadata(data: dict) -> tuple[int, str]:
+    """Return configured service port and public CA certificate path."""
+    repo_manager = data.get("repo_manager", {})
+    if not isinstance(repo_manager, dict):
+        return 0, ""
+    configured_port = repo_manager.get("port")
+    port = configured_port if isinstance(configured_port, int) else 0
+    certificates = repo_manager.get("certificates", {})
+    cert_path = (
+        certificates.get("server_crt", "")
+        if isinstance(certificates, dict)
+        else ""
+    )
+    return port, cert_path
+
+
 def parse_repo_status(file_path: str) -> dict:
     """Main entry: parse repo_status.yml and build repo lists.
 
@@ -219,15 +259,15 @@ def parse_repo_status(file_path: str) -> dict:
     repositories = data["repositories"]
     os_type = data.get("cluster_os_type", "rhel")
 
-    versions = list(repositories.keys())
+    versions = _ordered_versions(data)
     os_version = versions[0] if versions else "10.0"
 
-    repo_port = DEFAULT_PORT
+    repo_port, repo_cert_path = _repo_manager_metadata(data)
     repos_x86: list = []
     repos_aarch64: list = []
     for ver in versions:
         version_repos = repositories.get(ver, {})
-        if repo_port == DEFAULT_PORT:
+        if not repo_port:
             repo_port = _find_repo_port(version_repos)
 
         ver_prefix = str(ver).replace(".", "_")
@@ -240,13 +280,12 @@ def parse_repo_status(file_path: str) -> dict:
             entry["os_version"] = str(ver)
             repos_aarch64.append(entry)
 
-    repo_mgr = data.get("repo_manager", {})
-    certs = repo_mgr.get("certificates", {}) if isinstance(repo_mgr, dict) else {}
-    repo_cert_path = certs.get("server_crt", "")
+    repo_port = repo_port or DEFAULT_PORT
 
     return {
         "cluster_os_type": os_type,
         "cluster_os_version": str(os_version),
+        "cluster_os_versions": versions,
         "repo_port": repo_port,
         "repo_manager_repos_x86_64": repos_x86,
         "repo_manager_repos_aarch64": repos_aarch64,

--- a/src/image_build_manager/roles/fetch_build_packages/tasks/fetch_repo_manager_repos.yml
+++ b/src/image_build_manager/roles/fetch_build_packages/tasks/fetch_repo_manager_repos.yml
@@ -15,7 +15,7 @@
 # Resolve RPM repo URLs for image creation templates.
 # Priority: repo_manager output (repo_status.yml) > direct repo manager CLI query.
 
-- name: Select repo_manager output for {{ build_arch }} and {{ rhel_tag }}
+- name: Select repo_manager output for platform {{ build_arch ~ ' ' ~ rhel_tag }}
   ansible.builtin.set_fact:
     _all_repo_manager_repos: >-
       {{ hostvars['localhost']['repo_manager_repos_' + build_arch] | default([]) }}
@@ -45,7 +45,7 @@
     - _all_repo_manager_repos | length > 0
     - _matching_repo_manager_repos | length == 0
 
-- name: Fallback — fetch Pulp endpoints directly for {{ build_arch }} and {{ rhel_tag }}
+- name: Fallback — fetch Pulp endpoints directly for platform {{ build_arch ~ ' ' ~ rhel_tag }}
   when: _all_repo_manager_repos | length == 0
   block:
     - name: Fetch pulp endpoints for {{ build_arch }}

--- a/src/image_build_manager/roles/fetch_build_packages/tasks/fetch_repo_manager_repos.yml
+++ b/src/image_build_manager/roles/fetch_build_packages/tasks/fetch_repo_manager_repos.yml
@@ -15,19 +15,38 @@
 # Resolve RPM repo URLs for image creation templates.
 # Priority: repo_manager output (repo_status.yml) > direct repo manager CLI query.
 
+- name: Select repo_manager output for {{ build_arch }} and {{ rhel_tag }}
+  ansible.builtin.set_fact:
+    _all_repo_manager_repos: >-
+      {{ hostvars['localhost']['repo_manager_repos_' + build_arch] | default([]) }}
+    _matching_repo_manager_repos: >-
+      {{ hostvars['localhost']['repo_manager_repos_' + build_arch]
+         | default([])
+         | selectattr('os_version', 'equalto', rhel_tag | string)
+         | list }}
+
 - name: Use repo_manager output for repos (preferred) - {{ build_arch }}
-  when: hostvars['localhost']['repo_manager_repos_' + build_arch] | default([]) | length > 0
+  when: _matching_repo_manager_repos | length > 0
   block:
     - name: Set rhel_arch_repos from repo_manager output
       ansible.builtin.set_fact:
-        rhel_arch_repos: "{{ hostvars['localhost']['repo_manager_repos_' + build_arch] }}"
+        rhel_arch_repos: "{{ _matching_repo_manager_repos }}"
 
     - name: Display repo source
       ansible.builtin.debug:
         msg: "Using {{ rhel_arch_repos | length }} repos from repo_manager output for {{ build_arch }}"
 
-- name: Fallback — fetch pulp endpoints directly for {{ build_arch }}
-  when: hostvars['localhost']['repo_manager_repos_' + build_arch] | default([]) | length == 0
+- name: Fail when repo_status has no repositories for the selected platform
+  ansible.builtin.fail:
+    msg: >-
+      repo_status.yml has no repositories for {{ build_arch }} RHEL {{ rhel_tag }}.
+      Available Repo Manager versions: {{ repo_manager_os_versions | default([]) | join(', ') }}.
+  when:
+    - _all_repo_manager_repos | length > 0
+    - _matching_repo_manager_repos | length == 0
+
+- name: Fallback — fetch Pulp endpoints directly for {{ build_arch }} and {{ rhel_tag }}
+  when: _all_repo_manager_repos | length == 0
   block:
     - name: Fetch pulp endpoints for {{ build_arch }}
       ansible.builtin.command: >
@@ -39,8 +58,14 @@
       ansible.builtin.set_fact:
         pulp_arch_distributions: >-
           {{ pulp_endpoints.stdout | from_json
-            | selectattr('name', 'match', '^' + build_arch)
+            | selectattr('name', 'match', '^' + build_arch + '_rhel_' + (rhel_tag | string) + '_')
             | list }}
+
+    - name: Fail when Pulp has no matching fallback distributions
+      ansible.builtin.fail:
+        msg: >-
+          Pulp has no RPM distributions for {{ build_arch }} RHEL {{ rhel_tag }}.
+      when: pulp_arch_distributions | length == 0
 
     - name: Build rhel_repos list from pulp_arch_distributions
       ansible.builtin.set_fact:

--- a/src/image_build_manager/roles/image_build_setup/README.md
+++ b/src/image_build_manager/roles/image_build_setup/README.md
@@ -19,7 +19,9 @@ configuration, and conditionally validates/parses `repo_status.yml`.
 7. Sets initial OS facts (`cluster_os_type`, `cluster_os_version`, `repo_port`) from `repo_status.yml`
    - **Note**: `cluster_os_type` and `cluster_os_version` may be overridden downstream by
      `fetch_build_packages` from catalog baseos group or `package_groups.yml` OS metadata
-8. Builds per-architecture repo lists (`repo_manager_repos_x86_64`, `repo_manager_repos_aarch64`).
+8. Builds version-tagged, per-architecture repo lists
+   (`repo_manager_repos_x86_64`, `repo_manager_repos_aarch64`). The package
+   fetch role selects only entries matching the catalog-resolved OS version.
 9. Validates the repo manager certificate when a path is supplied and sets S3 endpoint facts.
 
 `repo_status.yml` is not required for `validate`, `credentials`, `prepare`,

--- a/src/image_build_manager/roles/image_build_setup/tasks/load_repo_status.yml
+++ b/src/image_build_manager/roles/image_build_setup/tasks/load_repo_status.yml
@@ -34,6 +34,7 @@
   ansible.builtin.set_fact:
     cluster_os_type: "{{ _repo_status_result.cluster_os_type }}"
     cluster_os_version: "{{ _repo_status_result.cluster_os_version }}"
+    repo_manager_os_versions: "{{ _repo_status_result.cluster_os_versions }}"
     repo_port: "{{ _repo_status_result.repo_port }}"
     repo_manager_repos_x86_64: "{{ _repo_status_result.repo_manager_repos_x86_64 }}"
     repo_manager_repos_aarch64: "{{ _repo_status_result.repo_manager_repos_aarch64 }}"

--- a/src/image_build_manager/samples/repo_manager_output/repo_status.yml
+++ b/src/image_build_manager/samples/repo_manager_output/repo_status.yml
@@ -12,41 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# ============================================================================
-# SAMPLE: repo_status.yml — repo_manager output contract
-# ============================================================================
+# SAMPLE: repo_status.yml — current repo_manager output contract.
 #
-# This is a REFERENCE TEMPLATE. In production, repo_manager generates this file.
-#
-# Runtime location (created by repo_manager or copied manually):
+# This fixture demonstrates a successful two-version Repo Manager run for the
+# RHEL 10.0 and RHEL 10.2 x86_64/aarch64 catalogs in src/main/samples. In a
+# deployment Repo Manager creates this file under:
 #   /opt/omnia/repo_manager/output/<project_name>/repo_status.yml
-#
-# Producer: repo_manager domain (repo_manager.yml)
-# Consumer: image_build_manager domain (image_build_manager.yml Step 4)
-#
-# Manual setup (if repo_manager was NOT run):
-#   1. Copy this file to the runtime location:
-#      mkdir -p /opt/omnia/repo_manager/output/project_default
-#      cp repo_status.yml /opt/omnia/repo_manager/output/project_default/
-#   2. Edit the copied file with your actual repo manager URLs and cert paths
-#   3. Verify: omnia-cli repo-manager
-#
-# image_build_manager pre-check validates:
-#   1. File exists at repo_manager_output_path
-#   2. overall_status == "success"
-#   3. rpm_repos contains valid URLs for the target architectures
-#   4. repo_manager section contains certificate and port
-# ============================================================================
+# Replace {{ admin_nic_ip }} before using this reference fixture directly.
 
 overall_status: "success"
 cluster_os_type: "rhel"
 repo_config: "partial"
 
+execution_contexts:
+  - context_id: "rhel_10.0"
+    os_type: "rhel"
+    os_version: "10.0"
+    architectures: ["x86_64", "aarch64"]
+  - context_id: "rhel_10.2"
+    os_type: "rhel"
+    os_version: "10.2"
+    architectures: ["x86_64", "aarch64"]
+
+overall_status_by_version:
+  "10.0": "success"
+  "10.2": "success"
+
 repo_manager:
   port: 2225
   certificates:
     server_crt: "/opt/omnia/repo_manager/pulp_config/settings/certs/pulp_webserver.crt"
-    server_key: "/opt/omnia/repo_manager/pulp_config/settings/certs/pulp_webserver.key"
     certs_dir: "/opt/omnia/repo_manager/pulp_config/settings/certs"
 
 repositories:
@@ -54,110 +49,121 @@ repositories:
     x86_64:
       baseos:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_baseos/"
-        priority: 100
       appstream:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_appstream/"
-        priority: 100
       codeready-builder:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_codeready-builder/"
-        priority: 100
       slurm_custom:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_slurm_custom/"
         priority: 100
-      ldms: {}
+      ldms:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_ldms/"
       epel:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_epel/"
-        priority: 100
       kubernetes-v1-35:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_kubernetes-v1-35/"
-        priority: 100
       cri-o-v1-35:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_cri-o-v1-35/"
-        priority: 100
       doca:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_doca/"
-        priority: 100
-      docker-ce:
-        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_docker-ce/"
-        priority: 100
       cuda:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_cuda/"
-        priority: 100
       nvidia-hpc-sdk:
         url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_nvidia-hpc-sdk/"
-        priority: 100
-      repo_manager_additional:
-        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_repo_manager-additional/"
-        priority: 100
-      additional_repos: {}
-
+      vast:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/rpms/x86_64_rhel_10.0_vast/"
     aarch64:
-      baseos: {}
-      appstream: {}
-      codeready-builder: {}
-      slurm_custom: {}
-      ldms: {}
-      repo_manager_additional:
-        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_repo_manager-additional/"
+      baseos:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_baseos/"
+      appstream:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_appstream/"
+      codeready-builder:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_codeready-builder/"
+      slurm_custom:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_slurm_custom/"
+      ldms:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_ldms/"
+      epel:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_epel/"
+      kubernetes-v1-35:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_kubernetes-v1-35/"
+      cri-o-v1-35:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_cri-o-v1-35/"
+      doca:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_doca/"
+      cuda:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_cuda/"
+      nvidia-hpc-sdk:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_nvidia-hpc-sdk/"
+      vast:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.0/rpms/aarch64_rhel_10.0_vast/"
+  "10.2":
+    x86_64:
+      baseos:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_baseos/"
+      appstream:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_appstream/"
+      codeready-builder:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_codeready-builder/"
+      slurm_custom:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_slurm_custom/"
         priority: 100
-      epel: {}
-      kubernetes-v1-35: {}
-      cri-o-v1-35: {}
-      doca: {}
-      docker-ce: {}
-      cuda: {}
-      nvidia-hpc-sdk: {}
-      additional_repos: {}
+      ldms:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_ldms/"
+      epel:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_epel/"
+      kubernetes-v1-35:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_kubernetes-v1-35/"
+      cri-o-v1-35:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_cri-o-v1-35/"
+      doca:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_doca/"
+      cuda:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_cuda/"
+      nvidia-hpc-sdk:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_nvidia-hpc-sdk/"
+      vast:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.2/rpms/x86_64_rhel_10.2_vast/"
+    aarch64:
+      baseos:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_baseos/"
+      appstream:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_appstream/"
+      codeready-builder:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_codeready-builder/"
+      slurm_custom:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_slurm_custom/"
+      ldms:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_ldms/"
+      epel:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_epel/"
+      kubernetes-v1-35:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_kubernetes-v1-35/"
+      cri-o-v1-35:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_cri-o-v1-35/"
+      doca:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_doca/"
+      cuda:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_cuda/"
+      nvidia-hpc-sdk:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_nvidia-hpc-sdk/"
+      vast:
+        url: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/aarch64/rhel/10.2/rpms/aarch64_rhel_10.2_vast/"
 
 registries:
-  user_registry1:
+  private_registry:
+    base_url: "https://harbor.example.com"
     port: 443
+    host: "harbor.example.com:443"
     tls:
-      capath: "/etc/omnia/certs/my-reg.example.com/ca.crt"
-      clientcertpath: "/etc/omnia/certs/my-reg.example.com/client.crt"
-      clientkeypath: "/etc/omnia/certs/my-reg.example.com/client.key"
       insecure: false
 
-  user_registry2:
-    host: "10.0.0.1"
-    port: 443
-    tls:
-      capath: "/etc/omnia/certs/internal-registry/ca.crt"
-      clientcertpath: "/etc/omnia/certs/internal-registry/client.crt"
-      clientkeypath: "/etc/omnia/certs/internal-registry/client.key"
-      insecure: false
-
+# File and Python outputs remain scoped to the primary execution context.
 file_repos:
   x86_64:
-    git:
-      karavi_observability: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/git/karavi-observability/"
-      helm_charts: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/git/helm-charts/"
-
     tarball:
-      sionlib: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/sionlib/"
-      msr_safe: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/msr-safe/"
-      papi: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/papi/"
-      geopm: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/geopm/"
-      likwid: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/likwid/"
-      osu_micro_benchmarks: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/osu-micro-benchmarks/"
-      imb: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/imb/"
-      nfs_subdir_external_provisioner_4_0_18: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/nfs-subdir-external-provisioner-4.0.18/"  # noqa: yaml[line-length]
       helm_v3_20_1_amd64: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/helm-v3.20.1-amd64/"
-      victoria_metrics_operator_0_59_3: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/victoria-metrics-operator-0.59.3/"  # noqa: yaml[line-length]
-      strimzi_kafka_operator_helm_3_chart_1_0_1: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/strimzi-kafka-operator-helm-3-chart-1.0.1/"  # noqa: yaml[line-length]
-      cert_manager_v1_10_0: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/tarball/cert-manager-v1.10.0/"
-
-    manifest:
-      metallb_native_v0_15_3: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/manifest/metallb-native-v0.15.3/"
-      calico_v3_31_4: "https://{{ admin_nic_ip }}:2225/pulp/content/offline_repo/cluster/x86_64/rhel/10.0/manifest/calico-v3.31.4/"
-
     pip_module:
-      kubernetes_33_1_0: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/kubernetes==33.1.0/"
-      prettytable_3_14_0: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/prettytable==3.14.0/"
-      PyMySQL_1_1_2: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/PyMySQL==1.1.2/"
-      omsdk_1_2_518: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/omsdk==1.2.518/"
-      cryptography_45_0_7: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/cryptography==45.0.7/"
-      prometheus_client_0_20_0: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/prometheus_client==0.20.0/"
       cffi_1_17_1: "https://{{ admin_nic_ip }}:2225/pypi/offline_repo/cluster/x86_64/rhel/10.0/pip_module/cffi==1.17.1/"
   aarch64: {}
 

--- a/src/image_build_manager/samples/repo_manager_output/repo_status_internet.yml
+++ b/src/image_build_manager/samples/repo_manager_output/repo_status_internet.yml
@@ -35,7 +35,7 @@
 #
 #   4. Run:  ansible-playbook image_build_manager.yml
 #
-# NOTE: CentOS Stream 10 repos are binary-compatible with RHEL 10.0 and
+# NOTE: CentOS Stream 10 repos are suitable for RHEL 10.x build-path testing and
 #       are freely accessible without a subscription.  For production RHEL
 #       deployments, use the subscription-based CDN URLs instead.
 #
@@ -51,11 +51,24 @@ overall_status: "success"
 cluster_os_type: "rhel"
 repo_config: "partial"
 
+execution_contexts:
+  - context_id: "rhel_10.0"
+    os_type: "rhel"
+    os_version: "10.0"
+    architectures: ["x86_64", "aarch64"]
+  - context_id: "rhel_10.2"
+    os_type: "rhel"
+    os_version: "10.2"
+    architectures: ["x86_64", "aarch64"]
+
+overall_status_by_version:
+  "10.0": "success"
+  "10.2": "success"
+
 repo_manager:
   port: ""
   certificates:
     server_crt: ""
-    server_key: ""
     certs_dir: ""
 
 repositories:
@@ -70,14 +83,9 @@ repositories:
       codeready-builder:
         url: "https://mirror.stream.centos.org/10-stream/CRB/x86_64/os/"
         priority: 100
-      # slurm_custom requires a user-provided repo — no public RHEL 10 / CentOS Stream 10
-      # repository ships slurm packages. Configure via user_repo_url_x86_64 in repo_manager_config.yml.
-      slurm_custom: {}
-      ldms: {}
       epel:
         url: "https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/"
         priority: 100
-      additional_repos: {}
 
     aarch64:
       baseos:
@@ -89,12 +97,36 @@ repositories:
       codeready-builder:
         url: "https://mirror.stream.centos.org/10-stream/CRB/aarch64/os/"
         priority: 100
-      slurm_custom: {}
-      ldms: {}
       epel:
         url: "https://dl.fedoraproject.org/pub/epel/10/Everything/aarch64/"
         priority: 100
-      additional_repos: {}
+  "10.2":
+    x86_64:
+      baseos:
+        url: "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/"
+        priority: 100
+      appstream:
+        url: "https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/"
+        priority: 100
+      codeready-builder:
+        url: "https://mirror.stream.centos.org/10-stream/CRB/x86_64/os/"
+        priority: 100
+      epel:
+        url: "https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/"
+        priority: 100
+    aarch64:
+      baseos:
+        url: "https://mirror.stream.centos.org/10-stream/BaseOS/aarch64/os/"
+        priority: 100
+      appstream:
+        url: "https://mirror.stream.centos.org/10-stream/AppStream/aarch64/os/"
+        priority: 100
+      codeready-builder:
+        url: "https://mirror.stream.centos.org/10-stream/CRB/aarch64/os/"
+        priority: 100
+      epel:
+        url: "https://dl.fedoraproject.org/pub/epel/10/Everything/aarch64/"
+        priority: 100
 
 registries: {}
 file_repos:

--- a/src/main/samples/README.md
+++ b/src/main/samples/README.md
@@ -7,18 +7,22 @@ serve as documentation and starting-point examples.
 
 | File | Domain | Description |
 |------|--------|-------------|
-| `catalog_rhel.json` | image_build_manager | Sample RHEL catalog JSON produced by repo_manager. Shows functional layers, groups, and packages structure. |
+| `catalog_rhel.json` | image_build_manager | Compact RHEL 10.0 catalog example. |
+| `catalog_rhel_10_0_x86_64.json` | repo_manager, image_build_manager | RHEL 10.0 x86_64 catalog. |
+| `catalog_rhel_10_0_aarch64.json` | repo_manager, image_build_manager | RHEL 10.0 aarch64 catalog. |
+| `catalog_rhel_10_0_x86_aarch64.json` | repo_manager, image_build_manager | RHEL 10.0 dual-architecture catalog. |
+| `catalog_rhel_10_2_x86_aarch64.json` | repo_manager, image_build_manager | RHEL 10.2 dual-architecture catalog. |
 
 ## Usage
 
 ```bash
 # Copy sample catalog to the convention path for testing:
 sudo mkdir -p /opt/omnia/catalog
-sudo cp samples/catalog_rhel.json /opt/omnia/catalog/
+sudo cp samples/catalog_rhel_10_2_x86_aarch64.json /opt/omnia/catalog/
 
-# Then configure image_build_config.yml:
-#   catalog_file: "/opt/omnia/catalog/catalog_rhel.json"
-#   functional_groups_source: "catalog"
+# Select the catalog and use catalog-backed functional groups:
+export CATALOG_FILE_PATH=/opt/omnia/catalog/catalog_rhel_10_2_x86_aarch64.json
+# Set functional_groups_source: "catalog" in image_build_config.yml.
 ```
 
 ## Catalog JSON Structure

--- a/test/image_build_manager/ut/test_driver_group_skip.py
+++ b/test/image_build_manager/ut/test_driver_group_skip.py
@@ -33,6 +33,10 @@ SAMPLE_CATALOG = (
     REPO_ROOT / "src" / "main" / "samples"
     / "catalog_rhel_10_0_x86_aarch64.json"
 )
+RHEL_10_2_CATALOG = (
+    REPO_ROOT / "src" / "main" / "samples"
+    / "catalog_rhel_10_2_x86_aarch64.json"
+)
 
 # ---------------------------------------------------------------------------
 # Mock ansible imports so parse_catalog.py can be imported outside Ansible
@@ -375,3 +379,18 @@ class TestSampleCatalogDriverGroups:
                 assert "nvidia-driver" not in pkg.lower() or "driver_group" not in fg_name, (
                     f"Driver package '{pkg}' leaked into compute group {fg_name}"
                 )
+
+
+@pytest.mark.parametrize("build_arch", ["x86_64", "aarch64"])
+def test_rhel_10_2_catalog_resolves_for_supported_architectures(build_arch):
+    """The shipped RHEL 10.2 catalog resolves build inputs for both arches."""
+    result = resolve_catalog(
+        catalog_file=str(RHEL_10_2_CATALOG),
+        build_arch=build_arch,
+    )
+
+    assert result["cluster_os_type"] == "rhel"
+    assert result["cluster_os_version"] == "10.2"
+    assert result["cluster_os_versions"] == ["10.2"]
+    assert result["base_image_packages"]
+    assert result["compute_images_dict"]

--- a/test/image_build_manager/ut/test_input_validation_schema.py
+++ b/test/image_build_manager/ut/test_input_validation_schema.py
@@ -209,17 +209,38 @@ def test_package_groups_schema_rejects_blank_package():
     assert errors
 
 
+@pytest.mark.parametrize(
+    "catalog_name",
+    [
+        "catalog_rhel_10_0_x86_aarch64.json",
+        "catalog_rhel_10_2_x86_aarch64.json",
+    ],
+)
+def test_supported_rhel_catalog_samples_pass_schema(catalog_name):
+    catalog_path = REPO_ROOT / "src/main/samples" / catalog_name
+    data = json.loads(catalog_path.read_text(encoding="utf-8"))
+    assert not _validate(data, "catalog.json", catalog_name)
+
+
 @pytest.fixture
 def valid_repo_status():
     return {
         "overall_status": "success",
         "cluster_os_type": "rhel",
         "repo_config": "partial",
+        "execution_contexts": [
+            {
+                "context_id": "rhel_10.0",
+                "os_type": "rhel",
+                "os_version": "10.0",
+                "architectures": ["x86_64", "aarch64"],
+            }
+        ],
+        "overall_status_by_version": {"10.0": "success"},
         "repo_manager": {
             "port": 2225,
             "certificates": {
                 "server_crt": "/opt/omnia/certs/server.crt",
-                "server_key": "/opt/omnia/certs/server.key",
                 "certs_dir": "/opt/omnia/certs",
             },
         },
@@ -255,12 +276,22 @@ def test_repo_status_requires_repo_manager_contract(valid_repo_status):
     assert any("repo_manager" in error for error in errors)
 
 
+@pytest.mark.parametrize(
+    "field", ["execution_contexts", "overall_status_by_version"]
+)
+def test_repo_status_requires_multi_context_contract_fields(
+    valid_repo_status, field
+):
+    del valid_repo_status[field]
+    errors = _validate(valid_repo_status, "repo_status.json", "repo_status.yml")
+    assert any(field in error for error in errors)
+
+
 def test_repo_status_allows_empty_internet_repo_manager_values(valid_repo_status):
     valid_repo_status["repo_manager"] = {
         "port": "",
         "certificates": {
             "server_crt": "",
-            "server_key": "",
             "certs_dir": "",
         },
     }
@@ -272,7 +303,6 @@ def test_repo_status_checks_repo_manager_structure_only(valid_repo_status):
         "port": "",
         "certificates": {
             "server_crt": "/optional/ca.crt",
-            "server_key": "",
             "certs_dir": "",
         },
     }
@@ -280,9 +310,45 @@ def test_repo_status_checks_repo_manager_structure_only(valid_repo_status):
 
 
 def test_repo_status_requires_certificate_structure(valid_repo_status):
-    del valid_repo_status["repo_manager"]["certificates"]["server_key"]
+    del valid_repo_status["repo_manager"]["certificates"]["certs_dir"]
+    errors = _validate(valid_repo_status, "repo_status.json", "repo_status.yml")
+    assert any("certs_dir" in error for error in errors)
+
+
+def test_repo_status_rejects_private_key_path(valid_repo_status):
+    valid_repo_status["repo_manager"]["certificates"]["server_key"] = (
+        "/opt/omnia/certs/server.key"
+    )
     errors = _validate(valid_repo_status, "repo_status.json", "repo_status.yml")
     assert any("server_key" in error for error in errors)
+
+
+def test_repo_status_accepts_sanitized_registry_metadata(valid_repo_status):
+    valid_repo_status["registries"] = {
+        "private_registry": {
+            "base_url": "https://harbor.example.com",
+            "port": 443,
+            "host": "harbor.example.com:443",
+            "tls": {"insecure": False},
+        }
+    }
+    assert not _validate(valid_repo_status, "repo_status.json", "repo_status.yml")
+
+
+def test_repo_status_rejects_registry_credential_paths(valid_repo_status):
+    valid_repo_status["registries"] = {
+        "private_registry": {
+            "base_url": "https://harbor.example.com",
+            "port": 443,
+            "host": "harbor.example.com:443",
+            "tls": {
+                "insecure": False,
+                "client_key_path": "/etc/omnia/registry.key",
+            },
+        }
+    }
+    errors = _validate(valid_repo_status, "repo_status.json", "repo_status.yml")
+    assert any("client_key_path" in error for error in errors)
 
 
 @pytest.mark.parametrize("invalid_port", ["2225", 0, 65536, True, None])
@@ -305,9 +371,38 @@ def test_repo_status_rejects_blank_url(valid_repo_status):
     assert errors
 
 
-def test_repo_status_requires_usable_x86_repository(valid_repo_status):
+def test_repo_status_allows_aarch64_only_repository_output(valid_repo_status):
     valid_repo_status["repositories"]["10.0"]["x86_64"] = {}
+    valid_repo_status["repositories"]["10.0"]["aarch64"] = {
+        "baseos": {
+            "url": "https://192.0.2.10:2225/pulp/content/aarch64/baseos/"
+        }
+    }
+    assert not REPO_VALIDATOR.validate(valid_repo_status, LOGGER)
+
+
+def test_repo_status_requires_at_least_one_usable_repository(valid_repo_status):
+    valid_repo_status["repositories"]["10.0"]["x86_64"] = {}
+    valid_repo_status["repositories"]["10.0"]["aarch64"] = {}
     assert REPO_VALIDATOR.validate(valid_repo_status, LOGGER)
+
+
+def test_repo_status_versions_must_match_contexts(valid_repo_status):
+    valid_repo_status["overall_status_by_version"]["10.2"] = "success"
+    errors = REPO_VALIDATOR.validate(valid_repo_status, LOGGER)
+    assert any("overall_status_by_version keys" in error for error in errors)
+
+
+def test_repo_status_architectures_must_match_context(valid_repo_status):
+    del valid_repo_status["repositories"]["10.0"]["aarch64"]
+    errors = REPO_VALIDATOR.validate(valid_repo_status, LOGGER)
+    assert any("architecture keys" in error for error in errors)
+
+
+def test_repo_status_requires_every_version_to_be_success(valid_repo_status):
+    valid_repo_status["overall_status_by_version"]["10.0"] = "pending"
+    errors = REPO_VALIDATOR.validate(valid_repo_status, LOGGER)
+    assert any("incomplete versions: 10.0" in error for error in errors)
 
 
 def test_repo_status_boolean_priority_fails(valid_repo_status):
@@ -326,6 +421,20 @@ def test_internet_repo_status_sample_passes_contract():
     data = yaml.safe_load(sample_path.read_text(encoding="utf-8"))
     assert not _validate(data, "repo_status.json", "repo_status.yml")
     assert not REPO_VALIDATOR.validate(data, LOGGER)
+
+
+def test_repo_manager_status_sample_matches_new_contract():
+    sample_path = (
+        REPO_ROOT
+        / "src/image_build_manager/samples/repo_manager_output/repo_status.yml"
+    )
+    sample_text = sample_path.read_text(encoding="utf-8").replace(
+        "{{ admin_nic_ip }}", "192.0.2.10"
+    )
+    data = yaml.safe_load(sample_text)
+    assert not _validate(data, "repo_status.json", "repo_status.yml")
+    assert not REPO_VALIDATOR.validate(data, LOGGER)
+    assert list(data["overall_status_by_version"]) == ["10.0", "10.2"]
 
 
 def test_repo_contract_runs_in_build_setup_not_general_validation():

--- a/test/image_build_manager/ut/test_parse_repo_status.py
+++ b/test/image_build_manager/ut/test_parse_repo_status.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the version-aware repo_status.yml consumer."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = (
+    REPO_ROOT
+    / "src/image_build_manager/plugins/modules/parse_repo_status.py"
+)
+SAMPLE_DIR = (
+    REPO_ROOT / "src/image_build_manager/samples/repo_manager_output"
+)
+
+
+if "ansible" not in sys.modules:
+    ansible = types.ModuleType("ansible")
+    module_utils = types.ModuleType("ansible.module_utils")
+    basic = types.ModuleType("ansible.module_utils.basic")
+
+    class FakeAnsibleModule:  # pylint: disable=too-few-public-methods
+        """Minimal import stub; module entry points are not exercised here."""
+
+    basic.AnsibleModule = FakeAnsibleModule
+    ansible.module_utils = module_utils
+    sys.modules["ansible"] = ansible
+    sys.modules["ansible.module_utils"] = module_utils
+    sys.modules["ansible.module_utils.basic"] = basic
+
+
+SPEC = importlib.util.spec_from_file_location("parse_repo_status", MODULE_PATH)
+PARSE_REPO_STATUS = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(PARSE_REPO_STATUS)
+
+
+def test_parse_multi_version_repo_manager_sample(tmp_path):
+    """Both RHEL versions remain identifiable for later catalog filtering."""
+    sample = (SAMPLE_DIR / "repo_status.yml").read_text(encoding="utf-8")
+    rendered = tmp_path / "repo_status.yml"
+    rendered.write_text(
+        sample.replace("{{ admin_nic_ip }}", "192.0.2.10"),
+        encoding="utf-8",
+    )
+
+    result = PARSE_REPO_STATUS.parse_repo_status(str(rendered))
+
+    assert result["cluster_os_version"] == "10.0"
+    assert result["cluster_os_versions"] == ["10.0", "10.2"]
+    assert result["repo_port"] == 2225
+    assert {repo["os_version"] for repo in result["repo_manager_repos_x86_64"]} == {
+        "10.0",
+        "10.2",
+    }
+    assert any(
+        repo["name"] == "10_2_baseos"
+        for repo in result["repo_manager_repos_x86_64"]
+    )
+
+
+def test_parse_internet_sample_uses_https_default_port():
+    """The internet-only fixture derives port 443 from its first HTTPS URL."""
+    result = PARSE_REPO_STATUS.parse_repo_status(
+        str(SAMPLE_DIR / "repo_status_internet.yml")
+    )
+
+    assert result["repo_port"] == 443
+    assert result["repo_cert_path"] == ""
+    assert result["cluster_os_versions"] == ["10.0", "10.2"]


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Fixes #4849

### Description of the Solution

This PR extends the repo status contract to support multiple RHEL versions (10.0 and 10.2) in a single `repo_status.yml` file. The changes enable image build manager to work with multi-version repository outputs while maintaining backward compatibility with existing single-version deployments.

**Key changes:**
- **Enhanced repo_status schema**: Added `execution_contexts` and `overall_status_by_version` fields to track per-version status and supported architectures
- **Updated repo_manager structure**: Removed `server_key` from required certificates (private keys excluded from output contract), added structured `registries` and `file_repos` sections
- **Multi-version parsing**: Updated `parse_repo_status` module to extract and normalize multi-version repository data
- **Validation updates**: Enhanced schema validation to enforce new multi-version contract requirements and reject private key paths
- **Sample files**: Added RHEL 10.2 catalog sample and updated repo status samples with multi-version examples
- **Test coverage**: Added comprehensive unit tests for multi-version parsing, schema validation, and catalog resolution

### Changes

#### Image Build Manager Schemas (`src/image_build_manager/plugins/module_utils/input_validation/schema/`)
- **catalog.json**: Changed schema URL from https to http for compatibility
- **repo_status.json**: Added multi-version support with execution contexts, version-specific status, structured registries, and file repositories

#### Image Build Manager Validators (`src/image_build_manager/plugins/module_utils/input_validation/validators/`)
- **repo_status_validator.py**: Updated to validate new multi-version contract fields and enforce consistency between contexts, versions, and architectures

#### Image Build Manager Modules (`src/image_build_manager/plugins/modules/`)
- **parse_repo_status.py**: Enhanced to parse multi-version repo status and extract per-version repository metadata

#### Image Build Manager Roles (`src/image_build_manager/roles/`)
- **fetch_build_packages/tasks/fetch_repo_manager_repos.yml**: Updated to handle multi-version repository data
- **image_build_setup/README.md**: Updated documentation to reflect multi-version support
- **image_build_setup/tasks/load_repo_status.yml**: Updated to load and validate multi-version repo status

#### Image Build Manager Samples (`src/image_build_manager/samples/repo_manager_output/`)
- **repo_status.yml**: Updated with multi-version structure (10.0 and 10.2)
- **repo_status_internet.yml**: Added new sample for internet-only mode with multi-version support

#### Main Samples (`src/main/samples/`)
- **README.md**: Updated to reference RHEL 10.2 catalog and document multi-version catalog usage

#### Tests (`test/image_build_manager/ut/`)
- **test_driver_group_skip.py**: Added RHEL 10.2 catalog resolution tests
- **test_input_validation_schema.py**: Added multi-version schema validation tests
- **test_parse_repo_status.py**: New test file for multi-version repo status parsing

### Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/image_build_manager/plugins/module_utils/input_validation/schema/catalog.json` | Modified | Updated schema URL |
| `src/image_build_manager/plugins/module_utils/input_validation/schema/repo_status.json` | Modified | Added multi-version contract fields |
| `src/image_build_manager/plugins/module_utils/input_validation/validators/repo_status_validator.py` | Modified | Enhanced validation for multi-version support |
| `src/image_build_manager/plugins/modules/parse_repo_status.py` | Modified | Added multi-version parsing logic |
| `src/image_build_manager/roles/fetch_build_packages/tasks/fetch_repo_manager_repos.yml` | Modified | Updated for multi-version repo data |
| `src/image_build_manager/roles/image_build_setup/README.md` | Modified | Updated documentation |
| `src/image_build_manager/roles/image_build_setup/tasks/load_repo_status.yml` | Modified | Updated to load multi-version status |
| `src/image_build_manager/samples/repo_manager_output/repo_status.yml` | Modified | Added multi-version example |
| `src/image_build_manager/samples/repo_manager_output/repo_status_internet.yml` | Added | Internet mode multi-version sample |
| `src/main/samples/README.md` | Modified | Updated catalog references |
| `test/image_build_manager/ut/test_driver_group_skip.py` | Modified | Added RHEL 10.2 tests |
| `test/image_build_manager/ut/test_input_validation_schema.py` | Modified | Added multi-version validation tests |
| `test/image_build_manager/ut/test_parse_repo_status.py` | Added | New multi-version parsing tests |

### Testing

- Added unit tests for multi-version repo status parsing and validation
- Added RHEL 10.2 catalog resolution tests for both x86_64 and aarch64 architectures
- Updated schema validation tests to enforce new multi-version contract requirements
- Verified that private key paths are rejected in repo status validation
- Tested internet mode sample with multi-version support

### Backward Compatibility

- The changes maintain backward compatibility with existing single-version repo_status.yml files through schema validation
- Private key paths are now explicitly rejected from the output contract (security improvement)
- Existing RHEL 10.0 workflows continue to work with the enhanced contract
- The multi-version structure is opt-in through the new fields

### Suggested Reviewers
- @sujit-jadhav @Rajeshkumar-s2 @balajikumaran-c-s 
