### PR TITLE
Fix orchestrator storage csi provisioning

### DIFF
--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -472,7 +472,6 @@
         - systemctl enable crio.service
         - sudo systemctl enable --now kubelet
         - mv /tmp/generate-control-plane-join.sh {{ k8s_client_mount_path }}
-        - kubeadm config images pull --kubernetes-version={{ service_k8s_version }}
 {% set role_name = 'service_kube_control_plane_first' %}
 {% include 'pull_additional_images.yaml.j2' %}
         - echo "Installing helm"
@@ -512,6 +511,20 @@
             done
             mkdir -p /etc/kubernetes/manifests
             systemctl start crio.service
+            crio_ready=false
+            for attempt in $(seq 1 60); do
+              if crictl info >/dev/null 2>&1; then
+                crio_ready=true
+                break
+              fi
+              echo "Waiting for CRI-O before pulling images (attempt ${attempt}/60)..."
+              sleep 2
+            done
+            if [ "$crio_ready" != "true" ]; then
+              echo "ERROR: CRI-O did not become ready within 2 minutes."
+              exit 1
+            fi
+            kubeadm config images pull --kubernetes-version={{ service_k8s_version }}
             systemctl start kubelet.service
 
             NODE_IP="{{ "{{" }} ds.meta_data.instance_data.v1.local_ipv4 {{ "}}" }}"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -379,7 +379,6 @@
         - systemctl start crio.service
         - systemctl enable crio.service
         - sudo systemctl enable --now kubelet
-        - kubeadm config images pull --kubernetes-version={{ service_k8s_version }}
 {% set role_name = 'service_kube_control_plane' %}
 {% include 'pull_additional_images.yaml.j2' %}
         - echo "Installing helm"
@@ -416,6 +415,20 @@
               find "$state_dir" -mindepth 1 -xdev -delete
             done
             systemctl start crio.service
+            crio_ready=false
+            for attempt in $(seq 1 60); do
+              if crictl info >/dev/null 2>&1; then
+                crio_ready=true
+                break
+              fi
+              echo "Waiting for CRI-O before pulling images (attempt ${attempt}/60)..."
+              sleep 2
+            done
+            if [ "$crio_ready" != "true" ]; then
+              echo "ERROR: CRI-O did not become ready within 2 minutes."
+              exit 1
+            fi
+            kubeadm config images pull --kubernetes-version={{ service_k8s_version }}
             systemctl start kubelet.service
 
             K8S_CLIENT_MOUNT_PATH="{{ k8s_client_mount_path }}"

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -264,7 +264,6 @@
         - systemctl start crio.service
         - systemctl enable crio.service
         - sudo systemctl enable --now kubelet
-        - kubeadm config images pull --kubernetes-version={{ service_k8s_version }}
 {% set role_name = 'service_kube_node' %}
 {% include 'pull_additional_images.yaml.j2' %}
         - |
@@ -283,6 +282,20 @@
               find "$state_dir" -mindepth 1 -xdev -delete
             done
             systemctl start crio.service
+            crio_ready=false
+            for attempt in $(seq 1 60); do
+              if crictl info >/dev/null 2>&1; then
+                crio_ready=true
+                break
+              fi
+              echo "Waiting for CRI-O before pulling images (attempt ${attempt}/60)..."
+              sleep 2
+            done
+            if [ "$crio_ready" != "true" ]; then
+              echo "ERROR: CRI-O did not become ready within 2 minutes."
+              exit 1
+            fi
+            kubeadm config images pull --kubernetes-version={{ service_k8s_version }}
             systemctl start kubelet.service
 
             K8S_CLIENT_MOUNT_PATH="{{ k8s_client_mount_path }}"

--- a/src/orchestrator/roles/k8s_config/tasks/get_powerscale_dependencies.yml
+++ b/src/orchestrator/roles/k8s_config/tasks/get_powerscale_dependencies.yml
@@ -18,17 +18,51 @@
 - name: Get CSI dependencies from local repo
   when: hostvars['localhost']['csi_driver_powerscale_support']
   block:
-    - name: Load csi_driver_powerscale.json and extract versioned package names
+    - name: Resolve PowerScale component identifiers from catalog
       ansible.builtin.set_fact:
-        csi_powerscale_packages_json: "{{ lookup('file', csi_powerscale_packages_file) | from_json }}"
-      delegate_to: localhost
+        powerscale_component_ids: >-
+          {{ hostvars['localhost']['catalog_data'].catalog.groups['powerscale_csi_group'].components
+             | default([]) }}
 
-    - name: Extract versioned directory names from JSON (these are used as-is for directories)
+    - name: Resolve PowerScale Git packages from catalog components
       ansible.builtin.set_fact:
