### PR TITLE
enhance precheck reachability, fix iDRAC deployment, and add credential cleanup

### DIFF
--- a/src/main/omnia-bash-completion
+++ b/src/main/omnia-bash-completion
@@ -100,7 +100,7 @@ _omnia_tags_for_domain() {
             printf '%s' "precheck credentials prepare deploy execute download status cleanup cleanup_pulp cleanup_repos upgrade rollback catalog_generate catalog_add catalog_delete catalog_validate"
             ;;
         telemetry)
-            printf '%s' "precheck validate validation execute deploy cleanup cleanup_idrac cleanup_ldms cleanup_ome cleanup_powerscale cleanup_ufm cleanup_vast upgrade rollback external_kafka external_victoria"
+            printf '%s' "precheck validate validation credentials execute deploy cleanup cleanup_idrac cleanup_ldms cleanup_ome cleanup_powerscale cleanup_ufm cleanup_vast upgrade rollback external_kafka external_victoria"
             ;;
         utils)
             printf '%s' "precheck setup collect install_os cleanup cleanup_logs cleanup_install_os upgrade rollback"

--- a/src/telemetry/playbooks/precheck/precheck.yml
+++ b/src/telemetry/playbooks/precheck/precheck.yml
@@ -32,18 +32,20 @@
 #     4. kube_vip SSH (port 22) is reachable
 #   [kube_vip]
 #     5. kubectl is available and K8s API server is accessible
-#     6. All control plane nodes are in Ready state (fail if any are not Ready)
-#     7. Worker node minimum readiness threshold met:
+#     6. All K8s nodes are reachable via SSH (port 22)
+#     7. All control plane nodes are in Ready state (fail if any are not Ready)
+#     8. Worker node minimum readiness threshold met:
 #          1 worker  → 1 Ready required
 #          2 workers → 2 Ready required
 #          3+ workers → at least 2 Ready required
-#     8. All pods (outside telemetry namespace) are Running or Succeeded
-#     9. [Conditional] isilon namespace exists and all its pods are Running
+#     9. All pods (outside telemetry namespace) are Running or Succeeded
+#    10. [Conditional] isilon namespace exists and all its pods are Running
 #          — only when powerscale.metrics_enabled or powerscale.logs_enabled = true
-#    10. [Conditional] PowerScale user has required privileges
+#    11. [Conditional] PowerScale user has required privileges
 #          — only when powerscale.metrics_enabled or powerscale.logs_enabled = true
-#    11. [Conditional] LDMS Slurm cluster validation:
+#    12. [Conditional] LDMS Slurm cluster validation:
 #          - At least 1 slurm_control_node and 1 slurm_node in cluster inventory
+#          - All Slurm nodes (control, compute, login, login_compiler) are reachable via SSH
 #          - slurmctld running on all slurm_control_node hosts
 #          - slurmd running on all slurm_node hosts
 #          — only when ldms.metrics_enabled = true
@@ -87,6 +89,11 @@
   gather_facts: false
   any_errors_fatal: true
   tasks:
+    - name: Check K8s node reachability
+      ansible.builtin.include_role:
+        name: precheck
+        tasks_from: check_k8s_node_reachability
+
     - name: Check K8s control plane nodes are all Ready
       ansible.builtin.include_role:
         name: precheck

--- a/src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml
+++ b/src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml
@@ -38,26 +38,28 @@
 - name: "Credentials | Complete cleanup — remove credential file and vault key"
   when: hostvars['localhost']['_cleanup_all'] | bool
   delegate_to: localhost
+  vars:
+    _cleanup_input_project_dir: "{{ hostvars['localhost']['input_project_dir'] | default(input_project_dir) }}"
   block:
     - name: "Credentials | Check credential file exists"
       ansible.builtin.stat:
-        path: "{{ cleanup_credential_file_path }}"
+        path: "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
       register: _cleanup_cred_file_stat
 
     - name: "Credentials | Delete credential file"
       ansible.builtin.file:
-        path: "{{ cleanup_credential_file_path }}"
+        path: "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
         state: absent
       when: _cleanup_cred_file_stat.stat.exists
 
     - name: "Credentials | Check vault key file exists"
       ansible.builtin.stat:
-        path: "{{ cleanup_credential_vault_key_path }}"
+        path: "{{ _cleanup_input_project_dir }}/.telemetry_credentials_key"
       register: _cleanup_vault_key_stat
 
     - name: "Credentials | Delete vault key file"
       ansible.builtin.file:
-        path: "{{ cleanup_credential_vault_key_path }}"
+        path: "{{ _cleanup_input_project_dir }}/.telemetry_credentials_key"
         state: absent
       when: _cleanup_vault_key_stat.stat.exists
 
