### PR TITLE
fix(main): align omnia-cli input and output diagnostics

### DIFF
--- a/src/main/docs/omnia-cli.md
+++ b/src/main/docs/omnia-cli.md
@@ -23,14 +23,14 @@ source /etc/bash_completion.d/omnia-bash-completion  # or re-login
 The same completion definitions can therefore be used for diagnostics such as
 `omnia-cli st<Tab>` and lifecycle commands such as
 `./omnia.sh --run image_<Tab> --tags pre<Tab>`.
-Completions are command-aware: `omnia-cli` uses the documented hyphenated names,
+Completions are command-aware: `omnia-cli` uses the canonical source domain names,
 and `omnia.sh --tags` suggests only tags supported by the selected domain.
 
 After installation, run `omnia-cli` directly without `./` or path prefix:
 
 ```bash
 omnia-cli status
-omnia-cli repo-manager
+omnia-cli repo_manager
 omnia-cli version
 ```
 
@@ -40,13 +40,13 @@ omnia-cli version
 |---------|-------------|
 | `status [--project <name>]` | Show all domain statuses for a project |
 | `check [--project <name>]` | Validate input files and output existence for all domains |
-| `edit <domain> [--project <name>]` | Select and edit a domain input file |
-| `repo-manager [--project <name>]` | Detailed repo_manager diagnostics |
-| `image-build [--project <name>]` | Detailed image_build_manager diagnostics |
+| `edit <domain> [file] [--project <name>]` | Show the domain input checklist and edit an input file |
+| `repo_manager [--project <name>]` | Detailed repo_manager diagnostics |
+| `image_build_manager [--project <name>]` | Detailed image_build_manager diagnostics |
 | `orchestrator [--project <name>]` | Orchestrator status |
 | `discovery [--project <name>]` | Discovery domain status |
 | `telemetry [--project <name>]` | Telemetry stack status |
-| `build-stream [--project <name>]` | Build stream (GitLab) status |
+| `build_stream [--project <name>]` | Build stream (GitLab) status |
 | `utils [--project <name>]` | Shared utilities status |
 | `logs <domain> [--project <name>] [--limit <n>]` | Browse and tail domain log files |
 | `version` | Show Omnia version info |
@@ -67,16 +67,16 @@ omnia-cli version
 ./omnia-cli status --project my_cluster
 
 # Detailed repo_manager check
-./omnia-cli repo-manager
+./omnia-cli repo_manager
 
 # Image build status for production
-./omnia-cli image-build --project prod
+./omnia-cli image_build_manager --project prod
 
 # Show version information
 ./omnia-cli version
 
 # Get help for a specific domain
-./omnia-cli help repo-manager
+./omnia-cli help repo_manager
 ```
 
 ## Status Output Format
@@ -94,11 +94,11 @@ The CLI uses symbols to indicate status:
 Omnia Domain Status  (project: project_default)
 ------------------------------------------------------------
 
-  ✔ repo manager  completed
+  ✔ repo_manager  completed
     RPM repository synchronization (Pulp)
     Last: 2026-07-29 10:30:15 (repo_status.yml)
 
-  ✔ image build manager  completed
+  ✔ image_build_manager  completed
     OS image building (MinIO + Registry + OpenCHAMI)
     Last: 2026-07-29 11:15:42 (build_status.yml)
 
@@ -116,60 +116,92 @@ Omnia Domain Status  (project: project_default)
 
 ## Domain-Specific Commands
 
-### repo-manager
+### repo_manager
 
 Detailed diagnostics for the repo_manager domain:
 
 - Checks output directory exists
 - Validates `repo_status.yml` and `overall_status`
-- Verifies `functional_group_packages.yml` exists
-- Checks Pulp certificate files
-- Counts RPM repos by architecture
+- Checks the Pulp certificate path when `server_crt` is configured
+- Counts execution contexts and repository URLs from the current output contract
+- Lists every generated artifact recursively
 
 ```bash
-./omnia-cli repo-manager
+./omnia-cli repo_manager
 ```
 
-### image-build
+### image_build_manager
 
 Detailed diagnostics for the image_build_manager domain:
 
 - Checks output directory exists
 - Validates `build_status.yml` and `overall_status`
-- Counts built images by architecture
+- Validates complete kernel, initrd, and rootfs entries for every functional group
+- Shows the build engine and S3 endpoint/bucket
 - Shows latest build log location
 - Displays last modified timestamp
 
 ```bash
