### PR TITLE
fix(setup): clarify environment replacement and catalog selection

### DIFF
--- a/src/main/docs/omnia-env.md
+++ b/src/main/docs/omnia-env.md
@@ -19,7 +19,7 @@ read its exported values.
 | `SYSTEM_HOSTNAME` | Short hostname of the OIM host (NOT FQDN) | `oim` |
 | `SYSTEM_DOMAIN_NAME` | Domain name of the OIM host | `omnia.cluster` |
 | `OMNIA_VENV_PATH` | Path to the shared Python virtual environment | `/opt/omnia/venv` |
-| `CATALOG_FILE_PATH` | Convention path for catalog JSON (reference only — actual path is set in `image_build_config.yml`) | `${OMNIA_DATA_PATH}/catalog/catalog_rhel.json` |
+| `CATALOG_FILE_PATH` | Active catalog JSON used by Repo Manager and catalog-mode image builds | `${OMNIA_DATA_PATH}/catalog/catalog_rhel.json` |
 
 ## Component Override Variables
 
@@ -93,10 +93,7 @@ OMNIA_VERSION=2.3
 # │ CATALOG — Repo Manager catalog for image build package resolution        │
 # └───────────────────────────────────────────────────────────────────────────┘
 
-# Default catalog JSON location (convention path).
-# The actual catalog_file path is set in image_build_config.yml (Section 5).
-# This env var documents the convention; image_build_manager reads
-# the catalog path from its domain config, not from this env var.
+# Catalog JSON used by Repo Manager and catalog-mode image builds.
 CATALOG_FILE_PATH=${OMNIA_DATA_PATH}/catalog/catalog_rhel.json
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
@@ -151,6 +148,31 @@ vi /etc/omnia/omnia.env
 Setup preserves this file even when the repository copy differs. To
 intentionally discard the installed values and replace them from
 `src/main/omnia.env`, use `./omnia.sh -s --force-env`.
+
+## Choose a Different Catalog
+
+Setup copies the default `samples/catalog_rhel.json`, which contains packages
+for both Slurm and service_k8s deployments, to `$OMNIA_DATA_PATH/catalog/`.
+To use another catalog while keeping the configured path, replace that file:
+
+```bash
+cp samples/catalogs/10.0/service_k8s_x86_64.json "$CATALOG_FILE_PATH"
+```
+
+To retain a separate filename, copy the catalog and update the authoritative
+environment file:
+
+```bash
+cp samples/catalogs/10.0/service_k8s_x86_64.json \
+  "${OMNIA_DATA_PATH}/catalog/service_k8s_x86_64.json"
+vi /etc/omnia/omnia.env
+# Set CATALOG_FILE_PATH=${OMNIA_DATA_PATH}/catalog/service_k8s_x86_64.json
+source /etc/profile.d/omnia-env.sh
+```
+
+If you update `src/main/omnia.env` instead, apply the repository file with
+`./omnia.sh -s --force-env`. This replaces the complete installed environment
+file, not only `CATALOG_FILE_PATH`.
 
 ## Validation
 

--- a/src/main/docs/omnia-setup.md
+++ b/src/main/docs/omnia-setup.md
@@ -44,6 +44,12 @@ The `omnia.sh` script handles initial setup and environment configuration for Om
 9. **Installs omnia-cli** — Copies `omnia-cli` to `/usr/local/bin/omnia-cli` and shared completion for `omnia-cli` and `omnia.sh` to `/etc/bash_completion.d/omnia-bash-completion` (use `--skip-omnia-cli` to suppress)
 10. **Displays summary** — Shows venv path, Python version, installed Ansible and collections
 
+After copying the default combined Slurm + service_k8s catalog, setup displays
+the active `CATALOG_FILE_PATH` and commands for either replacing the catalog at
+that path or copying a different catalog and updating the path. For example,
+the service_k8s-only sample is
+`samples/catalogs/10.0/service_k8s_x86_64.json`.
+
 Use `--deps-only` to skip input file staging in step 7 (e.g., in CI or if you manage input files externally). Dependencies are still installed.
 
 Use `--force-deps` to bypass the dependency cache and force a fresh `pip install` + `ansible-galaxy collection install`.

--- a/src/main/omnia.env
+++ b/src/main/omnia.env
@@ -15,8 +15,9 @@
 #   4. Run playbooks:      cd src/<domain> && ansible-playbook playbooks/<playbook>.yml
 #
 # IMPORTANT: After setup, edit /etc/omnia/omnia.env for configuration changes.