@@ -65,8 +67,8 @@
       ansible.builtin.debug:
         msg: >-
           Credential file and vault key removed:
-          {{ cleanup_credential_file_path }},
-          {{ cleanup_credential_vault_key_path }}
+          {{ _cleanup_input_project_dir }}/telemetry_credentials.yml,
+          {{ _cleanup_input_project_dir }}/.telemetry_credentials_key
       when: _cleanup_cred_file_stat.stat.exists or _cleanup_vault_key_stat.stat.exists
 
 # ---------------------------------------------------------------------------
@@ -78,10 +80,12 @@
     - _cleanup_credential_component is defined
     - _cleanup_credential_component in cleanup_credential_fields
   delegate_to: localhost
+  vars:
+    _cleanup_input_project_dir: "{{ hostvars['localhost']['input_project_dir'] | default(input_project_dir) }}"
   block:
     - name: "Credentials | Check credential file exists for component cleanup"
       ansible.builtin.stat:
-        path: "{{ cleanup_credential_file_path }}"
+        path: "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
       register: _cleanup_cred_file_component_stat
 
     - name: "Credentials | Blank fields"
@@ -89,13 +93,13 @@
       block:
         - name: "Credentials | Check vault key exists"
           ansible.builtin.stat:
-            path: "{{ cleanup_credential_vault_key_path }}"
+            path: "{{ _cleanup_input_project_dir }}/.telemetry_credentials_key"
           register: _cleanup_vault_key_component_stat
 
         - name: "Credentials | Skip if vault key missing"
           ansible.builtin.debug:
             msg: >-
-              Vault key not found at {{ cleanup_credential_vault_key_path }}.
+              Vault key not found at {{ _cleanup_input_project_dir }}/.telemetry_credentials_key.
               Cannot decrypt credential file — skipping credential cleanup for
               {{ _cleanup_credential_component }}.
           when: not _cleanup_vault_key_component_stat.stat.exists
@@ -105,15 +109,15 @@
           block:
             - name: "Credentials | Decrypt credential file"
               ansible.builtin.command: >-
-                ansible-vault decrypt "{{ cleanup_credential_file_path }}"
-                --vault-password-file "{{ cleanup_credential_vault_key_path }}"
+                ansible-vault decrypt "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
+                --vault-password-file "{{ _cleanup_input_project_dir }}/.telemetry_credentials_key"
               changed_when: false
               failed_when: false
               register: _cleanup_cred_decrypt_result
 
             - name: "Credentials | Load current credentials"
               ansible.builtin.include_vars:
-                file: "{{ cleanup_credential_file_path }}"
+                file: "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
                 name: _cleanup_current_creds
               when: _cleanup_cred_decrypt_result.rc == 0
               no_log: true
@@ -124,7 +128,7 @@
                   {{
                     dict(
                       cleanup_credential_fields[_cleanup_credential_component]
-                      | product([''])
+                      | product(['""'])
                       | list
                     )
                   }}
@@ -144,15 +148,15 @@
             - name: "Credentials | Write updated credential file"
               ansible.builtin.copy:
                 content: "{{ _cleanup_current_creds | to_nice_yaml(indent=2) }}"
-                dest: "{{ cleanup_credential_file_path }}"
+                dest: "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
                 mode: "0600"
               when: _cleanup_cred_decrypt_result.rc == 0
               no_log: true
 
             - name: "Credentials | Re-encrypt credential file"
               ansible.builtin.command: >-
-                ansible-vault encrypt "{{ cleanup_credential_file_path }}"
-                --vault-password-file "{{ cleanup_credential_vault_key_path }}"
+                ansible-vault encrypt "{{ _cleanup_input_project_dir }}/telemetry_credentials.yml"
+                --vault-password-file "{{ _cleanup_input_project_dir }}/.telemetry_credentials_key"
               changed_when: false
               failed_when: false
               when: _cleanup_cred_decrypt_result.rc == 0

--- a/src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml
+++ b/src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml
@@ -72,7 +72,7 @@
 # ---------------------------------------------------------------------------
 # Mode 2: Individual component cleanup — blank component-specific fields
 # ---------------------------------------------------------------------------
-- name: "Credentials | Component cleanup — blank {{ _cleanup_credential_component }} credentials"
+- name: "Credentials | Component cleanup — blank credentials"
   when:
     - not (hostvars['localhost']['_cleanup_all'] | bool)
     - _cleanup_credential_component is defined
@@ -84,7 +84,7 @@
         path: "{{ cleanup_credential_file_path }}"
       register: _cleanup_cred_file_component_stat
 
