### PR TITLE
Update user_registry to read from repo_status.yml

### DIFF
--- a/src/orchestrator/roles/configure_ochami/tasks/fetch_additional_images.yml
+++ b/src/orchestrator/roles/configure_ochami/tasks/fetch_additional_images.yml
@@ -29,17 +29,14 @@
     var: additional_images_dict
     verbosity: 2
 
-- name: Check if local_repo_config.yml exists
-  ansible.builtin.stat:
-    path: "{{ local_repo_config_path }}"
-  register: local_repo_config_stat
-
-- name: Read local_repo_config.yml
-  ansible.builtin.include_vars:
-    file: "{{ local_repo_config_path }}"
-    name: local_repo_config
-  when: local_repo_config_stat.stat.exists
-
-- name: Set fact for user_registry
+- name: Initialize user_registry list
   ansible.builtin.set_fact:
-    user_registry: "{{ local_repo_config.user_registry | default([]) }}"
+    user_registry: []
+
+- name: Build user_registry from repo_status.yml registries
+  ansible.builtin.set_fact:
+    user_registry: "{{ user_registry + [{'host': item.value.host}] }}"
+  loop: "{{ hostvars['localhost']['registries'] | default({}) | dict2items }}"
+  when:
+    - item.value.host is defined
+    - item.value.host | length > 0


### PR DESCRIPTION
 ## Summary
 This PR contributes to align repo_manger changes in accordance to orchestrator as part of [Issue-4849 ](https://github.com/dell/omnia/issues/4849)
   Change user_registry data source from local_repo_config.yml to repo_status.yml to align with repo_manager integration. The user_registry configuration is now read from the regis
   tries section in repo_status.yml, which is generated by the repo_manager based on repo_manager_config.yml.

   ## Changes
   - Modified `fetch_additional_images.yml` to read user_registry from repo_status.yml instead of local_repo_config.yml
   - Maintains backward compatibility with existing crio.conf template behavior
   - Preserves omnia-2.2 image pull behavior while modernizing the data source

   ## Testing
   - Verified that the transformation logic correctly converts repo_status.yml registries format to the expected user_registry format
   - Confirmed that templates maintain omnia-2.2 behavior (no changes to unqualified-search-registries or TLS configuration)
   - Tested with user registry configuration in repo_manager_config.yml
