### PR TITLE
fix(orchestrator): harden storage lifecycle and provisioning

### DIFF
--- a/src/orchestrator/playbooks/cleanup/README.md
+++ b/src/orchestrator/playbooks/cleanup/README.md
@@ -26,6 +26,10 @@ Run from the `src/orchestrator` directory:
 # All enabled components. Credential files are preserved.
 ansible-playbook playbooks/orchestrator.yml --tags cleanup
 
+# Non-interactive selection: clean Kubernetes and preserve Slurm storage.
+ansible-playbook playbooks/orchestrator.yml --tags cleanup \
+  -e cleanup_k8s=true -e cleanup_slurm=false
+
 # Credential files only.
 ansible-playbook playbooks/orchestrator.yml --tags cleanup_credentials
 
@@ -65,8 +69,11 @@ ansible-playbook playbooks/cleanup/cleanup_orchestrator.yml --tags slurm,k8s
 
 Slurm and Kubernetes cleanup remove their shared data first and then invoke
 scoped `storage_mounts` cleanup. This ordering keeps the share reachable while
-server-side data is deleted. Selecting `storage_mounts` directly cleans all
-Orchestrator-managed mounts.
+server-side data is deleted. A full `--tags cleanup` run does not execute an
+additional global storage-mount pass. Each domain performs its own scoped
+unmount and fstab cleanup after either deleting or preserving its data.
+Selecting `storage_mounts` directly through the component playbook still
+cleans all Orchestrator-managed mounts.
 
 Component storage is resolved through the same contract used during
 provisioning: `slurm_cluster[].nfs_storage_name`, optional
@@ -80,15 +87,19 @@ before shared data is removed.
 
 Components run in descending priority: OpenCHAMI 100, OpenLDAP 90, Slurm 80,
 Kubernetes 70, storage mounts 60, artifacts 50, and credentials 10. Slurm and
-Kubernetes perform their scoped unmount internally after deleting shared data;
-the later storage-mount pass is idempotent.
+Kubernetes perform their scoped unmount internally after deleting shared data.
+The independent storage-mount component is available only when explicitly
+selected through the component cleanup playbook.
 
 ## Shared (NFS) data cleanup
 
-By default, Slurm and K8s cleanup removes their directories from the **shared
-filesystem**, not just the local mount point — so the data is deleted on the NFS server.
-This is done by writing through the mount point while the share is still mounted, which
+When selected, Slurm and K8s cleanup removes data from the **shared filesystem**,
+not just the local mount point, so the data is deleted on the NFS server. This is
+done by writing through the mount point while the share is still mounted, which
 means no SSH access to the NFS server is required and it works with NFS appliances.
+Kubernetes cleanup removes every entry below its configured NFS mount, including
+hidden and dynamically generated content. Slurm cleanup removes its configured
+data directories while retaining `preserve_directories`.
 
 Order of operations per component:
 
@@ -112,26 +123,48 @@ removed.
 (`projects`, `scratch`, `apps`, …) may hold data Omnia did not create. Verify backups
 before running, and do a `DRY_RUN=true` pass first.
 
-## Confirmation
+## Shared-data selection and confirmation
 
-Cleanup asks for confirmation before deleting anything:
+For a full `orchestrator.yml --tags cleanup` run, Slurm and Kubernetes are
+selected independently with the `cleanup_slurm` and `cleanup_k8s` extra
+variables:
 
+| Value | Behaviour |
+|-------|-----------|
+| `true` | No prompt; delete that component's shared data, unmount its configured storage, and remove its fstab entries |
+| `false` | No prompt; preserve that component's data, then unmount its storage and remove its fstab entries |
+| omitted | Prompt for data deletion; only an exact `yes` deletes data, while every other answer preserves it; storage cleanup still runs |
+
+Examples:
+
+```bash
+# Clean both data domains without prompting.
+ansible-playbook playbooks/orchestrator.yml --tags cleanup \
+  -e cleanup_k8s=true -e cleanup_slurm=true
+
+# Preserve both data domains without prompting. Other enabled cleanup
+# components, such as OpenCHAMI, OpenLDAP, and artifacts, still run.
+ansible-playbook playbooks/orchestrator.yml --tags cleanup \
+  -e cleanup_k8s=false -e cleanup_slurm=false
+
+# Clean Slurm without prompting and ask independently about Kubernetes.
+ansible-playbook playbooks/orchestrator.yml --tags cleanup \
+  -e cleanup_slurm=true
 ```