-    - name: "Credentials | Blank {{ _cleanup_credential_component }} fields"
+    - name: "Credentials | Blank fields"
       when: _cleanup_cred_file_component_stat.stat.exists
       block:
         - name: "Credentials | Check vault key exists"

--- a/src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml
+++ b/src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml
@@ -1,0 +1,165 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# =============================================================================
+# Credential cleanup — remove credentials for cleaned-up components
+# =============================================================================
+# Two modes of operation:
+#
+#   1. Complete cleanup (_cleanup_all == true):
+#      Delete the entire credential file and its vault key.
+#      When all deployments are removed there is no reason to keep any
+#      stored credentials on disk.
+#
+#   2. Individual component cleanup (_cleanup_all == false):
+#      Decrypt the credential file, blank out only the fields belonging
+#      to the cleaned component, then re-encrypt.  Credentials for
+#      still-deployed components are preserved.
+#
+# Required variable (for individual mode):
+#   _cleanup_credential_component  — component name (idrac, ldms, powerscale, ufm, vast)
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Mode 1: Complete cleanup — delete credential file + vault key
+# ---------------------------------------------------------------------------
+- name: "Credentials | Complete cleanup — remove credential file and vault key"
+  when: hostvars['localhost']['_cleanup_all'] | bool
+  delegate_to: localhost
+  block:
+    - name: "Credentials | Check credential file exists"
+      ansible.builtin.stat:
+        path: "{{ cleanup_credential_file_path }}"
+      register: _cleanup_cred_file_stat
+
+    - name: "Credentials | Delete credential file"
+      ansible.builtin.file:
+        path: "{{ cleanup_credential_file_path }}"
+        state: absent
+      when: _cleanup_cred_file_stat.stat.exists
+
+    - name: "Credentials | Check vault key file exists"
+      ansible.builtin.stat:
+        path: "{{ cleanup_credential_vault_key_path }}"
+      register: _cleanup_vault_key_stat
+
+    - name: "Credentials | Delete vault key file"
+      ansible.builtin.file:
+        path: "{{ cleanup_credential_vault_key_path }}"
+        state: absent
+      when: _cleanup_vault_key_stat.stat.exists
+
+    - name: "Credentials | Complete credential cleanup done"
+      ansible.builtin.debug:
+        msg: >-
+          Credential file and vault key removed:
+          {{ cleanup_credential_file_path }},
+          {{ cleanup_credential_vault_key_path }}
+      when: _cleanup_cred_file_stat.stat.exists or _cleanup_vault_key_stat.stat.exists
+
+# ---------------------------------------------------------------------------
+# Mode 2: Individual component cleanup — blank component-specific fields
+# ---------------------------------------------------------------------------
+- name: "Credentials | Component cleanup — blank {{ _cleanup_credential_component }} credentials"
+  when:
+    - not (hostvars['localhost']['_cleanup_all'] | bool)
+    - _cleanup_credential_component is defined
+    - _cleanup_credential_component in cleanup_credential_fields
+  delegate_to: localhost
+  block:
+    - name: "Credentials | Check credential file exists for component cleanup"
+      ansible.builtin.stat:
+        path: "{{ cleanup_credential_file_path }}"
+      register: _cleanup_cred_file_component_stat
+
+    - name: "Credentials | Blank {{ _cleanup_credential_component }} fields"
+      when: _cleanup_cred_file_component_stat.stat.exists
+      block:
+        - name: "Credentials | Check vault key exists"
+          ansible.builtin.stat:
+            path: "{{ cleanup_credential_vault_key_path }}"
+          register: _cleanup_vault_key_component_stat
+
+        - name: "Credentials | Skip if vault key missing"
+          ansible.builtin.debug:
+            msg: >-
+              Vault key not found at {{ cleanup_credential_vault_key_path }}.
+              Cannot decrypt credential file — skipping credential cleanup for
+              {{ _cleanup_credential_component }}.
+          when: not _cleanup_vault_key_component_stat.stat.exists
+
+        - name: "Credentials | Decrypt, blank fields, re-encrypt"
+          when: _cleanup_vault_key_component_stat.stat.exists
+          block:
+            - name: "Credentials | Decrypt credential file"
+              ansible.builtin.command: >-
+                ansible-vault decrypt "{{ cleanup_credential_file_path }}"
+                --vault-password-file "{{ cleanup_credential_vault_key_path }}"
+              changed_when: false
+              failed_when: false
+              register: _cleanup_cred_decrypt_result
+
+            - name: "Credentials | Load current credentials"
+              ansible.builtin.include_vars:
+                file: "{{ cleanup_credential_file_path }}"
+                name: _cleanup_current_creds
+              when: _cleanup_cred_decrypt_result.rc == 0
+              no_log: true
+
+            - name: "Credentials | Build blanked credential field dict"
+              ansible.builtin.set_fact:
+                _cleanup_blanked_fields: >-
+                  {{
+                    dict(
+                      cleanup_credential_fields[_cleanup_credential_component]
+                      | product([''])
+                      | list
+                    )
+                  }}
+              when: _cleanup_cred_decrypt_result.rc == 0
+              no_log: true
+
+            - name: "Credentials | Merge blanked fields into credentials"
+              ansible.builtin.set_fact:
+                _cleanup_current_creds: >-
+                  {{
+                    _cleanup_current_creds
+                    | combine(_cleanup_blanked_fields)
+                  }}
+              when: _cleanup_cred_decrypt_result.rc == 0
+              no_log: true
+
+            - name: "Credentials | Write updated credential file"
+              ansible.builtin.copy:
+                content: "{{ _cleanup_current_creds | to_nice_yaml(indent=2) }}"
+                dest: "{{ cleanup_credential_file_path }}"
+                mode: "0600"
+              when: _cleanup_cred_decrypt_result.rc == 0
+              no_log: true
+
+            - name: "Credentials | Re-encrypt credential file"
+              ansible.builtin.command: >-
+                ansible-vault encrypt "{{ cleanup_credential_file_path }}"
+                --vault-password-file "{{ cleanup_credential_vault_key_path }}"
+              changed_when: false
+              failed_when: false
+              when: _cleanup_cred_decrypt_result.rc == 0
+
+            - name: "Credentials | Component credential cleanup done"
+              ansible.builtin.debug:
+                msg: >-
+                  Blanked credential fields for {{ _cleanup_credential_component }}:
+                  {{ cleanup_credential_fields[_cleanup_credential_component] | join(', ') }}
+              when: _cleanup_cred_decrypt_result.rc == 0