-        csi_powerscale_dir: "{{ csi_powerscale_packages_json['csi_driver_powerscale']['cluster'] | selectattr('type', 'equalto', 'git') | selectattr('package', 'search', 'csi-powerscale') | map(attribute='package') | first }}" # noqa: yaml[line-length]
-        helm_charts_dir: "{{ csi_powerscale_packages_json['csi_driver_powerscale']['cluster'] | selectattr('type', 'equalto', 'git') | selectattr('package', 'search', 'helm-charts') | map(attribute='package') | first }}" # noqa: yaml[line-length]
-        external_snapshotter_dir: "{{ csi_powerscale_packages_json['csi_driver_powerscale']['cluster'] | selectattr('type', 'equalto', 'git') | selectattr('package', 'search', 'external-snapshotter') | map(attribute='package') | first }}" # noqa: yaml[line-length]
-      delegate_to: localhost
+        powerscale_git_packages: >-
+          {{ powerscale_component_ids
+             | map('extract', hostvars['localhost']['catalog_data'].catalog.packages)
+             | selectattr('packagetype', 'defined')
+             | selectattr('packagetype', 'equalto', 'git')
+             | list }}
+
+    - name: Select required PowerScale Git packages
+      ansible.builtin.set_fact:
+        csi_powerscale_package_matches: >-
+          {{ powerscale_git_packages
+             | selectattr('name', 'match', '^csi-powerscale-v')
+             | map(attribute='name') | list }}
+        helm_charts_package_matches: >-
+          {{ powerscale_git_packages
+             | selectattr('name', 'match', '^helm-charts-')
+             | map(attribute='name') | list }}
+        external_snapshotter_package_matches: >-
+          {{ powerscale_git_packages
+             | selectattr('name', 'match', '^external-snapshotter-v')
+             | map(attribute='name') | list }}
+
+    - name: Validate required PowerScale Git packages
+      ansible.builtin.assert:
+        that:
+          - csi_powerscale_package_matches | length == 1
+          - helm_charts_package_matches | length == 1
+          - external_snapshotter_package_matches | length == 1
+          - offline_git_path | default('') | length > 0
+        fail_msg: "{{ powerscale_catalog_fail_msg }}"
+        quiet: true
+
+    - name: Set PowerScale versioned directory names
+      ansible.builtin.set_fact:
+        csi_powerscale_dir: "{{ csi_powerscale_package_matches | first }}"
+        helm_charts_dir: "{{ helm_charts_package_matches | first }}"
+        external_snapshotter_dir: "{{ external_snapshotter_package_matches | first }}"
 
     - name: Display extracted PowerScale versioned directory names
       ansible.builtin.debug:
@@ -126,7 +160,9 @@
 
     - name: Get csi-powerscale git tar
       ansible.builtin.get_url:
-        url: "{{ offline_git_path }}/{{ csi_powerscale_dir }}/{{ csi_powerscale_dir }}.tar.gz"
+        url: >-
+          {{ offline_git_path | regex_replace('/$', '') }}/{{
+          csi_powerscale_dir }}/{{ csi_powerscale_dir }}.tar.gz
         dest: "{{ k8s_client_mount_path }}/{{ csi_powerscale_dir }}.tar.gz"
         mode: "{{ permission_644 }}"
 
@@ -138,13 +174,17 @@
 
     - name: Get dell/helm-charts git tar
       ansible.builtin.get_url:
-        url: "{{ offline_git_path }}/{{ helm_charts_dir }}/{{ helm_charts_dir }}.tar.gz"
+        url: >-
+          {{ offline_git_path | regex_replace('/$', '') }}/{{
+          helm_charts_dir }}/{{ helm_charts_dir }}.tar.gz
         dest: "{{ k8s_client_mount_path }}/{{ csi_powerscale_dir }}/{{ helm_charts_git }}"
         mode: "{{ permission_644 }}"
 
     - name: Get external-snapshotter git tar
       ansible.builtin.get_url:
-        url: "{{ offline_git_path }}/{{ external_snapshotter_dir }}/{{ external_snapshotter_dir }}.tar.gz"
+        url: >-
+          {{ offline_git_path | regex_replace('/$', '') }}/{{
+          external_snapshotter_dir }}/{{ external_snapshotter_dir }}.tar.gz
         dest: "{{ k8s_client_mount_path }}/{{ csi_powerscale_dir }}/{{ external_snapshotter_git }}"
         mode: "{{ permission_644 }}"
 