-# Use ./omnia.sh --setup-venv --force-env only to intentionally replace the
-# installed configuration with this repository template.
+# If you change this repository file after setup, apply those changes with:
+#   ./omnia.sh -s --force-env
+# This command replaces the entire installed configuration with this file.
 #
 # =============================================================================
 

--- a/src/main/omnia.sh
+++ b/src/main/omnia.sh
@@ -179,7 +179,12 @@ validate_env() {
     actual_hostname="$(hostname -s 2>/dev/null || hostname 2>/dev/null)"
     if [ -n "$actual_hostname" ] && [ "$actual_hostname" != "$SYSTEM_HOSTNAME" ]; then
         echo -e "${RED}ERROR: SYSTEM_HOSTNAME (${SYSTEM_HOSTNAME}) does not match actual hostname (${actual_hostname})${NC}"
-        echo -e "${YELLOW}  Fix: update SYSTEM_HOSTNAME in ${env_file}${NC}"
+        echo -e "${YELLOW}  Fix the installed configuration: update SYSTEM_HOSTNAME in ${env_file}, then re-run ./omnia.sh -s${NC}"
+        if [ "$env_file" = "$SYSTEM_ENV_FILE" ]; then
+            echo -e "${YELLOW}  If you corrected ${SCRIPT_DIR}/omnia.env instead, apply it with:${NC}"
+            echo -e "${YELLOW}    ./omnia.sh -s --force-env${NC}"
+            echo -e "${YELLOW}  Note: --force-env replaces all values in ${SYSTEM_ENV_FILE} with the repository file.${NC}"
+        fi
         echo -e "${YELLOW}  Or:  hostnamectl set-hostname ${SYSTEM_HOSTNAME}${NC}"
         errors=$((errors + 1))
     fi
@@ -305,7 +310,9 @@ install_system_env() {
         echo -e "  ${GREEN}Using existing: ${system_env_file}${NC}"
         if [ -f "$source_env_file" ] && ! diff -q "$source_env_file" "$system_env_file" >/dev/null 2>&1; then
             echo -e "  ${YELLOW}Repository omnia.env differs; preserving the system configuration.${NC}"
-            echo -e "  ${DIM}Use --force-env only when you intend to replace ${system_env_file}.${NC}"
+            echo -e "  ${YELLOW}To apply changes made in ${source_env_file}, run:${NC}"
+            echo -e "    ${YELLOW}./omnia.sh -s --force-env${NC}"
+            echo -e "  ${DIM}This replaces all values in ${system_env_file} with the repository file.${NC}"
         fi
     else
         if [ ! -f "$source_env_file" ]; then
@@ -1100,6 +1107,9 @@ copy_catalog() {
     local catalog_source="${SCRIPT_DIR}/samples/catalog_rhel.json"
     local catalog_target_dir="${OMNIA_DATA_PATH}/catalog"
     local catalog_target_file="${catalog_target_dir}/catalog_rhel.json"
+    local configured_catalog_file="${CATALOG_FILE_PATH:-$catalog_target_file}"
+    local configured_catalog_dir
+    configured_catalog_dir="$(dirname "$configured_catalog_file")"
 
     echo -e "${BLUE}================================================================================${NC}"
     echo -e "${BLUE}               Catalog Copy${NC}"
@@ -1133,7 +1143,32 @@ copy_catalog() {
 
     echo ""
     echo -e "${GREEN}Catalog files copied to: ${catalog_target_dir}/${NC}"
-    echo -e "${GREEN}  CATALOG_FILE_PATH=${catalog_target_file}${NC}"
+    echo -e "${GREEN}Configured catalog file:${NC}"
+    echo -e "  ${GREEN}CATALOG_FILE_PATH=${configured_catalog_file}${NC}"
+    echo -e "  ${DIM}The default catalog contains packages for both Slurm and service_k8s deployments.${NC}"
+    if [ "$configured_catalog_file" != "$catalog_target_file" ]; then
+        echo -e "  ${YELLOW}The configured path differs from the copied default (${catalog_target_file}).${NC}"
+        echo -e "  ${YELLOW}Copy the catalog you want to ${configured_catalog_file} before running catalog-based workflows.${NC}"
+    fi
+    echo ""
+    echo -e "${YELLOW}To use a different catalog:${NC}"
+    echo -e "  ${YELLOW}1. Keep the current path and replace its contents:${NC}"
+    echo -e "     mkdir -p \"${configured_catalog_dir}\""
+    echo -e "     cp /path/to/catalog.json \"${configured_catalog_file}\""
+    echo ""
+    echo -e "  ${YELLOW}2. Or keep a separate filename and update the catalog path:${NC}"
+    echo -e "     cp /path/to/catalog.json \"${configured_catalog_dir}/custom_catalog.json\""
+    echo -e "     vi ${ACTIVE_ENV_FILE:-$SYSTEM_ENV_FILE}"
+    echo -e "     Set: CATALOG_FILE_PATH=${configured_catalog_dir}/custom_catalog.json"
+    echo -e "     source ${PROFILE_DROP_IN}"
+    echo ""
+    echo -e "  ${YELLOW}Example (RHEL 10.0, service_k8s only):${NC}"
+    printf '     cp "%s" \\\n' "${SCRIPT_DIR}/samples/catalogs/10.0/service_k8s_x86_64.json"
+    echo -e "       \"${configured_catalog_dir}/service_k8s_x86_64.json\""
+    echo -e "     Set CATALOG_FILE_PATH=${configured_catalog_dir}/service_k8s_x86_64.json in ${ACTIVE_ENV_FILE:-$SYSTEM_ENV_FILE}"
+    echo ""
+    echo -e "  ${DIM}If you edit ${SCRIPT_DIR}/omnia.env instead of ${ACTIVE_ENV_FILE:-$SYSTEM_ENV_FILE},${NC}"
+    echo -e "  ${DIM}apply it with ./omnia.sh -s --force-env (this replaces the installed env file).${NC}"
     echo ""
 }
 


### PR DESCRIPTION
### PR Title

fix(setup): clarify environment replacement and catalog selection

### Issues Resolved by this Pull Request

Related to #4849.

### Description of the Solution

Improves `omnia.sh --setup-venv` guidance so users who correct `src/main/omnia.env` after initial setup are explicitly told to apply it with `./omnia.sh -s --force-env`, including the fact that this replaces the complete installed environment file. It also expands the Catalog Copy summary with the configured `CATALOG_FILE_PATH`, explains that the default catalog supports both Slurm and service_k8s, and provides commands for selecting and activating a different catalog.

### Changes

#### Environment setup (`src/main/omnia.sh`, `src/main/omnia.env`)

- Add actionable recovery instructions to `SYSTEM_HOSTNAME` validation failures.
- Replace the ambiguous environment-difference warning with the exact `./omnia.sh -s --force-env` command.
- Warn that `--force-env` replaces all values in `/etc/omnia/omnia.env`.
- Clarify the post-install environment workflow in the repository template.

#### Catalog selection (`src/main/omnia.sh`)

- Display the configured `CATALOG_FILE_PATH` after catalog staging.
- Identify the default catalog as supporting both Slurm and service_k8s deployments.
- Warn when the configured catalog path differs from the copied default path.
- Show commands for replacing the current catalog or retaining a separate catalog filename.
- Include a concrete RHEL 10.0 service_k8s-only catalog example and environment reload instructions.

#### Documentation (`src/main/docs`)

- Document `CATALOG_FILE_PATH` as the active catalog consumed by Repo Manager and catalog-mode image builds.
- Add catalog selection and environment activation examples.
- Align setup documentation with the new runtime guidance.

### Files Changed

| File | Change Type | Description |
|---|---|---|
| `src/main/omnia.sh` | Modified | Adds explicit environment replacement recovery and detailed catalog selection output. |
| `src/main/omnia.env` | Modified | Documents how repository environment changes are applied after setup. |
| `src/main/docs/omnia-env.md` | Modified | Corrects catalog-path semantics and adds custom catalog instructions. |
| `src/main/docs/omnia-setup.md` | Modified | Documents the expanded Catalog Copy summary and service_k8s example. |

### Testing

- `bash -n src/main/omnia.sh` — passed locally.
- `src/main/omnia.sh --help` — rendered successfully locally.
- `git diff --check` — passed locally.
- Mocked hostname mismatch and Catalog Copy output paths — rendered the expected recovery and catalog-selection instructions locally.
- GitHub CI: ShellCheck, unit tests and coverage, Ansible Lint, Bandit, copyright, HPC compliance, secret scanning, test co-change, build, dependency audit, commit validation, and PR hygiene passed.
- GitHub CI currently reports failures for DCO and linked-issue/IP-policy validation; this description uses `Related to #4849` because the stacked PR does not itself resolve the broader issue.

### Backward Compatibility

No breaking changes. Existing environment precedence, catalog-copy behavior, command-line options, configuration variables, and file locations remain unchanged; the PR improves setup output and documentation only.

### Suggested Reviewers

| Reviewer | Review Focus |
|---|---|
| Omnia setup/CLI maintainers | Environment precedence, `--force-env` recovery guidance, and shell output. |
| Repo Manager and Image Build Manager maintainers | `CATALOG_FILE_PATH` semantics and custom catalog workflow. |
