### PR TITLE
fix(telemetry): correct iDRAC offline installs and MySQL inputs

### DIFF
--- a/src/telemetry/input/telemetry_packages.yml
+++ b/src/telemetry/input/telemetry_packages.yml
@@ -233,7 +233,7 @@ pip_modules:
   # Required for: MySQL operations via kubernetes module
   idrac:
     kubernetes: "33.1.0"
-    pymysql: "1.1.1"
+    pymysql: "1.1.2"
 
   # PowerScale / CSI volume exporter
   # Required for: K8s API interaction, PowerScale API calls, metrics export

--- a/src/telemetry/plugins/modules/insert_idracips_mysqldb.py
+++ b/src/telemetry/plugins/modules/insert_idracips_mysqldb.py
@@ -55,7 +55,7 @@ options:
     description: Name of the MySQL database.
     type: str
     required: true
-  mysql_user:
+  mysqldb_user:
     description: MySQL username for authentication.
     type: str
     required: true
@@ -103,8 +103,8 @@ EXAMPLES = r'''
     idrac_podnames_ips: "{{ idrac_podname_ips }}"
     mysqldb_container_port: 3306
     mysqldb_name: idrac_telemetry_db
-    mysql_user: "{{ mysql_user }}"
-    mysqldb_password: "{{ mysql_password }}"
+    mysqldb_user: "{{ mysqldb_user }}"
+    mysqldb_password: "{{ mysqldb_password }}"
     bmc_username: "{{ bmc_username }}"
     bmc_password: "{{ bmc_password }}"
     telemetry_idrac: "{{ telemetry_idrac }}"
@@ -292,8 +292,8 @@ def main():
         "idrac_podnames_ips": {"type": "dict", "required": True},
         "mysqldb_container_port": {"type": "int", "required": True},
         "mysqldb_name": {"type": "str", "required": True},
-        "mysql_user": {"type": "str", "required": True, "no_log": True},
-        "mysql_password": {"type": "str", "required": True, "no_log": True},
+        "mysqldb_user": {"type": "str", "required": True, "no_log": True},
+        "mysqldb_password": {"type": "str", "required": True, "no_log": True},
         "bmc_username": {"type": "str", "required": True, "no_log": True},
         "bmc_password": {"type": "str", "required": True, "no_log": True},
         "telemetry_idrac": {"type": "list", "elements": "str", "required": True},
@@ -318,8 +318,8 @@ def main():
     idrac_podnames_ips = module.params['idrac_podnames_ips']
     container_port = module.params['mysqldb_container_port']
     db_name = module.params['mysqldb_name']
-    db_user = module.params['mysql_user']
-    db_password = module.params['mysql_password']
+    db_user = module.params['mysqldb_user']
+    db_password = module.params['mysqldb_password']
     bmc_username = module.params['bmc_username']
     bmc_password = module.params['bmc_password']
     telemetry_idrac = module.params['telemetry_idrac']

--- a/src/telemetry/roles/common/tasks/install_python_dependencies.yml
+++ b/src/telemetry/roles/common/tasks/install_python_dependencies.yml
@@ -26,7 +26,7 @@
 #
 # Installation modes:
 #   - online:  Install from PyPI (pip install <package>==<version>)
-#   - offline: Install from Pulp repo (pip install --index-url <repo_url>/pip_module/ <package>==<version>)
+#   - offline: Install from a package-specific directory under <repo_url>/pip_module/
 #
 # Parameters:
 #   component: Component name to look up in telemetry_packages.yml (required)
@@ -70,9 +70,9 @@
     fail_msg: "repo_url must be set in telemetry_packages.yml when install_mode is 'offline'"
   when: install_mode == "offline"
 
-- name: Build pip index URL from repo_url
+- name: Build pip module URL from repo_url
   ansible.builtin.set_fact:
-    pip_index_url: "{{ repo_url }}/pip_module/"
+    pip_module_url: "{{ repo_url }}/pip_module/"
   when: install_mode == "offline"
 
 - name: Get packages for component from telemetry_packages.yml
@@ -92,5 +92,6 @@
   ansible.builtin.include_tasks: install_single_python_package.yml
   vars:
     package_name: "{{ item.key }}"
+    package_distribution_name: "{{ telemetry_pip_distribution_names[item.key] | default(item.key) }}"
     package_version: "{{ item.value }}"
     component_name: "{{ component }}"

--- a/src/telemetry/roles/common/tasks/install_single_python_package.yml
+++ b/src/telemetry/roles/common/tasks/install_single_python_package.yml
@@ -19,11 +19,12 @@
 # Called in a loop by install_python_dependencies.yml
 #
 # Parameters:
-#   - package_name: Python package name (e.g., kubernetes)
+#   - package_name: Python import name (e.g., kubernetes)
+#   - package_distribution_name: Catalog/Pulp package name (e.g., PyMySQL)
 #   - package_version: Package version (e.g., 33.1.0)
 #   - component_name: Component name for logging (e.g., idrac, powerscale)
 #   - install_mode: 'online' or 'offline' (set by caller)
-#   - pip_index_url: Pulp repo URL for offline mode (set by caller)
+#   - pip_module_url: Pulp pip-module base URL for offline mode (set by caller)
 # =============================================================================
 
 - name: Check if Python module is installed
@@ -42,7 +43,7 @@
     - name: Install Python module in online mode (from PyPI)
       when: install_mode == "online"
       ansible.builtin.command: >
-        python3 -m pip install {{ package_name }}=={{ package_version }}
+        python3 -m pip install {{ package_distribution_name }}=={{ package_version }}
       register: pip_install_online
       changed_when: true
 
@@ -56,15 +57,24 @@
 
     - name: Install Python module in offline mode (from Pulp repo)
       when: install_mode == "offline"
-      ansible.builtin.command: >
-        python3 -m pip install --index-url {{ pip_index_url }}
-        {{ package_name }}=={{ package_version }}
+      ansible.builtin.command:
+        argv:
+          - python3
+          - -m
+          - pip
+          - install
+          - --no-index
+          - --find-links
+          - "{{ pip_module_url }}{{ package_distribution_name }}=={{ package_version }}/"
+          - "{{ package_distribution_name }}=={{ package_version }}"
       register: pip_install_offline
       changed_when: true
 
     - name: Fail if offline installation failed
       ansible.builtin.fail:
-        msg: "Failed to install {{ package_name }}=={{ package_version }} from {{ pip_index_url }}. Check Pulp repo availability."
+        msg: >-
+          Failed to install {{ package_distribution_name }}=={{ package_version }} from
+          {{ pip_module_url }}{{ package_distribution_name }}=={{ package_version }}/. Check Pulp repo availability.
       when:
         - install_mode == "offline"
         - pip_install_offline.rc is defined

--- a/src/telemetry/roles/common/vars/main.yml
+++ b/src/telemetry/roles/common/vars/main.yml
@@ -41,6 +41,11 @@ verify_timeout: "300s"
 # =============================================================================
 # Python dependency installation
 # =============================================================================
+# Internal mapping from Python import names to catalog/Pulp distribution names.
+# This is implementation metadata and is intentionally not user-configurable.
+telemetry_pip_distribution_names:
+  pymysql: "PyMySQL"
+
 # Offline Python packages directory - derived from telemetry_data_path
 # This is a fallback when repo_url is not accessible
 # The primary source is always repo_url from telemetry_packages.yml

--- a/src/telemetry/roles/deploy_idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
+++ b/src/telemetry/roles/deploy_idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
@@ -310,10 +310,9 @@
       insert_idracips_mysqldb:
         telemetry_namespace: "{{ telemetry_namespace }}"
         idrac_podnames_ips: "{{ idrac_podname_idracips.idrac_podname_ips }}"
-        mysqldb_k8s_name: "{{ mysqldb_k8s_name }}"
         mysqldb_container_port: "{{ mysqldb_container_port1 }}"
         mysqldb_name: "{{ mysqldb_name }}"
-        mysql_user: "{{ telemetry_credentials.mysqldb_user }}"
+        mysqldb_user: "{{ telemetry_credentials.mysqldb_user }}"
         mysqldb_password: "{{ telemetry_credentials.mysqldb_password }}"
         bmc_username: "{{ telemetry_credentials.bmc_username }}"
         bmc_password: "{{ telemetry_credentials.bmc_password }}"


### PR DESCRIPTION
## Fixes #4849 
## PR Description

### Description of the Solution

**Summary**: Fixes two failures that block iDRAC telemetry deployment. The change installs Python dependencies from the package-specific Pulp layout, aligns the configured PyMySQL version and distribution name with synchronized catalog content, and makes the iDRAC MySQL insertion task use one consistent credential contract.

### Changes

#### Offline Python dependency installation

- Replaced the unsupported generic `pip_module` index lookup with package-specific `--no-index --find-links` installation.
- Separated Python import names from catalog/Pulp distribution names so `pymysql` is imported while `PyMySQL` is installed.
- Kept the distribution-name mapping as internal common-role metadata rather than exposing it in the user input file.
- Updated the iDRAC PyMySQL version from `1.1.1` to the catalog-provided `1.1.2`.
- Continued using `ansible.builtin.command` with an explicit argument list for offline installation.

#### iDRAC MySQL inventory synchronization

- Standardized the insert module and its caller on `mysqldb_user` and `mysqldb_password`.
- Updated the module documentation, example, argument specification, and parameter access to use the same names.
- Removed the obsolete `mysqldb_k8s_name` argument from the insert-module invocation.
- Preserved `no_log: true` protection for database and BMC credentials.

### Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/telemetry/input/telemetry_packages.yml` | Modified | Aligns the iDRAC PyMySQL version with catalog content. |
| `src/telemetry/plugins/modules/insert_idracips_mysqldb.py` | Modified | Standardizes MySQL credential arguments and documentation. |
| `src/telemetry/roles/common/tasks/install_python_dependencies.yml` | Modified | Resolves internal distribution names and builds the package directory URL. |
| `src/telemetry/roles/common/tasks/install_single_python_package.yml` | Modified | Installs online and offline dependencies using the distribution name and package-specific Pulp content. |
| `src/telemetry/roles/common/vars/main.yml` | Modified | Defines the internal `pymysql` to `PyMySQL` distribution mapping. |
| `src/telemetry/roles/deploy_idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml` | Modified | Aligns the insert call with the module contract and removes an obsolete argument. |

### Testing

- GitHub CI passed Ansible Lint, Pylint, Unit Tests & Coverage, Bandit, ShellCheck, Secret Leak Scan, Dependency Vulnerability Scan, HPC Compliance Scanner, Commit Hygiene, and PR Hygiene Check.
- `git diff --check` passed.
- Python AST syntax validation passed for `insert_idracips_mysqldb.py`.
- Safe YAML parsing passed for all five modified YAML files.
- A manual offline deployment progressed beyond the original Python dependency installation failure and reached iDRAC inventory processing.
- End-to-end deployment verification after the MySQL argument correction is pending.

### Backward Compatibility

- The Telemetry credential-file schema is unchanged and continues to use `mysqldb_user` and `mysqldb_password`.
- The repository's only insert-module caller is updated with the module contract.
- Direct external calls using `mysql_user` or `mysql_password` must migrate to `mysqldb_user` and `mysqldb_password`; compatibility aliases are intentionally not included.
- Online installation remains supported and now uses the catalog/PyPI distribution name.

### Suggested Reviewers