--- a/src/orchestrator/roles/k8s_config/vars/main.yml
+++ b/src/orchestrator/roles/k8s_config/vars/main.yml
@@ -17,7 +17,6 @@ input_project_dir: "{{ hostvars['localhost']['omnia_project_input_dir'] }}"
 # Versioned JSON file: service_k8s_v<version>.json (e.g., service_k8s_v1.35.1.json)
 k8s_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars['localhost']['cluster_os_type'] }}/{{ hostvars['localhost']['cluster_os_version'] }}/service_k8s_v{{ hostvars['localhost']['service_k8s_version'] }}.json" # noqa: yaml[line-length]
 calico_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ calico_package }}/{{ calico_package }}.yml"
-csi_powerscale_packages_file: "{{ input_project_dir }}/config/x86_64/{{ hostvars['localhost']['cluster_os_type'] }}/{{ hostvars['localhost']['cluster_os_version'] }}/csi_driver_powerscale.json" # noqa: yaml[line-length]
 metallb_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ metallb_package }}/{{ metallb_package }}.yml"
 multus_manifest_yaml_url: "{{ offline_manifest_path | regex_replace('/$', '') }}/{{ multus_package }}/{{ multus_package }}.yml"
 helm_tarball_url: "{{ offline_tarball_path | regex_replace('/$', '') }}/{{ helm_package }}/{{ helm_package }}.tar.gz"
@@ -49,8 +48,15 @@ k8s_pip_packages: []
 cp_ips: "{{ (cp_first_ip_list + cp_ip_list) | unique }}"
 folder_mode: "0755"
 
-# csi variables
-fail_msg_download: "Failed to get required dependencies. Make sure to verify entries in csi_driver_powerscale.json and run local_repo.yml first."
+# CSI variables
+powerscale_catalog_fail_msg: >-
+  PowerScale CSI dependencies could not be resolved. Ensure the active catalog
+  defines powerscale_csi_group with exactly one csi-powerscale, helm-charts,
+  and external-snapshotter Git package, and that Repo Manager has generated
+  offline_git_path in repo_status.yml.
+fail_msg_download: >-
+  Failed to stage the PowerScale CSI dependencies from Repo Manager. Verify
+  the powerscale_csi_group catalog packages and Repo Manager Git artifacts.
 helm_charts_git: "helm-charts.tar.gz"
 external_snapshotter_git: "external-snapshotter.tar.gz"
 empty_certificate_template_path: "{{ role_path }}/files/empty_certificate_template.yml"

--- a/src/orchestrator/roles/mount_config/tasks/oim_mount.yml
+++ b/src/orchestrator/roles/mount_config/tasks/oim_mount.yml
@@ -52,18 +52,13 @@
          + (mounts | selectattr('name', 'in', filter_service_k8s_nfs) | list) }}
   when: ('service_k8s' in omnia_run_tags) and (service_k8s_support)
 
-- name: Build list of NFS names already handled by Slurm/K8s blocks
-  ansible.builtin.set_fact:
-    _handled_nfs_names: "{{ filter_slurm_nfs + filter_service_k8s_nfs }}"
-
-- name: Add remaining mount_on_oim storage (excludes Slurm/K8s-specific NFS)
+- name: Add storage explicitly configured for OIM mounting
   ansible.builtin.set_fact:
     storage_to_be_mounted: >-
       {{ (storage_to_be_mounted
           + (mounts
              | selectattr('mount_on_oim', 'defined')
              | selectattr('mount_on_oim', 'equalto', true)
-             | rejectattr('name', 'in', _handled_nfs_names)
              | list))
          | unique(attribute='name')
          | list }}

--- a/src/orchestrator/roles/orchestrator_credentials/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/tasks/main.yml
@@ -189,6 +189,12 @@
         loop_var: cred_field
       when: openldap_support | default(false) | bool
 
+    - name: Prompt for conditional mandatory orchestrator credentials (PowerScale CSI)
+      ansible.builtin.include_tasks: prompt_credential_field.yml
+      loop: "{{ omnia_credentials.csi_driver_powerscale.conditional_mandatory }}"
+      loop_control:
+        loop_var: cred_field
+
     # Step 7: Expose credentials as facts for downstream roles
     - name: Reload final credentials
       when: credential_files[0].file_path is file

--- a/src/orchestrator/roles/orchestrator_credentials/tasks/prompt_credential_field.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/tasks/prompt_credential_field.yml
@@ -13,13 +13,16 @@
 # limitations under the License.
 ---
 # Prompt for a single orchestrator credential field.
