### PR TITLE
Fix Kubernetes firewall rules to use the trusted zone explicitly

### DIFF
--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
@@ -397,33 +397,33 @@
         - systemctl start firewalld
 
         # Open essential ports
-        - firewall-cmd --permanent --add-port=22/tcp
-        - firewall-cmd --permanent --add-port=6443/tcp
-        - firewall-cmd --permanent --add-port=2379-2380/tcp
-        - firewall-cmd --permanent --add-port=10250/tcp
-        - firewall-cmd --permanent --add-port=10251/tcp
-        - firewall-cmd --permanent --add-port=10252/tcp
-        - firewall-cmd --permanent --add-port=10257/tcp
-        - firewall-cmd --permanent --add-port=10259/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=22/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=6443/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=2379-2380/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10250/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10251/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10252/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10257/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10259/tcp
 
         # CNI-related ports if running workloads on control plane (NodePort, CNI, etc.)
-        - firewall-cmd --permanent --add-port=30000-32767/tcp
-        - firewall-cmd --permanent --add-port=179/tcp
-        - firewall-cmd --permanent --add-port=4789/udp
-        - firewall-cmd --permanent --add-port=5473/tcp
-        - firewall-cmd --permanent --add-port=51820/udp
-        - firewall-cmd --permanent --add-port=51821/udp
-        - firewall-cmd --permanent --add-port=9100/tcp
-        - firewall-cmd --permanent --add-port=7472/tcp
-        - firewall-cmd --permanent --add-port=7472/udp
-        - firewall-cmd --permanent --add-port=7946/tcp
-        - firewall-cmd --permanent --add-port=7946/udp
-        - firewall-cmd --permanent --add-port=9090/tcp
-        - firewall-cmd --permanent --add-port=8080/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=30000-32767/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=179/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=4789/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=5473/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=51820/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=51821/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=9100/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7472/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7472/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=7946/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7946/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=9090/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=8080/tcp
         
         # Enable services