--- a/src/telemetry/roles/cleanup/tasks/cleanup_sources.yml
+++ b/src/telemetry/roles/cleanup/tasks/cleanup_sources.yml
@@ -47,6 +47,14 @@
     hostvars['localhost']['_cleanup_all'] | bool
     or hostvars['localhost']['_cleanup_idrac'] | bool
 
+- name: Cleanup iDRAC credentials
+  ansible.builtin.include_tasks: cleanup_credentials.yml
+  vars:
+    _cleanup_credential_component: idrac
+  when: >-
+    not (hostvars['localhost']['_cleanup_all'] | bool)
+    and hostvars['localhost']['_cleanup_idrac'] | bool
+
 - name: Mark LDMS cleanup as attempted
   ansible.builtin.set_fact:
     _cleanup_active_component: ldms
@@ -80,6 +88,14 @@
   when: >-
     hostvars['localhost']['_cleanup_all'] | bool
     or hostvars['localhost']['_cleanup_ldms'] | bool
+
+- name: Cleanup LDMS credentials
+  ansible.builtin.include_tasks: cleanup_credentials.yml
+  vars:
+    _cleanup_credential_component: ldms
+  when: >-
+    not (hostvars['localhost']['_cleanup_all'] | bool)
+    and hostvars['localhost']['_cleanup_ldms'] | bool
 
 - name: Mark OME cleanup as attempted
   ansible.builtin.set_fact:
@@ -149,6 +165,14 @@
     hostvars['localhost']['_cleanup_all'] | bool
     or hostvars['localhost']['_cleanup_powerscale'] | bool
 
+- name: Cleanup PowerScale credentials
+  ansible.builtin.include_tasks: cleanup_credentials.yml
+  vars:
+    _cleanup_credential_component: powerscale
+  when: >-
+    not (hostvars['localhost']['_cleanup_all'] | bool)
+    and hostvars['localhost']['_cleanup_powerscale'] | bool
+
 - name: Mark UFM cleanup as attempted
   ansible.builtin.set_fact:
     _cleanup_active_component: ufm
@@ -183,6 +207,14 @@
     hostvars['localhost']['_cleanup_all'] | bool
     or hostvars['localhost']['_cleanup_ufm'] | bool
 
+- name: Cleanup UFM credentials
+  ansible.builtin.include_tasks: cleanup_credentials.yml
+  vars:
+    _cleanup_credential_component: ufm
+  when: >-
+    not (hostvars['localhost']['_cleanup_all'] | bool)
+    and hostvars['localhost']['_cleanup_ufm'] | bool
+
 - name: Mark VAST cleanup as attempted
   ansible.builtin.set_fact:
     _cleanup_active_component: vast