-# Called from main.yml in a loop over omnia_credentials.*.mandatory.
+# Called from main.yml for mandatory and conditionally mandatory credentials.
+# A conditionally mandatory username/password pair may be skipped by pressing
+# Enter when required=false. Supplying a username makes its password required.
 
 # Determine if prompt is needed (skip if value already stored and non-empty)
 - name: Reset prompt flags
   ansible.builtin.set_fact:
     _need_username: false
     _need_password: false
+    _credential_required: "{{ cred_field.required | default(true) | bool }}"
 
 - name: Check if username prompt is needed
   ansible.builtin.set_fact:
@@ -56,7 +59,7 @@
       ansible.builtin.fail:
         msg: "{{ mandatory_warning_msg }} {{ cred_field.username }} cannot be empty."
       when:
-        - cred_field.condition is not defined
+        - _credential_required | bool
         - _username_input.user_input | length == 0
 
 # Prompt password if needed
@@ -64,6 +67,11 @@
   when:
     - cred_field.password is defined
     - _need_password | default(false) | bool
+    - >-
+      _credential_required | bool or
+      (_username_input.user_input |
+       default(orchestrator_loaded_creds[cred_field.username] | default('')) |
+       string | length > 0)
   block:
     - name: "Prompt for [{{ cred_field.password }}]" # noqa name[template]
       ansible.builtin.pause:
@@ -91,7 +99,9 @@
 
 # Update credential file
 - name: Update credential file with new values
-  when: (_need_username | default(false) | bool) or (_need_password | default(false) | bool)
+  when: >-
+    (_username_input.user_input | default('') | length > 0) or
+    (_password_input.user_input | default('') | length > 0)
   block:
     - name: Check if credential file is vault-encrypted before update
       ansible.builtin.shell: |

--- a/src/orchestrator/roles/orchestrator_credentials/vars/main.yml
+++ b/src/orchestrator/roles/orchestrator_credentials/vars/main.yml
@@ -38,6 +38,11 @@ omnia_credentials:
   openldap:
     mandatory:
       - { username: openldap_db_username, password: openldap_db_password }
+  csi_driver_powerscale:
+    conditional_mandatory:
+      - username: csi_username
+        password: csi_password
+        required: "{{ csi_driver_powerscale_support | default(false) | bool }}"
 
 # Error messages
 mandatory_warning_msg: "WARNING: The following are mandatory credentials and cannot be left empty."

--- a/src/orchestrator/roles/orchestrator_setup/tasks/main.yml
+++ b/src/orchestrator/roles/orchestrator_setup/tasks/main.yml
@@ -400,7 +400,7 @@
         openldap_support: "{{ _catalog_group_names | select('match', '.*openldap.*') | list | length > 0 }}"
         ucx_support: "{{ _catalog_group_names | select('match', '.*ucx.*') | list | length > 0 }}"
         openmpi_support: "{{ _catalog_group_names | select('match', '.*openmpi.*') | list | length > 0 }}"
-        csi_driver_powerscale_support: "{{ _catalog_group_names | select('match', '.*csi.*powerscale.*') | list | length > 0 }}"
+        csi_driver_powerscale_support: "{{ 'powerscale_csi_group' in _catalog_group_names }}"
         dcgm_support: "{{ _orch_config.dcgm_enabled | default(true) | bool }}"
         cacheable: true
 


### PR DESCRIPTION
## Fixes #4849 

# PR Description

### Description of the Solution

**Summary**: This PR stabilizes Orchestrator storage mounting, PowerScale CSI dependency resolution, credential collection, and Kubernetes node initialization. It ensures workload NFS shares configured with `mount_on_oim` are mounted before artifacts are staged, obtains PowerScale dependencies from the active catalog and Repo Manager output contract, conditionally collects CSI credentials, and waits for CRI-O readiness before pulling Kubernetes images.

### Changes

#### Kubernetes node initialization

- Moves `kubeadm config images pull` after first-boot container-state cleanup and CRI-O startup.
- Adds a bounded CRI-O readiness check with 60 attempts and a two-second interval.
- Fails with an actionable error if CRI-O does not become ready within two minutes.
- Pulls the required Kubernetes images only after CRI-O can successfully respond to `crictl info`.
- Applies the corrected initialization order to the first control plane, additional control planes, and worker nodes.
- Prevents stale or unresolved CRI-O image metadata from leaving CoreDNS and other Kubernetes pods in `CreateContainerError`.

#### PowerScale CSI dependency resolution

- Removes the legacy dependency on a version-specific `csi_driver_powerscale.json` file.
- Resolves PowerScale component identifiers from `powerscale_csi_group` in the active catalog.
- Resolves Git packages through the catalog package mapping and Repo Manager-provided `offline_git_path`.
- Requires exactly one matching package for:
  - PowerScale CSI driver
  - Dell Helm charts
  - External snapshotter