-        - firewall-cmd --permanent --add-service=http
-        - firewall-cmd --permanent --add-service=https
+        - firewall-cmd --permanent --zone=trusted --add-service=http
+        - firewall-cmd --permanent --zone=trusted --add-service=https
 
         # Add pod/service networks
         - firewall-cmd --permanent --zone=trusted --add-source={{ k8s_service_addresses }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
@@ -304,33 +304,33 @@
         - systemctl start firewalld
 
         # Open essential ports
-        - firewall-cmd --permanent --add-port=22/tcp
-        - firewall-cmd --permanent --add-port=6443/tcp
-        - firewall-cmd --permanent --add-port=2379-2380/tcp
-        - firewall-cmd --permanent --add-port=10250/tcp
-        - firewall-cmd --permanent --add-port=10251/tcp
-        - firewall-cmd --permanent --add-port=10252/tcp
-        - firewall-cmd --permanent --add-port=10257/tcp
-        - firewall-cmd --permanent --add-port=10259/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=22/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=6443/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=2379-2380/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10250/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10251/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10252/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10257/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10259/tcp
 
         # CNI-related ports if running workloads on control plane (NodePort, CNI, etc.)
-        - firewall-cmd --permanent --add-port=30000-32767/tcp
-        - firewall-cmd --permanent --add-port=179/tcp
-        - firewall-cmd --permanent --add-port=4789/udp
-        - firewall-cmd --permanent --add-port=5473/tcp
-        - firewall-cmd --permanent --add-port=51820/udp
-        - firewall-cmd --permanent --add-port=51821/udp
-        - firewall-cmd --permanent --add-port=9100/tcp
-        - firewall-cmd --permanent --add-port=7472/tcp
-        - firewall-cmd --permanent --add-port=7472/udp
-        - firewall-cmd --permanent --add-port=7946/tcp
-        - firewall-cmd --permanent --add-port=7946/udp
-        - firewall-cmd --permanent --add-port=9090/tcp
-        - firewall-cmd --permanent --add-port=8080/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=30000-32767/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=179/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=4789/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=5473/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=51820/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=51821/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=9100/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7472/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7472/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=7946/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7946/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=9090/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=8080/tcp
         
         # Enable services
-        - firewall-cmd --permanent --add-service=http
-        - firewall-cmd --permanent --add-service=https
+        - firewall-cmd --permanent --zone=trusted --add-service=http
+        - firewall-cmd --permanent --zone=trusted --add-service=https
 
         # Add pod/service networks
         - firewall-cmd --permanent --zone=trusted --add-source={{ k8s_service_addresses }}

--- a/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
+++ b/src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2
@@ -196,25 +196,25 @@
         - systemctl start firewalld
 
         # Open required ports for kube node
-        - firewall-cmd --permanent --add-port=22/tcp
-        - firewall-cmd --permanent --add-port=10250/tcp
-        - firewall-cmd --permanent --add-port=30000-32767/tcp
-        - firewall-cmd --permanent --add-port=179/tcp
-        - firewall-cmd --permanent --add-port=4789/udp
-        - firewall-cmd --permanent --add-port=5473/tcp
-        - firewall-cmd --permanent --add-port=51820/udp
-        - firewall-cmd --permanent --add-port=51821/udp
-        - firewall-cmd --permanent --add-port=9100/tcp
-        - firewall-cmd --permanent --add-port=7472/tcp
-        - firewall-cmd --permanent --add-port=7472/udp
-        - firewall-cmd --permanent --add-port=7946/tcp
-        - firewall-cmd --permanent --add-port=7946/udp
-        - firewall-cmd --permanent --add-port=9090/tcp
-        - firewall-cmd --permanent --add-port=8080/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=22/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=10250/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=30000-32767/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=179/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=4789/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=5473/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=51820/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=51821/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=9100/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7472/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7472/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=7946/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=7946/udp
+        - firewall-cmd --permanent --zone=trusted --add-port=9090/tcp
+        - firewall-cmd --permanent --zone=trusted --add-port=8080/tcp
 
         # Enable services
-        - firewall-cmd --permanent --add-service=http
-        - firewall-cmd --permanent --add-service=https
+        - firewall-cmd --permanent --zone=trusted --add-service=http
+        - firewall-cmd --permanent --zone=trusted --add-service=https
 
         # Add Kubernetes pod/service CIDRs (replace with your actual values)
         - firewall-cmd --permanent --zone=trusted --add-source={{ k8s_service_addresses }}


### PR DESCRIPTION
  ## Description
related to #4849 

  This PR fixes Kubernetes firewall validation failures on control-plane and worker nodes.

  The cloud-init templates previously added Kubernetes ports without specifying a firewalld zone:

  firewall-cmd --permanent --add-port=6443/tcp

  At that point, the rules could be added to the existing default zone, usually public. The templates later changed the default zone to trusted, while the FVT
  checked the current default zone using:

  firewall-cmd --list-all

  As a result, the rules existed under a different zone and the FVT reported all required Kubernetes ports as missing.

  ## Changes

  - Added --zone=trusted to all Kubernetes firewall-cmd --add-port commands.
  - Added --zone=trusted to the HTTP and HTTPS service rules.
  - Updated firewall configuration for:
      - First Kubernetes control-plane node
      - Additional Kubernetes control-plane nodes
      - Kubernetes worker nodes

  - No new ports were introduced; existing rules are now assigned deterministically to the intended zone.

  Example:

  firewall-cmd --permanent --zone=trusted --add-port=6443/tcp

  ## Files Changed

  - src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_first_x86_64.yaml.j2
  - src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_control_plane_x86_64.yaml.j2
  - src/orchestrator/roles/configure_ochami/templates/metadata_svc/ms-group-service_kube_node_x86_64.yaml.j2

  ## Validation

  - Jinja parsing passed for all three templates.
  - Verified that every control-plane and worker port expected by the FVT is explicitly configured in the trusted zone.
  - git diff --check passed.
  - Orchestrator Ansible syntax check passed.
  - Kubernetes firewall FVT should be rerun after regenerating metadata and PXE provisioning the nodes.

  ## Expected Result

  The following tests should pass after reprovisioning:

  test_k8s_firewall_ports_control_plane
  test_k8s_firewall_ports_workers

  All required Kubernetes ports will appear in the trusted zone consistently, independent of the firewalld default zone at the time each command executes.