-About to permanently delete data for: openchami, openldap, artifacts, storage_mounts, slurm, k8s
-This includes data on shared NFS storage, which cannot be recovered.
-Type 'yes' to proceed (anything else aborts)
-```
 
-Anything other than `yes` aborts before any component runs.
-
-Non-interactive runs (CI, scripts, cron) receive no input and therefore **abort**. Pass
-`SKIP_APPROVAL=true` to bypass the prompt:
+An omitted value is intentionally interactive. Non-interactive automation must
+set both extra variables or use `SKIP_APPROVAL=true`. `SKIP_APPROVAL=true`
+selects any omitted Slurm or Kubernetes cleanup, preserving the historical
+non-interactive full-cleanup behavior:
 
 ```bash
 SKIP_APPROVAL=true ansible-playbook playbooks/orchestrator.yml --tags cleanup
 ```
 
 Confirmation is skipped automatically when `DRY_RUN=true`, since nothing is modified.
+
+Explicit component runs through `cleanup_orchestrator.yml` retain one
+all-or-nothing confirmation for the selected component list.
 
 ## Dry run mode
 

--- a/src/orchestrator/playbooks/cleanup/cleanup_full.yml
+++ b/src/orchestrator/playbooks/cleanup/cleanup_full.yml
@@ -17,7 +17,12 @@
 #
 # USAGE (via orchestrator.yml):
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup
-#       Cleans every enabled component. Credentials are preserved.
+#       Cleans every enabled component. Prompts independently before deleting
+#       Slurm and Kubernetes shared data. Credentials are preserved.
+#   ansible-playbook playbooks/orchestrator.yml --tags cleanup \
+#       -e cleanup_slurm=true -e cleanup_k8s=false
+#       Deletes Slurm shared data without prompting, preserves Kubernetes
+#       shared data, and unmounts both selected storage domains.
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup_credentials
 #       Cleans orchestrator credential files only.
 #   ansible-playbook playbooks/orchestrator.yml --tags cleanup,cleanup_credentials

--- a/src/orchestrator/playbooks/cleanup/tasks/prepare_and_select.yml
+++ b/src/orchestrator/playbooks/cleanup/tasks/prepare_and_select.yml
@@ -126,6 +126,93 @@
     enabled_components: "{{ target_components }}"
   when: effective_tags | length > 0 and effective_tags[0] != 'all'
 
+- name: Validate full-cleanup data selection values
+  ansible.builtin.assert:
+    that:
+      - >-
+        cleanup_slurm is not defined or
+        (cleanup_slurm | string | trim | lower) in ['true', 'false']
+      - >-
+        cleanup_k8s is not defined or
+        (cleanup_k8s | string | trim | lower) in ['true', 'false']
+    fail_msg: >-
+      cleanup_slurm and cleanup_k8s accept only true or false. Omit a value
+      to receive an interactive confirmation prompt.
+  when: effective_tags | length == 0 or effective_tags[0] == 'all'
+
+# Shared-data decisions are independent during a full cleanup. Explicit true
+# or false values are non-interactive; omitted values require confirmation.
+- name: Confirm Slurm shared-data cleanup
+  ansible.builtin.pause:
+    prompt: |
+      Permanently delete all Slurm shared data except configured preserved directories,
+      then unmount its storage and remove its fstab entries?
+      Type 'yes' to delete Slurm data. Any other answer preserves the data;
+      the storage is still unmounted and removed from fstab.
+  register: cleanup_slurm_confirmation
+  when:
+    - effective_tags | length == 0 or effective_tags[0] == 'all'
+    - enabled_components.slurm is defined
+    - cleanup_slurm is not defined
+    - not skip_approval | bool
+    - not dry_run | bool
+
+- name: Confirm Kubernetes shared-data cleanup
+  ansible.builtin.pause:
+    prompt: |
+      Permanently delete all Kubernetes shared data, then unmount its storage
+      and remove its fstab entries?
+      Type 'yes' to delete Kubernetes data. Any other answer preserves the
+      data; the storage is still unmounted and removed from fstab.
+  register: cleanup_k8s_confirmation
+  when:
+    - effective_tags | length == 0 or effective_tags[0] == 'all'
+    - enabled_components.k8s is defined
+    - cleanup_k8s is not defined
+    - not skip_approval | bool
+    - not dry_run | bool
+
+- name: Resolve full-cleanup shared-data decisions
+  ansible.builtin.set_fact:
+    cleanup_slurm_approved: >-
+      {{ enabled_components.slurm is defined and
+         ((cleanup_slurm | bool) if cleanup_slurm is defined
+          else true if (skip_approval | bool or dry_run | bool)
+          else (cleanup_slurm_confirmation.user_input | default('')
+                | trim | lower) == 'yes') }}
+    cleanup_k8s_approved: >-
+      {{ enabled_components.k8s is defined and
+         ((cleanup_k8s | bool) if cleanup_k8s is defined
+          else true if (skip_approval | bool or dry_run | bool)
+          else (cleanup_k8s_confirmation.user_input | default('')
+                | trim | lower) == 'yes') }}
+  when: effective_tags | length == 0 or effective_tags[0] == 'all'
+
+# storage_mounts is not a separate full-cleanup pass. Slurm and Kubernetes
+# always invoke scoped mount cleanup themselves, whether data deletion was
+# approved or declined.
+- name: Remove redundant global storage-mount cleanup from full cleanup
+  ansible.builtin.set_fact:
+    enabled_components: >-
+      {{ (enabled_components | dict2items
+          | rejectattr('key', 'equalto', 'storage_mounts')
+          | items2dict) }}
+  when: effective_tags | length == 0 or effective_tags[0] == 'all'
+
+- name: Display full-cleanup shared-data decisions
+  ansible.builtin.debug:
+    msg:
+      - "Shared-data cleanup decisions:"
+      - >-
+        Slurm: {{ 'delete data, unmount, and remove fstab entries'
+        if cleanup_slurm_approved | bool
+        else 'preserve data, then unmount and remove fstab entries' }}
+      - >-
+        Kubernetes: {{ 'delete data, unmount, and remove fstab entries'
+        if cleanup_k8s_approved | bool
+        else 'preserve data, then unmount and remove fstab entries' }}
+  when: effective_tags | length == 0 or effective_tags[0] == 'all'
+
 - name: Set execution order (priority descending)
   ansible.builtin.set_fact:
     execution_order: "{{ enabled_components | dict2items | sort(attribute='value.priority', reverse=true) | map(attribute='key') | list }}"
@@ -138,10 +225,10 @@
       Components: {{ execution_order | join(' -> ') }}
       Total: {{ execution_order | length }}
 
-# Confirmation is required by default. A non-interactive run (no TTY) receives
-# empty input and aborts, rather than hanging -- automation must pass
-# SKIP_APPROVAL=true explicitly.
-- name: Confirm destructive cleanup
+# Explicit component cleanup retains its existing all-or-nothing confirmation.
+# Full cleanup instead uses the independent Slurm and Kubernetes decisions
+# above, allowing either data set to be preserved without aborting the rest.
+- name: Confirm explicitly selected component cleanup
   ansible.builtin.pause:
     prompt: |
       About to permanently delete data for: {{ execution_order | join(', ') }}
@@ -149,15 +236,19 @@
       Type 'yes' to proceed (anything else aborts)
   register: cleanup_confirmation
   when:
+    - effective_tags | length > 0
+    - effective_tags[0] != 'all'
     - not skip_approval | bool
     - not dry_run | bool
 
-- name: Abort when cleanup is not confirmed
+- name: Abort when explicitly selected component cleanup is not confirmed
   ansible.builtin.fail:
     msg: >-
       Cleanup aborted: confirmation not given. Re-run and type 'yes' at the
       prompt, or set SKIP_APPROVAL=true for non-interactive use.
   when:
+    - effective_tags | length > 0
+    - effective_tags[0] != 'all'
     - not skip_approval | bool
     - not dry_run | bool
     - cleanup_confirmation.user_input | default('') | trim | lower != 'yes'

--- a/src/orchestrator/plugins/module_utils/orchestrator_validation/messages/orchestrator_messages.py
+++ b/src/orchestrator/plugins/module_utils/orchestrator_validation/messages/orchestrator_messages.py
@@ -231,6 +231,15 @@ def storage_required_msg(references: list[str]) -> str:
     )
 
 
+def cluster_storage_name_required_msg(section: str) -> str:
+    """Return the missing required cluster-storage reference message."""
+    return (
+        f"omnia_config.yml: '{section}' must define a non-empty "
+        "nfs_storage_name because matching functional groups are selected "
+        "in pxe_mapping_file.csv."
+    )
+
+
 def duplicate_storage_names_msg(names: list[str]) -> str:
     """Return the duplicate storage mount-name error message."""
     return f"storage_config.yml contains duplicate mount names: {', '.join(names)}"

--- a/src/orchestrator/plugins/module_utils/orchestrator_validation/validators/orchestrator_config_validator.py
+++ b/src/orchestrator/plugins/module_utils/orchestrator_validation/validators/orchestrator_config_validator.py
@@ -258,37 +258,85 @@ def _validate_network_spec_cross(
             )
 
 
-def _referenced_storage_names(omnia_config: Any) -> set[str]:
-    """Return storage names referenced by supported cluster definitions."""
+def _requested_storage_sections(input_project_dir: str) -> set[str]:
+    """Return cluster sections selected by PXE functional-group names."""
+    orchestrator_config = _load_yaml_mapping(
+        os.path.join(input_project_dir, "orchestrator_config.yml")
+    )
+    path = _resolve_pxe_mapping_path(orchestrator_config, input_project_dir)
+    if not os.path.isfile(path):
+        return set()
+    try:
+        header, rows = _read_csv_rows(path)
+    except (csv.Error, OSError, UnicodeError):
+        return set()
+    if "FUNCTIONAL_GROUP_NAME" not in header:
+        return set()
+
+    functional_groups = _column_values(
+        rows, header.index("FUNCTIONAL_GROUP_NAME")
+    )
+    requested: set[str] = set()
+    if any(name.startswith("service_kube_") for name in functional_groups):
+        requested.add("service_k8s_cluster")
+    if any(
+        name.startswith(("slurm_", "login_")) for name in functional_groups
+    ):
+        requested.add("slurm_cluster")
+    return requested
+
+
+def _referenced_storage_names(
+    omnia_config: Any, requested_sections: set[str]
+) -> tuple[set[str], list[str]]:
+    """Return storage references and selected sections missing NFS names."""
     references: set[str] = set()
+    missing_nfs_sections: list[str] = []
     if not isinstance(omnia_config, dict):
-        return references
-    for section in ("slurm_cluster", "service_k8s_cluster"):
+        return references, sorted(requested_sections)
+    for section in sorted(requested_sections):
         entries = omnia_config.get(section, [])
-        if not isinstance(entries, list):
+        if not isinstance(entries, list) or not entries:
+            missing_nfs_sections.append(section)
             continue
+        section_missing_nfs = False
         for entry in entries:
             if not isinstance(entry, dict):
+                section_missing_nfs = True
                 continue
-            for field in ("nfs_storage_name", "vast_storage_name"):
+            nfs_name = entry.get("nfs_storage_name")
+            if not isinstance(nfs_name, str) or not nfs_name.strip():
+                section_missing_nfs = True
+            fields = ["nfs_storage_name"]
+            if section == "slurm_cluster":
+                fields.append("vast_storage_name")
+            for field in fields:
                 value = entry.get(field)
                 if isinstance(value, str) and value.strip():
                     references.add(value.strip())
-    return references
+        if section_missing_nfs:
+            missing_nfs_sections.append(section)
+    return references, missing_nfs_sections
+
+
+def _load_yaml_mapping(path: str) -> dict[str, Any]:
+    """Load a YAML mapping, returning an empty mapping when unavailable."""
+    real_path = os.path.realpath(path)
+    if not os.path.isfile(real_path):
+        return {}
+    try:
+        with open(real_path, "r", encoding="utf-8") as yaml_file:
+            data = yaml.safe_load(yaml_file)
+    except (OSError, UnicodeError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _load_omnia_config(input_project_dir: str) -> Any:
     """Load project-level Omnia configuration for storage references."""
-    omnia_config_path = os.path.realpath(
+    return _load_yaml_mapping(
         os.path.join(input_project_dir, "omnia_config.yml")
     )
-    if not os.path.isfile(omnia_config_path):
-        return None
-    try:
-        with open(omnia_config_path, "r", encoding="utf-8") as omnia_file:
-            return yaml.safe_load(omnia_file)
-    except (OSError, UnicodeError, yaml.YAMLError):
-        return None
 
 
 def validate_storage_references(
@@ -310,7 +358,16 @@ def validate_storage_references(
     storage_path = os.path.realpath(
         os.path.join(input_project_dir, "storage_config.yml")
     )
-    references = _referenced_storage_names(_load_omnia_config(input_project_dir))
+    requested_sections = _requested_storage_sections(input_project_dir)
+    references, missing_nfs_sections = _referenced_storage_names(
+        _load_omnia_config(input_project_dir), requested_sections
+    )
+    for section in missing_nfs_sections:
+        record_error(
+            errors,
+            logger,
+            msg.cluster_storage_name_required_msg(section),
+        )
     if references and storage_data is None and not os.path.isfile(storage_path):
         record_error(errors, logger, msg.storage_required_msg(sorted(references)))
         return errors

--- a/src/orchestrator/roles/cleanup/components/k8s/tasks/cleanup.yml
+++ b/src/orchestrator/roles/cleanup/components/k8s/tasks/cleanup.yml
@@ -123,6 +123,7 @@
       Removing K8s shared data from '{{ cleanup_k8s_clean_base }}'
       ({{ 'via mount point' if cleanup_k8s_share_mounted | bool else 'local NFS export on this OIM' }}).
   when:
+    - cleanup_k8s_approved | default(true) | bool
     - k8s_config.cleanup_nfs_server | default(false) | bool
     - cleanup_k8s_clean_base | length > 0
   tags: k8s
@@ -134,6 +135,7 @@
       mounted and this host does not export '{{ cleanup_k8s_export_path }}'. Mount the share
       and re-run, or remove the data on the NFS server directly.
   when:
+    - cleanup_k8s_approved | default(true) | bool
     - k8s_config.cleanup_nfs_server | default(false) | bool
     - cleanup_k8s_clean_base | length == 0
   tags: k8s
@@ -146,18 +148,78 @@
       is available. Mount the share and rerun cleanup, or remove its data
       directly on the NFS server.
   when:
+    - cleanup_k8s_approved | default(true) | bool
     - k8s_config.cleanup_nfs_server | default(false) | bool
     - cleanup_k8s_clean_base | length == 0
   tags: k8s
 
-- name: Remove K8s data from the shared filesystem (before unmounting)
-  ansible.builtin.file:
-    path: "{{ cleanup_k8s_clean_base }}/{{ item }}"
-    state: absent
-  loop: "{{ k8s_config.cleanup_directories }}"
+- name: Validate K8s cleanup target is not a protected system path
+  ansible.builtin.assert:
+    that:
+      - cleanup_k8s_clean_base is match('^/')
+      - cleanup_k8s_clean_base not in k8s_config.protected_cleanup_paths
+    fail_msg: >-
+      Refusing to remove Kubernetes data from unsafe path
+      '{{ cleanup_k8s_clean_base }}'. Correct the matching mount_point or NFS
+      export in storage_config.yml.
   when:
+    - cleanup_k8s_approved | default(true) | bool
     - k8s_config.cleanup_nfs_server | default(false) | bool
     - cleanup_k8s_clean_base | length > 0
+  tags: k8s
+
+- name: Discover all K8s shared-data entries
+  ansible.builtin.find:
+    paths: "{{ cleanup_k8s_clean_base }}"
+    file_type: any
+    hidden: true
+    recurse: false
+  register: cleanup_k8s_shared_entries
+  when:
+    - cleanup_k8s_approved | default(true) | bool
+    - k8s_config.cleanup_nfs_server | default(false) | bool
+    - cleanup_k8s_clean_base | length > 0
+  tags: k8s
+
+- name: Remove all K8s data from the shared filesystem before unmounting
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ cleanup_k8s_shared_entries.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when:
+    - cleanup_k8s_approved | default(true) | bool
+    - k8s_config.cleanup_nfs_server | default(false) | bool
+    - cleanup_k8s_clean_base | length > 0
+  tags: k8s
+
+- name: Verify K8s shared-data directory is empty
+  ansible.builtin.find:
+    paths: "{{ cleanup_k8s_clean_base }}"
+    file_type: any
+    hidden: true
+    recurse: false
+  register: cleanup_k8s_remaining_entries
+  when:
+    - cleanup_k8s_approved | default(true) | bool
+    - k8s_config.cleanup_nfs_server | default(false) | bool
+    - cleanup_k8s_clean_base | length > 0
+    - not dry_run | default(false) | bool
+  tags: k8s
+
+- name: Fail when K8s shared data remains
+  ansible.builtin.assert:
+    that:
+      - cleanup_k8s_remaining_entries.matched | int == 0
+    fail_msg: >-
+      Kubernetes shared data remains under '{{ cleanup_k8s_clean_base }}'.
+      The storage will not be unmounted until the directory is empty.
+  when:
+    - cleanup_k8s_approved | default(true) | bool
+    - k8s_config.cleanup_nfs_server | default(false) | bool
+    - cleanup_k8s_clean_base | length > 0
+    - not dry_run | default(false) | bool
   tags: k8s
 
 # storage_mounts is a declared dependency of this component, so it always runs
@@ -168,17 +230,10 @@
     trigger_component: "k8s"
   tags: k8s
 
-# Removes the now-empty local mount point stubs. Has no effect on NFS server
-# data, which was already handled above while the share was still mounted.
-- name: Remove local K8s mount point directories (after unmounting)
-  ansible.builtin.file:
-    path: "{{ cleanup_k8s_mount_point }}/{{ item }}"
-    state: absent
-  loop: "{{ k8s_config.cleanup_directories }}"
-  when: k8s_config.nfs_cleanup | default(false) | bool
-  tags: k8s
-
 - name: Display K8s cleanup completion
   ansible.builtin.debug:
-    msg: "K8s cleanup operations completed (OIM node - NFS data cleaned)"
+    msg: >-
+      K8s cleanup operations completed (shared data
+      {{ 'deleted' if cleanup_k8s_approved | default(true) | bool else 'preserved' }};
+      storage unmounted and fstab entries removed)
   tags: k8s

--- a/src/orchestrator/roles/cleanup/components/k8s/vars/component_spec.yml
+++ b/src/orchestrator/roles/cleanup/components/k8s/vars/component_spec.yml
@@ -23,10 +23,26 @@ k8s_config:
   cleanup_nfs_server: true
   cleanup_node_ips: false
 
-  # Default cleanup directories (relative to mount points)
-  cleanup_directories:
-    - "config"
-    - "manifests"
+  # Never allow a configuration error to turn cleanup into a system-root wipe.
+  protected_cleanup_paths:
+    - "/"
+    - "/bin"
+    - "/boot"
+    - "/dev"
+    - "/etc"
+    - "/home"
+    - "/lib"
+    - "/lib64"
+    - "/opt"
+    - "/proc"
+    - "/root"
+    - "/run"
+    - "/sbin"
+    - "/srv"
+    - "/sys"
+    - "/tmp"
+    - "/usr"
+    - "/var"
 
   # Dependencies - components that must run before this
   dependencies:

--- a/src/orchestrator/roles/cleanup/components/slurm/tasks/cleanup.yml
+++ b/src/orchestrator/roles/cleanup/components/slurm/tasks/cleanup.yml
@@ -123,6 +123,7 @@
       Removing Slurm shared data from '{{ cleanup_slurm_clean_base }}'
       ({{ 'via mount point' if cleanup_slurm_share_mounted | bool else 'local NFS export on this OIM' }}).
   when:
+    - cleanup_slurm_approved | default(true) | bool
     - slurm_config.cleanup_nfs_server | default(false) | bool
     - cleanup_slurm_clean_base | length > 0
   tags: slurm
@@ -134,6 +135,7 @@
       mounted and this host does not export '{{ cleanup_slurm_export_path }}'. Mount the share
       and re-run, or remove the data on the NFS server directly.
   when:
+    - cleanup_slurm_approved | default(true) | bool
     - slurm_config.cleanup_nfs_server | default(false) | bool
     - cleanup_slurm_clean_base | length == 0
   tags: slurm
@@ -146,6 +148,7 @@
       is available. Mount the share and rerun cleanup, or remove its data
       directly on the NFS server.
   when:
+    - cleanup_slurm_approved | default(true) | bool
     - slurm_config.cleanup_nfs_server | default(false) | bool
     - cleanup_slurm_clean_base | length == 0
   tags: slurm
@@ -156,6 +159,7 @@
     state: absent
   loop: "{{ slurm_config.cleanup_directories | difference(slurm_config.preserve_directories) }}"
   when:
+    - cleanup_slurm_approved | default(true) | bool
     - slurm_config.cleanup_nfs_server | default(false) | bool
     - cleanup_slurm_clean_base | length > 0
   tags: slurm
@@ -175,9 +179,13 @@
     path: "{{ cleanup_slurm_mount_point }}/{{ item }}"
     state: absent
   loop: "{{ slurm_config.cleanup_directories | difference(slurm_config.preserve_directories) }}"
+  when: cleanup_slurm_approved | default(true) | bool
   tags: slurm
 
 - name: Display Slurm cleanup completion
   ansible.builtin.debug:
-    msg: "Slurm cleanup operations completed (OIM node - NFS data cleaned)"
+    msg: >-
+      Slurm cleanup operations completed (shared data
+      {{ 'deleted' if cleanup_slurm_approved | default(true) | bool else 'preserved' }};
+      storage unmounted and fstab entries removed)
   tags: slurm

--- a/src/orchestrator/roles/cleanup/config/default_cleanup.yml
+++ b/src/orchestrator/roles/cleanup/config/default_cleanup.yml
@@ -76,12 +76,11 @@ cleanup_components:
     rollback_supported: false
     preserve: []
     cleanup_paths:
-      - "config"
-      - "manifests"
+      - "all entries under the configured Kubernetes NFS mount"
     cleanup_node_ips: false
     nfs_cleanup: true
     unmount_mounts: true
-    description: "K8s configuration and NFS directories"
+    description: "All Kubernetes shared data, storage mount, and fstab entry"
 
   storage_mounts:
     enabled: true

--- a/src/orchestrator/roles/orchestrator_validations/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/main.yml
@@ -40,8 +40,6 @@
 
 - name: Validate NFS storage configuration
   ansible.builtin.include_tasks: validate_storage_config.yml
-  when: (hostvars['localhost']['slurm_support'] | default(false) | bool) or
-        (hostvars['localhost']['service_k8s_support'] | default(false) | bool)
 
 - name: Update hosts file
   ansible.builtin.include_tasks: update_hosts.yml

--- a/src/orchestrator/roles/orchestrator_validations/tasks/validate_storage_config.yml
+++ b/src/orchestrator/roles/orchestrator_validations/tasks/validate_storage_config.yml
@@ -14,40 +14,104 @@
 ---
 # validate_storage_config.yml — Validate NFS server reachability for storage mounts.
 #
-# Runs only when slurm_support or service_k8s_support is enabled.
-# Resolves nfs_storage_name from omnia_config.yml → looks up the matching
-# mount entry in storage_config.yml → extracts the NFS server IP from
-# the source field → pings the server to verify reachability.
+# Storage requirements are derived from functional groups selected in the PXE
+# mapping, not from catalog capability flags. A configured cluster storage name
+# is therefore validated only when nodes from that cluster are being deployed.
 #
 # Local/non-NFS sources (/dev/*, UUID=*, LABEL=*, //*) are skipped.
 #
 # Prerequisites:
-#   - storage_config.yml and omnia_config.yml already loaded via include_inputs.yml
-#   - slurm_support / service_k8s_support flags set by orchestrator_setup
+#   - functional_groups generated from pxe_mapping_file.csv
+#   - storage_config.yml and omnia_config.yml available in the project input
 
-- name: Load storage_config.yml
-  ansible.builtin.include_vars:
-    file: "{{ storage_config_file }}"
-    name: storage_config
+- name: Determine storage requirements from selected functional groups
+  ansible.builtin.set_fact:
+    service_k8s_storage_required: >-
+      {{ functional_groups | default([])
+         | map(attribute='name')
+         | select('match', '^service_kube_')
+         | list | length > 0 }}
+    slurm_storage_required: >-
+      {{ functional_groups | default([])
+         | map(attribute='name')
+         | select('match', '^(slurm_|login_)')
+         | list | length > 0 }}
 
-- name: Load omnia_config.yml
-  ansible.builtin.include_vars:
-    file: "{{ omnia_config_file }}"
-    name: omnia_config
+- name: Skip storage validation when no selected nodes require cluster storage
+  ansible.builtin.debug:
+    msg: >-
+      PXE mapping contains no Kubernetes, Slurm, or login functional groups.
+      Skipping cluster storage validation.
+  when:
+    - not service_k8s_storage_required | bool
+    - not slurm_storage_required | bool
+
+- name: Initialize selected storage names
+  ansible.builtin.set_fact:
+    nfs_names_to_validate: []
+
+- name: Load storage inputs required by selected functional groups
+  when: service_k8s_storage_required | bool or slurm_storage_required | bool
+  block:
+    - name: Load storage_config.yml
+      ansible.builtin.include_vars:
+        file: "{{ storage_config_file }}"
+        name: storage_config
+
+    - name: Load omnia_config.yml
+      ansible.builtin.include_vars:
+        file: "{{ omnia_config_file }}"
+        name: omnia_config
+
+    - name: Require Kubernetes NFS storage names for selected Kubernetes nodes
+      ansible.builtin.assert:
+        that:
+          - omnia_config.service_k8s_cluster | default([]) | length > 0
+          - >-
+            omnia_config.service_k8s_cluster | default([])
+            | selectattr('nfs_storage_name', 'defined')
+            | map(attribute='nfs_storage_name')
+            | map('trim') | reject('equalto', '') | list | length
+            == (omnia_config.service_k8s_cluster | default([]) | length)
+        fail_msg: "{{ k8s_nfs_name_required_msg }}"
+        quiet: true
+      when: service_k8s_storage_required | bool
+
+    - name: Require Slurm NFS storage names for selected Slurm nodes
+      ansible.builtin.assert:
+        that:
+          - omnia_config.slurm_cluster | default([]) | length > 0
+          - >-
+            omnia_config.slurm_cluster | default([])
+            | selectattr('nfs_storage_name', 'defined')
+            | map(attribute='nfs_storage_name')
+            | map('trim') | reject('equalto', '') | list | length
+            == (omnia_config.slurm_cluster | default([]) | length)
+        fail_msg: "{{ slurm_nfs_name_required_msg }}"
+        quiet: true
+      when: slurm_storage_required | bool
 
 # Build the list of NFS storage names that need validation
 - name: Collect NFS storage names referenced by enabled features
   ansible.builtin.set_fact:
     nfs_names_to_validate: >-
-      {{
-        ((omnia_config.slurm_cluster | default([]) | map(attribute='nfs_storage_name') | select('defined') | list)
-          if (hostvars['localhost']['slurm_support'] | default(false) | bool)
+      {{ (
+        ((omnia_config.slurm_cluster | default([])
+          | map(attribute='nfs_storage_name') | select('defined')
+          | map('trim') | reject('equalto', '') | list)
+          + (omnia_config.slurm_cluster | default([])
+             | map(attribute='vast_storage_name') | select('defined')
+             | map('trim') | reject('equalto', '') | list)
+          if (slurm_storage_required | bool)
           else [])
         +
-        ((omnia_config.service_k8s_cluster | default([]) | map(attribute='nfs_storage_name') | select('defined') | list)
-          if (hostvars['localhost']['service_k8s_support'] | default(false) | bool)
+        ((omnia_config.service_k8s_cluster | default([])
+          | map(attribute='nfs_storage_name') | select('defined')
+          | map('trim') | reject('equalto', '') | list)
+          if (service_k8s_storage_required | bool)
           else [])
-      }}
+      ) | unique | list }}
+  when: service_k8s_storage_required | bool or slurm_storage_required | bool
 
 - name: Skip validation when no NFS storage names are configured
   ansible.builtin.debug:

--- a/src/orchestrator/roles/orchestrator_validations/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_validations/vars/main.yml
@@ -79,6 +79,14 @@ storage_config_file: "{{ hostvars['localhost']['omnia_project_input_dir'] }}/sto
 omnia_config_file: "{{ hostvars['localhost']['omnia_project_input_dir'] }}/omnia_config.yml"
 nfs_name_not_found_msg: >-
   Failed. nfs_storage_name referenced in omnia_config.yml does not match any mount entry in storage_config.yml.
+k8s_nfs_name_required_msg: >-
+  Failed. Kubernetes functional groups are selected in pxe_mapping_file.csv,
+  so every service_k8s_cluster entry in omnia_config.yml must define
+  nfs_storage_name.
+slurm_nfs_name_required_msg: >-
+  Failed. Slurm or login functional groups are selected in pxe_mapping_file.csv,
+  so every slurm_cluster entry in omnia_config.yml must define
+  nfs_storage_name.
 nfs_source_empty_msg: >-
   Failed. Mount entry has an empty or missing 'source' field in storage_config.yml.
 nfs_source_format_msg: >-

--- a/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
+++ b/src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml
@@ -26,11 +26,9 @@
 - name: Validate repo_manager configuration is available for node configuration
   ansible.builtin.assert:
     that:
-      - pulp_cert_path is defined
-      - pulp_cert_path | length > 0
-      - pulp_port is defined
-      - cluster_os_type is defined
-      - cluster_os_type | length > 0
+      - hostvars['localhost']['pulp_cert_path'] | default('') | length > 0
+      - hostvars['localhost']['pulp_port'] is defined
+      - hostvars['localhost']['cluster_os_type'] | default('') | length > 0
     fail_msg: "{{ repo_config_not_available_msg }}"
 
 - name: Include vars from slurm defaults

--- a/src/orchestrator/roles/slurm_config/tasks/create_slurm_dir.yml
+++ b/src/orchestrator/roles/slurm_config/tasks/create_slurm_dir.yml
@@ -137,7 +137,7 @@
   ansible.builtin.copy:
     src: "{{ pulp_webserver_cert_path }}"
     dest: "{{ slurm_config_path }}/cert"
-    mode: "{{ file_mode }}"
+    mode: "{{ conf_file_mode }}"
   become: true
 
 - name: Set hpc_tools_path


### PR DESCRIPTION
## Fixes https://github.com/dell/omnia/issues/4849

## PR Description

### Issues Resolved by this Pull Request

This pull request resolves Orchestrator failures caused by validating storage
that is supported by the catalog but not selected in the PXE mapping. It also
corrects incomplete Kubernetes shared-data cleanup, ambiguous full-cleanup
confirmation behavior, and provisioning failures caused by incorrect variable
names or host scope.

### Description of the Solution

**Summary**: This pull request aligns storage validation and cleanup with the
functional groups actually selected for deployment. Kubernetes and Slurm
storage is required only when corresponding nodes occur in
`pxe_mapping_file.csv`; when selected, each required storage name must resolve
to exactly one complete `storage_config.yml` entry. The cleanup workflow now
supports independent Kubernetes and Slurm data decisions, removes all selected
Kubernetes shared data safely before unmounting, and preserves explicit
credential-cleanup behavior.

The change also fixes two provisioning defects: Slurm certificate staging now
uses the role's defined file-mode variable, and Repo Manager facts created on
`localhost` are validated through the correct Ansible host scope when metadata
is configured on `oim`.

### Changes

#### Functional-group-aware storage validation

- Derives Kubernetes and Slurm storage requirements from functional-group names
  selected in `pxe_mapping_file.csv`, instead of catalog capability flags.
- Skips cluster-storage validation when the mapping contains no Kubernetes,
  Slurm, or login functional groups.
- Requires a non-empty `nfs_storage_name` only for cluster sections selected by
  the PXE mapping.
- Includes an optional `vast_storage_name` in validation only when the selected
  Slurm configuration explicitly supplies it.
- Requires every selected storage reference to match exactly one complete mount
  entry in `storage_config.yml`.
- Applies the same selection rules in both Python L1/L2 cross-file validation
  and Ansible runtime validation.
- Adds actionable validation messages for selected cluster sections that omit
  required NFS storage names.

#### Cleanup selection and safety

- Adds independent `cleanup_slurm` and `cleanup_k8s` controls for full cleanup.
- Treats explicit `true` as approval to delete that domain's shared data and
  explicit `false` as an instruction to preserve its data without prompting.
- Prompts independently when either value is omitted; only an exact `yes`
  authorizes shared-data deletion.
- Continues scoped unmount and `/etc/fstab` cleanup whether shared data is
  deleted or preserved.
- Removes the redundant global storage-mount pass from full cleanup; Slurm and
  Kubernetes invoke their own scoped mount cleanup in the correct order.
- Deletes every immediate entry below the configured Kubernetes shared mount,
  including hidden and dynamically generated content.
- Rejects protected system paths before Kubernetes data removal and verifies
  that the selected shared directory is empty before unmounting.
- Preserves the existing Slurm `preserve_directories` behavior.
- Documents interactive, non-interactive, component-level, and dry-run cleanup
  workflows.

#### Provisioning reliability

- Uses `conf_file_mode` when copying the Pulp certificate into the Slurm shared
  configuration directory, avoiding an undefined `file_mode` failure.
- Reads `pulp_cert_path`, `pulp_port`, and `cluster_os_type` from
  `hostvars['localhost']`, matching the host on which `orchestrator_setup`
  publishes Repo Manager contract facts.

### Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/orchestrator/playbooks/cleanup/README.md` | Modified | Documents full-cleanup selection, confirmation, data preservation, unmount behavior, and examples |
| `src/orchestrator/playbooks/cleanup/cleanup_full.yml` | Modified | Documents the independent Slurm and Kubernetes cleanup controls |
| `src/orchestrator/playbooks/cleanup/tasks/prepare_and_select.yml` | Modified | Validates cleanup inputs, resolves per-domain decisions, and removes the redundant global mount pass |
| `src/orchestrator/plugins/module_utils/orchestrator_validation/messages/orchestrator_messages.py` | Modified | Adds the missing selected-cluster storage-name validation message |
| `src/orchestrator/plugins/module_utils/orchestrator_validation/validators/orchestrator_config_validator.py` | Modified | Scopes cross-file storage validation to PXE-selected cluster sections |
| `src/orchestrator/roles/cleanup/components/k8s/tasks/cleanup.yml` | Modified | Safely removes and verifies all Kubernetes shared data before scoped unmounting |
| `src/orchestrator/roles/cleanup/components/k8s/vars/component_spec.yml` | Modified | Defines protected system paths for destructive Kubernetes cleanup |
| `src/orchestrator/roles/cleanup/components/slurm/tasks/cleanup.yml` | Modified | Honors the resolved Slurm data-deletion decision while retaining scoped unmount behavior |
| `src/orchestrator/roles/cleanup/config/default_cleanup.yml` | Modified | Aligns Kubernetes cleanup metadata with complete shared-data removal |
| `src/orchestrator/roles/orchestrator_validations/tasks/main.yml` | Modified | Runs storage validation so it can make its own mapping-based selection decision |
| `src/orchestrator/roles/orchestrator_validations/tasks/validate_storage_config.yml` | Modified | Resolves and validates only storage referenced by selected Kubernetes, Slurm, or login nodes |
| `src/orchestrator/roles/orchestrator_validations/vars/main.yml` | Modified | Adds runtime messages for missing selected-cluster NFS storage names |
| `src/orchestrator/roles/provision_common/tasks/configure_metadata_svc.yml` | Modified | Validates Repo Manager facts through the correct `localhost` host scope |
| `src/orchestrator/roles/slurm_config/tasks/create_slurm_dir.yml` | Modified | Uses the defined Slurm configuration file mode for Pulp certificate staging |

### Testing

- GitHub `Unit Tests & Coverage (3.12)` passed for PR head
  `600975b8943014035ef03b58d35e7becc043eb4b`.
- GitHub `Ansible Lint`, Python build, and Test Co-Change checks passed.
- GitHub Bandit, pip-audit, secret scan, ShellCheck, and HPC compliance checks
  passed.
- GitHub PR hygiene, copyright, commit-author/message, and DCO checks passed.
- All three commits contain a `Signed-off-by` trailer.

### Backward Compatibility

- No persistent input schema or file format changes are introduced.
- Existing storage configuration remains valid when its cluster functional
  groups are selected in `pxe_mapping_file.csv`.
- Catalog-supported Kubernetes or Slurm features no longer require storage when
  no corresponding functional groups are selected for deployment.
- Full cleanup remains opt-in through `--tags cleanup`, and credentials remain
  preserved unless `--tags cleanup_credentials` is explicitly selected.
- Unattended cleanup should set both `cleanup_k8s` and `cleanup_slurm`, or use
  `SKIP_APPROVAL=true`, to avoid interactive prompts.
- An explicit `false` preserves shared data but intentionally still unmounts
  the corresponding storage and removes its managed `/etc/fstab` entries.
