### PR TITLE
test(utils): remove duplicate install_os full deployment test

### DIFF
--- a/test/utils/fvt/install_os/test_playbook.py
+++ b/test/utils/fvt/install_os/test_playbook.py
@@ -249,65 +249,6 @@ def test_deploy_install_os_deploy(host):
     pytest.fail("install_os deploy tag failed")
 
 
-@pytest.mark.deploy
-@pytest.mark.functional
-@pytest.mark.order(24)
-def test_deploy_install_os_full(host):
-    """Deploy install_os.yml with all tags (full execution).
-
-    Validates complete end-to-end OS installation. Requires actual hardware and full config.
-    """
-    tc = TC["deploy_install_os_full"]
-    tl = TestLogger(tc["title"], tc["id"])
-
-    # Pre-verification: Check config has all required parameters
-    from library.functions import get_utils_input_path, validate_install_os_config
-    input_path = get_utils_input_path(host)
-    config_path = f"{input_path}/install_os_config.yml"
-
-    config_result = validate_install_os_config(host, config_path)
-    if not config_result["success"]:
-        tl.failed(f"Config validation failed: {config_result['error']}")
-        pytest.fail(f"Config validation failed: {config_result['error']}")
-
-    config = config_result.get("config", {})
-
-    # Check all required parameters for full execution
-    source_iso = config.get("source_iso_path", "")
-    custom_iso = config.get("custom_iso_path", "")
-    bmc_ip = config.get("target_bmc_ip", "")
-    admin_ip = config.get("target_admin_ip", "")
-    hostname = config.get("target_hostname", "")
-
-    missing_params = []
-    if not source_iso:
-        missing_params.append("source_iso_path")
-    if not custom_iso:
-        missing_params.append("custom_iso_path")
-    if not bmc_ip:
-        missing_params.append("target_bmc_ip")
-    if not admin_ip:
-        missing_params.append("target_admin_ip")
-    if not hostname:
-        missing_params.append("target_hostname")
-
-    if missing_params:
-        tl.skipped(f"Missing required config parameters: {', '.join(missing_params)}")
-        pytest.skip(f"Missing required config parameters: {', '.join(missing_params)}")
-
-    result = run_playbook(playbook=PLAYBOOK_INSTALL_OS)
-
-    if result["success"]:
-        tl.passed(LOG["playbook_success"].format(duration=result["duration"]))
-        return
-
-    tl.failed(
-        LOG["playbook_failed"].format(rc=result["rc"], duration=result["duration"]),
-        result.get("error", "See playbook output above"),
-    )
-    pytest.fail("install_os full execution failed")
-
-
 # =============================================================================
 # NEGATIVE TEST CASES (Validation Only - No Actual Deployment)
 # =============================================================================

--- a/test/utils/library/vars/test_case_vars.py
+++ b/test/utils/library/vars/test_case_vars.py
@@ -187,10 +187,6 @@ TEST_CASES = {
         "id": "UTILS_FVT_INSTALL_OS_E004",
         "title": "Deploy install_os.yml (generate_ks tag)",
     },
-    "deploy_install_os_full": {
-        "id": "UTILS_FVT_INSTALL_OS_E005",
-        "title": "Deploy install_os.yml (full execution)",
-    },
 
     # ══════════════════════════════════════════════════════════════════════════
     # INSTALL_OS SCENARIO - Verification Tests


### PR DESCRIPTION
 PR Description

Fixes #4849 

 Issues Resolved by this Pull Request

 Related to domain modernization and test automation cleanup

 Description of the Solution

 Summary: Removes duplicate full deployment test case for install_os scenario to eliminate redundant test execution and align
 with upstream cleanup changes.

 Changes

 Test Case Cleanup

 Removed Duplicate Full Deployment Test

   • Removed  UTILS_FVT_INSTALL_OS_E005  (deploy_install_os_full) test case from test_case_vars.py
   • Removed  test_deploy_install_os_full  function from test_playbook.py
   • Reason: Both E000 and E005 run full stack deployment when OMNIA_DEPLOY_TAG is not set, causing redundant execution
   • Impact: UTILS_FVT_INSTALL_OS_E000 (deploy_install_os) serves as the sanity full deployment test

 Testing

 Test Execution

   • ✅ All install_os tests pass with single full deployment test
   • ✅ Eliminates redundant execution (no duplicate full stack runs)
   • ✅ Maintains complete test coverage across all scenarios

 Backward Compatibility

 ✅ No breaking changes

   • All other test cases preserved
   • Test execution commands unchanged
   • No configuration file changes required

 Suggested Reviewers

 @Venu-p1 @snarthan

 Review Checklist

 Please verify the following:

   • [ ] Review PR description and understand the changes
   • [ ] Verify duplicate test case is removed
   • [ ] Verify E000 serves as sanity full deployment test
   • [ ] Run install_os tests locally to confirm no regression
   • [ ] Verify test coverage remains complete