@@ -216,3 +248,11 @@
   when: >-
     hostvars['localhost']['_cleanup_all'] | bool
     or hostvars['localhost']['_cleanup_vast'] | bool
+
+- name: Cleanup VAST credentials
+  ansible.builtin.include_tasks: cleanup_credentials.yml
+  vars:
+    _cleanup_credential_component: vast
+  when: >-
+    not (hostvars['localhost']['_cleanup_all'] | bool)
+    and hostvars['localhost']['_cleanup_vast'] | bool

--- a/src/telemetry/roles/cleanup/tasks/finalize.yml
+++ b/src/telemetry/roles/cleanup/tasks/finalize.yml
@@ -61,6 +61,10 @@
       }}
   when: _cleanup_verification_attempted | default(false) | bool
 
+- name: Cleanup credentials for complete cleanup
+  ansible.builtin.include_tasks: cleanup_credentials.yml
+  when: _cleanup_all | bool
+
 - name: Write telemetry_status.yml with cleanup status
   ansible.builtin.include_role:
     name: common

--- a/src/telemetry/roles/cleanup/tasks/main.yml
+++ b/src/telemetry/roles/cleanup/tasks/main.yml
@@ -30,6 +30,7 @@
 #     tasks_from: powerscale       # Cleanup PowerScale
 #     tasks_from: ufm              # Cleanup UFM
 #     tasks_from: vast             # Cleanup VAST
+#     tasks_from: cleanup_credentials  # Cleanup credentials (auto-invoked)
 
 #
 # Calling main.yml directly is a no-op (this file).

--- a/src/telemetry/roles/cleanup/vars/main.yml
+++ b/src/telemetry/roles/cleanup/vars/main.yml
@@ -346,3 +346,35 @@ vast_resources:
   - { type: "service", name: "vast-external" }
   - { type: "vmservicescrape", name: "vast-storage-metrics" }
 vast_pod_label: "app=vast-external"
+
+# =============================================================================
+# Credential cleanup — component-to-credential-field mapping
+# =============================================================================
+# Maps each source component to its credential fields in telemetry_credentials.yml.
+# Used by cleanup_credentials.yml to blank component-specific fields during
+# individual cleanup, or to delete the entire file during complete cleanup.
+#
+# Components without credential fields (ome, kafka, victoria_metrics,
+# victoria_logs) are intentionally absent — they have no stored credentials.
+
+cleanup_credential_file_path: "{{ input_project_dir }}/telemetry_credentials.yml"
+cleanup_credential_vault_key_path: "{{ input_project_dir }}/.telemetry_credentials_key"
+
+cleanup_credential_fields:
+  idrac:
+    - bmc_username
+    - bmc_password
+    - mysqldb_user
+    - mysqldb_password
+    - mysqldb_root_password
+  ldms:
+    - ldms_sampler_password
+  powerscale:
+    - csi_username
+    - csi_password
+  ufm:
+    - ufm_username
+    - ufm_password
+  vast:
+    - vast_username
+    - vast_password

--- a/src/telemetry/roles/deploy_idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
+++ b/src/telemetry/roles/deploy_idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml
@@ -225,6 +225,7 @@
 
     - name: Validate BMC reachability from control plane
       update_bmc_group_entry:
+        csv_path: "{{ bmc_group_data_filename }}"
         nodes: "{{ filtered_bmc_ip_dict_list }}"
         bmc_username: "{{ telemetry_credentials.bmc_username }}"
         bmc_password: "{{ telemetry_credentials.bmc_password }}"

--- a/src/telemetry/roles/deploy_idrac_telemetry/tasks/retry_unreachable_bmcs.yml
+++ b/src/telemetry/roles/deploy_idrac_telemetry/tasks/retry_unreachable_bmcs.yml
@@ -22,6 +22,7 @@
 
 - name: Validate unreachable BMCs from second worker node
   update_bmc_group_entry:
+    csv_path: "{{ bmc_group_data_filename }}"
     nodes: "{{ retry_bmc_ip_dict_list }}"
     bmc_username: "{{ telemetry_credentials.bmc_username }}"
     bmc_password: "{{ telemetry_credentials.bmc_password }}"