-./omnia-cli image-build
+./omnia-cli image_build_manager
 ```
 
 ### logs
 
-Browse and tail domain log files interactively. Searches the following locations:
+Browse and tail domain log files interactively. Results from every location are
+combined, de-duplicated, sorted newest first, and limited globally by `--limit`.
+Each entry shows its source, relative path, size, timestamp, and full path.
+The command searches:
 
-1. Domain log directory: `$OMNIA_DATA_PATH/<domain>/log/<project>/`
-2. Domain log directory (flat): `$OMNIA_DATA_PATH/<domain>/log/` (logs directly in the log folder)
-3. Ansible logs: `/var/log/omnia/`
-4. Domain output directory: `$OMNIA_DATA_PATH/<domain>/output/<project>/*.log`
+1. Runtime logs: `$OMNIA_DATA_PATH/<domain>/log/`, including project and shared subdirectories
+2. Domain Ansible logs: `/var/log/omnia/<domain>/`, including phase files such as `prepare.log`
+3. Legacy domain-named logs directly below `/var/log/omnia/`
+4. Log files anywhere below `$OMNIA_DATA_PATH/<domain>/output/<project>/`
+
+Set `OMNIA_ANSIBLE_LOG_PATH` only when Ansible logs use a non-standard root;
+the default is `/var/log/omnia`.
 
 ```bash
-./omnia-cli logs image-build
-./omnia-cli logs repo-manager --project prod
+./omnia-cli logs image_build_manager
+./omnia-cli logs repo_manager --project prod
 ./omnia-cli logs orchestrator --limit 50
 ./omnia-cli logs discovery -l 100
 ```
 
 ### edit
 
-List a domain's input files and select one to open in `$EDITOR` (defaults to
-`vi`). Credential and Vault-encrypted files are opened with `ansible-vault edit`;
-plain-text files use the configured editor.
+Show a customer input checklist, then list the files available to edit. The
+checklist marks each known file as `required`, `conditional`, `optional`, or
+`generated`, marks only absent required files as missing, and explains what the
+customer must review. Select a number interactively or provide the filename directly. YAML,
+JSON, CSV, INI-style, TOML, log, and text files are supported. Credential and
+Vault-encrypted files are opened with `ansible-vault edit`; plain-text files use
+the configured editor. When shell completion is installed, press Tab after the
+domain to complete staged input filenames, including CSV files.
 
 ```bash
-./omnia-cli edit image-build
-./omnia-cli edit repo-manager --project prod
+./omnia-cli edit image_build_manager
+./omnia-cli edit repo_manager --project prod
+EDITOR=vim ./omnia-cli edit orchestrator pxe_mapping_file.csv
 ```
+
+Only a file shown in the editable-file list can be opened directly. This keeps
+relative-path traversal and hidden Vault key files out of the editor workflow.
+After customer inputs are filled, run the complete respective domain flow. That
+flow creates or updates any required Vault-encrypted credential document; no
+separate credentials-only step is needed. Generated credentials must never be
+committed.
+
+## Customer Input Summary
+
+| Domain | Always review/provide | Conditional or optional | Generated and external dependencies |
+|--------|-----------------------|-------------------------|-------------------------------------|
+| repo_manager | `repo_manager_config.yml`, `repo_manager_endpoint_config.yml` | Registry TLS/auth sections when used | Full `repo_manager` run generates required credentials; `CATALOG_FILE_PATH` must reference the approved catalog JSON |
+| image_build_manager | `image_build_config.yml` | `package_groups.yml` for config mode; ARM values when ARM builds are enabled | Full `image_build_manager` run generates required credentials; successful `repo_status.yml` is required; catalog mode uses `CATALOG_FILE_PATH` |
+| orchestrator | `orchestrator_config.yml`, `network_spec.yml`, `omnia_config.yml`, reviewed `pxe_mapping_file.csv`, `storage_config.yml`, `security_config.yml` | Provide selected Slurm and Kubernetes storage inputs; HA is required when provisioning Kubernetes; cloud-init and PXE overrides are optional | Replace sample networks with customer values; `primary_oim_admin_ip` must equal `SYSTEM_ADMIN_NIC_IPV4`; the full run generates required credentials |
+| discovery | `discovery_config.yml`, `network_spec.yml` | Values depend on the selected discovery mechanism | Replace samples with customer admin/IB networks; `primary_oim_admin_ip` must equal `SYSTEM_ADMIN_NIC_IPV4`; full `discovery` run generates required credentials |
+| telemetry | `telemetry_config.yml`, `telemetry_storage_config.yml`, `telemetry_packages.yml` | Storage sections depend on enabled sinks/bridges; `bmc_group_data.csv` is required for iDRAC telemetry | Full `telemetry` run generates required credentials; cluster inventory normally comes from Orchestrator |
+| build_stream | `build_stream_config.yml` with enable flag, BSM address, and GitLab host | GitLab sizing and project settings have defaults | Run `omnia.sh --prepare-base` first for repo_manager, MinIO, and Registry prerequisites; the full `build_stream` run generates its credentials |
+| utils | No single domain-wide mandatory file; choose a workflow | `collect_pxe.yml` for collect, `install_os_config.yml` for install, optional `backup_oim_logs_config.yml` | The full selected flow generates required install_os credentials |
 
 ## Output Directory Resolution
 
@@ -192,7 +224,33 @@ Each domain has a known status file pattern:
 | build_stream | `build_stream_status.yml` |
 | utils | `utils_status.yml` |
 
-The CLI will also search for any `*status*.yml` or `*status*.yaml` files
-if the expected file is not found. Additionally, domain-specific status
-commands list all output files (`.yml`, `.yaml`, `.json`, `.log`, `.txt`)
-found in the output directory.
+Only the domain's canonical status file determines its status. Other status
+files are listed as flow artifacts and cannot replace the canonical file.
+Domain-specific commands recursively list every output artifact regardless of format, including
+CSV files, archives, and symlinks such as Discovery's latest CSV mapping. Build
+Stream statuses `prepared` and `running` are treated as healthy in addition to
+the standard `success` state used by other domains.
+
+An empty output directory is normal after input staging and is reported as
+`not run`, without a failure marker. If non-Orchestrator artifacts exist but the
+canonical status is absent, the CLI warns that a run may be incomplete or may
+predate the current contract. Orchestrator is handled separately because its
+inventory and internal state artifacts can be generated before its provision or
+PXE phase writes `orchestrator_status.yml`.
+
+## Generated Output Summary
+
+| Domain | Generated output |
+|--------|------------------|
+| repo_manager | `repo_status.yml` |
+| image_build_manager | Latest `build_status.yml` and timestamped `build_status_<version>_<timestamp>.yml` snapshot |
+| discovery | Timestamped `bmc_pxe_mapping_file_<timestamp>.csv`, latest `bmc_pxe_mapping_file.csv` symlink, timestamped `bmc_discovery_report_<timestamp>.csv`, and `discovery_status.yml` |
+| orchestrator | `orchestrator_state.yml`, `.data/functional_groups_config.yml`, `orchestrator_inventory.yaml`, `bmc_group_data.csv`, provision/PXE reports, and aggregate `orchestrator_status.yml` |
+| telemetry | `telemetry_status.yml`, containing the latest deploy or cleanup component results |
+| build_stream | `build_stream_status.yml`, written by an enabled prepare/build flow |
+| utils | `utils_status.yml`, optional `install_os_status.yml`, collected-log bundles, and OIM log-backup bundles |
+
+For a successful Discovery status, the CLI also verifies that both timestamped
+CSV outputs and the valid latest-mapping symlink exist. For Orchestrator, it
+checks `provisioning_report.yml` after a completed provisioning phase and
+`pxeboot_status.yml` plus `failed_nodes.json` after a completed PXE phase.

--- a/src/main/omnia-bash-completion
+++ b/src/main/omnia-bash-completion
@@ -29,8 +29,16 @@
 _omnia_domains="build_stream discovery image_build_manager orchestrator \
 repo_manager telemetry utils"
 _omnia_prepare_domains="repo_manager image_build_manager orchestrator"
-_omnia_cli_domains="repo-manager image-build orchestrator discovery telemetry \
-build-stream utils"
+_omnia_cli_domains="repo_manager image_build_manager orchestrator discovery telemetry \
+build_stream utils"
+
+_omnia_cli_internal_domain() {
+    case "$1" in
+        repo_manager|image_build_manager|orchestrator|discovery|telemetry|build_stream|utils)
+            echo "$1"
+            ;;
+    esac
+}
 
 _omnia_init_completion() {
     if declare -F _init_completion > /dev/null; then
@@ -122,8 +130,8 @@ _omnia_cli_completions() {
     _omnia_init_completion || return
 
     # All top-level commands
-    local commands="status check edit logs repo-manager image-build \
-orchestrator discovery telemetry build-stream utils version help"
+    local commands="status check edit logs repo_manager image_build_manager \
+orchestrator discovery telemetry build_stream utils version help"
 
     # Determine which command was typed (skip flags and their values)
     local command=""
@@ -191,6 +199,7 @@ orchestrator discovery telemetry build-stream utils version help"
         edit|logs|log|help)
             # These commands take a domain as the next positional arg
             local has_domain=0
+            local cli_domain=""
             for ((i = 1; i < cword; i++)); do
                 case "${words[i]}" in
                     --project|-p|--limit|-l)
@@ -203,6 +212,9 @@ orchestrator discovery telemetry build-stream utils version help"
                     *)
                         if [ "${words[i]}" != "$command" ]; then
                             has_domain=1
+                            if [ -z "$cli_domain" ]; then
+                                cli_domain="${words[i]}"
+                            fi
                         fi
                         ;;
                 esac
@@ -219,12 +231,38 @@ orchestrator discovery telemetry build-stream utils version help"
                             _omnia_complete_words "--project -p --limit -l" "$cur"
                             ;;
                     esac
+                elif [ "$command" = "edit" ]; then
+                    local internal_domain
+                    internal_domain=$(_omnia_cli_internal_domain "$cli_domain")
+                    local project_name="${OMNIA_PROJECT_NAME:-project_default}"
+                    for ((i = 1; i < cword; i++)); do
+                        if [ "${words[i]}" = "--project" ] || [ "${words[i]}" = "-p" ]; then
+                            if ((i + 1 < cword)); then
+                                project_name="${words[i + 1]}"
+                            fi
+                            break
+                        fi
+                    done
+
+                    local input_dir="${OMNIA_DATA_PATH:-/opt/omnia}/${internal_domain}/input/${project_name}"
+                    COMPREPLY=()
+                    if [ -n "$internal_domain" ] && [ -d "$input_dir" ]; then
+                        local input_file relative_file lower_file
+                        while IFS= read -r -d '' input_file; do
+                            relative_file="${input_file#"$input_dir/"}"
+                            lower_file="${relative_file,,}"
+                            case "$lower_file" in
+                                *.yml|*.yaml|*.json|*.csv|*.cfg|*.conf|*.ini|*.toml|*.log|*.txt)
+                                    [[ "$relative_file" == "$cur"* ]] && COMPREPLY+=("$relative_file")
+                                    ;;
+                            esac
+                        done < <(find "$input_dir" \( -type f -o -type l \) -print0 2>/dev/null)
+                    fi
                 fi
             fi
             ;;
-        status|check|repo-manager|repo_manager|image-build|image_build| \
-        image-build-manager|image_build_manager|orchestrator|discovery| \
-        telemetry|build-stream|build_stream|utils)
+        status|check|repo_manager|image_build_manager|orchestrator|discovery| \
+        telemetry|build_stream|utils)
             # These commands only take --project
             if [[ "$cur" == -* ]]; then
                 _omnia_complete_words "--project -p" "$cur"

--- a/src/main/omnia-cli
+++ b/src/main/omnia-cli
@@ -27,10 +27,10 @@
 # Usage:
 #   ./omnia-cli status [--project <name>]
 #   ./omnia-cli check [--project <name>]
-#   ./omnia-cli edit <domain> [--project <name>]
+#   ./omnia-cli edit <domain> [file] [--project <name>]
 #   ./omnia-cli logs <domain> [--project <name>] [--limit <n>]
-#   ./omnia-cli repo-manager [--project <name>]
-#   ./omnia-cli image-build [--project <name>]
+#   ./omnia-cli repo_manager [--project <name>]
+#   ./omnia-cli image_build_manager [--project <name>]
 #   ./omnia-cli <domain> [--project <name>]
 #   ./omnia-cli version
 #   ./omnia-cli help [<domain>]
@@ -100,15 +100,83 @@ declare -A DOMAIN_DESCRIPTIONS=(
     [utils]="Shared utilities and helper roles"
 )
 
-# Known domain input config file names (relative to input/<project>/)
-declare -A DOMAIN_INPUT_FILES=(
-    [repo_manager]="repo_manager_config.yml"
-    [image_build_manager]="image_build_config.yml"
-    [orchestrator]="orchestrator_config.yml"
-    [discovery]="discovery_config.yml"
-    [telemetry]="telemetry_config.yml"
-    [build_stream]="build_stream_config.yml"
-    [utils]="utils_config.yml"
+# Customer-facing input inventory. Requirement levels reflect the domain input
+# contracts; generated credential files are deliberately not treated as
+# customer-authored plaintext configuration.
+declare -A DOMAIN_GUIDE_FILES=(
+    [repo_manager]="repo_manager_config.yml repo_manager_endpoint_config.yml repo_manager_config_credentials.yml"
+    [image_build_manager]="image_build_config.yml package_groups.yml image_build_credentials.yml"
+    [orchestrator]="orchestrator_config.yml network_spec.yml omnia_config.yml pxe_mapping_file.csv storage_config.yml security_config.yml high_availability_config.yml additional_cloud_init.yml set_pxe_boot_config.yml orchestrator_credentials.yml"
+    [discovery]="discovery_config.yml network_spec.yml discovery_credentials.yml"
+    [telemetry]="telemetry_config.yml telemetry_storage_config.yml telemetry_packages.yml bmc_group_data.csv telemetry_credentials.yml"
+    [build_stream]="build_stream_config.yml build_stream_credentials.yml"
+    [utils]="collect_pxe.yml install_os_config.yml backup_oim_logs_config.yml install_os_credentials.yml"
+)
+
+declare -A INPUT_FILE_LEVEL=(
+    [repo_manager/repo_manager_config.yml]="required"
+    [repo_manager/repo_manager_endpoint_config.yml]="required"
+    [repo_manager/repo_manager_config_credentials.yml]="generated"
+    [image_build_manager/image_build_config.yml]="required"
+    [image_build_manager/package_groups.yml]="conditional"
+    [image_build_manager/image_build_credentials.yml]="generated"
+    [orchestrator/orchestrator_config.yml]="required"
+    [orchestrator/network_spec.yml]="required"
+    [orchestrator/omnia_config.yml]="required"
+    [orchestrator/pxe_mapping_file.csv]="required"
+    [orchestrator/storage_config.yml]="required"
+    [orchestrator/security_config.yml]="required"
+    [orchestrator/high_availability_config.yml]="conditional"
+    [orchestrator/additional_cloud_init.yml]="optional"
+    [orchestrator/set_pxe_boot_config.yml]="optional"
+    [orchestrator/orchestrator_credentials.yml]="generated"
+    [discovery/discovery_config.yml]="required"
+    [discovery/network_spec.yml]="required"
+    [discovery/discovery_credentials.yml]="generated"
+    [telemetry/telemetry_config.yml]="required"
+    [telemetry/telemetry_storage_config.yml]="required"
+    [telemetry/telemetry_packages.yml]="required"
+    [telemetry/bmc_group_data.csv]="conditional"
+    [telemetry/telemetry_credentials.yml]="generated"
+    [build_stream/build_stream_config.yml]="required"
+    [build_stream/build_stream_credentials.yml]="generated"
+    [utils/collect_pxe.yml]="conditional"
+    [utils/install_os_config.yml]="conditional"
+    [utils/backup_oim_logs_config.yml]="optional"
+    [utils/install_os_credentials.yml]="generated"
+)
+
+declare -A INPUT_FILE_DESCRIPTIONS=(
+    [repo_manager/repo_manager_config.yml]="Review repository policy, every selected OS/architecture URL, caching, priorities, and private registries."
+    [repo_manager/repo_manager_endpoint_config.yml]="Review the Pulp HTTPS port and optional advertised IP; the IP defaults to SYSTEM_ADMIN_NIC_IPV4."
+    [repo_manager/repo_manager_config_credentials.yml]="Created and Vault-encrypted by the repo_manager run when repository or registry authentication is needed."
+    [image_build_manager/image_build_config.yml]="Review repo_manager output path, S3 provider/endpoint, build engine, package source, build controls, and optional ARM host."
+    [image_build_manager/package_groups.yml]="Required in config mode; in catalog mode the staged file is still schema-validated when present."
+    [image_build_manager/image_build_credentials.yml]="Created and Vault-encrypted by the image_build_manager run for S3 and optional ARM SSH secrets."
+    [orchestrator/orchestrator_config.yml]="Review mapping path, DHCP lease, upstream build/repository paths, catalog path, PXE setting, and boot parameters."
+    [orchestrator/network_spec.yml]="Replace all sample network values; primary_oim_admin_ip must equal SYSTEM_ADMIN_NIC_IPV4 and match the configured OIM NIC."
+    [orchestrator/omnia_config.yml]="Define Kubernetes and Slurm clusters, deployment selections, functional groups, and storage names."
+    [orchestrator/pxe_mapping_file.csv]="Review the Discovery mapping and correct every hostname, group, service tag, MAC, and node IP before provisioning."
+    [orchestrator/storage_config.yml]="Required: provide storage inputs for both selected Slurm and Kubernetes clusters; referenced names must match omnia_config.yml."
+    [orchestrator/security_config.yml]="Review the security/OpenLDAP connection type used by provisioning."
+    [orchestrator/high_availability_config.yml]="Required when provisioning Kubernetes; cluster names must match omnia_config.yml and HA/VIP values must reflect the customer network."
+    [orchestrator/additional_cloud_init.yml]="Optional custom write_files/runcmd content; used only when its path is set in orchestrator_config.yml."
+    [orchestrator/set_pxe_boot_config.yml]="Optional PXE/node-registration timing and restart overrides; built-in defaults apply when absent."
+    [orchestrator/orchestrator_credentials.yml]="Created and Vault-encrypted by the orchestrator run for node, BMC, and service secrets."
+    [discovery/discovery_config.yml]="Review enable_bmc_discovery and provide a reachable OME IPv4 address for OME discovery."
+    [discovery/network_spec.yml]="Replace all sample values with the customer admin and optional InfiniBand networks; primary_oim_admin_ip must equal SYSTEM_ADMIN_NIC_IPV4."
+    [discovery/discovery_credentials.yml]="Created and Vault-encrypted by the discovery run when OME authentication is required."
+    [telemetry/telemetry_config.yml]="Set the generated cluster inventory path and review every enabled source, target, sink, bridge, and PowerScale option."
+    [telemetry/telemetry_storage_config.yml]="Review storage for each enabled Kafka, VictoriaMetrics, VictoriaLogs, or Vector component."
+    [telemetry/telemetry_packages.yml]="Review install mode, offline repo URL, cluster mount, registry, images, charts, Git repositories, and Python modules."
+    [telemetry/bmc_group_data.csv]="Required when iDRAC telemetry is enabled; copy the Orchestrator-generated file and review its BMC entries."
+    [telemetry/telemetry_credentials.yml]="Created and Vault-encrypted by the telemetry run for enabled services that require authentication."
+    [build_stream/build_stream_config.yml]="Review enable_build_stream, OIM BSM IP/port, reachable GitLab host, sizing, HTTPS port, and project settings."
+    [build_stream/build_stream_credentials.yml]="Created and Vault-encrypted by the build_stream run for GitLab, BSM, and PostgreSQL secrets."
+    [utils/collect_pxe.yml]="Required only for the collect flow; provide customer admin-network IPs for each Kubernetes, Slurm, or login group."
+    [utils/install_os_config.yml]="Required only for install_os; review ISO paths, target BMC/admin network, architecture, disk, Kickstart, and SSH settings."
+    [utils/backup_oim_logs_config.yml]="Optional for backup_oim_logs; review canonical domain names and the local or NFS destination."
+    [utils/install_os_credentials.yml]="Created and Vault-encrypted by the install_os run for BMC and operating-system passwords."
 )
 
 readonly DOMAIN_ORDER=(
@@ -121,8 +189,9 @@ readonly DOMAIN_ORDER=(
     utils
 )
 
-# Ansible log default location
-readonly ANSIBLE_LOG_DEFAULT="/var/log/omnia"
+# Ansible log location (override is useful for non-default installations and
+# isolated diagnostics; production keeps the standard /var/log/omnia path).
+readonly ANSIBLE_LOG_DEFAULT="${OMNIA_ANSIBLE_LOG_PATH:-/var/log/omnia}"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Environment Loading
@@ -145,18 +214,339 @@ load_env() {
 # ─────────────────────────────────────────────────────────────────────────────
 _parse_status() {
     local file="$1"
-    grep -E '^\s*overall_status:' "$file" 2>/dev/null \
-        | head -n 1 \
-        | sed -E 's/.*: *"?([^"]*)"?/\1/' \
-        | tr -d '[:space:]'
+    _parse_yaml_key "$file" "overall_status"
 }
 
 _parse_yaml_key() {
     local file="$1" key="$2"
-    grep -E "^\s*${key}:" "$file" 2>/dev/null \
+    grep -E "^[[:space:]]*${key}:" "$file" 2>/dev/null \
         | head -n 1 \
-        | sed -E 's/.*: *"?([^"]*)"?/\1/' \
-        | tr -d '[:space:]'
+        | sed -E \
+            -e 's/^[^:]*:[[:space:]]*//' \
+            -e 's/[[:space:]]+#.*$//' \
+            -e 's/^[[:space:]]+//' \
+            -e 's/[[:space:]]+$//' \
+            -e 's/^"(.*)"$/\1/' \
+            -e "s/^'(.*)'$/\1/"
+}
+
+_count_yaml_key() {
+    local file="$1" key="$2"
+    grep -Ec "^[[:space:]-]*${key}:" "$file" 2>/dev/null || true
+}
+
+# Return success when a domain status represents a usable/healthy state.
+# Most domains use "success". Build Stream exposes lifecycle readiness through
+# "prepared" and "running" instead (see its output contract).
+_is_healthy_status() {
+    local domain="$1" status="$2"
+
+    case "${domain}:${status}" in
+        *:success|build_stream:prepared|build_stream:running)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Find operator-editable domain input files.
+_find_editable_files() {
+    local directory="$1"
+
+    find "$directory" \( -type f -o -type l \) \( \
+        -iname "*.yml" -o -iname "*.yaml" -o \
+        -iname "*.json" -o -iname "*.csv" -o \
+        -iname "*.cfg" -o -iname "*.conf" -o \
+        -iname "*.ini" -o -iname "*.toml" -o \
+        -iname "*.log" -o -iname "*.txt" \
+    \) 2>/dev/null | sort
+}
+
+# Output reporting is format-agnostic: domains also produce archives, images,
+# certificates, and other artifacts that should remain visible to operators.
+_find_output_files() {
+    local directory="$1"
+
+    find "$directory" \( -type f -o -type l \) 2>/dev/null | sort
+}
+
+_show_output_files() {
+    local output_dir="$1"
+    local output_files
+    output_files=$(_find_output_files "$output_dir")
+
+    if [ -z "$output_files" ]; then
+        return
+    fi
+
+    local file_count
+    file_count=$(printf '%s\n' "$output_files" | wc -l)
+    echo ""
+    echo -e "  ${BOLD}Output artifacts${NC}  ${DIM}(${file_count} file(s))${NC}"
+    while IFS= read -r output_file; do
+        local relative_path file_size link_target=""
+        relative_path="${output_file#"$output_dir/"}"
+        file_size=$(stat -c '%s' "$output_file" 2>/dev/null || echo "?")
+        if [ -L "$output_file" ]; then
+            link_target=" -> $(readlink "$output_file" 2>/dev/null || true)"
+        fi
+        echo -e "    ${DIM}${relative_path}${link_target}  (${file_size} bytes)${NC}"
+    done <<< "$output_files"
+}
+
+_show_domain_output_details() {
+    local domain="$1" status_file="$2"
+    local value another_value
+
+    case "$domain" in
+        orchestrator)
+            value=$(_parse_yaml_key "$status_file" "last_completed_phase")
+            [ -n "$value" ] && echo -e "  Last completed phase: ${value}"
+            value=$(_parse_yaml_key "$status_file" "total_nodes")
+            another_value=$(_parse_yaml_key "$status_file" "success_count")
+            if [ -n "$value" ]; then
+                echo -e "  Nodes: ${another_value:-0}/${value} successful"
+            fi
+            value=$(_parse_yaml_key "$status_file" "failure_count")
+            [ -n "$value" ] && echo -e "  Failed nodes: ${value}"
+            ;;
+        discovery)
+            value=$(_parse_yaml_key "$status_file" "discovery_mechanism")
+            [ -n "$value" ] && echo -e "  Discovery mechanism: ${value}"
+            value=$(_parse_yaml_key "$status_file" "servers_discovered")
+            [ -n "$value" ] && echo -e "  Servers discovered: ${value}"
+            value=$(_parse_yaml_key "$status_file" "bmc_pxe_mapping_file")
+            [ -n "$value" ] && echo -e "  Latest PXE mapping: ${DIM}${value}${NC}"
+            ;;
+        telemetry)
+            value=$(_parse_yaml_key "$status_file" "type")
+            [ -n "$value" ] && echo -e "  Flow: ${value}"
+            value=$(_parse_yaml_key "$status_file" "namespace")
+            another_value=$(_parse_yaml_key "$status_file" "kube_vip")
+            [ -n "$value" ] && echo -e "  Namespace: ${value}"
+            [ -n "$another_value" ] && echo -e "  Kubernetes VIP: ${another_value}"
+            ;;
+        build_stream)
+            value=$(_parse_yaml_key "$status_file" "gitlab_url")
+            another_value=$(_parse_yaml_key "$status_file" "bsm_api_url")
+            [ -n "$value" ] && echo -e "  GitLab URL: ${value}"
+            [ -n "$another_value" ] && echo -e "  BSM API URL: ${another_value}"
+            ;;
+        utils)
+            value=$(_parse_yaml_key "$status_file" "playbook")
+            [ -n "$value" ] && echo -e "  Latest Utils flow: ${value}"
+            ;;
+    esac
+}
+
+_show_expected_domain_outputs() {
+    local domain="$1"
+
+    echo ""
+    echo -e "  ${BOLD}Outputs created by the relevant flow${NC}"
+    case "$domain" in
+        repo_manager)
+            echo -e "    ${DIM}repo_status.yml — repository synchronization contract${NC}"
+            ;;
+        image_build_manager)
+            echo -e "    ${DIM}build_status.yml — latest image manifest${NC}"
+            echo -e "    ${DIM}build_status_<version>_<timestamp>.yml — immutable build snapshot${NC}"
+            ;;
+        orchestrator)
+            echo -e "    ${DIM}orchestrator_state.yml — generated downstream run state${NC}"
+            echo -e "    ${DIM}.data/functional_groups_config.yml — generated functional groups${NC}"
+            echo -e "    ${DIM}orchestrator_inventory.yaml and bmc_group_data.csv — generated inventories${NC}"
+            echo -e "    ${DIM}provisioning_report.yml — provision flow report${NC}"
+            echo -e "    ${DIM}pxeboot_status.yml and failed_nodes.json — PXE flow reports${NC}"
+            echo -e "    ${DIM}orchestrator_status.yml — latest aggregate provision/PXE status${NC}"
+            ;;
+        discovery)
+            echo -e "    ${DIM}bmc_pxe_mapping_file_<timestamp>.csv — discovered PXE mapping${NC}"
+            echo -e "    ${DIM}bmc_pxe_mapping_file.csv — symlink to the latest mapping${NC}"
+            echo -e "    ${DIM}bmc_discovery_report_<timestamp>.csv — NIC/link report${NC}"
+            echo -e "    ${DIM}discovery_status.yml — discovery execution status${NC}"
+            ;;
+        telemetry)
+            echo -e "    ${DIM}telemetry_status.yml — latest deploy or cleanup component status${NC}"
+            ;;
+        build_stream)
+            echo -e "    ${DIM}build_stream_status.yml — enabled prepare/build endpoint status${NC}"
+            ;;
+        utils)
+            echo -e "    ${DIM}utils_status.yml — latest Utils workflow status${NC}"
+            echo -e "    ${DIM}install_os_status.yml — install_os result${NC}"
+            echo -e "    ${DIM}collect/omnia_logs_<timestamp>/ — collected-log archive and metadata${NC}"
+            echo -e "    ${DIM}backup_oim_logs/omnia_oim_logs_<timestamp>/ — default OIM backup artifacts${NC}"
+            ;;
+    esac
+}
+
+_validate_domain_output_artifacts() {
+    local domain="$1" output_dir="$2" status_file="$3"
+    local artifact_issues=0 overall_status
+    overall_status=$(_parse_status "$status_file")
+
+    case "$domain" in
+        discovery)
+            if _is_healthy_status "$domain" "$overall_status"; then
+                local mapping_count report_count latest_mapping
+                mapping_count=$(find "$output_dir" -maxdepth 1 -type f \
+                    -name 'bmc_pxe_mapping_file_*.csv' 2>/dev/null | wc -l)
+                report_count=$(find "$output_dir" -maxdepth 1 -type f \
+                    -name 'bmc_discovery_report_*.csv' 2>/dev/null | wc -l)
+                latest_mapping="${output_dir}/bmc_pxe_mapping_file.csv"
+
+                if [ "$mapping_count" -gt 0 ]; then
+                    echo -e "  ${PASS} Timestamped PXE mapping CSV: ${mapping_count}"
+                else
+                    echo -e "  ${FAIL} Timestamped PXE mapping CSV missing"
+                    artifact_issues=$((artifact_issues + 1))
+                fi
+                if [ -e "$latest_mapping" ]; then
+                    echo -e "  ${PASS} Latest PXE mapping: ${DIM}bmc_pxe_mapping_file.csv${NC}"
+                else
+                    echo -e "  ${FAIL} Latest PXE mapping missing or points to a missing file"
+                    artifact_issues=$((artifact_issues + 1))
+                fi
+                if [ "$report_count" -gt 0 ]; then
+                    echo -e "  ${PASS} Timestamped discovery report CSV: ${report_count}"
+                else
+                    echo -e "  ${FAIL} Timestamped discovery report CSV missing"
+                    artifact_issues=$((artifact_issues + 1))
+                fi
+            fi
+            ;;
+        orchestrator)
+            local last_phase
+            last_phase=$(_parse_yaml_key "$status_file" "last_completed_phase")
+            if [ "$last_phase" = "provisioning" ] && \
+               [ ! -f "${output_dir}/provisioning_report.yml" ]; then
+                echo -e "  ${FAIL} provisioning_report.yml missing for completed provisioning phase"
+                artifact_issues=$((artifact_issues + 1))
+            elif [ "$last_phase" = "provisioning" ]; then
+                echo -e "  ${PASS} Provisioning report: ${DIM}provisioning_report.yml${NC}"
+            fi
+            if [ "$last_phase" = "pxeboot" ]; then
+                local pxe_artifact
+                for pxe_artifact in pxeboot_status.yml failed_nodes.json; do
+                    if [ -f "${output_dir}/${pxe_artifact}" ]; then
+                        echo -e "  ${PASS} PXE report: ${DIM}${pxe_artifact}${NC}"
+                    else
+                        echo -e "  ${FAIL} ${pxe_artifact} missing for completed PXE phase"
+                        artifact_issues=$((artifact_issues + 1))
+                    fi
+                done
+            fi
+            ;;
+    esac
+
+    return "$artifact_issues"
+}
+
+_input_level_marker() {
+    local level="$1"
+
+    case "$level" in
+        required)    echo -e "${RED}[required]${NC}" ;;
+        conditional) echo -e "${YELLOW}[conditional]${NC}" ;;
+        optional)    echo -e "${BLUE}[optional]${NC}" ;;
+        generated)   echo -e "${CYAN}[generated]${NC}" ;;
+        *)           echo -e "${DIM}[custom]${NC}" ;;
+    esac
+}
+
+_show_domain_input_notes() {
+    local domain="$1" input_dir="$2"
+    local project="${input_dir##*/}"
+    local base="${OMNIA_DATA_PATH:-/opt/omnia}"
+
+    echo -e "  ${BOLD}After reviewing the inputs:${NC}"
+    case "$domain" in
+        repo_manager)
+            echo "    - Set CATALOG_FILE_PATH to the approved customer catalog JSON."
+            echo "    - Run: omnia.sh --run repo_manager"
+            echo "      The domain run creates or updates encrypted credentials when required."
+            ;;
+        image_build_manager)
+            echo "    - Ensure repo_manager output reports success at repo_manager_output_path."
+            echo "    - For catalog mode, set CATALOG_FILE_PATH; for config mode, review package_groups.yml."
+            echo "    - Run: omnia.sh --run image_build_manager"
+            echo "      The domain run creates or updates encrypted credentials when required."
+            ;;
+        orchestrator)
+            echo "    - Review, then copy ${base}/discovery/output/${project}/bmc_pxe_mapping_file.csv"
+            echo "      to ${input_dir}/pxe_mapping_file.csv"
+            if [ -n "${SYSTEM_ADMIN_NIC_IPV4:-}" ]; then
+                echo "    - Set network_spec.yml primary_oim_admin_ip to SYSTEM_ADMIN_NIC_IPV4=${SYSTEM_ADMIN_NIC_IPV4}."
+            else
+                echo "    - Set network_spec.yml primary_oim_admin_ip equal to SYSTEM_ADMIN_NIC_IPV4 from omnia.env."
+            fi
+            echo "    - Provide storage_config.yml inputs for the selected Slurm and Kubernetes clusters."
+            echo "    - Ensure Image Build and Repo Manager status paths point to successful outputs."
+            echo "    - Run: omnia.sh --run orchestrator"
+            echo "      The domain run creates or updates encrypted credentials when required."
+            ;;
+        discovery)
+            echo "    - Replace the sample admin/IB values with the customer network configuration."
+            if [ -n "${SYSTEM_ADMIN_NIC_IPV4:-}" ]; then
+                echo "    - Set network_spec.yml primary_oim_admin_ip to SYSTEM_ADMIN_NIC_IPV4=${SYSTEM_ADMIN_NIC_IPV4}."
+            else
+                echo "    - Set network_spec.yml primary_oim_admin_ip equal to SYSTEM_ADMIN_NIC_IPV4 from omnia.env."
+            fi
+            echo "    - If OME discovery is enabled, confirm OME reachability."
+            echo "    - Run: omnia.sh --run discovery"
+            echo "      The domain run creates or updates encrypted credentials when required."
+            ;;
+        telemetry)
+            echo "    - Set cluster_inventory to Orchestrator's generated inventory."
+            echo "    - Provide bmc_group_data.csv only when iDRAC telemetry is enabled."
+            echo "    - Review storage/package requirements for every enabled source, sink, and bridge."
+            echo "    - Run: omnia.sh --run telemetry"
+            echo "      The domain run creates or updates encrypted credentials when required."
+            ;;
+        build_stream)
+            echo "    - Set enable_build_stream, BSM host/port, and a reachable GitLab host."
+            echo "    - Run omnia.sh --prepare-base first so repo_manager, MinIO, and Registry prerequisites exist."
+            echo "    - Run: omnia.sh --run build_stream"
+            echo "      The domain run creates or updates encrypted credentials when required."
+            ;;
+        utils)
+            echo "    - Utils workflows are independent; review only the input for the selected flow."
+            echo "    - Run: omnia.sh --run utils --tags <collect|install_os|backup_oim_logs>"
+            echo "      The install_os flow creates encrypted credentials when required."
+            ;;
+    esac
+    echo ""
+}
+
+_show_input_guide() {
+    local domain="$1" input_dir="$2"
+    local guide_files="${DOMAIN_GUIDE_FILES[$domain]:-}"
+
+    echo -e "  ${BOLD}Customer input checklist${NC}"
+    echo -e "  ${DIM}Required = always review; conditional = required only for the described feature.${NC}"
+    echo ""
+
+    local filename
+    for filename in $guide_files; do
+        local key="${domain}/${filename}"
+        local level="${INPUT_FILE_LEVEL[$key]:-custom}"
+        local description="${INPUT_FILE_DESCRIPTIONS[$key]:-Customer-provided domain input.}"
+        local level_marker
+        level_marker=$(_input_level_marker "$level")
+        local missing_marker=""
+        if [ "$level" = "required" ] && \
+           [ ! -e "${input_dir}/${filename}" ] && [ ! -L "${input_dir}/${filename}" ]; then
+            missing_marker="  ${RED}[missing]${NC}"
+        fi
+
+        echo -e "    ${level_marker} ${BOLD}${filename}${NC}${missing_marker}"
+        echo -e "      ${DIM}${description}${NC}"
+    done
+    echo ""
+    _show_domain_input_notes "$domain" "$input_dir"
 }
 
 _resolve_output_dir() {
@@ -202,25 +592,41 @@ cmd_check() {
     local issues=0
 
     for domain in "${DOMAIN_ORDER[@]}"; do
-        local display_name
-        display_name=$(echo "$domain" | tr '_' ' ')
         local input_dir
         input_dir=$(_resolve_input_dir "$domain" "$project")
         local output_dir
         output_dir=$(_resolve_output_dir "$domain" "$project")
-        local config_file="${DOMAIN_INPUT_FILES[$domain]:-}"
 
-        echo -e "  ${BOLD}${display_name}${NC}"
+        echo -e "  ${BOLD}${domain}${NC}"
 
-        # Check input directory
         if [ -d "$input_dir" ]; then
             echo -e "    ${PASS} Input dir exists  ${DIM}${input_dir}${NC}"
-            # Check config file
-            if [ -n "$config_file" ] && [ -f "${input_dir}/${config_file}" ]; then
-                echo -e "    ${PASS} Config file: ${config_file}"
-            elif [ -n "$config_file" ]; then
-                echo -e "    ${WARN} Config file missing: ${config_file}"
-                issues=$((issues + 1))
+
+            local filename
+            for filename in ${DOMAIN_GUIDE_FILES[$domain]:-}; do
+                local requirement_key="${domain}/${filename}"
+                if [ "${INPUT_FILE_LEVEL[$requirement_key]:-}" != "required" ]; then
+                    continue
+                fi
+                if [ -f "${input_dir}/${filename}" ] || [ -L "${input_dir}/${filename}" ]; then
+                    echo -e "    ${PASS} Required input: ${filename}"
+                else
+                    echo -e "    ${FAIL} Required input missing: ${filename}"
+                    issues=$((issues + 1))
+                fi
+            done
+
+            if { [ "$domain" = "orchestrator" ] || [ "$domain" = "discovery" ]; } && \
+               [ -n "${SYSTEM_ADMIN_NIC_IPV4:-}" ] && \
+               [ -f "${input_dir}/network_spec.yml" ]; then
+                local configured_admin_ip
+                configured_admin_ip=$(_parse_yaml_key "${input_dir}/network_spec.yml" "primary_oim_admin_ip")
+                if [ "$configured_admin_ip" = "$SYSTEM_ADMIN_NIC_IPV4" ]; then
+                    echo -e "    ${PASS} primary_oim_admin_ip matches SYSTEM_ADMIN_NIC_IPV4 (${SYSTEM_ADMIN_NIC_IPV4})"
+                else
+                    echo -e "    ${FAIL} primary_oim_admin_ip (${configured_admin_ip:-unset}) must match SYSTEM_ADMIN_NIC_IPV4 (${SYSTEM_ADMIN_NIC_IPV4})"
+                    issues=$((issues + 1))
+                fi
             fi
         else
             echo -e "    ${SKIP} Input dir not staged  ${DIM}${input_dir}${NC}"
@@ -232,15 +638,23 @@ cmd_check() {
             if [ -f "${output_dir}/${status_file_name}" ]; then
                 local st
                 st=$(_parse_status "${output_dir}/${status_file_name}")
-                if [ "$st" = "success" ]; then
+                if _is_healthy_status "$domain" "$st"; then
                     echo -e "    ${PASS} Output: ${status_file_name}  ${GREEN}${st}${NC}"
                 else
                     echo -e "    ${FAIL} Output: ${status_file_name}  ${RED}${st:-unknown}${NC}"
                     issues=$((issues + 1))
                 fi
             else
-                echo -e "    ${WARN} Output dir exists but ${status_file_name} missing"
-                issues=$((issues + 1))
+                local existing_outputs
+                existing_outputs=$(_find_output_files "$output_dir")
+                if [ -z "$existing_outputs" ]; then
+                    echo -e "    ${SKIP} No run output yet"
+                elif [ "$domain" = "orchestrator" ]; then
+                    echo -e "    ${SKIP} Pre-provisioning artifacts exist; no provision/PXE status yet"
+                else
+                    echo -e "    ${WARN} Output artifacts exist but ${status_file_name} is missing"
+                    issues=$((issues + 1))
+                fi
             fi
         else
             echo -e "    ${SKIP} Output dir not created  ${DIM}(domain not yet run)${NC}"
@@ -256,6 +670,7 @@ cmd_check() {
         echo -e "  ${YELLOW}${issues} issue(s) found.${NC}"
     fi
     echo ""
+    return "$issues"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -279,12 +694,8 @@ cmd_status() {
         local status_file_name="${DOMAIN_STATUS_FILES[$domain]}"
         local desc="${DOMAIN_DESCRIPTIONS[$domain]}"
 
-        # Format domain name for display
-        local display_name
-        display_name=$(echo "$domain" | tr '_' ' ')
-
         if [ ! -d "$output_dir" ]; then
-            echo -e "  ${SKIP} ${BOLD}${display_name}${NC}"
+            echo -e "  ${SKIP} ${BOLD}${domain}${NC}"
             echo -e "    ${DIM}${desc}${NC}"
             echo -e "    ${DIM}No output directory${NC}"
             echo ""
@@ -297,25 +708,29 @@ cmd_status() {
 
         if [ -f "$status_file" ]; then
             overall_status=$(_parse_status "$status_file")
-        else
-            # Fallback: search for any *status*.yml
-            for sf in "${output_dir}"/*status*.yml "${output_dir}"/*status*.yaml; do
-                if [ -f "$sf" ]; then
-                    status_file="$sf"
-                    overall_status=$(_parse_status "$sf")
-                    break
-                fi
-            done
         fi
 
-        if [ "$overall_status" = "success" ]; then
+        if _is_healthy_status "$domain" "$overall_status"; then
             completed=$((completed + 1))
-            echo -e "  ${PASS} ${BOLD}${display_name}${NC}  ${GREEN}completed${NC}"
+            local healthy_label="$overall_status"
+            if [ "$healthy_label" = "success" ]; then
+                healthy_label="completed"
+            fi
+            echo -e "  ${PASS} ${BOLD}${domain}${NC}  ${GREEN}${healthy_label}${NC}"
         elif [ -n "$overall_status" ]; then
-            echo -e "  ${FAIL} ${BOLD}${display_name}${NC}  ${RED}${overall_status}${NC}"
+            echo -e "  ${FAIL} ${BOLD}${domain}${NC}  ${RED}${overall_status}${NC}"
+        elif [ -f "$status_file" ]; then
+            echo -e "  ${FAIL} ${BOLD}${domain}${NC}  ${RED}${status_file_name} has no valid overall_status${NC}"
         else
-            # output_dir exists (guaranteed by continue above) but no status parsed
-            echo -e "  ${WARN} ${BOLD}${display_name}${NC}  ${YELLOW}output exists, no status${NC}"
+            local existing_outputs
+            existing_outputs=$(_find_output_files "$output_dir")
+            if [ -z "$existing_outputs" ]; then
+                echo -e "  ${SKIP} ${BOLD}${domain}${NC}  ${DIM}not run${NC}"
+            elif [ "$domain" = "orchestrator" ]; then
+                echo -e "  ${SKIP} ${BOLD}${domain}${NC}  ${DIM}pre-provisioning artifacts only${NC}"
+            else
+                echo -e "  ${WARN} ${BOLD}${domain}${NC}  ${YELLOW}${status_file_name} missing${NC}"
+            fi
         fi
 
         echo -e "    ${DIM}${desc}${NC}"
@@ -335,17 +750,17 @@ cmd_status() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Command: repo-manager — Detailed repo_manager status
+# Command: repo_manager — Detailed repo_manager status
 # ─────────────────────────────────────────────────────────────────────────────
 cmd_repo_manager() {
     local project="$1"
     local repo_dir
     repo_dir=$(_resolve_output_dir "repo_manager" "$project")
     local status_file="${repo_dir}/repo_status.yml"
-    local pkg_file="${repo_dir}/functional_group_packages.yml"
+    local validation_errors=0
 
     echo ""
-    echo -e "${BOLD}${BLUE}Repo Manager Status${NC}  ${DIM}(project: ${project})${NC}"
+    echo -e "${BOLD}${BLUE}repo_manager Status${NC}  ${DIM}(project: ${project})${NC}"
     echo -e "${DIM}$(printf '%.0s─' {1..60})${NC}"
     echo ""
     echo -e "  Output dir: ${DIM}${repo_dir}${NC}"
@@ -353,20 +768,27 @@ cmd_repo_manager() {
 
     # Check directory
     if [ ! -d "$repo_dir" ]; then
-        echo -e "  ${FAIL} Output directory not found"
+        echo -e "  ${SKIP} No repo_manager run output found."
+        echo -e "  ${DIM}Run: omnia.sh --run repo_manager${NC}"
+        _show_expected_domain_outputs "repo_manager"
         echo ""
-        echo -e "  ${YELLOW}Run repo_manager first or copy output files:${NC}"
-        echo -e "    mkdir -p ${repo_dir}"
-        echo -e "    cp repo_status.yml ${repo_dir}/"
-        echo -e "    cp functional_group_packages.yml ${repo_dir}/"
-        echo ""
-        return 1
+        return 0
     fi
     echo -e "  ${PASS} Directory exists"
 
     # Check repo_status.yml
     if [ ! -f "$status_file" ]; then
-        echo -e "  ${FAIL} repo_status.yml missing"
+        local existing_outputs
+        existing_outputs=$(_find_output_files "$repo_dir")
+        if [ -z "$existing_outputs" ]; then
+            echo -e "  ${SKIP} No repo_manager run output found."
+            echo -e "  ${DIM}Run: omnia.sh --run repo_manager${NC}"
+            _show_expected_domain_outputs "repo_manager"
+            echo ""
+            return 0
+        fi
+        echo -e "  ${FAIL} Output artifacts exist but repo_status.yml is missing"
+        _show_output_files "$repo_dir"
         echo ""
         return 1
     fi
@@ -378,8 +800,10 @@ cmd_repo_manager() {
         echo -e "  ${PASS} repo_status.yml  (overall_status: ${GREEN}${overall_status}${NC})"
     elif [ -n "$overall_status" ]; then
         echo -e "  ${FAIL} repo_status.yml  (overall_status: ${RED}${overall_status}${NC})"
+        validation_errors=$((validation_errors + 1))
     else
-        echo -e "  ${WARN} repo_status.yml  (overall_status: ${YELLOW}unknown${NC})"
+        echo -e "  ${FAIL} repo_status.yml  (overall_status: ${RED}unknown${NC})"
+        validation_errors=$((validation_errors + 1))
     fi
 
     # Parse OS metadata
@@ -388,86 +812,90 @@ cmd_repo_manager() {
     os_ver=$(_parse_yaml_key "$status_file" "cluster_os_version")
     if [ -n "$os_type" ]; then
         echo -e "  ${PASS} OS: ${os_type} ${os_ver}"
-    fi
-
-    # Check functional_group_packages.yml (from package_list or default)
-    local pkg_list_path
-    pkg_list_path=$(grep -E '^\s*package_list:' "$status_file" 2>/dev/null | head -n 1 | sed 's/.*: *//' | tr -d '[:space:]')
-    if [ -n "$pkg_list_path" ] && [ -f "$pkg_list_path" ]; then
-        echo -e "  ${PASS} functional_group_packages  (from package_list: ${DIM}${pkg_list_path}${NC})"
-    elif [ -f "$pkg_file" ]; then
-        echo -e "  ${PASS} functional_group_packages  (${DIM}${pkg_file}${NC})"
     else
-        echo -e "  ${FAIL} functional_group_packages  ${RED}MISSING${NC}"
+        echo -e "  ${FAIL} cluster_os_type missing from repo_status.yml"
+        validation_errors=$((validation_errors + 1))
     fi
 
-    # Check certificates
+    # Validate the certificate path recorded in the current output contract.
     local cert_path
-    cert_path=$(grep -E '^\s*server_crt:' "$status_file" 2>/dev/null | head -n 1 | sed 's/.*: *//' | tr -d '[:space:]')
+    cert_path=$(_parse_yaml_key "$status_file" "server_crt")
     if [ -n "$cert_path" ]; then
         if [ -f "$cert_path" ]; then
             echo -e "  ${PASS} Repo manager certificate  (${DIM}${cert_path}${NC})"
         else
             echo -e "  ${FAIL} Repo manager certificate  ${RED}MISSING${NC} (expected: ${cert_path})"
+            validation_errors=$((validation_errors + 1))
         fi
+    else
+        echo -e "  ${DIM}Repo manager certificate: not configured${NC}"
     fi
 
-    # Count repos
-    local x86_count aarch64_count
-    x86_count=$(grep -c 'x86_64' "$status_file" 2>/dev/null || echo "0")
-    aarch64_count=$(grep -c 'aarch64' "$status_file" 2>/dev/null || echo "0")
+    local context_count repo_url_count
+    context_count=$(_count_yaml_key "$status_file" "context_id")
+    repo_url_count=$(_count_yaml_key "$status_file" "url")
     echo ""
-    echo -e "  RPM repos (x86_64 lines):   ${x86_count}"
-    echo -e "  RPM repos (aarch64 lines):  ${aarch64_count}"
+    echo -e "  Execution contexts: ${context_count}"
+    echo -e "  Repository URLs:    ${repo_url_count}"
+    if [ "$context_count" -eq 0 ]; then
+        echo -e "  ${FAIL} No execution contexts recorded"
+        validation_errors=$((validation_errors + 1))
+    fi
+    if [ "$repo_url_count" -eq 0 ]; then
+        echo -e "  ${FAIL} No repository URLs recorded"
+        validation_errors=$((validation_errors + 1))
+    fi
+
+    _show_output_files "$repo_dir"
 
     echo ""
-    if [ "$overall_status" = "success" ]; then
-        echo -e "  ${GREEN}Repo manager output is ready.${NC}"
+    if [ "$validation_errors" -eq 0 ]; then
+        echo -e "  ${GREEN}repo_manager output validation passed.${NC}"
         return 0
     else
-        echo -e "  ${YELLOW}Repo manager output may not be complete. Check overall_status.${NC}"
+        echo -e "  ${RED}repo_manager output validation failed: ${validation_errors} issue(s).${NC}"
         return 1
     fi
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Command: image-build — Detailed image_build_manager status
+# Command: image_build_manager — Detailed image_build_manager status
 # ─────────────────────────────────────────────────────────────────────────────
-cmd_image_build() {
+cmd_image_build_manager() {
     local project="$1"
     local output_dir
     output_dir=$(_resolve_output_dir "image_build_manager" "$project")
     local status_file="${output_dir}/build_status.yml"
+    local validation_errors=0
 
     echo ""
-    echo -e "${BOLD}${BLUE}Image Build Manager Status${NC}  ${DIM}(project: ${project})${NC}"
+    echo -e "${BOLD}${BLUE}image_build_manager Status${NC}  ${DIM}(project: ${project})${NC}"
     echo -e "${DIM}$(printf '%.0s─' {1..60})${NC}"
     echo ""
     echo -e "  Output dir: ${DIM}${output_dir}${NC}"
     echo ""
 
     if [ ! -d "$output_dir" ]; then
-        echo -e "  ${SKIP} No output directory — image_build_manager has not been run"
+        echo -e "  ${SKIP} No image_build_manager run output found."
+        echo -e "  ${DIM}Run: omnia.sh --run image_build_manager${NC}"
+        _show_expected_domain_outputs "image_build_manager"
         echo ""
-        return 1
+        return 0
     fi
 
     # Check build_status.yml
     if [ ! -f "$status_file" ]; then
-        echo -e "  ${WARN} build_status.yml not found"
-        # Check if there are any status files at all
-        local found_any=0
-        for sf in "${output_dir}"/*status*.yml "${output_dir}"/*status*.yaml; do
-            if [ -f "$sf" ]; then
-                found_any=1
-                local st
-                st=$(_parse_status "$sf")
-                echo -e "  ${WARN} $(basename "$sf"): ${st:-unknown}"
-            fi
-        done
-        if [ "$found_any" -eq 0 ]; then
-            echo -e "  ${SKIP} No status files found"
+        local existing_outputs
+        existing_outputs=$(_find_output_files "$output_dir")
+        if [ -z "$existing_outputs" ]; then
+            echo -e "  ${SKIP} No image_build_manager run output found."
+            echo -e "  ${DIM}Run: omnia.sh --run image_build_manager${NC}"
+            _show_expected_domain_outputs "image_build_manager"
+            echo ""
+            return 0
         fi
+        echo -e "  ${FAIL} Output artifacts exist but build_status.yml is missing"
+        _show_output_files "$output_dir"
         echo ""
         return 1
     fi
@@ -479,21 +907,45 @@ cmd_image_build() {
         echo -e "  ${PASS} build_status.yml  (overall_status: ${GREEN}${overall_status}${NC})"
     elif [ -n "$overall_status" ]; then
         echo -e "  ${FAIL} build_status.yml  (overall_status: ${RED}${overall_status}${NC})"
+        validation_errors=$((validation_errors + 1))
     else
-        echo -e "  ${WARN} build_status.yml  (overall_status: ${YELLOW}unknown${NC})"
+        echo -e "  ${FAIL} build_status.yml  (overall_status: ${RED}unknown${NC})"
+        validation_errors=$((validation_errors + 1))
     fi
 
-    # Count built images
-    local image_count
-    image_count=$(grep -c 'functional_group:' "$status_file" 2>/dev/null || echo "0")
-    echo -e "  Images built: ${image_count}"
+    local build_type endpoint bucket image_count kernel_count initrd_count rootfs_count
+    build_type=$(_parse_yaml_key "$status_file" "image_build_type")
+    endpoint=$(_parse_yaml_key "$status_file" "endpoint_url")
+    bucket=$(_parse_yaml_key "$status_file" "bucket")
+    image_count=$(_count_yaml_key "$status_file" "functional_group")
+    kernel_count=$(_count_yaml_key "$status_file" "kernel")
+    initrd_count=$(_count_yaml_key "$status_file" "initrd")
+    rootfs_count=$(_count_yaml_key "$status_file" "image")
+    echo -e "  Build type: ${build_type:-unknown}"
+    echo -e "  S3 endpoint: ${endpoint:-unknown}"
+    echo -e "  S3 bucket: ${bucket:-unknown}"
+    echo -e "  Functional-group images: ${image_count}"
 
-    # Show per-arch counts
-    local x86_count aarch64_count
-    x86_count=$(grep -c 'x86_64' "$status_file" 2>/dev/null || echo "0")
-    aarch64_count=$(grep -c 'aarch64' "$status_file" 2>/dev/null || echo "0")
-    echo -e "  x86_64 entries:  ${x86_count}"
-    echo -e "  aarch64 entries: ${aarch64_count}"
+    case "$build_type" in
+        image-builder|image-thrillhouse) ;;
+        *)
+            echo -e "  ${FAIL} Unsupported or missing image_build_type"
+            validation_errors=$((validation_errors + 1))
+            ;;
+    esac
+    if [ -z "$endpoint" ] || [ -z "$bucket" ]; then
+        echo -e "  ${FAIL} S3 endpoint_url and bucket must be recorded"
+        validation_errors=$((validation_errors + 1))
+    fi
+
+    if [ "$image_count" -eq 0 ]; then
+        echo -e "  ${FAIL} No functional-group images recorded"
+        validation_errors=$((validation_errors + 1))
+    elif [ "$kernel_count" -ne "$image_count" ] || [ "$initrd_count" -ne "$image_count" ] || \
+         [ "$rootfs_count" -ne "$image_count" ]; then
+        echo -e "  ${FAIL} Incomplete artifact entries (kernel: ${kernel_count}, initrd: ${initrd_count}, image: ${rootfs_count})"
+        validation_errors=$((validation_errors + 1))
+    fi
 
     # Show log file if exists (logs are under shared_path/log/<project>, not output_dir)
     local image_build_base="${OMNIA_DATA_PATH:-/opt/omnia}/image_build_manager"
@@ -514,12 +966,14 @@ cmd_image_build() {
         echo -e "  Last modified: ${DIM}${last_mod}${NC}"
     fi
 
+    _show_output_files "$output_dir"
+
     echo ""
-    if [ "$overall_status" = "success" ]; then
-        echo -e "  ${GREEN}Image build completed successfully.${NC}"
+    if [ "$validation_errors" -eq 0 ]; then
+        echo -e "  ${GREEN}image_build_manager output validation passed.${NC}"
         return 0
     else
-        echo -e "  ${YELLOW}Image build may not be complete.${NC}"
+        echo -e "  ${RED}image_build_manager output validation failed: ${validation_errors} issue(s).${NC}"
         return 1
     fi
 }
@@ -533,11 +987,10 @@ cmd_domain_status() {
     output_dir=$(_resolve_output_dir "$domain" "$project")
     local status_file_name="${DOMAIN_STATUS_FILES[$domain]:-status.yml}"
     local desc="${DOMAIN_DESCRIPTIONS[$domain]:-$domain domain}"
-    local display_name
-    display_name=$(echo "$domain" | tr '_' ' ')
+    local command_status=0
 
     echo ""
-    echo -e "${BOLD}${BLUE}${display_name} Status${NC}  ${DIM}(project: ${project})${NC}"
+    echo -e "${BOLD}${BLUE}${domain} Status${NC}  ${DIM}(project: ${project})${NC}"
     echo -e "${DIM}$(printf '%.0s─' {1..60})${NC}"
     echo ""
     echo -e "  ${DIM}${desc}${NC}"
@@ -545,65 +998,50 @@ cmd_domain_status() {
     echo ""
 
     if [ ! -d "$output_dir" ]; then
-        echo -e "  ${SKIP} No output directory — ${domain} has not been run"
+        echo -e "  ${SKIP} No ${domain} run output found."
+        echo -e "  ${DIM}Run: omnia.sh --run ${domain}${NC}"
+        _show_expected_domain_outputs "$domain"
         echo ""
-        return 1
+        return 0
     fi
 
-    # Find status files
-    local found=0
     local status_file="${output_dir}/${status_file_name}"
 
     if [ -f "$status_file" ]; then
-        found=1
         local overall_status
         overall_status=$(_parse_status "$status_file")
-        if [ "$overall_status" = "success" ]; then
+        if _is_healthy_status "$domain" "$overall_status"; then
             echo -e "  ${PASS} ${status_file_name}  (overall_status: ${GREEN}${overall_status}${NC})"
         elif [ -n "$overall_status" ]; then
             echo -e "  ${FAIL} ${status_file_name}  (overall_status: ${RED}${overall_status}${NC})"
+            command_status=1
         else
-            echo -e "  ${WARN} ${status_file_name}  (overall_status: ${YELLOW}unknown${NC})"
+            echo -e "  ${FAIL} ${status_file_name}  (overall_status: ${RED}unknown${NC})"
+            command_status=1
+        fi
+        _show_domain_output_details "$domain" "$status_file"
+        _validate_domain_output_artifacts "$domain" "$output_dir" "$status_file" || command_status=1
+    else
+        local existing_outputs
+        existing_outputs=$(_find_output_files "$output_dir")
+        if [ -z "$existing_outputs" ]; then
+            echo -e "  ${SKIP} No ${domain} run output found."
+            echo -e "  ${DIM}Run: omnia.sh --run ${domain}${NC}"
+            _show_expected_domain_outputs "$domain"
+        elif [ "$domain" = "orchestrator" ]; then
+            echo -e "  ${SKIP} Provisioning/PXE has not produced orchestrator_status.yml yet."
+            echo -e "  ${DIM}Existing setup or inventory artifacts are listed below.${NC}"
+            _show_expected_domain_outputs "$domain"
+        else
+            echo -e "  ${WARN} Output artifacts exist but ${status_file_name} is missing."
+            echo -e "  ${DIM}The last run may be incomplete or may predate the current status contract.${NC}"
+            command_status=1
         fi
     fi
 
-    # Also check for any other status files
-    for sf in "${output_dir}"/*status*.yml "${output_dir}"/*status*.yaml; do
-        if [ -f "$sf" ] && [ "$sf" != "$status_file" ]; then
-            found=1
-            local st
-            st=$(_parse_status "$sf")
-            local fname
-            fname=$(basename "$sf")
-            if [ "$st" = "success" ]; then
-                echo -e "  ${PASS} ${fname}: ${GREEN}${st}${NC}"
-            elif [ -n "$st" ]; then
-                echo -e "  ${FAIL} ${fname}: ${RED}${st}${NC}"
-            else
-                echo -e "  ${WARN} ${fname}: ${YELLOW}(no overall_status)${NC}"
-            fi
-        fi
-    done
-
-    if [ "$found" -eq 0 ]; then
-        echo -e "  ${WARN} No status files found in output directory"
-    fi
-
-    # List any output files in the directory
-    local output_files
-    output_files=$(find "$output_dir" -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" -o -name "*.json" -o -name "*.log" -o -name "*.txt" \) 2>/dev/null | sort)
-    if [ -n "$output_files" ]; then
-        local file_count
-        file_count=$(echo "$output_files" | wc -l)
-        echo ""
-        echo -e "  ${BOLD}Output files${NC}  ${DIM}(${file_count} file(s))${NC}"
-        while IFS= read -r ofile; do
-            local ofname ofsize
-            ofname=$(basename "$ofile")
-            ofsize=$(stat -c '%s' "$ofile" 2>/dev/null || echo "?")
-            echo -e "    ${DIM}${ofname}  (${ofsize} bytes)${NC}"
-        done <<< "$output_files"
-    fi
+    # Secondary flow reports and generated CSV/archive files are artifacts, not
+    # substitutes for the domain's canonical status file.
+    _show_output_files "$output_dir"
 
     # Last modified
     local last_mod
@@ -613,6 +1051,7 @@ cmd_domain_status() {
         echo -e "  Last modified: ${DIM}${last_mod}${NC}"
     fi
     echo ""
+    return "$command_status"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -673,6 +1112,11 @@ _edit_file() {
             ansible-vault edit "$target"
         fi
     else
+        if ! command -v "$editor" >/dev/null 2>&1; then
+            echo -e "  ${FAIL} ${RED}Editor not found: ${editor}${NC}"
+            echo -e "  ${DIM}Set EDITOR to an installed executable, for example EDITOR=vi.${NC}"
+            return 1
+        fi
         echo -e "  Opening ${target} in ${editor}..."
         "$editor" "$target"
     fi
@@ -682,19 +1126,20 @@ _edit_file() {
 # Command: edit — Open or list input configuration files for a domain
 # ─────────────────────────────────────────────────────────────────────────────
 cmd_edit() {
-    local domain="$1" project="$2"
+    local domain="$1" project="$2" requested_file="${3:-}"
+    local edit_status=0
     local base="${OMNIA_DATA_PATH:-/opt/omnia}"
     local input_dir
     input_dir=$(_resolve_input_dir "$domain" "$project")
-    local display_name
-    display_name=$(echo "$domain" | tr '_' ' ')
 
     echo ""
-    echo -e "${BOLD}${BLUE}Edit ${display_name} Input Files${NC}  ${DIM}(project: ${project})${NC}"
+    echo -e "${BOLD}${BLUE}Edit ${domain} Input Files${NC}  ${DIM}(project: ${project})${NC}"
     echo -e "${DIM}$(printf '%.0s─' {1..60})${NC}"
     echo ""
     echo -e "  Input dir: ${DIM}${input_dir}${NC}"
     echo ""
+
+    _show_input_guide "$domain" "$input_dir"
 
     if [ ! -d "$input_dir" ]; then
         echo -e "  ${FAIL} Input directory not found"
@@ -708,7 +1153,7 @@ cmd_edit() {
 
     # List all files in the input directory
     local files
-    files=$(find "$input_dir" -maxdepth 2 -type f \( -name "*.yml" -o -name "*.yaml" -o -name "*.json" -o -name "*.cfg" -o -name "*.conf" -o -name "*.ini" \) 2>/dev/null | sort)
+    files=$(_find_editable_files "$input_dir")
 
     if [ -z "$files" ]; then
         echo -e "  ${WARN} No configuration files found in input directory"
@@ -716,7 +1161,7 @@ cmd_edit() {
         return 0
     fi
 
-    echo -e "  ${BOLD}Configuration files:${NC}"
+    echo -e "  ${BOLD}Files available to edit:${NC}"
     echo ""
 
     local idx=0
@@ -729,14 +1174,16 @@ cmd_edit() {
         fsize=$(stat -c '%s' "$f" 2>/dev/null || echo "?")
         local fmod
         fmod=$(stat -c '%y' "$f" 2>/dev/null | cut -d. -f1 || echo "?")
+        local requirement_key="${domain}/$(basename "$f")"
+        local requirement_level="${INPUT_FILE_LEVEL[$requirement_key]:-custom}"
+        local requirement_marker
+        requirement_marker=$(_input_level_marker "$requirement_level")
         # Mark vault/credential files with a lock indicator
         local marker=""
         if _is_vault_encrypted "$f"; then
             marker="  ${YELLOW}[vault-encrypted]${NC}"
-        elif _is_credential_file "$f"; then
-            marker="  ${YELLOW}[credentials]${NC}"
         fi
-        echo -e "    ${CYAN}${idx})${NC} ${rel_path}${marker}  ${DIM}(${fsize} bytes, ${fmod})${NC}"
+        echo -e "    ${CYAN}${idx})${NC} ${rel_path} ${requirement_marker}${marker}  ${DIM}(${fsize} bytes, ${fmod})${NC}"
         file_arr+=("$f")
     done <<< "$files"
 
@@ -744,7 +1191,33 @@ cmd_edit() {
 
     # Check if we have an interactive TTY and an editor
     local editor="${EDITOR:-${VISUAL:-vi}}"
-    if [ -t 0 ] && [ -t 1 ]; then
+
+    # A caller may name a file directly, which is useful over SSH and in
+    # customer runbooks. Only files from the discovered safe list can open.
+    if [ -n "$requested_file" ]; then
+        local matched_target=""
+        local match_count=0
+        for f in "${file_arr[@]}"; do
+            local candidate_rel="${f#"$input_dir/"}"
+            if [ "$candidate_rel" = "$requested_file" ] || \
+               [ "$(basename "$f")" = "$requested_file" ]; then
+                matched_target="$f"
+                match_count=$((match_count + 1))
+            fi
+        done
+
+        if [ "$match_count" -eq 0 ]; then
+            echo -e "  ${FAIL} ${RED}Input file is not available to edit: ${requested_file}${NC}"
+            echo -e "  ${DIM}Choose one of the files listed above.${NC}"
+            return 1
+        elif [ "$match_count" -gt 1 ]; then
+            echo -e "  ${FAIL} ${RED}File name is ambiguous: ${requested_file}${NC}"
+            echo -e "  ${DIM}Use the relative path shown in the list.${NC}"
+            return 1
+        fi
+
+        _edit_file "$matched_target" "$editor" || edit_status=$?
+    elif [ -t 0 ] && [ -t 1 ]; then
         echo -e "  ${DIM}Enter file number to edit (or 'q' to quit, 'a' for all in ${editor}):${NC}"
         echo -n "  > "
         read -r choice
@@ -768,8 +1241,13 @@ cmd_edit() {
                     echo -e "  ${YELLOW}Skipping ${vault_count} credential/vault file(s) — edit them individually.${NC}"
                 fi
                 if [ "${#plain_files[@]}" -gt 0 ]; then
-                    echo -e "  Opening ${#plain_files[@]} file(s) in ${editor}..."
-                    "$editor" "${plain_files[@]}"
+                    if command -v "$editor" >/dev/null 2>&1; then
+                        echo -e "  Opening ${#plain_files[@]} file(s) in ${editor}..."
+                        "$editor" "${plain_files[@]}"
+                    else
+                        echo -e "  ${FAIL} ${RED}Editor not found: ${editor}${NC}"
+                        edit_status=1
+                    fi
                 else
                     echo -e "  ${DIM}No plain-text files to open.${NC}"
                 fi
@@ -777,17 +1255,19 @@ cmd_edit() {
             *)
                 if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#file_arr[@]}" ]; then
                     local target="${file_arr[$((choice - 1))]}"
-                    _edit_file "$target" "$editor"
+                    _edit_file "$target" "$editor" || edit_status=$?
                 else
                     echo -e "  ${RED}Invalid selection: ${choice}${NC}"
+                    edit_status=1
                 fi
                 ;;
         esac
     else
         echo -e "  ${DIM}Set \$EDITOR and run interactively to edit files.${NC}"
-        echo -e "  ${DIM}Example: EDITOR=vim omnia-cli edit ${display_name}${NC}"
+        echo -e "  ${DIM}Example: EDITOR=vim omnia-cli edit ${domain} <file>${NC}"
     fi
     echo ""
+    return "$edit_status"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -795,139 +1275,103 @@ cmd_edit() {
 # ─────────────────────────────────────────────────────────────────────────────
 cmd_logs() {
     local domain="$1" project="$2" limit="$3"
+    local view_status=0
     local base="${OMNIA_DATA_PATH:-/opt/omnia}"
-    local display_name
-    display_name=$(echo "$domain" | tr '_' ' ')
-    
+
     # Use provided limit or default
     local log_limit="${limit:-$DEFAULT_LOG_LIMIT}"
 
     echo ""
-    echo -e "${BOLD}${BLUE}${display_name} Logs${NC}  ${DIM}(project: ${project})${NC}"
+    echo -e "${BOLD}${BLUE}${domain} Logs${NC}  ${DIM}(project: ${project})${NC}"
     echo -e "${DIM}$(printf '%.0s─' {1..60})${NC}"
     echo ""
 
-    local found_logs=0
-    local log_arr=()
-    local idx=0
-
-    # 1. Domain-specific logs
-    #    Search both <base>/<domain>/log/<project>/ and <base>/<domain>/log/
-    local domain_log_project="${base}/${domain}/log/${project}"
-    local domain_log_flat="${base}/${domain}/log"
-    local domain_log_dirs_to_check=("$domain_log_project")
-    # Also check the flat log dir (logs may live directly under log/)
-    if [ "$domain_log_flat" != "$domain_log_project" ] && [ -d "$domain_log_flat" ]; then
-        domain_log_dirs_to_check+=("$domain_log_flat")
-    fi
-
-    for domain_log_dir in "${domain_log_dirs_to_check[@]}"; do
-        if [ -d "$domain_log_dir" ]; then
-            local log_files find_args
-            # Use -maxdepth 6 to catch deeply nested structures (e.g., rhel/10.0/x86_64/group/logs/)
-            find_args=("$domain_log_dir" -maxdepth 6 -name "*.log" -type f)
-            # When scanning the flat dir, exclude the project subdir (already scanned)
-            if [ "$domain_log_dir" = "$domain_log_flat" ] && [ -d "$domain_log_project" ]; then
-                find_args+=(-not -path "${domain_log_project}/*")
-            fi
-            log_files=$(find "${find_args[@]}" -printf '%T@ %p\n' 2>/dev/null | sort -rn)
-            if [ -n "$log_files" ]; then
-                found_logs=1
-                local count
-                count=$(echo "$log_files" | wc -l)
-                echo -e "  ${BOLD}Domain logs${NC}  ${DIM}(${domain_log_dir})${NC}"
-                echo -e "  ${DIM}Found ${count} log file(s) — most recent first:${NC}"
-                echo ""
-
-                while IFS= read -r line; do
-                    idx=$((idx + 1))
-                    local fpath
-                    fpath=$(echo "$line" | cut -d' ' -f2-)
-                    local fname
-                    fname=$(basename "$fpath")
-                    local fsize
-                    fsize=$(stat -c '%s' "$fpath" 2>/dev/null || echo "?")
-                    local fmod
-                    fmod=$(stat -c '%y' "$fpath" 2>/dev/null | cut -d. -f1 || echo "?")
-                    echo -e "    ${CYAN}${idx})${NC} ${fname}  ${DIM}(${fsize} bytes, ${fmod})${NC}"
-                    log_arr+=("$fpath")
-                    [ "$idx" -ge "$log_limit" ] && break
-                done <<< "$log_files"
-                echo ""
-            fi
-        fi
-    done
-
-    # 2. Ansible logs (under /var/log/omnia/)
-    local ansible_log_dirs=("${ANSIBLE_LOG_DEFAULT}")
-    for alog_dir in "${ansible_log_dirs[@]}"; do
-        if [ -d "$alog_dir" ]; then
-            local ansible_logs
-            ansible_logs=$(find "$alog_dir" -maxdepth 3 \
-                \( -name "*${domain}*" -o -name "ansible*.log" \) \
-                -type f -printf '%T@ %p\n' 2>/dev/null \
-                | sort -rn | head -n "$log_limit")
-            if [ -n "$ansible_logs" ]; then
-                found_logs=1
-                echo -e "  ${BOLD}Ansible logs${NC}  ${DIM}(${alog_dir})${NC}"
-                while IFS= read -r line; do
-                    idx=$((idx + 1))
-                    local alog
-                    alog=$(echo "$line" | cut -d' ' -f2-)
-                    local aname
-                    aname=$(basename "$alog")
-                    local asize
-                    asize=$(stat -c '%s' "$alog" 2>/dev/null || echo "?")
-                    local amod
-                    amod=$(stat -c '%y' "$alog" 2>/dev/null | cut -d. -f1 || echo "?")
-                    echo -e "    ${CYAN}${idx})${NC} ${aname}  ${DIM}(${asize} bytes, ${amod})${NC}"
-                    log_arr+=("$alog")
-                    [ "$idx" -ge "$log_limit" ] && break
-                done <<< "$ansible_logs"
-                echo ""
-            fi
-        fi
-    done
-
-    # 3. Domain output directory for any .log files
+    local runtime_log_dir="${base}/${domain}/log"
+    local ansible_domain_log_dir="${ANSIBLE_LOG_DEFAULT}/${domain}"
     local output_dir
     output_dir=$(_resolve_output_dir "$domain" "$project")
-    if [ -d "$output_dir" ]; then
-        local output_logs
-        output_logs=$(find "$output_dir" -maxdepth 3 -name "*.log" -type f \
-            -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -n "$log_limit")
-        if [ -n "$output_logs" ]; then
-            found_logs=1
-            echo -e "  ${BOLD}Output logs${NC}  ${DIM}(${output_dir})${NC}"
-            while IFS= read -r line; do
-                idx=$((idx + 1))
-                local olog
-                olog=$(echo "$line" | cut -d' ' -f2-)
-                local oname
-                oname=$(basename "$olog")
-                local osize
-                osize=$(stat -c '%s' "$olog" 2>/dev/null || echo "?")
-                local omod
-                omod=$(stat -c '%y' "$olog" 2>/dev/null | cut -d. -f1 || echo "?")
-                echo -e "    ${CYAN}${idx})${NC} ${oname}  ${DIM}(${osize} bytes, ${omod})${NC}"
-                log_arr+=("$olog")
-                [ "$idx" -ge "$log_limit" ] && break
-            done <<< "$output_logs"
-            echo ""
-        fi
-    fi
 
-    if [ "$found_logs" -eq 0 ]; then
-        echo -e "  ${WARN} No log files found for ${display_name}"
+    # Gather all supported locations first, then globally sort and limit them.
+    # Scanning the exact Ansible domain directory includes phase logs such as
+    # prepare.log and cleanup.log whose basename does not contain the domain.
+    local all_logs
+    all_logs=$(
+        {
+            if [ -d "$runtime_log_dir" ]; then
+                find "$runtime_log_dir" -maxdepth 7 \
+                    \( -type f -o -type l \) -iname "*.log" \
+                    -printf '%T@ %p\n' 2>/dev/null
+            fi
+            if [ -d "$ansible_domain_log_dir" ]; then
+                find "$ansible_domain_log_dir" -maxdepth 4 \
+                    \( -type f -o -type l \) -iname "*.log" \
+                    -printf '%T@ %p\n' 2>/dev/null
+            fi
+            if [ -d "$ANSIBLE_LOG_DEFAULT" ]; then
+                find "$ANSIBLE_LOG_DEFAULT" -maxdepth 1 \
+                    \( -type f -o -type l \) -iname "*${domain}*.log" \
+                    -printf '%T@ %p\n' 2>/dev/null
+            fi
+            if [ -d "$output_dir" ]; then
+                find "$output_dir" \
+                    \( -type f -o -type l \) -iname "*.log" \
+                    -printf '%T@ %p\n' 2>/dev/null
+            fi
+        } | sort -rn -u
+    )
+
+    if [ -z "$all_logs" ]; then
+        echo -e "  ${WARN} No log files found for ${domain}"
         echo ""
-        echo -e "  ${DIM}Logs are created when you run the domain via omnia.sh --run ${domain}${NC}"
-        echo -e "  ${DIM}Expected locations:${NC}"
-        echo -e "    ${DIM}${domain_log_project}/*.log${NC}"
-        echo -e "    ${DIM}${domain_log_flat}/*.log${NC}"
-        echo -e "    ${DIM}${ANSIBLE_LOG_DEFAULT}/*${domain}*.log${NC}"
+        echo -e "  ${DIM}Logs are created when you run: omnia.sh --run ${domain}${NC}"
+        echo -e "  ${DIM}Searched:${NC}"
+        echo -e "    ${DIM}${runtime_log_dir}/${project}/ and shared runtime subdirectories${NC}"
+        echo -e "    ${DIM}${ansible_domain_log_dir}/${NC}"
+        echo -e "    ${DIM}${output_dir}/${NC}"
         echo ""
         return 1
     fi
+
+    local total_count shown_logs shown_count
+    total_count=$(printf '%s\n' "$all_logs" | wc -l)
+    shown_logs=$(printf '%s\n' "$all_logs" | head -n "$log_limit")
+    shown_count=$(printf '%s\n' "$shown_logs" | wc -l)
+
+    echo -e "  ${BOLD}Log files${NC}  ${DIM}(showing ${shown_count} of ${total_count}, newest first)${NC}"
+    echo ""
+
+    local log_arr=()
+    local idx=0
+    while IFS= read -r line; do
+        idx=$((idx + 1))
+        local fpath="${line#* }"
+        local source_label relative_path
+        case "$fpath" in
+            "${ansible_domain_log_dir}/"*)
+                source_label="ansible"
+                relative_path="${fpath#"$ansible_domain_log_dir/"}"
+                ;;
+            "${output_dir}/"*)
+                source_label="output"
+                relative_path="${fpath#"$output_dir/"}"
+                ;;
+            "${runtime_log_dir}/"*)
+                source_label="runtime"
+                relative_path="${fpath#"$runtime_log_dir/"}"
+                ;;
+            *)
+                source_label="system"
+                relative_path="$fpath"
+                ;;
+        esac
+        local fsize fmod
+        fsize=$(stat -c '%s' "$fpath" 2>/dev/null || echo "?")
+        fmod=$(stat -c '%y' "$fpath" 2>/dev/null | cut -d. -f1 || echo "?")
+        echo -e "    ${CYAN}${idx})${NC} ${BOLD}[${source_label}]${NC} ${relative_path}"
+        echo -e "       ${DIM}${fsize} bytes, ${fmod} — ${fpath}${NC}"
+        log_arr+=("$fpath")
+    done <<< "$shown_logs"
+    echo ""
 
     # Interactive mode: offer to tail the latest log
     if [ -t 0 ] && [ -t 1 ] && [ "${#log_arr[@]}" -gt 0 ]; then
@@ -943,21 +1387,28 @@ cmd_logs() {
                 local latest="${log_arr[0]}"
                 echo -e "  ${DIM}Tailing ${latest} (Ctrl+C to stop)...${NC}"
                 echo ""
-                tail -f "$latest"
+                tail -f "$latest" || view_status=$?
                 ;;
             *)
                 if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#log_arr[@]}" ]; then
                     local target="${log_arr[$((choice - 1))]}"
                     local pager="${PAGER:-less}"
-                    echo -e "  Opening ${target} in ${pager}..."
-                    "$pager" "$target"
+                    if command -v "$pager" >/dev/null 2>&1; then
+                        echo -e "  Opening ${target} in ${pager}..."
+                        "$pager" "$target" || view_status=$?
+                    else
+                        echo -e "  ${FAIL} ${RED}Pager not found: ${pager}${NC}"
+                        view_status=1
+                    fi
                 else
                     echo -e "  ${RED}Invalid selection: ${choice}${NC}"
+                    view_status=1
                 fi
                 ;;
         esac
     fi
     echo ""
+    return "$view_status"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -995,23 +1446,21 @@ cmd_version() {
 # ─────────────────────────────────────────────────────────────────────────────
 show_domain_help() {
     local domain="$1"
-    local display_name
-    display_name=$(echo "$domain" | tr '_' '-')
 
     case "$domain" in
         repo_manager)
             cat <<EOF
-${BOLD}omnia-cli repo-manager${NC} — Repo Manager diagnostics
+${BOLD}omnia-cli repo_manager${NC} — repo_manager diagnostics
 
 USAGE:
-  omnia-cli repo-manager [--project <name>]
+  omnia-cli repo_manager [--project <name>]
 
 CHECKS:
   - Output directory exists at \${OMNIA_DATA_PATH}/repo_manager/output/<project>/
   - repo_status.yml exists and overall_status == "success"
-  - functional_group_packages.yml found (from package_list or default)
-  - Repo manager certificate file exists at path from repo_status.yml
-  - RPM repo URL counts for x86_64 and aarch64
+  - Certificate file exists when server_crt is set in repo_status.yml
+  - Execution contexts and repository URLs are present
+  - All recursively generated output artifacts are listed
 
 ENVIRONMENT:
   OMNIA_DATA_PATH       Root data directory (default: /opt/omnia)
@@ -1020,15 +1469,16 @@ EOF
             ;;
         image_build_manager)
             cat <<EOF
-${BOLD}omnia-cli image-build${NC} — Image Build Manager diagnostics
+${BOLD}omnia-cli image_build_manager${NC} — image_build_manager diagnostics
 
 USAGE:
-  omnia-cli image-build [--project <name>]
+  omnia-cli image_build_manager [--project <name>]
 
 CHECKS:
   - Output directory exists
   - build_status.yml exists and overall_status == "success"
-  - Per-architecture image counts
+  - Build engine, S3 endpoint/bucket, and complete image artifact entries
+  - Latest and timestamped status artifacts
   - Latest build log location
 
 ENVIRONMENT:
@@ -1038,12 +1488,12 @@ EOF
             ;;
         *)
             cat <<EOF
-${BOLD}omnia-cli ${display_name}${NC} — ${DOMAIN_DESCRIPTIONS[$domain]:-$domain status}
+${BOLD}omnia-cli ${domain}${NC} — ${DOMAIN_DESCRIPTIONS[$domain]:-$domain status}
 
 USAGE:
-  omnia-cli ${display_name} [--project <name>]
-  omnia-cli edit ${display_name} [--project <name>]
-  omnia-cli logs ${display_name} [--project <name>]
+  omnia-cli ${domain} [--project <name>]
+  omnia-cli edit ${domain} [file] [--project <name>]
+  omnia-cli logs ${domain} [--project <name>]
 
 CHECKS:
   - Output directory exists at \${OMNIA_DATA_PATH}/${domain}/output/<project>/
@@ -1051,15 +1501,17 @@ CHECKS:
   - overall_status validation
 
 EDIT:
-  Lists input config files in \${OMNIA_DATA_PATH}/${domain}/input/<project>/
-  Opens selected file in \$EDITOR (default: vi)
+  Shows required, conditional, optional, and generated input guidance.
+  Lists input files in \${OMNIA_DATA_PATH}/${domain}/input/<project>/
+  Opens a selected file in \$EDITOR (default: vi).
+  A file can be opened directly: omnia-cli edit ${domain} <file>
 
 LOGS:
-  Shows domain logs from \${OMNIA_DATA_PATH}/${domain}/log/<project>/
-  Also checks \${OMNIA_DATA_PATH}/${domain}/log/ directly
-  Shows ansible logs from /var/log/omnia/
+  Combines runtime, output, and Ansible logs and sorts them newest first.
+  Includes phase logs from \${OMNIA_ANSIBLE_LOG_PATH:-/var/log/omnia}/${domain}/
+  Shows source labels, relative paths, timestamps, sizes, and full paths.
   Offers to tail or view selected log in \$PAGER (default: less)
-  Default limit: 30 logs (use --limit <n> to change)
+  Default global limit: 30 logs (use --limit <n> to change)
 EOF
             ;;
     esac
@@ -1078,14 +1530,14 @@ USAGE:
 COMMANDS:
   ${BOLD}status${NC}              Show all domain statuses for a project
   ${BOLD}check${NC}               Validate input files and output existence for all domains
-  ${BOLD}edit${NC} <domain>        List and edit input configuration files for a domain
+  ${BOLD}edit${NC} <domain> [file] Show input requirements and edit a domain input file
   ${BOLD}logs${NC} <domain>        View domain execution logs and ansible logs (default: 30, use --limit <n>)
-  ${BOLD}repo-manager${NC}        Detailed repo_manager diagnostics
-  ${BOLD}image-build${NC}         Detailed image_build_manager diagnostics
+  ${BOLD}repo_manager${NC}        Detailed repo_manager diagnostics
+  ${BOLD}image_build_manager${NC} Detailed image_build_manager diagnostics
   ${BOLD}orchestrator${NC}        Orchestrator status
   ${BOLD}discovery${NC}           Discovery domain status
   ${BOLD}telemetry${NC}           Telemetry stack status
-  ${BOLD}build-stream${NC}        Build stream (GitLab) status
+  ${BOLD}build_stream${NC}        Build stream (GitLab) status
   ${BOLD}utils${NC}               Shared utilities status
   ${BOLD}version${NC}             Show Omnia version info
   ${BOLD}help${NC} [<domain>]     Show help (or domain-specific help)
@@ -1100,22 +1552,58 @@ ENVIRONMENT:
     OMNIA_PROJECT_NAME     Project name (default: project_default)
     SYSTEM_ADMIN_NIC_IPV4  Admin NIC IPv4 (used by some domain checks)
     OMNIA_VENV_PATH        Python venv path (default: /opt/omnia/venv)
+    OMNIA_ANSIBLE_LOG_PATH Ansible log root (default: /var/log/omnia)
 
 EXAMPLES:
   omnia-cli status                          # All domains, default project
   omnia-cli check                           # Validate input/output for all domains
   omnia-cli status --project my_cluster     # All domains, custom project
-  omnia-cli repo-manager                    # Detailed repo check
-  omnia-cli image-build --project prod      # Image build status for 'prod'
-  omnia-cli edit repo-manager               # Edit repo_manager input config files
-  omnia-cli logs image-build                # View image_build_manager logs
+  omnia-cli repo_manager                    # Detailed repo check
+  omnia-cli image_build_manager --project prod # Image build status for 'prod'
+  omnia-cli edit repo_manager               # Show input guide and choose a file
+  omnia-cli edit orchestrator pxe_mapping_file.csv # Open a known file directly
+  omnia-cli logs image_build_manager        # View image_build_manager logs
   omnia-cli logs orchestrator --project prod # View orchestrator logs for 'prod'
-  omnia-cli logs repo-manager --limit 50     # Show up to 50 logs
-  omnia-cli help repo-manager               # Domain-specific help
+  omnia-cli logs repo_manager --limit 50     # Show up to 50 logs
+  omnia-cli help repo_manager               # Domain-specific help
 
 SEE ALSO:
   omnia.sh --setup-venv     Set up Python + Ansible venv
   omnia.sh --help           Main Omnia setup help
+EOF
+}
+
+show_edit_help() {
+    cat <<EOF
+${BOLD}omnia-cli edit${NC} — Guided domain input editor
+
+USAGE:
+  omnia-cli edit <domain> [file] [--project <name>]
+
+BEHAVIOR:
+  - Shows required, conditional, optional, and generated input files.
+  - Marks absent required files as missing.
+  - Opens plain files with \$EDITOR and Vault credentials with ansible-vault.
+  - Accepts a listed filename directly or prompts for a number interactively.
+
+EXAMPLE:
+  EDITOR=vim omnia-cli edit orchestrator pxe_mapping_file.csv
+EOF
+}
+
+show_logs_help() {
+    cat <<EOF
+${BOLD}omnia-cli logs${NC} — Domain log browser
+
+USAGE:
+  omnia-cli logs <domain> [--project <name>] [--limit <n>]
+
+BEHAVIOR:
+  - Combines runtime, output, and Ansible domain logs.
+  - De-duplicates and sorts all results newest first.
+  - Applies --limit globally (default: ${DEFAULT_LOG_LIMIT}).
+  - Shows source, relative path, size, timestamp, and full path.
+  - Opens a numbered log with \$PAGER or tails the newest log with 't'.
 EOF
 }
 
@@ -1124,14 +1612,10 @@ EOF
 # ─────────────────────────────────────────────────────────────────────────────
 _domain_from_arg() {
     case "$1" in
-        repo-manager|repo_manager)   echo "repo_manager" ;;
-        image-build|image_build|image-build-manager|image_build_manager) echo "image_build_manager" ;;
-        orchestrator)                echo "orchestrator" ;;
-        discovery)                   echo "discovery" ;;
-        telemetry)                   echo "telemetry" ;;
-        build-stream|build_stream)   echo "build_stream" ;;
-        utils)                       echo "utils" ;;
-        *)                           echo "" ;;
+        repo_manager|image_build_manager|orchestrator|discovery|telemetry|build_stream|utils)
+            echo "$1"
+            ;;
+        *) echo "" ;;
     esac
 }
 
@@ -1189,19 +1673,24 @@ main() {
             cmd_status "$project" || true
             ;;
         check)
-            cmd_check "$project" || true
+            cmd_check "$project"
             ;;
-        repo-manager|repo_manager)
-            cmd_repo_manager "$project" || true
+        repo_manager)
+            cmd_repo_manager "$project"
             ;;
-        image-build|image_build|image-build-manager|image_build_manager)
-            cmd_image_build "$project" || true
+        image_build_manager)
+            cmd_image_build_manager "$project"
             ;;
         edit)
+            if [ "${positional_args[0]:-}" = "--help" ] || \
+               [ "${positional_args[0]:-}" = "-h" ]; then
+                show_edit_help
+                return 0
+            fi
             if [ "${#positional_args[@]}" -eq 0 ]; then
                 echo -e "${RED}edit requires a domain argument${NC}"
-                echo -e "Usage: omnia-cli edit <domain> [--project <name>]"
-                echo -e "Domains: repo-manager, image-build, orchestrator, discovery, telemetry, build-stream, utils"
+                echo -e "Usage: omnia-cli edit <domain> [file] [--project <name>]"
+                echo -e "Domains: repo_manager, image_build_manager, orchestrator, discovery, telemetry, build_stream, utils"
                 exit 1
             fi
             local domain
@@ -1210,13 +1699,23 @@ main() {
                 echo -e "${RED}Unknown domain: ${positional_args[0]}${NC}"
                 exit 1
             fi
-            cmd_edit "$domain" "$project" || true
+            if [ "${positional_args[1]:-}" = "--help" ] || \
+               [ "${positional_args[1]:-}" = "-h" ]; then
+                show_edit_help
+                return 0
+            fi
+            cmd_edit "$domain" "$project" "${positional_args[1]:-}"
             ;;
         logs|log)
+            if [ "${positional_args[0]:-}" = "--help" ] || \
+               [ "${positional_args[0]:-}" = "-h" ]; then
+                show_logs_help
+                return 0
+            fi
             if [ "${#positional_args[@]}" -eq 0 ]; then
                 echo -e "${RED}logs requires a domain argument${NC}"
                 echo -e "Usage: omnia-cli logs <domain> [--project <name>] [--limit <n>]"
-                echo -e "Domains: repo-manager, image-build, orchestrator, discovery, telemetry, build-stream, utils"
+                echo -e "Domains: repo_manager, image_build_manager, orchestrator, discovery, telemetry, build_stream, utils"
                 exit 1
             fi
             local domain
@@ -1225,7 +1724,12 @@ main() {
                 echo -e "${RED}Unknown domain: ${positional_args[0]}${NC}"
                 exit 1
             fi
-            cmd_logs "$domain" "$project" "$log_limit" || true
+            if [ "${positional_args[1]:-}" = "--help" ] || \
+               [ "${positional_args[1]:-}" = "-h" ]; then
+                show_logs_help
+                return 0
+            fi
+            cmd_logs "$domain" "$project" "$log_limit"
             ;;
         version|--version|-v)
             cmd_version
@@ -1249,7 +1753,7 @@ main() {
             local domain
             domain=$(_domain_from_arg "$command")
             if [ -n "$domain" ]; then
-                cmd_domain_status "$domain" "$project" || true
+                cmd_domain_status "$domain" "$project"
             else
                 echo -e "${RED}Unknown command: ${command}${NC}"
                 echo ""

--- a/test/main/ut/test_omnia_cli.py
+++ b/test/main/ut/test_omnia_cli.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused local tests for omnia-cli domain file and status handling."""
+
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OMNIA_CLI = REPO_ROOT / "src" / "main" / "omnia-cli"
+OMNIA_COMPLETION = REPO_ROOT / "src" / "main" / "omnia-bash-completion"
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+
+DOMAIN_STATUS_FILES = {
+    "repo_manager": ("repo_status.yml", "success"),
+    "image_build_manager": ("build_status.yml", "success"),
+    "orchestrator": ("orchestrator_status.yml", "success"),
+    "discovery": ("discovery_status.yml", "success"),
+    "telemetry": ("telemetry_status.yml", "success"),
+    "build_stream": ("build_stream_status.yml", "prepared"),
+    "utils": ("utils_status.yml", "success"),
+}
+
+
+class OmniaCliTest(unittest.TestCase):
+    """Exercise the CLI against an isolated runtime data tree."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="omnia-cli-test-")
+        self.data_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def run_cli(self, *args, env_overrides=None):
+        result, output = self.invoke_cli(*args, env_overrides=env_overrides)
+        self.assertEqual(result.returncode, 0, output)
+        return output
+
+    def invoke_cli(self, *args, env_overrides=None):
+        env = os.environ.copy()
+        env["OMNIA_DATA_PATH"] = str(self.data_path)
+        env["OMNIA_PROJECT_NAME"] = "project_default"
+        env.update(env_overrides or {})
+        result = subprocess.run(
+            [str(OMNIA_CLI), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        output = ANSI_ESCAPE.sub("", result.stdout + result.stderr)
+        return result, output
+
+    def runtime_dir(self, domain, area):
+        path = self.data_path / domain / area / "project_default"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def test_csv_input_is_available_to_edit(self):
+        input_dir = self.runtime_dir("orchestrator", "input")
+        (input_dir / "orchestrator_config.yml").write_text(
+            "---\nenable_pxe_boot: true\n", encoding="utf-8"
+        )
+        (input_dir / "pxe_mapping_file.csv").write_text(
+            "BMC_IP,HOSTNAME\n192.0.2.10,node01\n", encoding="utf-8"
+        )
+
+        output = self.run_cli("edit", "orchestrator")
+
+        self.assertIn("orchestrator_config.yml", output)
+        self.assertIn("pxe_mapping_file.csv", output)
+        self.assertIn("Customer input checklist", output)
+        self.assertIn("[required] pxe_mapping_file.csv", output)
+
+    def test_known_input_file_can_be_opened_directly(self):
+        input_dir = self.runtime_dir("orchestrator", "input")
+        mapping_file = input_dir / "pxe_mapping_file.csv"
+        mapping_file.write_text(
+            "BMC_IP,HOSTNAME\n192.0.2.10,node01\n", encoding="utf-8"
+        )
+
+        output = self.run_cli(
+            "edit",
+            "orchestrator",
+            "pxe_mapping_file.csv",
+            env_overrides={"EDITOR": "/bin/true"},
+        )
+
+        self.assertIn(f"Opening {mapping_file} in /bin/true", output)
+
+    def test_direct_edit_failure_has_nonzero_exit_status(self):
+        input_dir = self.runtime_dir("orchestrator", "input")
+        (input_dir / "pxe_mapping_file.csv").write_text(
+            "BMC_IP,HOSTNAME\n192.0.2.10,node01\n", encoding="utf-8"
+        )
+        env = os.environ.copy()
+        env.update(
+            {
+                "OMNIA_DATA_PATH": str(self.data_path),
+                "OMNIA_PROJECT_NAME": "project_default",
+                "EDITOR": "editor-that-does-not-exist",
+            }
+        )
+
+        result = subprocess.run(
+            [str(OMNIA_CLI), "edit", "orchestrator", "pxe_mapping_file.csv"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Editor not found", result.stdout + result.stderr)
+
+    def test_edit_completes_staged_input_filenames(self):
+        input_dir = self.runtime_dir("orchestrator", "input")
+        (input_dir / "pxe_mapping_file.csv").write_text(
+            "BMC_IP,HOSTNAME\n192.0.2.10,node01\n", encoding="utf-8"
+        )
+        (input_dir / "orchestrator_config.yml").write_text(
+            "---\nenable_pxe_boot: true\n", encoding="utf-8"
+        )
+
+        completion_script = f'''
+source "{OMNIA_COMPLETION}"
+OMNIA_DATA_PATH="{self.data_path}"
+OMNIA_PROJECT_NAME="project_default"
+COMP_WORDS=(omnia-cli edit orchestrator p)
+COMP_CWORD=3
+_omnia_cli_completions
+printf '%s\n' "${{COMPREPLY[@]}}"
+'''
+        result = subprocess.run(
+            ["bash", "-c", completion_script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "pxe_mapping_file.csv")
+
+    def test_edit_and_logs_have_command_specific_help(self):
+        edit_help = self.run_cli("edit", "--help")
+        logs_help = self.run_cli("logs", "--help")
+
+        self.assertIn("Guided domain input editor", edit_help)
+        self.assertIn("omnia-cli edit <domain> [file]", edit_help)
+        self.assertIn("Domain log browser", logs_help)
+        self.assertIn("De-duplicates and sorts all results", logs_help)
+
+    def test_each_domain_shows_customer_input_guidance(self):
+        expected_guidance = {
+            "repo_manager": "repo_manager_endpoint_config.yml",
+            "image_build_manager": "package_groups.yml",
+            "orchestrator": "pxe_mapping_file.csv",
+            "discovery": "discovery_credentials.yml",
+            "telemetry": "bmc_group_data.csv",
+            "build_stream": "build_stream_credentials.yml",
+            "utils": "collect_pxe.yml",
+        }
+
+        for domain_arg, expected_file in expected_guidance.items():
+            with self.subTest(domain=domain_arg):
+                self.runtime_dir(domain_arg, "input")
+                output = self.run_cli("edit", domain_arg)
+                self.assertIn("Customer input checklist", output)
+                self.assertIn(expected_file, output)
+
+    def test_every_shipped_domain_input_has_a_requirement_label(self):
+        domain_args = {
+            "repo_manager": "repo_manager",
+            "image_build_manager": "image_build_manager",
+            "orchestrator": "orchestrator",
+            "discovery": "discovery",
+            "telemetry": "telemetry",
+            "build_stream": "build_stream",
+            "utils": "utils",
+        }
+
+        for domain, domain_arg in domain_args.items():
+            with self.subTest(domain=domain):
+                source_dir = REPO_ROOT / "src" / domain / "input"
+                input_dir = self.runtime_dir(domain, "input")
+                for source_file in source_dir.iterdir():
+                    if source_file.is_file():
+                        shutil.copy2(source_file, input_dir / source_file.name)
+
+                output = self.run_cli("edit", domain_arg)
+                editable_files = output.split("Files available to edit:", 1)[1]
+                for source_file in source_dir.iterdir():
+                    if not source_file.is_file():
+                        continue
+                    self.assertRegex(
+                        editable_files,
+                        re.escape(source_file.name)
+                        + r" \[(required|conditional|optional|generated)\]",
+                    )
+
+    def test_discovery_csv_files_and_latest_symlink_are_shown(self):
+        output_dir = self.runtime_dir("discovery", "output")
+        (output_dir / "discovery_status.yml").write_text(
+            "---\noverall_status: success\n", encoding="utf-8"
+        )
+        timestamped = output_dir / "bmc_pxe_mapping_file_20260911.csv"
+        timestamped.write_text(
+            "BMC_IP,HOSTNAME\n192.0.2.10,node01\n", encoding="utf-8"
+        )
+        (output_dir / "bmc_pxe_mapping_file.csv").symlink_to(
+            timestamped.name
+        )
+        (output_dir / "bmc_discovery_report_20260911.csv").write_text(
+            "BMC_IP,LINK_STATUS\n192.0.2.10,up\n", encoding="utf-8"
+        )
+
+        output = self.run_cli("discovery")
+
+        self.assertIn("bmc_pxe_mapping_file_20260911.csv", output)
+        self.assertIn("bmc_pxe_mapping_file.csv", output)
+        self.assertIn("bmc_discovery_report_20260911.csv", output)
+
+    def test_nested_outputs_are_format_agnostic(self):
+        output_dir = self.runtime_dir("utils", "output")
+        (output_dir / "utils_status.yml").write_text(
+            "---\noverall_status: success\n", encoding="utf-8"
+        )
+        bundle_dir = output_dir / "collect" / "omnia_logs_20260911"
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "metadata.json").write_text("{}\n", encoding="utf-8")
+        (bundle_dir / "omnia_logs_20260911.tar.gz").write_bytes(b"archive")
+
+        output = self.run_cli("utils")
+
+        self.assertIn("collect/omnia_logs_20260911/metadata.json", output)
+        self.assertIn(
+            "collect/omnia_logs_20260911/omnia_logs_20260911.tar.gz", output
+        )
+
+    def test_all_domain_success_states_are_healthy(self):
+        for domain, (status_file, status) in DOMAIN_STATUS_FILES.items():
+            output_dir = self.runtime_dir(domain, "output")
+            (output_dir / status_file).write_text(
+                f"---\noverall_status: {status}\n", encoding="utf-8"
+            )
+
+        output = self.run_cli("status")
+
+        self.assertIn("build_stream  prepared", output)
+        self.assertIn("7/7 domains completed", output)
+
+    def test_utils_check_has_no_fictitious_primary_config(self):
+        input_dir = self.runtime_dir("utils", "input")
+        (input_dir / "install_os_config.yml").write_text(
+            "---\narchitecture: x86_64\n", encoding="utf-8"
+        )
+
+        output = self.run_cli("check")
+
+        self.assertNotIn("utils_config.yml", output)
+        self.assertIn("No issues found.", output)
+
+    def test_edit_guidance_marks_storage_required_without_ready_or_credential_tag(self):
+        self.runtime_dir("orchestrator", "input")
+
+        output = self.run_cli(
+            "edit",
+            "orchestrator",
+            env_overrides={"SYSTEM_ADMIN_NIC_IPV4": "192.0.2.25"},
+        )
+
+        self.assertIn("[required] storage_config.yml", output)
+        self.assertIn("selected Slurm and Kubernetes clusters", output)
+        self.assertIn("SYSTEM_ADMIN_NIC_IPV4=192.0.2.25", output)
+        self.assertIn("Run: omnia.sh --run orchestrator", output)
+        self.assertNotIn("ready", output.lower())
+        self.assertNotIn("--tags credentials", output)
+
+    def test_check_validates_all_required_orchestrator_inputs_and_admin_ip(self):
+        input_dir = self.runtime_dir("orchestrator", "input")
+        for filename in (
+            "orchestrator_config.yml",
+            "omnia_config.yml",
+            "pxe_mapping_file.csv",
+            "storage_config.yml",
+            "security_config.yml",
+        ):
+            (input_dir / filename).write_text("---\n", encoding="utf-8")
+        (input_dir / "network_spec.yml").write_text(
+            '---\nprimary_oim_admin_ip: "192.0.2.25"\n', encoding="utf-8"
+        )
+
+        output = self.run_cli(
+            "check", env_overrides={"SYSTEM_ADMIN_NIC_IPV4": "192.0.2.25"}
+        )
+        self.assertIn("Required input: storage_config.yml", output)
+        self.assertIn("primary_oim_admin_ip matches SYSTEM_ADMIN_NIC_IPV4", output)
+
+        (input_dir / "storage_config.yml").unlink()
+        result, output = self.invoke_cli(
+            "check", env_overrides={"SYSTEM_ADMIN_NIC_IPV4": "192.0.2.26"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Required input missing: storage_config.yml", output)
+        self.assertIn("must match SYSTEM_ADMIN_NIC_IPV4", output)
+
+    def test_check_validates_discovery_admin_ip_against_environment(self):
+        input_dir = self.runtime_dir("discovery", "input")
+        (input_dir / "discovery_config.yml").write_text("---\n", encoding="utf-8")
+        (input_dir / "network_spec.yml").write_text(
+            '---\nprimary_oim_admin_ip: "192.0.2.30"\n', encoding="utf-8"
+        )
+
+        result, output = self.invoke_cli(
+            "check", env_overrides={"SYSTEM_ADMIN_NIC_IPV4": "192.0.2.31"}
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("primary_oim_admin_ip (192.0.2.30)", output)
+        self.assertIn("SYSTEM_ADMIN_NIC_IPV4 (192.0.2.31)", output)
+
+    def test_repo_manager_uses_current_output_contract_and_unquotes_certificate(self):
+        output_dir = self.runtime_dir("repo_manager", "output")
+        cert = self.data_path / "pulp_webserver.crt"
+        cert.write_text("certificate\n", encoding="utf-8")
+        (output_dir / "repo_status.yml").write_text(
+            "---\n"
+            'overall_status: "success"\n'
+            'cluster_os_type: "rhel"\n'
+            "execution_contexts:\n"
+            '  - context_id: "rhel_10.0"\n'
+            "repo_manager:\n"
+            "  certificates:\n"
+            f'    server_crt: "{cert}"\n'
+            "repositories:\n"
+            "  x86_64:\n"
+            '    baseos:\n      url: "https://192.0.2.25/repo"\n',
+            encoding="utf-8",
+        )
+
+        output = self.run_cli("repo_manager")
+
+        self.assertIn(f"Repo manager certificate  ({cert})", output)
+        self.assertIn("Execution contexts: 1", output)
+        self.assertIn("Repository URLs:    1", output)
+        self.assertIn("repo_manager output validation passed", output)
+        self.assertNotIn("functional_group_packages", output)
+        self.assertNotIn("output is ready", output)
+
+    def test_image_build_manager_validates_and_lists_current_artifacts(self):
+        output_dir = self.runtime_dir("image_build_manager", "output")
+        status_content = (
+            "---\n"
+            "overall_status: success\n"
+            "image_build_type: image-builder\n"
+            "s3_configurations:\n"
+            '  endpoint_url: "http://192.0.2.25:9000"\n'
+            '  bucket: "boot-images"\n'
+            "functional_group_images:\n"
+            "  - x86_64:\n"
+            "      - functional_group: compute_x86_64\n"
+            "        kernel: boot-images/compute/vmlinuz\n"
+            "        initrd: boot-images/compute/initramfs.img\n"
+            "        image: boot-images/compute/rootfs\n"
+        )
+        (output_dir / "build_status.yml").write_text(
+            status_content, encoding="utf-8"
+        )
+        snapshot = output_dir / "build_status_2.3_20260911_1734.yml"
+        snapshot.write_text(status_content, encoding="utf-8")
+
+        output = self.run_cli("image_build_manager")
+
+        self.assertIn("Build type: image-builder", output)
+        self.assertIn("Functional-group images: 1", output)
+        self.assertIn(snapshot.name, output)
+        self.assertIn("image_build_manager output validation passed", output)
+
+    def test_only_canonical_domain_names_are_accepted(self):
+        help_output = self.run_cli("help")
+        self.assertIn("repo_manager", help_output)
+        self.assertIn("image_build_manager", help_output)
+        self.assertIn("build_stream", help_output)
+        self.assertNotIn("repo-manager", help_output)
+
+        result, output = self.invoke_cli("repo-manager")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unknown command: repo-manager", output)
+
+    def test_secondary_utils_status_does_not_replace_canonical_status(self):
+        output_dir = self.runtime_dir("utils", "output")
+        (output_dir / "install_os_status.yml").write_text(
+            "---\nstatus: success\n", encoding="utf-8"
+        )
+
+        result, output = self.invoke_cli("utils")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Output artifacts exist but utils_status.yml is missing", output)
+        self.assertIn("install_os_status.yml", output)
+
+    def test_empty_staged_output_directories_mean_not_run(self):
+        for domain in DOMAIN_STATUS_FILES:
+            with self.subTest(domain=domain):
+                self.runtime_dir(domain, "output")
+                output = self.run_cli(domain)
+                self.assertIn(f"No {domain} run output found", output)
+                self.assertIn("Outputs created by the relevant flow", output)
+                self.assertNotIn("Required status file missing", output)
+                self.assertNotIn("✗", output)
+
+        check_output = self.run_cli("check")
+        self.assertIn("No run output yet", check_output)
+        self.assertIn("No issues found", check_output)
+
+    def test_orchestrator_inventory_can_exist_before_provisioning_status(self):
+        output_dir = self.runtime_dir("orchestrator", "output")
+        (output_dir / "orchestrator_inventory.yaml").write_text(
+            "---\nall: {}\n", encoding="utf-8"
+        )
+        (output_dir / "bmc_group_data.csv").write_text(
+            "BMC_IP,GROUP_NAME\n", encoding="utf-8"
+        )
+
+        output = self.run_cli("orchestrator")
+
+        self.assertIn("Provisioning/PXE has not produced orchestrator_status.yml", output)
+        self.assertIn("orchestrator_inventory.yaml", output)
+        self.assertIn("bmc_group_data.csv", output)
+
+    def test_successful_discovery_requires_its_generated_csv_artifacts(self):
+        output_dir = self.runtime_dir("discovery", "output")
+        (output_dir / "discovery_status.yml").write_text(
+            "---\noverall_status: success\n", encoding="utf-8"
+        )
+
+        result, output = self.invoke_cli("discovery")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Timestamped PXE mapping CSV missing", output)
+        self.assertIn("Latest PXE mapping missing", output)
+        self.assertIn("Timestamped discovery report CSV missing", output)
+
+    def test_completed_orchestrator_pxe_phase_requires_both_reports(self):
+        output_dir = self.runtime_dir("orchestrator", "output")
+        (output_dir / "orchestrator_status.yml").write_text(
+            "---\noverall_status: success\nlast_completed_phase: pxeboot\n",
+            encoding="utf-8",
+        )
+        (output_dir / "pxeboot_status.yml").write_text(
+            "---\noverall_status: success\n", encoding="utf-8"
+        )
+
+        result, output = self.invoke_cli("orchestrator")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("PXE report: pxeboot_status.yml", output)
+        self.assertIn("failed_nodes.json missing for completed PXE phase", output)
+
+        (output_dir / "failed_nodes.json").write_text(
+            '{"failed_nodes": []}\n', encoding="utf-8"
+        )
+        output = self.run_cli("orchestrator")
+        self.assertIn("PXE report: failed_nodes.json", output)
+
+    def test_domain_specific_status_details_follow_each_output_contract(self):
+        cases = {
+            "orchestrator": (
+                "orchestrator_status.yml",
+                "overall_status: success\nlast_completed_phase: provisioning\n"
+                "total_nodes: 4\nsuccess_count: 4\nfailure_count: 0\n",
+                ("Last completed phase: provisioning", "Nodes: 4/4 successful"),
+            ),
+            "discovery": (
+                "discovery_status.yml",
+                "overall_status: success\ndiscovery_mechanism: ome\n"
+                "servers_discovered: 4\n",
+                ("Discovery mechanism: ome", "Servers discovered: 4"),
+            ),
+            "telemetry": (
+                "telemetry_status.yml",
+                "overall_status: success\ntype: deploy\nnamespace: telemetry\n"
+                "kube_vip: 192.0.2.40\n",
+                ("Flow: deploy", "Kubernetes VIP: 192.0.2.40"),
+            ),
+            "build_stream": (
+                "build_stream_status.yml",
+                "overall_status: prepared\n"
+                "gitlab_url: https://192.0.2.41:443\n"
+                "bsm_api_url: https://192.0.2.42:8010\n",
+                ("GitLab URL: https://192.0.2.41:443", "BSM API URL:"),
+            ),
+            "utils": (
+                "utils_status.yml",
+                "overall_status: success\nplaybook: install_os\n",
+                ("Latest Utils flow: install_os", "utils_status.yml"),
+            ),
+        }
+
+        for domain, (filename, content, expected_values) in cases.items():
+            with self.subTest(domain=domain):
+                output_dir = self.runtime_dir(domain, "output")
+                (output_dir / filename).write_text(
+                    "---\n" + content, encoding="utf-8"
+                )
+                if domain == "orchestrator":
+                    (output_dir / "provisioning_report.yml").write_text(
+                        "---\noverall_status: success\n", encoding="utf-8"
+                    )
+                elif domain == "discovery":
+                    timestamped = output_dir / "bmc_pxe_mapping_file_20260911.csv"
+                    timestamped.write_text("BMC_IP\n192.0.2.10\n", encoding="utf-8")
+                    (output_dir / "bmc_pxe_mapping_file.csv").symlink_to(
+                        timestamped.name
+                    )
+                    (output_dir / "bmc_discovery_report_20260911.csv").write_text(
+                        "BMC_IP\n192.0.2.10\n", encoding="utf-8"
+                    )
+                output = self.run_cli(domain)
+                for expected in expected_values:
+                    self.assertIn(expected, output)
+
+    def test_logs_are_globally_sorted_limited_and_source_labeled(self):
+        runtime_dir = self.data_path / "discovery" / "log" / "project_default"
+        runtime_dir.mkdir(parents=True)
+        output_dir = self.runtime_dir("discovery", "output") / "nested"
+        output_dir.mkdir()
+
+        old_log = runtime_dir / "old.log"
+        newest_log = runtime_dir / "newest.log"
+        recent_log = output_dir / "recent.log"
+        for path in (old_log, newest_log, recent_log):
+            path.write_text("test log\n", encoding="utf-8")
+        os.utime(old_log, (2_000_000_000, 2_000_000_000))
+        os.utime(recent_log, (2_000_000_010, 2_000_000_010))
+        os.utime(newest_log, (2_000_000_020, 2_000_000_020))
+
+        output = self.run_cli(
+            "logs",
+            "discovery",
+            "--limit",
+            "2",
+            env_overrides={
+                "OMNIA_ANSIBLE_LOG_PATH": str(self.data_path / "ansible-logs")
+            },
+        )
+
+        self.assertIn("showing 2 of 3, newest first", output)
+        self.assertIn("[runtime] project_default/newest.log", output)
+        self.assertIn("[output] nested/recent.log", output)
+        self.assertNotIn("old.log", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Title

fix(main): align omnia-cli input and output diagnostics

### Issues Resolved by this Pull Request

Fixes #4849

### Description of the Solution

Aligns `omnia-cli` with the current input and output contracts for every Omnia domain so operators see accurate requirements, generated artifacts, and execution state. The CLI now supports CSV inputs and outputs, uses canonical source domain names, distinguishes a domain that has not run from an incomplete run, and validates domain-specific artifacts without reporting stale or unrelated files as success.

The change also improves guided input editing and log discovery, documents the customer-facing workflow, and adds focused automated coverage for all supported domains.

### Changes

#### CLI diagnostics (`src/main/omnia-cli`)

- Uses the canonical domain names `repo_manager`, `image_build_manager`, `build_stream`, `orchestrator`, `discovery`, `telemetry`, and `utils` consistently in commands, help, and status output.
- Adds per-domain input inventories with `required`, `conditional`, `optional`, and `generated` classifications and customer guidance.
- Treats Orchestrator `storage_config.yml` as required and validates Discovery and Orchestrator `primary_oim_admin_ip` against `SYSTEM_ADMIN_NIC_IPV4`.
- Directs users to run the complete respective domain flow to generate Vault-encrypted credentials; it does not recommend a credentials-only tag.
- Supports direct editing and discovery of YAML, JSON, CSV, INI-style, TOML, log, and text inputs while preventing hidden Vault-key and path-traversal access.
- Uses only each domain's canonical status file, reports empty staged output directories as not run, and returns failures to callers instead of suppressing exit codes.
- Recursively lists format-agnostic output artifacts, including Discovery CSV files and symlinks, Orchestrator inventory and phase reports, and Utils archives.
- Validates the current Repo Manager output contract and certificate path, Image Build Manager manifests, successful Discovery CSV artifacts, and completed Orchestrator provisioning/PXE reports.
- Combines runtime, Ansible, and output logs; removes duplicates, sorts globally by modification time, applies one global limit, and labels each result by source.

#### Shell completion (`src/main/omnia-bash-completion`)

- Completes canonical domain commands only.
- Completes staged editable filenames, including CSV inputs, for `omnia-cli edit`.

#### Documentation (`src/main/docs/omnia-cli.md`)

- Documents canonical commands, guided input requirements, generated outputs, status semantics, log behavior, and domain-flow credential creation.

#### Tests (`test/main/ut/test_omnia_cli.py`)

- Adds isolated coverage for input classifications, CSV editing/completion, network-IP validation, canonical command names, status contracts, generated artifact validation, not-run behavior, and globally sorted logs.

### Files Changed

| File | Change Type | Description |
|---|---|---|
| `src/main/omnia-cli` | Modified | Aligns domain input, output, status, edit, log, validation, and help behavior with current contracts. |
| `src/main/omnia-bash-completion` | Modified | Uses canonical domain names and completes supported staged input files. |
| `src/main/docs/omnia-cli.md` | Modified | Documents the revised customer input and generated-output workflows. |
| `test/main/ut/test_omnia_cli.py` | Added | Provides focused unit and integration-style CLI coverage across all domains. |

### Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q --confcutdir=test/main/ut test/main/ut/test_omnia_cli.py` — 24 passed, 26 subtests passed.
- `bash -n src/main/omnia-cli` — passed.
- `bash -n src/main/omnia-bash-completion` — passed.
- `git diff --check` — passed.
- Manual smoke checks exercised aggregate status/check output and the Repo Manager, Discovery, Orchestrator, Telemetry, and Build Stream domain views against staged/runtime data.
- GitHub checks currently all pass, including unit tests, ShellCheck, Ansible Lint, security scans, DCO, commit policy, WIP, and PR hygiene.

### Backward Compatibility

- Callers using the former `repo-manager`, `image-build`, or `build-stream` aliases must switch to the canonical `repo_manager`, `image_build_manager`, and `build_stream` commands.
- Failed domain checks and diagnostics now return non-zero exit codes instead of being silently converted to success.
- Orchestrator input checking now requires `storage_config.yml`, consistent with its current domain input contract.
- Existing project directory layouts and domain-generated data formats are unchanged; no data migration is required.

### Suggested Reviewers

| Reviewer | Review Focus |
|---|---|
| Omnia main-domain maintainer | CLI command behavior, error propagation, help, and completion contracts. |
| Discovery and Orchestrator domain owners | Network input guidance, generated CSV/inventory artifacts, and phase-aware status validation. |
| Repo Manager and Image Build Manager domain owners | Current status schemas, certificate handling, repository counts, and image manifest validation. |
| Test automation maintainer | Cross-domain fixtures, command exit behavior, and regression coverage. |

No matching CODEOWNERS entry or existing reviewer request was available, so reviewer roles are suggested instead of unverified usernames.