- Validates that every selected package contains a non-empty offline Git path.
- Normalizes trailing slashes before constructing package download URLs.
- Adds actionable failure messages for incomplete catalog or Repo Manager output.

#### PowerScale CSI credentials

- Adds conditional collection of `csi_username` and `csi_password`.
- Makes the credentials mandatory when `powerscale_csi_group` is enabled by the active catalog.
- Allows users to skip optional PowerScale credentials by pressing Enter when PowerScale CSI is not enabled.
- Requires a password when an optional username is supplied.
- Reuses existing non-empty encrypted credential values without prompting again.
- Prevents empty optional values from being written to the credential file.
- Preserves secret masking through `no_log`.

#### Storage mounting

- Honors `mount_on_oim: true` for all configured NFS entries.
- Removes the exclusion that prevented Slurm and Kubernetes NFS entries from participating in general OIM mounting.
- Deduplicates selected storage entries by name.
- Ensures provisioning artifacts are written to the actual mounted share instead of an unmounted local directory with the same path.

#### Catalog capability detection

- Detects PowerScale CSI support using the exact `powerscale_csi_group` catalog group.
- Replaces the broad regular-expression match that could incorrectly enable PowerScale behavior for similarly named groups.

### Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2` | Modified | Waits for CRI-O readiness before pulling images on the first control-plane node |
| `src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2` | Modified | Applies the corrected CRI-O and image-pull ordering to additional control-plane nodes |
| `src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2` | Modified | Applies the corrected CRI-O and image-pull ordering to worker nodes |
| `src/orchestrator/roles/k8s_config/tasks/get_powerscale_dependencies.yml` | Modified | Resolves and validates PowerScale dependencies from catalog and Repo Manager output |
| `src/orchestrator/roles/k8s_config/vars/main.yml` | Modified | Removes the legacy package JSON path and adds actionable dependency failure messages |
| `src/orchestrator/roles/mount_config/tasks/oim_mount.yml` | Modified | Mounts every configured `mount_on_oim` storage entry, including workload NFS shares |
| `src/orchestrator/roles/orchestrator_credentials/tasks/main.yml` | Modified | Invokes conditional PowerScale CSI credential collection |
| `src/orchestrator/roles/orchestrator_credentials/tasks/prompt_credential_field.yml` | Modified | Supports optional and conditionally mandatory username/password pairs |
| `src/orchestrator/roles/orchestrator_credentials/vars/main.yml` | Modified | Defines conditional PowerScale CSI credential metadata |
| `src/orchestrator/roles/orchestrator_setup/tasks/main.yml` | Modified | Detects PowerScale CSI support using the exact catalog group name |

### Testing

- Verified the Orchestrator playbook syntax successfully.
- Verified the changed production Ansible content with `ansible-lint` locally without failures or warnings.
- Ran cleanup with Kubernetes and Slurm share cleanup enabled.
- Verified configured NFS and VAST shares were mounted, cleaned, and unmounted.
- Ran the Orchestrator `prepare` and `execute` lifecycle stages successfully.
- Verified provisioning output for 19 expected and registered nodes, seven functional groups, seven boot configurations, and seven metadata groups without missing entries.
- Verified all 19 nodes completed PXE restart and fresh boot/cloud-init registration.
- Verified the PowerScale CSI deployment:
  - `isilon` namespace active
  - PowerScale controller running with all containers ready
  - PowerScale node pods running
  - CSI credential and certificate secrets present
  - PowerScale StorageClass using `csi-isilon.dellemc.com`
- Verified CoreDNS recovery and availability after correcting the CRI-O image initialization order.
- GitHub checks completed successfully for commit hygiene, PR hygiene, ShellCheck, unit tests, Pylint, Bandit, secret scanning, dependency scanning, HPC compliance, and network policy. Ansible Lint was still running when this description was prepared.

### Backward Compatibility

- No input schema or existing storage configuration format is changed.
- Existing `mount_on_oim` configurations now behave consistently for general, Slurm, and Kubernetes NFS entries.
- Existing encrypted Orchestrator credentials continue to be reused.
- Environments without PowerScale CSI can skip the optional CSI credentials.
- Environments enabling `powerscale_csi_group` must provide PowerScale credentials and valid catalog entries for the CSI driver, Helm charts, and external snapshotter.
- PowerScale dependencies must be present in the active catalog and have Repo Manager-generated `offline_git_path` values.
- Kubernetes bootstrap retains the existing image versions and configuration; only initialization ordering and readiness handling change.

### Suggested Reviewers

@sujit-jadhav @abhishek-sa1 @snarthan  Please review