--- a/src/telemetry/roles/precheck/tasks/check_k8s_node_reachability.yml
+++ b/src/telemetry/roles/precheck/tasks/check_k8s_node_reachability.yml
@@ -1,0 +1,159 @@
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+# =============================================================================
+# check_k8s_node_reachability.yml — Runs on: kube_vip
+# =============================================================================
+# Verifies that all K8s nodes from the cluster inventory are reachable via SSH.
+# This check prevents deployment failures due to unreachable nodes.
+
+- name: Resolve cluster inventory file path
+  ansible.builtin.set_fact:
+    cluster_inventory_path: >-
+      {%- set inv_path = hostvars['localhost']['telemetry_config'].cluster_inventory -%}
+      {%- if inv_path.startswith('/') -%}
+        {{ inv_path }}
+      {%- else -%}
+        {{ playbook_dir | dirname }}/input/{{ inv_path }}
+      {%- endif -%}
+  delegate_to: localhost
+  run_once: true
+
+- name: Parse cluster inventory file with Python YAML
+  ansible.builtin.shell: |
+    python3 -c "
+    import yaml, json
+    try:
+        data = yaml.safe_load(open('{{ cluster_inventory_path }}'))
+        print(json.dumps(data))
+    except Exception as e:
+        print(json.dumps({'_parse_error': str(e)}))
+    "
+  register: cluster_inv_parse
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+
+- name: Set cluster inventory data
+  ansible.builtin.set_fact:
+    cluster_inv: "{{ cluster_inv_parse.stdout | from_json }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: Extract K8s control plane node IPs from inventory
+  ansible.builtin.set_fact:
+    k8s_control_ips: >-
+      {{
+        cluster_inv.all.children | default({}) |
+        dict2items |
+        selectattr('key', 'match', '^service_kube_control_plane') |
+        map(attribute='value.hosts') |
+        map('dict2items') |
+        flatten |
+        map(attribute='value.ansible_host') |
+        list
+      }}
+  delegate_to: localhost
+  run_once: true
+
+- name: Extract K8s worker node IPs from inventory
+  ansible.builtin.set_fact:
+    k8s_worker_ips: >-
+      {{
+        cluster_inv.all.children | default({}) |
+        dict2items |
+        selectattr('key', 'match', '^service_kube_node') |
+        map(attribute='value.hosts') |
+        map('dict2items') |
+        flatten |
+        map(attribute='value.ansible_host') |
+        list
+      }}
+  delegate_to: localhost
+  run_once: true
+
+- name: Build list of all K8s node IPs from inventory
+  ansible.builtin.set_fact:
+    k8s_node_ip_list: "{{ (k8s_control_ips | default([])) + (k8s_worker_ips | default([])) }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: Check network reachability for all K8s nodes from inventory
+  ansible.builtin.shell:
+    cmd: "timeout 5 nc -zv {{ item }} 22 2>&1 || echo 'UNREACHABLE'"
+  delegate_to: localhost
+  loop: "{{ k8s_node_ip_list }}"
+  loop_control:
+    label: "{{ item }}"
+  register: k8s_node_reachability_check
+  changed_when: false
+  failed_when: false
+  when: k8s_node_ip_list | length > 0
+  run_once: true
+
+- name: Collect unreachable K8s nodes
+  ansible.builtin.set_fact:
+    unreachable_k8s_nodes: >-
+      {{
+        k8s_node_reachability_check.results |
+        selectattr('stdout', 'search', 'UNREACHABLE') |
+        map(attribute='item') |
+        list
+      }}
+  delegate_to: localhost
+  run_once: true
+  when: k8s_node_ip_list | length > 0
+
+- name: Fail if any K8s nodes are unreachable
+  ansible.builtin.fail:
+    msg: |
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      [PRECHECK FAIL] K8s Nodes Unreachable
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      The following K8s nodes from cluster inventory are not reachable via SSH (port 22):
+      {% for node in unreachable_k8s_nodes %}
+        - {{ node }}
+      {% endfor %}
+
+      Telemetry deployment requires all K8s nodes in the cluster inventory to be reachable.
+      Cannot proceed until all nodes are accessible.
+
+      Action required for each unreachable node:
+      1. Verify the node is powered on
+      2. Check network connectivity from the Ansible controller
+      3. Ensure SSH service is running on the node
+      4. Verify firewall rules allow SSH (port 22) access
+      5. Test connectivity: ping <node-ip> and ssh root@<node-ip>
+      6. Check if the IP address in cluster inventory is correct
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  when:
+    - k8s_node_ip_list | length > 0
+    - unreachable_k8s_nodes | length > 0
+  delegate_to: localhost
+  run_once: true
+
+- name: Display K8s node reachability check — PASSED
+  ansible.builtin.debug:
+    msg:
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "[PRECHECK] K8s Node Reachability — PASSED"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "  All {{ k8s_node_ip_list | length }} K8s node(s) from inventory are reachable via SSH  ✓"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  when:
+    - k8s_node_ip_list | length > 0
+    - unreachable_k8s_nodes | length == 0
+  delegate_to: localhost
+  run_once: true

--- a/src/telemetry/roles/precheck/tasks/check_ldms_slurm_nodes.yml
+++ b/src/telemetry/roles/precheck/tasks/check_ldms_slurm_nodes.yml
@@ -213,6 +213,73 @@
   delegate_to: localhost
   run_once: true  # noqa
 
+# --- Network reachability validation for all Slurm nodes ---
+- name: Check network reachability for all Slurm nodes
+  # HPC: run_once: true prevents loop fan-out
+  ansible.builtin.shell:
+    cmd: "timeout 5 nc -zv {{ item }} 22 2>&1 || echo 'UNREACHABLE'"
+  delegate_to: localhost
+  loop: "{{ all_slurm_node_ips }}"
+  loop_control:
+    label: "{{ item }}"
+  register: node_reachability_check
+  changed_when: false
+  failed_when: false
+  run_once: true
+
+- name: Collect unreachable Slurm nodes
+  # HPC: run_once: true prevents loop fan-out
+  ansible.builtin.set_fact:
+    unreachable_nodes: >-
+      {{
+        node_reachability_check.results |
+        selectattr('stdout', 'search', 'UNREACHABLE') |
+        map(attribute='item') |
+        list
+      }}
+  delegate_to: localhost
+  run_once: true  # noqa
+
+- name: Fail if any Slurm nodes are unreachable
+  # HPC: run_once: true prevents loop fan-out
+  ansible.builtin.fail:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════
+      LDMS VALIDATION FAILED: Slurm nodes unreachable
+      ════════════════════════════════════════════════════════════════════════
+      The following Slurm nodes are not reachable via SSH (port 22):
+      {% for node in unreachable_nodes %}
+        - {{ node }}
+      {% endfor %}
+
+      LDMS requires all Slurm nodes to be reachable for service validation
+      and deployment. Cannot proceed with telemetry deployment until
+      all nodes are accessible.
+
+      Action required for each unreachable node:
+      1. Verify the node is powered on
+      2. Check network connectivity from the Ansible controller
+      3. Ensure SSH service is running on the node
+      4. Verify firewall rules allow SSH (port 22) access
+      5. Test connectivity: ping <node-ip> and ssh root@<node-ip>
+      ════════════════════════════════════════════════════════════════════════
+  when: unreachable_nodes | length > 0
+  delegate_to: localhost
+  run_once: true  # noqa
+
+- name: Display node reachability check — PASSED
+  # HPC: run_once: true prevents loop fan-out
+  ansible.builtin.debug:
+    msg:
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "[PRECHECK] Slurm Node Reachability — PASSED"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "  All {{ all_slurm_node_ips | length }} Slurm node(s) are reachable via SSH  ✓"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  when: unreachable_nodes | length == 0
+  delegate_to: localhost
+  run_once: true  # noqa
+
 # --- Service validation on Slurm control nodes ---
 - name: Check slurmctld service status on Slurm control nodes
   ansible.builtin.systemd:
@@ -289,5 +356,8 @@
   vars:
     control_count: "{{ slurm_control_hosts | length }}"
     compute_count: "{{ slurm_compute_hosts | length }}"
+    login_count: "{{ slurm_login_hosts | length }}"
+    login_compiler_count: "{{ slurm_login_compiler_hosts | length }}"
+    total_count: "{{ all_slurm_node_ips | length }}"
   delegate_to: localhost
   run_once: true  # noqa

--- a/src/telemetry/roles/precheck/tasks/main.yml
+++ b/src/telemetry/roles/precheck/tasks/main.yml
@@ -20,6 +20,9 @@
 # Runs all K8s cluster health checks on kube_vip.
 # (kube_vip input/reachability checks are done on localhost via validate_kube_vip.yml)
 
+- name: Check K8s node reachability
+  ansible.builtin.include_tasks: check_k8s_node_reachability.yml
+
 - name: Check K8s control plane nodes
   ansible.builtin.include_tasks: check_control_plane.yml
 


### PR DESCRIPTION
Issues Resolved by this Pull Request
Fixes: https://github.com/dell/omnia/issues/4849

## PR Description

### Description of the Solution

**Summary**: This PR addresses three key improvements to the telemetry system: (1) enhances precheck validation with comprehensive node reachability checks to prevent late-stage deployment failures, (2) fixes iDRAC deployment issues with CSV path parameters, and (3) implements credential cleanup functionality to securely remove sensitive credential data when corresponding deployments no longer exist.

### Changes

#### Precheck Enhancements
- Added new `check_k8s_node_reachability.yml` task to validate SSH reachability for all K8s nodes from cluster inventory
- Enhanced `check_ldms_slurm_nodes.yml` with network reachability checks for all Slurm node types (control, compute, login, login_compiler)
- Updated precheck documentation to reflect new reachability validation steps
- Integrated K8s node reachability check into precheck playbook and main task file

#### iDRAC Deployment Fixes
- Fixed missing `csv_path` parameter in `update_bmc_group_entry` module calls in `initiate_telemetry_service_cluster.yml`
- Fixed missing `csv_path` parameter in `update_bmc_group_entry` module calls in `retry_unreachable_bmcs.yml`
- Changed from undefined `telemetry_data_path` variable to properly defined `bmc_group_data_filename`

#### Variable Fixes
- Fixed undefined variable issues in LDMS validation success messages by adding missing `login_count`, `login_compiler_count`, and `total_count` variables

#### Credential Cleanup Functionality
- Added credential file path and vault key path configuration variables to cleanup role
- Added component-to-credential-field mapping for idrac, ldms, powerscale, ufm, vast
- Created new `cleanup_credentials.yml` task file for credential cleanup logic
- Integrated credential cleanup after each component cleanup in `cleanup_sources.yml`
- Added complete credential file deletion in `finalize.yml` for full cleanup mode
- Updated role documentation in `main.yml`

**Credential Cleanup Logic**:
- Complete cleanup mode: Deletes credential file and vault key when all components are removed
- Individual cleanup mode: Decrypts credential file, blanks component-specific fields, re-encrypts
- Preserves credentials for still-deployed components during individual cleanup
- Handles missing vault key gracefully with appropriate logging

### Files Changed

| File | Change Type | Description |
|------|------------|-------------|
| `src/telemetry/roles/precheck/tasks/check_k8s_node_reachability.yml` | Added | New task for K8s node SSH reachability validation |
| `src/telemetry/roles/precheck/tasks/check_ldms_slurm_nodes.yml` | Modified | Added Slurm node reachability checks and fixed variable issues |
| `src/telemetry/roles/precheck/tasks/main.yml` | Modified | Integrated K8s node reachability check |
| `src/telemetry/playbooks/precheck/precheck.yml` | Modified | Updated documentation and added K8s reachability check |
| `src/telemetry/roles/deploy_idrac_telemetry/tasks/initiate_telemetry_service_cluster.yml` | Modified | Fixed CSV path parameter in BMC validation |
| `src/telemetry/roles/deploy_idrac_telemetry/tasks/retry_unreachable_bmcs.yml` | Modified | Fixed CSV path parameter in retry BMC validation |
| `src/telemetry/roles/cleanup/vars/main.yml` | Modified | Added credential paths and component field mapping |
| `src/telemetry/roles/cleanup/tasks/cleanup_credentials.yml` | Added | Core credential cleanup logic (decrypt/blank/encrypt) |
| `src/telemetry/roles/cleanup/tasks/cleanup_sources.yml` | Modified | Integrated credential cleanup after each component |
| `src/telemetry/roles/cleanup/tasks/finalize.yml` | Modified | Added complete credential file deletion |
| `src/telemetry/roles/cleanup/tasks/main.yml` | Modified | Updated documentation |

### Testing

**Precheck and iDRAC Fixes**:
- Verified precheck successfully detects unreachable K8s nodes with wrong IPs and fails early with clear error messages
- Verified precheck passes with correct K8s node IPs
- Verified Slurm node reachability checks work correctly
- Verified iDRAC deployment completes successfully with fixed CSV path parameters
- Verified full telemetry deployment pipeline completes successfully (Kafka, VictoriaMetrics, VictoriaLogs, iDRAC, LDMS)

**Credential Cleanup**:
- Verified YAML syntax for all modified files
- Tested credential field mapping configuration
- Verified individual component cleanup logic for blanking specific fields
- Verified complete cleanup logic for file deletion

### Backward Compatibility

**Precheck and iDRAC Fixes**:
- No breaking changes - all enhancements are additive
- Existing precheck behavior preserved with additional validation steps
- Fixed CSV path issues resolve runtime errors without changing module behavior
- Variable fixes prevent template rendering failures

**Credential Cleanup**:
- No breaking changes to existing cleanup functionality
- Credential cleanup is additive - existing cleanup flows work unchanged
- Components without stored credentials (OME, Kafka, VictoriaMetrics, VictoriaLogs) are unaffected
- Missing credential file or vault key is handled gracefully with appropriate logging

### Suggested Reviewers

@priti-parate @abhishek-sa1 

